### PR TITLE
Removing the uncompressed JS

### DIFF
--- a/createReleasePackage.sh
+++ b/createReleasePackage.sh
@@ -24,6 +24,12 @@ rm -R public/images/Screenshots
 rm .gitattributes .gitignore composer.json composer.lock gruntfile.js package-lock.json package.json
 rm createReleasePackage.sh
 
+#removing js directories
+find ./src/domain/ -maxdepth 2 -name "js" -exec rm -r {} \;
+
+#removing uncompiled js files
+find ./public/js/ -mindepth 1 ! -name "*compiled*" -exec rm -f -r {} \;
+
 #Exiting release folder and creating archives for Github
 cd ..
 version=`grep "appVersion" leantime/config/appSettings.php |awk -F' = ' '{print substr($2,2,length($2)-3)}'`


### PR DESCRIPTION
Removing the uncompressed JS folders and files (in src/domain and in public/js)

1. find all directories with name 'js' and remove this directory.
2. find and remove all files within public/js (that is not public/js itself) and where the name does not contain the string 'compiled'.

**note**
- the public/js one creates 2 errors where he wants to remove files that are already removed. 
- This can be ignored - although not as pretty as I would like.