### PR TITLE
use appUrl in CURRENT_URL

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -61,7 +61,13 @@ class settings {
 
     public function getFullURL () {
 
-        return $this->getBaseURL().rtrim($_SERVER['REQUEST_URI'],"/");;
+        return $this->getBaseURL().rtrim($this->getRequestURI(),"/");
+
+    }
+	
+    public function getRequestURI () {
+
+        return $_SERVER['REQUEST_URI'];
 
     }
 

--- a/public/index.php
+++ b/public/index.php
@@ -11,10 +11,11 @@ $config = new leantime\core\config();
 
 if(isset($config->appUrl) && $config->appUrl != ""){
     define('BASE_URL', $config->appUrl);
+    define('CURRENT_URL', $config->appUrl.$settings->getRequestURI());
 } else{
     define('BASE_URL', $settings->getBaseURL());
+    define('CURRENT_URL', $settings->getFullURL());
 }
-define('CURRENT_URL', $settings->getFullURL());
 
 $login = leantime\core\login::getInstance(leantime\core\session::getSID());
 


### PR DESCRIPTION
With more digging it was found that ultimately the problem in #208 is in the mishandling of the configurable `$appUrl` variable. This variable is essentially ignored in the calls to `CURRENT_URL`. This problem could cause various other issues in the future. Here is a quick fix that was tested for my use case. I removed my "workaround" that I put in the mentioned issue, used port 80, and included the changes here. Feel free to suggest changes if needed.