### PR TITLE
Make top right menus UI consistent

### DIFF
--- a/src/domain/general/templates/headMenu.tpl.php
+++ b/src/domain/general/templates/headMenu.tpl.php
@@ -62,6 +62,7 @@ if(is_array($currentLink)) {
     <li class="appsDropdown">
         <a href='javascript:void(0);' class="dropdown-toggle profileHandler" data-toggle="dropdown" >
             <img src="<?=BASE_URL ?>/images/svg/apps-grid-icon.svg" style="width:13px; vertical-align: middle;">
+                &nbsp;<i class="fas fa-caret-down"></i>
         </a>
 
         <ul class="dropdown-menu">

--- a/src/domain/general/templates/loginInfo.tpl.php
+++ b/src/domain/general/templates/loginInfo.tpl.php
@@ -3,7 +3,6 @@
 <div class="userinfo">
     <a href='<?=BASE_URL ?>/users/editOwn/' class="dropdown-toggle profileHandler" data-toggle="dropdown">
         <img src="<?php echo $this->get('profilePicture'); ?>" class="profilePicture"/>
-        <span class="username"><?php $this->e($this->get('userName')); ?></span>
         <i class="fa fa-caret-down" aria-hidden="true"></i>
     </a>
     <ul class="dropdown-menu">


### PR DESCRIPTION
Add a caret-down next to the new company management / administration menu on the top right to show that it is a drop-down menu, rather than a function, consistent with the profile menu next to it.

Remove the name from the profile menu item (only show the image) to make it consistent with the overall menu items that only show icons, rather than text.

An alternative would be to have a text for all items (at it was the case in some old version). I prefer the new set-up.