### PR TITLE
FIX Fixed the problem of missing psettings when initializing zp_projects

### DIFF
--- a/src/core/class.install.php
+++ b/src/core/class.install.php
@@ -461,10 +461,11 @@ namespace leantime\core {
                   `hourBudget` varchar(255) NOT NULL,
                   `dollarBudget` int(11) DEFAULT NULL,
                   `active` int(11) DEFAULT NULL,
+                  `psettings` MEDIUMTEXT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
                 
-                insert  into `zp_projects`(`id`,`name`,`clientId`,`details`,`state`,`hourBudget`,`dollarBudget`,`active`) values (3,'Leantime Onboarding',1,'<p>This is you first project to get you started</p>',0,'0',0,NULL);
+                insert  into `zp_projects`(`id`,`name`,`clientId`,`details`,`state`,`hourBudget`,`dollarBudget`,`active`,`psettings`) values (3,'Leantime Onboarding',1,'<p>This is you first project to get you started</p>',0,'0',0,NULL,NULL);
                 
                 CREATE TABLE `zp_punch_clock` (
                   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
I'm new to PR, so I don't know if this is the right branch name and how to do it, but I had a problem with a new install, so I fixed it.

It seems that psettings is missing when initializing zp_projects.