### PR TITLE
Focus headline when creating new todo

### DIFF
--- a/src/domain/dashboard/templates/show.tpl.php
+++ b/src/domain/dashboard/templates/show.tpl.php
@@ -62,7 +62,7 @@
 
                         <ul class="sortableTicketList" >
                             <li class="">
-                                <a href="javascript:void(0);" class="quickAddLink" id="ticket_new_link"  onclick="jQuery('#ticket_new').toggle('fast'); jQuery(this).toggle('fast');"><i class="fas fa-plus-circle"></i> <?php echo $this->__("links.quick_add_todo"); ?></a>
+                                <a href="javascript:void(0);" class="quickAddLink" id="ticket_new_link" onclick="jQuery('#ticket_new').toggle('fast', function() {jQuery(this).find('input[name=headline]').focus();}); jQuery(this).toggle('fast');"><i class="fas fa-plus-circle"></i> <?php echo $this->__("links.quick_add_todo"); ?></a>
                                 <div class="ticketBox hideOnLoad" id="ticket_new" style="text-align:center;">
 
                                     <form method="post" class="form-group">

--- a/src/domain/tickets/templates/showKanban.tpl.php
+++ b/src/domain/tickets/templates/showKanban.tpl.php
@@ -218,7 +218,7 @@
 
 							<div class="contentInner <?php echo"status_".$key;?>" >
                                 <div>
-                                    <a href="javascript:void(0);" class="quickAddLink" id="ticket_new_link_<?=$key?>"  onclick="jQuery('#ticket_new_<?=$key?>').toggle('fast'); jQuery(this).toggle('fast');"><i class="fas fa-plus-circle"></i> <?php echo $this->__("links.add_todo_no_icon"); ?></a>
+                                    <a href="javascript:void(0);" class="quickAddLink" id="ticket_new_link_<?=$key?>" onclick="jQuery('#ticket_new_<?=$key?>').toggle('fast', function() {jQuery(this).find('input[name=headline]').focus();}); jQuery(this).toggle('fast');"><i class="fas fa-plus-circle"></i> <?php echo $this->__("links.add_todo_no_icon"); ?></a>
                                     <div class="ticketBox hideOnLoad " id="ticket_new_<?=$key?>">
 
                                         <form method="post">


### PR DESCRIPTION
Small usability improvement: When adding a new To-Do on the kanban board,
the headline field will be focused once the jQuery transition has finished.
