### PR TITLE
feat: ignore own account in email notifications to reduce mails

### DIFF
--- a/src/domain/projects/services/class.projects.php
+++ b/src/domain/projects/services/class.projects.php
@@ -136,6 +136,9 @@ namespace leantime\domain\services {
 
             //Email
             $users = $this->getUsersToNotify($projectId);
+            $users = array_filter($users, function($user, $k) { 
+                return $user != $_SESSION['userdata']['mail']; 
+            }, ARRAY_FILTER_USE_BOTH);
 
             $mailer = new core\mailer();
             $mailer->setSubject($subject);


### PR DESCRIPTION
As a user I already know when I created/edited a ticket some moments ago, so a notifaction by mail should not be sent. 

Please feel free to comment if you have some thoughts about this change.