### PR TITLE
Update the docker start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ docker run -d -p 80:80 --network leantime-net \
 -e LEAN_DB_USER=admin \
 -e LEAN_DB_PASSWORD=321.qwerty \
 -e LEAN_DB_DATABASE=leantime \
+-e LEAN_EMAIL_RETURN=changeme@local.local \
 --name leantime leantime/leantime:latest
 ```
 


### PR DESCRIPTION
Change of the docker command to include the LEAN_EMAIL_RETURN by default. 
Without an email you cannot add new items in Leantime (error 500 - even when no smtp data is entered and notification is disabled).