### PR TITLE
479: Adds support for reverse proxy protocol

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -53,7 +53,7 @@ class settings {
 
 	public function getBaseURL () {
 
-        $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+        $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') ? "https://" : "http://";
         $domainName = $_SERVER['HTTP_HOST'].'';
         return $protocol.$domainName;
 


### PR DESCRIPTION
If the HTTP_X_FORWARDED_PROTO header is available then use this to check if this is a secure request.

This fixes broken popups when running the system behind a reverse proxy that provides a TLS connection.

See #479.