### PR TITLE
fix: use PDO injection for IN clause for tickets query for users filter

### DIFF
--- a/src/core/class.db.php
+++ b/src/core/class.db.php
@@ -259,4 +259,28 @@ class db
         
     }
 
+    /**
+     * This function will generate a pdo binding string (":editors0,:editors1,:editors2,:editors3") to be used in a PDO
+     * query that uses the IN() clause, to assist in proper PDO array bindings to avoid SQL injection.
+     *
+     * A counted for loop is user rather than foreach with a key to avoid issues if the array passed has any
+     * arbitrary keys
+     *
+     * @param $name string
+     * @param $count int
+     * @return string
+     */
+    public static function arrayToPdoBindingString($name, $count)
+    {
+        $bindingStatement = "";
+        for ($i = 0; $i < $count; $i++) {
+            $bindingStatement .= ":" . $name . $i;
+            if ($i != $count-1) {
+                $bindingStatement .= ",";
+            }
+        }
+
+        return $bindingStatement;
+    }
+
 }

--- a/src/domain/tickets/repositories/class.tickets.php
+++ b/src/domain/tickets/repositories/class.tickets.php
@@ -806,8 +806,10 @@ namespace leantime\domain\repositories {
                 $query .= " AND zp_tickets.projectId = :projectId";
             }
 
+
             if($searchCriteria["users"]  != "") {
-                $query .= " AND zp_tickets.editorId IN(".strip_tags($searchCriteria["users"]).")";
+                $editorIdIn = core\db::arrayToPdoBindingString("users", count(explode(",", $searchCriteria["users"])));
+                $query .= " AND zp_tickets.editorId IN(" . $editorIdIn. ")";
             }
 
             if($searchCriteria["milestone"]  != "") {
@@ -865,6 +867,12 @@ namespace leantime\domain\repositories {
 
             if($searchCriteria["type"]  != "") {
                 $stmn->bindValue(':searchType', $searchCriteria["type"], PDO::PARAM_STR);
+            }
+
+            if($searchCriteria["users"]  != "") {
+                foreach(explode(",", $searchCriteria["users"]) as $key => $user) {
+                    $stmn->bindValue(":users" . $key, $user, PDO::PARAM_STR);
+                }
             }
 
             if($searchCriteria["term"]  != "") {


### PR DESCRIPTION
Fixes the issue reported in #179 by introducing a simple new static function in `db` that will create a binding string for use in PDO queries with `IN` clauses, and in the tickets repository, iterating over the users filter array to match the binding string. 