### PR TITLE
Fixed the issue of the logo.png loading through http instead of https…

### DIFF
--- a/src/content.php
+++ b/src/content.php
@@ -25,7 +25,7 @@
 
         <div class="logo" style="<?php if(isset($_SESSION['menuState']) && $_SESSION['menuState'] == 'closed') echo 'margin-left:-260px;'; ?>">
             <a class="barmenu <?php if(!isset($_SESSION['menuState']) || $_SESSION['menuState'] == 'open') echo 'open'; ?>" href="javascript:void(0);"></a>
-            <a href="<?=BASE_URL ?>" style="background-image:url('<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>')">&nbsp;</a>
+            <a href="<?=BASE_URL ?>" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
         </div>
         <div class="headerinner" style="<?php if(isset($_SESSION['menuState']) && $_SESSION['menuState'] == 'closed') echo 'margin-left:0px;'; ?>">
             <div class="userloggedinfo">

--- a/src/install.php
+++ b/src/install.php
@@ -33,7 +33,7 @@ $install = new leantime\core\install($config, $settings);
 <div class="header hidden-gt-sm">
 
     <div class="logo" style="margin-left:0px;">
-        <a href="<?=BASE_URL?>" style="background-image:url(<?php echo $config->logoPath; ?>">&nbsp;</a>
+        <a href="<?=BASE_URL?>" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
     </div>
 
 </div>
@@ -45,7 +45,7 @@ $install = new leantime\core\install($config, $settings);
 
             </div>
             <div class="col-md-6" style="position:relative;">
-                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>" /></a>
+                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo $config->logoPath; ?>" /></a>
                 <h1 style="font-family:Exo;  font-size: 64px; padding-left:15px; font-weight:400;"><?php echo $language->__("headlines.drive_impact"); ?></h1>
                 <span class="iq-objects-04 iq-fadebounce">
 				    <span class="iq-round"></span>

--- a/src/login.php
+++ b/src/login.php
@@ -37,7 +37,7 @@
 <div class="header hidden-gt-sm">
 
     <div class="logo" style="margin-left:0px;">
-        <a href="<?=BASE_URL ?>/" style="background-image:url(<?=BASE_URL ?><?php echo $_SESSION["companysettings.logoPath"]; ?>">&nbsp;</a>
+        <a href="<?=BASE_URL ?>/" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
     </div>
 
 </div>
@@ -50,7 +50,7 @@
 
             </div>
             <div class="col-md-6" style="position:relative;">
-                <a href="<?=BASE_URL ?>" target="_blank"><img src="<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>" /></a>
+                <a href="<?=BASE_URL ?>" target="_blank"><img src="<?php echo $config->logoPath; ?>" /></a>
                 <h1 style="font-family:Exo;  font-size: 64px; padding-left:15px; font-weight:400;"><?php echo $language->__("headlines.drive_impact"); ?></h1>
                 <span class="iq-objects-04 iq-fadebounce">
 				    <span class="iq-round"></span>

--- a/src/resetPassword.php
+++ b/src/resetPassword.php
@@ -33,7 +33,7 @@
 <div class="header hidden-gt-sm">
 
     <div class="logo" style="margin-left:0px;">
-        <a href="<?=BASE_URL ?>" style="background-image:url(<?php echo $config->logoPath; ?>">&nbsp;</a>
+        <a href="<?=BASE_URL ?>" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
     </div>
 
 </div>
@@ -45,7 +45,7 @@
 
             </div>
             <div class="col-md-6" style="position:relative;">
-                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>" /></a>
+                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo $config->logoPath; ?>" /></a>
                 <h1 style="font-family:Exo;  font-size: 64px; padding-left:15px; font-weight:400;"><?php echo $language->__("headlines.drive_impact"); ?></h1>
                 <span class="iq-objects-04 iq-fadebounce">
 				    <span class="iq-round"></span>

--- a/src/twoFA.php
+++ b/src/twoFA.php
@@ -40,8 +40,7 @@
 <div class="header hidden-gt-sm">
 
     <div class="logo" style="margin-left:0px;">
-        <a href="<?= BASE_URL ?>/"
-           style="background-image:url(<?= BASE_URL ?><?php echo $_SESSION["companysettings.logoPath"]; ?>">&nbsp;</a>
+        <a href="<?= BASE_URL ?>/" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
     </div>
 
 </div>
@@ -55,8 +54,7 @@
 
             </div>
             <div class="col-md-6" style="position:relative;">
-                <a href="<?= BASE_URL ?>" target="_blank"><img
-                            src="<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>"/></a>
+                <a href="<?= BASE_URL ?>" target="_blank"><img src="<?php echo $config->logoPath; ?>"/></a>
                 <h1 style="font-family:Exo;  font-size: 64px; padding-left:15px; font-weight:400;"><?php echo $language->__("headlines.drive_impact"); ?></h1>
                 <span class="iq-objects-04 iq-fadebounce">
 				    <span class="iq-round"></span>

--- a/src/update.php
+++ b/src/update.php
@@ -33,7 +33,7 @@ $install = new leantime\core\install($config, $settings);
 <div class="header hidden-gt-sm">
 
     <div class="logo" style="margin-left:0px;">
-        <a href="<?=BASE_URL ?>/" style="background-image:url(<?php echo $config->logoPath; ?>">&nbsp;</a>
+        <a href="<?=BASE_URL ?>/" style="background-image:url(<?php echo $config->logoPath; ?>)">&nbsp;</a>
     </div>
 
 </div>
@@ -45,7 +45,7 @@ $install = new leantime\core\install($config, $settings);
 
             </div>
             <div class="col-md-6" style="position:relative;">
-                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>" /></a>
+                <a href="<?=BASE_URL ?>/" target="_blank"><img src="<?php echo $config->logoPath; ?>" /></a>
                 <h1 style="font-family:Exo;  font-size: 64px; padding-left:15px; font-weight:400;"><?php echo $language->__("headlines.drive_impact"); ?></h1>
                 <span class="iq-objects-04 iq-fadebounce">
 				    <span class="iq-round"></span>


### PR DESCRIPTION
… when appURL is set to https.

This fix involves changing the references to the logoPath from using the `$_SESSION` variable to using the `$config` variable. Examples below:

`<a href="<?=BASE_URL ?>" style="background-image:url('<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>')">&nbsp;</a>`

in the header for content.php, login.php, and twoFA.php vs

`<a href="<?=BASE_URL ?>" style="background-image:url(<?php echo $config->logoPath; ?>">&nbsp;</a>`

in the header for install.php, update.php, and resetPassword.php (actually, these pages use both - the `$config` variable in the header to grab the logo.png, and the `$_SESSION` variable further down the page). There is also a typo in the pages using the `$config` variable - no closing parenthesis on the background-image:url setting. Also inconsistent use of quotes for this value.

When loaded, the above resolve to

`<a href="https://URL" style="background-image:url('http://URL/images/logo.png')">&nbsp;</a>`

and

`<a href="https://URL" style="background-image:url(/images/logo.png">&nbsp;</a>`

respectively.

Changing all instances to use the `$config` variable (and adding the missing parenthesis) resolves the mixed-content issue of having the logo be loaded through http.