### PR TITLE
fix: issue#875 add support for utf-8 character in datatables export button

### DIFF
--- a/src/domain/tickets/js/ticketsController.js
+++ b/src/domain/tickets/js/ticketsController.js
@@ -1375,6 +1375,8 @@ leantime.ticketsController = (function () {
                     {
                         extend: 'csvHtml5',
                         title: leantime.i18n.__("label.filename_fileexport"),
+                        charset: 'utf-8',
+                        bom: true,
                         exportOptions: {
                             format: {
                                 body: function ( data, row, column, node ) {

--- a/src/domain/timesheets/js/timesheetsController.js
+++ b/src/domain/timesheets/js/timesheetsController.js
@@ -136,6 +136,8 @@ leantime.timesheetsController = (function () {
                     {
                         extend: 'csvHtml5',
                         title: leantime.i18n.__("label.filename_fileexport"),
+                        charset: 'utf-8',
+                        bom: true,
                         exportOptions: {
                             format: {
                                 body: function ( data, row, column, node ) {


### PR DESCRIPTION
**According to issue #875** with broken export with utf-8 characters in datatables export button by adding charset: 'utf-8' and bom: true in datatables button

**Before fix**
![image](https://user-images.githubusercontent.com/11164699/185062676-886e2770-189b-42d0-bb0f-bd743c43028a.png)

**After fix**
![image](https://user-images.githubusercontent.com/11164699/185062764-c08febd9-15cc-4da7-8af2-d422212aa4bf.png)
