### PR TITLE
fix and improve S3 support for non-AWS S3 Servers like MINIO

### DIFF
--- a/config/configuration.sample.php
+++ b/config/configuration.sample.php
@@ -61,6 +61,7 @@ class config
     $this->userFilePath= $this->configEnvironmentHelper("LEAN_USER_FILE_PATH", $this->userFilePath);
               
     $this->useS3 = $this->configEnvironmentHelper("LEAN_USE_S3", $this->useS3, "boolean");
+    $this->s3EndPoint = $this->configEnvironmentHelper("LEAN_S3_END_POINT", $this->s3EndPoint);
     $this->s3Key = $this->configEnvironmentHelper("LEAN_S3_KEY", $this->s3Key);
     $this->s3Secret = $this->configEnvironmentHelper("LEAN_S3_SECRET", $this->s3Secret);
     $this->s3Bucket = $this->configEnvironmentHelper("LEAN_S3_BUCKET", $this->s3Bucket);

--- a/config/configuration.sample.php
+++ b/config/configuration.sample.php
@@ -25,6 +25,7 @@ class config
   public $s3Key = ""; //S3 Key
   public $s3Secret = ""; //S3 Secret
   public $s3Bucket = ""; //Your S3 bucket
+  public $s3UsePathStyleEndpoint = false; // false => https://[bucket].[endpoint] ; true => https://[endpoint]/[bucket]
   public $s3Region = ""; //S3 region
   public $s3FolderName = ""; //Foldername within S3 (can be emtpy)
   public $s3EndPoint = ""; //S3 EndPoint S3 Compatible (https://sfo2.digitaloceanspaces.com)
@@ -65,6 +66,7 @@ class config
     $this->s3Key = $this->configEnvironmentHelper("LEAN_S3_KEY", $this->s3Key);
     $this->s3Secret = $this->configEnvironmentHelper("LEAN_S3_SECRET", $this->s3Secret);
     $this->s3Bucket = $this->configEnvironmentHelper("LEAN_S3_BUCKET", $this->s3Bucket);
+    $this->s3UsePathStyleEndpoint = $this->configEnvironmentHelper("LEAN_S3_PATH_STYLE_ENDPOINT", $this->s3UsePathStyleEndpoint, "boolean");
     $this->s3Region = $this->configEnvironmentHelper("LEAN_S3_REGION", $this->s3Region);
     $this->s3FolderName = $this->configEnvironmentHelper("LEAN_S3_FOLDER_NAME", $this->s3FolderName);
               

--- a/config/configuration.sample.php
+++ b/config/configuration.sample.php
@@ -66,7 +66,7 @@ class config
     $this->s3Key = $this->configEnvironmentHelper("LEAN_S3_KEY", $this->s3Key);
     $this->s3Secret = $this->configEnvironmentHelper("LEAN_S3_SECRET", $this->s3Secret);
     $this->s3Bucket = $this->configEnvironmentHelper("LEAN_S3_BUCKET", $this->s3Bucket);
-    $this->s3UsePathStyleEndpoint = $this->configEnvironmentHelper("LEAN_S3_PATH_STYLE_ENDPOINT", $this->s3UsePathStyleEndpoint, "boolean");
+    $this->s3UsePathStyleEndpoint = $this->configEnvironmentHelper("LEAN_S3_USE_PATH_STYLE_ENDPOINT", $this->s3UsePathStyleEndpoint, "boolean");
     $this->s3Region = $this->configEnvironmentHelper("LEAN_S3_REGION", $this->s3Region);
     $this->s3FolderName = $this->configEnvironmentHelper("LEAN_S3_FOLDER_NAME", $this->s3FolderName);
               

--- a/public/backup.php
+++ b/public/backup.php
@@ -45,7 +45,7 @@ function uploadS3($backupFile, $config){
             'version'     => 'latest',
             'region'      => $config->s3Region,
             'endpoint'    => $config->s3EndPoint,
-            'use_path_style_endpoint' => $this->config->s3UsePathStyleEndpoint,
+            'use_path_style_endpoint' => $config->s3UsePathStyleEndpoint,
             'credentials' => [
                 'key'    => $config->s3Key,
                 'secret' => $config->s3Secret
@@ -54,10 +54,12 @@ function uploadS3($backupFile, $config){
     );
 
     try {
-       
+        // implode all non-empty elements to allow s3FolderName to be empty. 
+        // otherwise you will get an error as the key starts with a slash
+        $fileKey = implode('/', array_filter(array($config->s3FolderName, 'backupdb' , $backupFile)));
         $result = $s3Client->putObject([
             'Bucket' => $config->s3Bucket,
-            'Key'    => $config->s3FolderName . '/backupdb/' . $backupFile,
+            'Key'    => $fileKey,
             'Body'   => fopen($config->dbBackupPath.$backupFile, 'r'),
             'ACL'    => 'private'
         ]);

--- a/public/backup.php
+++ b/public/backup.php
@@ -45,6 +45,7 @@ function uploadS3($backupFile, $config){
             'version'     => 'latest',
             'region'      => $config->s3Region,
             'endpoint'    => $config->s3EndPoint,
+            'use_path_style_endpoint' => $this->config->s3UsePathStyleEndpoint,
             'credentials' => [
                 'key'    => $config->s3Key,
                 'secret' => $config->s3Secret

--- a/public/download.php
+++ b/public/download.php
@@ -120,6 +120,7 @@ function getFileFromS3(){
         'version'     => 'latest',
         'region'      => $config->s3Region,
         'endpoint' => $config->s3EndPoint,
+        'use_path_style_endpoint' => $this->config->s3UsePathStyleEndpoint,
         'credentials' => [
             'key'    => $config->s3Key,
             'secret' => $config->s3Secret

--- a/public/download.php
+++ b/public/download.php
@@ -120,7 +120,7 @@ function getFileFromS3(){
         'version'     => 'latest',
         'region'      => $config->s3Region,
         'endpoint' => $config->s3EndPoint,
-        'use_path_style_endpoint' => $this->config->s3UsePathStyleEndpoint,
+        'use_path_style_endpoint' => $config->s3UsePathStyleEndpoint,
         'credentials' => [
             'key'    => $config->s3Key,
             'secret' => $config->s3Secret
@@ -128,10 +128,12 @@ function getFileFromS3(){
     ]);
 
     try {
-
+        // implode all non-empty elements to allow s3FolderName to be empty. 
+        // otherwise you will get an error as the key starts with a slash
+        $fileName = implode('/', array_filter(array($config->s3FolderName, $encName.".".$ext)));
         $cmd = $s3Client->getCommand('GetObject', [
             'Bucket' => $config->s3Bucket,
-            'Key' => $config->s3FolderName."/".$encName.".".$ext,
+            'Key' => $fileName,
             'ResponseContentDisposition' => "filename=".$realName.".".$ext.""
         ]);
 

--- a/src/core/class.fileupload.php
+++ b/src/core/class.fileupload.php
@@ -231,9 +231,12 @@ class fileupload
             try {
                 // Upload data.
                 $file = fopen($this->file_tmp_name, "rb");
+                // implode all non-empty elements to allow s3FolderName to be empty. 
+                // otherwise you will get an error as the key starts with a slash
+                $fileName = implode('/', array_filter(array($config->s3FolderName, $this->file_name)));
 
-                $this->s3Client->upload($this->config->s3Bucket, $this->config->s3FolderName."/".$this->file_name, $file, "public-read");
-                $url =  $this->s3Client->getObjectUrl($this->config->s3Bucket, $this->config->s3FolderName."/".$this->file_name);
+                $this->s3Client->upload($this->config->s3Bucket, $fileName, $file, "public-read");
+                $url =  $this->s3Client->getObjectUrl($this->config->s3Bucket, $fileName);
 
                 return $url;
 
@@ -270,8 +273,11 @@ class fileupload
         try {
             // Upload data.
             $file = fopen($this->file_tmp_name, "rb");
+            // implode all non-empty elements to allow s3FolderName to be empty. 
+            // otherwise you will get an error as the key starts with a slash
+            $fileName = implode('/', array_filter(array($config->s3FolderName, $this->file_name)));
 
-            $this->s3Client->upload($this->config->s3Bucket, $this->config->s3FolderName."/".$this->file_name, $file, "authenticated-read");
+            $this->s3Client->upload($this->config->s3Bucket, $fileName, $file, "authenticated-read");
 
             return true;
 

--- a/src/core/class.fileupload.php
+++ b/src/core/class.fileupload.php
@@ -93,6 +93,7 @@ class fileupload
                 'version'     => 'latest',
                 'region'      => $this->config->s3Region,
                 'endpoint'    => $this->config->s3EndPoint,
+                'use_path_style_endpoint' => $this->config->s3UsePathStyleEndpoint,
                 'credentials' => [
                  'key'    => $this->config->s3Key,
                  'secret' => $this->config->s3Secret

--- a/src/core/class.fileupload.php
+++ b/src/core/class.fileupload.php
@@ -92,7 +92,7 @@ class fileupload
                 [
                 'version'     => 'latest',
                 'region'      => $this->config->s3Region,
-                'endpoint'    => $this->s3EndPoint,
+                'endpoint'    => $this->config->s3EndPoint,
                 'credentials' => [
                  'key'    => $this->config->s3Key,
                  'secret' => $this->config->s3Secret


### PR DESCRIPTION
This PR fixes and improves the handling of S3 storage servers, that are not on AWS S3.

**Changes:**

- fix configuration of s3EndPoint by ENV
- fix upload to S3 when folderName is empty
- allow path-style buckets instead of relying on default subdomain style. This adds new s3UsePathStyleEndpoint config variable and LEAN_S3_PATH_STYLE_ENDPOINT environment variable

A temporary docker image, which we use internally until these changes are releases, can be found on docker-hub: https://hub.docker.com/r/droidsolutions/leantime-s3-fix/tags