### PR TITLE
Zip not readable in Windows

### DIFF
--- a/createReleasePackage.sh
+++ b/createReleasePackage.sh
@@ -1,31 +1,33 @@
 #!/bin/sh
 
-mkdir release
+# Creating folder for release build
+mkdir -p release
 cd release
 
-git clone  https://github.com/Leantime/leantime.git
-
+#Pulling latest master from Github
+rm -R -f leantime
+git clone https://github.com/Leantime/leantime.git
 cd leantime
 
+#Pulling dependencies in
 npm install
-
 composer install --no-dev
 
+#Building dependencies
 ./node_modules/.bin/grunt Build-All
 
+#Removing unneeded items for release
 rm -f -R .git
 rm -f -R .github
 rm -R node_modules
 rm -R public/images/Screenshots
 rm .gitattributes .gitignore composer.json composer.lock gruntfile.js package-lock.json package.json
+rm createReleasePackage.sh
 
+#Exiting release folder and creating archives for Github
 cd ..
-
-zip -r -X Leantime-v$1.zip leantime/.
-
+zip -r -X Leantime-v$1.zip leantime
 tar -zcvf Leantime-v$1.tar.gz leantime
 
+#Removing 
 rm -R leantime
-
-
-


### PR DESCRIPTION
Issues is the "leantime/." path in the zip command. Just leantime like in the tar is good.
Also 
- Removed the createReleasePackage.sh file that is in the repository now
- Added the -p paramter to mkdir release (only if directory does not already exists)
- Remove leftover leantime directory before pulling the latest from Github (should never happen, but we both know Murphy).
- Added documentation

Open questions
==========
Is the .idea directory needed for release?