### PR TITLE
Easy version in createReleasePackage.sh

### DIFF
--- a/createReleasePackage.sh
+++ b/createReleasePackage.sh
@@ -26,8 +26,9 @@ rm createReleasePackage.sh
 
 #Exiting release folder and creating archives for Github
 cd ..
-zip -r -X Leantime-v$1.zip leantime
-tar -zcvf Leantime-v$1.tar.gz leantime
+version=`grep "appVersion" leantime/config/appSettings.php |awk -F' = ' '{print substr($2,2,length($2)-3)}'`
+zip -r -X "Leantime-v$version$1.zip" leantime
+tar -zcvf "Leantime-v$version$1.tar.gz" leantime
 
 #Removing 
 rm -R leantime


### PR DESCRIPTION
This pulls the version out of the appSettings.php file, so you don't have to add it as a parameter.
You can still add a parameter; this will be added after the version 
(createReleasePackage "-alpha" would result in "Leantime-v2.2.4-alpha.zip" (and tar.gz)

This needs to be tested on a mac before being accepted.