### PR TITLE
Display certain IDs in frontend

### DIFF
--- a/resources/language/de-DE.ini
+++ b/resources/language/de-DE.ini
@@ -729,6 +729,7 @@ label.copy_of = "Kopievon"
 label.assignSameUsers = "Den gleichen Benutzern zuweisen"
 label.newProjectName = "Neuer Projektname"
 label.client_id = "Kundennummer"
+label.ticket_id = "Ticketnummer"
 
 dropdown.how_big_todo = "Wie aufwendig ist diese Aufgabe?"
 dropdown.select_priority = "Welche Priorität hat diese Aufgabe?"

--- a/resources/language/de-DE.ini
+++ b/resources/language/de-DE.ini
@@ -728,6 +728,7 @@ label.twoFA_setup = "Zwei-Faktor Authentifikation einrichten"
 label.copy_of = "Kopievon"
 label.assignSameUsers = "Den gleichen Benutzern zuweisen"
 label.newProjectName = "Neuer Projektname"
+label.client_id = "Kundennummer"
 
 dropdown.how_big_todo = "Wie aufwendig ist diese Aufgabe?"
 dropdown.select_priority = "Welche Priorität hat diese Aufgabe?"

--- a/resources/language/de-DE_informal.ini
+++ b/resources/language/de-DE_informal.ini
@@ -729,6 +729,7 @@ label.copy_of = "Kopievon"
 label.assignSameUsers = "Den gleichen Benutzern zuweisen"
 label.newProjectName = "Neuer Projektname"
 label.client_id = "Kundennummer"
+label.ticket_id = "Ticketnummer"
 
 dropdown.how_big_todo = "Wie aufwendig ist diese Aufgabe?"
 dropdown.select_priority = "Welche Priorität hat diese Aufgabe?"

--- a/resources/language/de-DE_informal.ini
+++ b/resources/language/de-DE_informal.ini
@@ -728,6 +728,7 @@ label.twoFA_setup = "Zwei-Faktor Authentifikation einrichten"
 label.copy_of = "Kopievon"
 label.assignSameUsers = "Den gleichen Benutzern zuweisen"
 label.newProjectName = "Neuer Projektname"
+label.client_id = "Kundennummer"
 
 dropdown.how_big_todo = "Wie aufwendig ist diese Aufgabe?"
 dropdown.select_priority = "Welche Priorität hat diese Aufgabe?"

--- a/resources/language/en-US.ini
+++ b/resources/language/en-US.ini
@@ -733,6 +733,7 @@ label.copy_of = "Copy of"
 label.assignSameUsers = "Assign the same users"
 label.newProjectName = "New Project Name"
 label.client_id = "Client ID"
+label.ticket_id = "Ticket ID"
 
 dropdown.how_big_todo = "How large is this To-Do?"
 dropdown.select_priority = "What is the priority of this task?"

--- a/resources/language/en-US.ini
+++ b/resources/language/en-US.ini
@@ -732,6 +732,7 @@ label.twoFA_setup = "Set Up New Two-factor Authentication"
 label.copy_of = "Copy of"
 label.assignSameUsers = "Assign the same users"
 label.newProjectName = "New Project Name"
+label.client_id = "Client ID"
 
 dropdown.how_big_todo = "How large is this To-Do?"
 dropdown.select_priority = "What is the priority of this task?"

--- a/src/domain/clients/controllers/class.showClient.php
+++ b/src/domain/clients/controllers/class.showClient.php
@@ -52,6 +52,7 @@ namespace leantime\domain\controllers {
             $row = $clientRepo->getClient($id);
 
             $clientValues = array(
+                'id' => $row['id'],
                 'name' => $row['name'],
                 'street' => $row['street'],
                 'zip' => $row['zip'],

--- a/src/domain/clients/templates/showAll.tpl.php
+++ b/src/domain/clients/templates/showAll.tpl.php
@@ -28,6 +28,7 @@
             </colgroup>
             <thead>
                 <tr>
+                    <th class='head0'><?php echo $this->__('label.client_id'); ?></th>
                     <th class='head1'><?php echo $this->__('label.client_name'); ?></th>
                     <th class='head0'><?php echo $this->__('label.url') ?></th>
                     <th class='head1'><?php echo $this->__('label.number_of_projects'); ?></th>
@@ -37,6 +38,7 @@
 
             <?php foreach($this->get('allClients') as $row) { ?>
                 <tr>
+                    <td><?php echo $row['id']; ?></td>
                     <td>
                 <?php echo $this->displayLink('clients.showClient', $this->escape($row['name']), array('id' => $this->escape($row['id']))) ?>
                     </td>

--- a/src/domain/clients/templates/showClient.tpl.php
+++ b/src/domain/clients/templates/showClient.tpl.php
@@ -35,6 +35,13 @@ $users = $this->get('users');
                             <h4 class="widgettitle title-light"><span class="iconfa iconfa-leaf"></span> <?php echo $this->__('subtitle.details'); ?></h4>
 
                             <div class="form-group">
+                                <label class="span4 control-label"><?php echo $this->__('label.client_id') ?></label>
+                                <div class="span6">
+                                    <input type="text" name="id" id="id" value="<?php $this->e($values['id']); ?>" readonly />
+                                </div>
+                            </div>
+
+                            <div class="form-group">
                                 <label class="span4 control-label"><?php echo $this->__('label.name') ?></label>
                                 <div class="span6">
                                     <input type="text" name="name" id="name" value="<?php $this->e($values['name']); ?>" />

--- a/src/domain/tickets/templates/showKanban.tpl.php
+++ b/src/domain/tickets/templates/showKanban.tpl.php
@@ -267,6 +267,7 @@
                                                     </div>
                                                 <?php } ?>
                                                 <small><i class="fa <?php echo $todoTypeIcons[strtolower($row['type'])]; ?>"></i> <?php echo $this->__("label.".strtolower($row['type'])); ?></small>
+                                                <small>#<?php echo $row['id']; ?></small>
 
                                                 <h4><a href="<?=BASE_URL ?>/tickets/showTicket/<?php echo $row["id"];?>"><?php $this->e($row["headline"]);?></a></h4>
                                                 <p class="description"><?php echo $this->truncate(html_entity_decode($row["description"]), 200, '...', false, true);?><?php if(strlen($row["description"]) >= 200) echo" (...)";?></p>

--- a/src/domain/tickets/templates/submodules/ticketDetails.sub.php
+++ b/src/domain/tickets/templates/submodules/ticketDetails.sub.php
@@ -13,6 +13,12 @@
             <div class="span12">
                 <h4 class="widgettitle title-light"><span class="iconfa iconfa-leaf"></span><?php echo $this->__('subtitle.general'); ?></h4>
                 <div class="form-group">
+                    <label class="span4 control-label"><?php echo $this->__('label.ticket_id'); ?></label>
+                    <div class="span6">
+                        <input type="text" value="<?php $this->e($ticket->id); ?>" name="id" autocomplete="off" style="width:99%;" readonly/>
+                    </div>
+                </div>
+                <div class="form-group">
                     <label class="span4 control-label"><?php echo $this->__('label.ticket_title'); ?>*</label>
                     <div class="span6">
                         <input type="text" value="<?php $this->e($ticket->headline); ?>" name="headline" autocomplete="off"  style="width:99%;"/>


### PR DESCRIPTION
Closes #702 

Displays the client & ticket ID in certain places:

| Page | What |
| --- | --- |
| Kanban | Ticket ID |
| Ticket Details | Ticket ID |
| All Clients Table | Client ID |
| Client Details | Client ID |

---

### Screenshots

![Ticket ID in Kanban](https://user-images.githubusercontent.com/7105632/166889428-8ff4d2b9-d25d-443e-9ea5-43d25045385b.png)
![Ticket ID in Ticket Details](https://user-images.githubusercontent.com/7105632/166889507-cae71e86-c8c9-4644-95ba-44196d14ef77.png)
![Client ID in All Clients Table](https://user-images.githubusercontent.com/7105632/166889595-3c45b394-d03d-4cc8-a7f7-924460732d67.png)
![Client ID in Client Details](https://user-images.githubusercontent.com/7105632/166889650-8b370575-2891-4560-8863-fd7d8a177f33.png)
