### PR TITLE
Fixes issue of priority not being set on ticket update

### DIFF
--- a/src/domain/tickets/services/class.tickets.php
+++ b/src/domain/tickets/services/class.tickets.php
@@ -362,6 +362,7 @@ namespace leantime\domain\services {
                 'sprint' => $values['sprint'],
                 'storypoints' => $values['storypoints'],
                 'hourRemaining' => $values['hourRemaining'],
+                'priority' => $values['priority'],
                 'acceptanceCriteria' => $values['acceptanceCriteria'],
                 'editFrom' => $values['editFrom'],
                 'editTo' => $values['editTo'],


### PR DESCRIPTION
Updating the ticket priority using the showTicket template does not work, as the priority is not set at all in the updateTicket method as it is in the addTicket method.
