### PR TITLE
fix: prevent password change if password is empty

### DIFF
--- a/src/domain/users/controllers/class.editUser.php
+++ b/src/domain/users/controllers/class.editUser.php
@@ -65,7 +65,7 @@ namespace leantime\domain\controllers {
 								'hours' => ($_POST['hours']),
 								'wage' => ($_POST['wage']),
 								'clientId' => ($_POST['client']),
-								'password' => (password_hash($_POST['password'], PASSWORD_DEFAULT)),
+								'password' = ($row['password']),
 							);
 
 							$changedEmail = 0;
@@ -74,6 +74,9 @@ namespace leantime\domain\controllers {
 								$changedEmail = 1;
 							}
 
+							if ($_POST['password'] != '' && $_POST['password'] == $_POST['password2']) {
+								$values['password'] = password_hash($_POST['password'], PASSWORD_DEFAULT);
+							}
 
 							if ($values['user'] !== '') {
 								if ($_POST['password'] == $_POST['password2']) {


### PR DESCRIPTION
The `$_POST['password'] != ''`(L83) check only happens when `$changedEmail == 1`(L81)

https://github.com/Leantime/leantime/blob/23e0799206a5bcd2ff033203816abe3f661cd2bd/src/domain/users/controllers/class.editUser.php#L78-L88

so this is hashing an empty string if `$_POST['password']` is empty.

https://github.com/Leantime/leantime/blob/23e0799206a5bcd2ff033203816abe3f661cd2bd/src/domain/users/controllers/class.editUser.php#L58-L69

This is why #412, #416, #427 happens.

The original nested `if`s between L78 to L114 is a little bit confusing, so instead of fixing the `if`s, I decide to read the original hashed password from `$row`, and change the value if passwords are match and not empty.