### PR TITLE
Add support for port in pdo mysql

### DIFF
--- a/config/configuration.sample.php
+++ b/config/configuration.sample.php
@@ -19,6 +19,7 @@ class config
     public $dbUser = ''; //Database username
     public $dbPassword = ''; //Database password
     public $dbDatabase = ''; //Database name
+    public $dbPort = '3306'; //Database port
 
     /* Fileupload */
     public $userFilePath = 'userfiles/'; //Local relative path to store uploaded files (if not using S3)
@@ -114,6 +115,7 @@ class config
         $this->dbUser = $this->configEnvironmentHelper("LEAN_DB_USER", $this->dbUser);
         $this->dbPassword = $this->configEnvironmentHelper("LEAN_DB_PASSWORD", $this->dbPassword);
         $this->dbDatabase = $this->configEnvironmentHelper("LEAN_DB_DATABASE", $this->dbDatabase);
+        $this->dbPort = $this->configEnvironmentHelper("LEAN_DB_PORT", $this->dbPort);
 
         /* Fileupload */
         $this->userFilePath = $this->configEnvironmentHelper("LEAN_USER_FILE_PATH", $this->userFilePath);

--- a/public/backup.php
+++ b/public/backup.php
@@ -22,7 +22,7 @@ function runBackup($backupFile, $config){
 
     $backupPath = $config->dbBackupPath.$backupFile;
     $output = array();
-    exec("mysqldump --user={$config->dbUser} --password={$config->dbPassword} --host={$config->dbHost} {$config->dbDatabase} --result-file={$backupPath} 2>&1", $output,$worked);
+    exec("mysqldump --user={$config->dbUser} --password={$config->dbPassword} --host={$config->dbHost} {$config->dbDatabase} --port={$config->dbPort} --result-file={$backupPath} 2>&1", $output,$worked);
 
     switch ($worked) {
         case 0:

--- a/src/core/class.db.php
+++ b/src/core/class.db.php
@@ -38,7 +38,7 @@ class db
      * @access private
      * @var    string database port default: 3306
      */
-    private $port='';
+    private $port='3306';
 
 
     public $database='';

--- a/src/core/class.db.php
+++ b/src/core/class.db.php
@@ -34,6 +34,12 @@ class db
 
     private $databaseName='';
 
+    /**
+     * @access private
+     * @var    string database port default: 3306
+     */
+    private $port='';
+
 
     public $database='';
     /**
@@ -57,11 +63,12 @@ class db
             $this->password = $config->dbPassword;
             $this->databaseName = $config->dbDatabase;
             $this->host= $config->dbHost;
+            $this->port= $config->dbPort;
 
         try{
 
             $driver_options = array( PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4,sql_mode="NO_ENGINE_SUBSTITUTION"' );
-            $this->database = new PDO('mysql:host=' . $this->host . ';dbname='. $this->databaseName .'', $this->user, $this->password, $driver_options);
+            $this->database = new PDO('mysql:host=' . $this->host . ';port='. $this->port .';dbname='. $this->databaseName .'', $this->user, $this->password, $driver_options);
             $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         }catch(PDOException $e){

--- a/src/core/class.install.php
+++ b/src/core/class.install.php
@@ -54,7 +54,7 @@ namespace leantime\core {
          * @access private
          * @var string
          */
-        private $port = '';
+        private $port = '3306';
 
         /**
          * db update scripts listed out by version number with leading zeros A.BB.CC => ABBCC

--- a/src/core/class.install.php
+++ b/src/core/class.install.php
@@ -50,6 +50,13 @@ namespace leantime\core {
         private $host = '';
 
         /**
+         * database port
+         * @access private
+         * @var string
+         */
+        private $port = '';
+
+        /**
          * db update scripts listed out by version number with leading zeros A.BB.CC => ABBCC
          * @access private
          * @var array
@@ -97,11 +104,12 @@ namespace leantime\core {
             $this->user = $this->config->dbUser;
             $this->password = $this->config->dbPassword;
             $this->host = $this->config->dbHost;
+            $this->port = $this->config->dbPort;
 
             try {
 
                 $driver_options = array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4,sql_mode="NO_ENGINE_SUBSTITUTION"');
-                $this->database = new PDO('mysql:host=' . $this->host . '', $this->user, $this->password,
+                $this->database = new PDO('mysql:host=' . $this->host . ';port=' . $this->port, $this->user, $this->password,
                     $driver_options);
                 $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 


### PR DESCRIPTION
Description:
I recently had issue with database configuration that is not using default 3306 port. So, I tried adding the port support in these files.

**configuration.sample.php**
- new port variable.
- new environment variable for port.

**class.db.php**
- new port variable
- add port to existing pdo connection string

**class.install.php**
- new port variable
- add port to existing pdo connection string

**backup.php**
- add port flag to mysqldump command

pl. sorry if I made any mistake, this is my first github PR, all advice are welcome.