### PR TITLE
SSL warning fix

### DIFF
--- a/src/layouts/app.php
+++ b/src/layouts/app.php
@@ -15,7 +15,7 @@
 
         <div class="logo" style="<?php if(isset($_SESSION['menuState']) && $_SESSION['menuState'] == 'closed') echo 'margin-left:-260px;'; ?>">
 
-            <a href="<?=BASE_URL ?>" style="background-image:url('<?php echo htmlentities($_SESSION["companysettings.logoPath"]); ?>')">&nbsp;</a>
+            <a href="<?=BASE_URL ?>" style="background-image:url('<?php echo str_replace('http:','',htmlentities($_SESSION["companysettings.logoPath"])); ?>')">&nbsp;</a>
         </div>
 
         <div class="leftmenu">


### PR DESCRIPTION
Remove "http:" prefix for logo image path to avoid SSL warning for non-secure image loaded