### PR TITLE
Fixed editor role cannot create or edit to-do in showKanban

### DIFF
--- a/src/domain/auth/services/class.auth.php
+++ b/src/domain/auth/services/class.auth.php
@@ -422,7 +422,8 @@ namespace leantime\domain\services {
                 //Do not overwrite admin or owner roles
             }elseif($_SESSION['userdata']['role'] == roles::$owner
                 || $_SESSION['userdata']['role'] == roles::$admin
-                || $_SESSION['userdata']['role'] == roles::$manager) {
+                || $_SESSION['userdata']['role'] == roles::$manager
+                || $_SESSION['userdata']['role'] == roles::$editor) {
 
                 $roleToCheck = $_SESSION['userdata']['role'];
 
@@ -479,7 +480,8 @@ namespace leantime\domain\services {
             //Do not overwrite admin or owner roles
             }elseif($_SESSION['userdata']['role'] == roles::$owner
                 || $_SESSION['userdata']['role'] == roles::$admin
-            || $_SESSION['userdata']['role'] == roles::$manager) {
+                || $_SESSION['userdata']['role'] == roles::$manager
+                || $_SESSION['userdata']['role'] == roles::$editor) {
 
                 $roleToCheck = $_SESSION['userdata']['role'];
 


### PR DESCRIPTION
Fixed a bug that user with editor role cannot create, edit or move cards in showKanban