### PR TITLE
Updated "badges" with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 # Leantime&trade; #
 
-![License Badge](https://img.shields.io/github/license/leantime/leantime?style=flat-square) 
-![Version](https://img.shields.io/github/package-json/v/leantime/leantime/master?style=flat-square)
-![Docker Hub Badge](https://img.shields.io/docker/pulls/leantime/leantime?style=flat-square)
-<a href="https://discord.gg/4zMzJtAq9z">![Discord Badge](https://img.shields.io/discord/990001288026677318?label=Discord&style=flat-square)</a>
+[![License Badge](https://img.shields.io/github/license/leantime/leantime?style=flat-square)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
+[![Version](https://img.shields.io/github/package-json/v/leantime/leantime/master?style=flat-square)](https://github.com/Leantime/leantime/releases)
+[![Docker Hub Badge](https://img.shields.io/docker/pulls/leantime/leantime?style=flat-square)](https://hub.docker.com/r/leantime/leantime)
+[![Discord Badge](https://img.shields.io/discord/990001288026677318?label=Discord&style=flat-square)](https://discord.gg/4zMzJtAq9z)
+
 <br />
 
 Leantime is a lean open source project management system for startups and innovators written in PHP, Javascript with MySQL. [https://leantime.io](https://leantime.io)


### PR DESCRIPTION
Updated the badges so
- license leads to the license information
- Version leads to the release page
- Docker hub leads to the docker hub
- Discord already lead to discord, but now with correct Github syntax