### PR TITLE
set UTF-8 for both SMTP and php Mail

### DIFF
--- a/src/core/class.mailer.php
+++ b/src/core/class.mailer.php
@@ -67,7 +67,8 @@ namespace leantime\core {
 
             //PHPMailer
             $this->mailAgent = new PHPMailer();
-
+		
+	    $this->mailAgent->CharSet = 'UTF-8';                    //Ensure UTF-8 is used for emails
 
             //Use SMTP or php mail().
             if($config->useSMTP === true) {
@@ -83,8 +84,7 @@ namespace leantime\core {
                 $this->mailAgent->SMTPAutoTLS = $config->smtpAutoTLS ?? true;                 // Enable TLS encryption automatically if a server supports it
                 $this->mailAgent->SMTPSecure = $config->smtpSecure;                            // Enable TLS encryption, `ssl` also accepted
                 $this->mailAgent->Port = $config->smtpPort;                                    // TCP port to connect to
-                $this->mailAgent->CharSet = 'UTF-8';                    //Ensure UTF-8 is used for emails
-
+                
             }else{
 
                 $this->mailAgent->isMail();


### PR DESCRIPTION
UTF-8 charset was set only in SMTP mode :

```
if($config->useSMTP === true) {
   ...
   $this->mailAgent->CharSet = 'UTF-8';
}
```

I've moved it above the "if" statement so that it applies to both SMTP and php Mail(). Character encoding for accentuated characters is now correct even with the php Mail() builtin function (it was not the case before).