### PR TITLE
Remove font of qr-code plugin

### DIFF
--- a/createReleasePackage.sh
+++ b/createReleasePackage.sh
@@ -16,6 +16,9 @@ composer install --no-dev
 #Building dependencies
 ./node_modules/.bin/grunt Build-All
 
+#Remove font for QR code generator (not needed if no label is used)
+rm -f vendor/endroid/qr-code/assets/fonts/noto_sans.otf
+
 #Removing unneeded items for release
 rm -f -R .git
 rm -f -R .github


### PR DESCRIPTION
By removing the font used for labels under the qr-code (what we don't use at the moment), we can reduce the Release by ~15MB.