### PR TITLE
Changed timesheet labels to default format.

### DIFF
--- a/src/domain/tickets/templates/submodules/timesheet.sub.php
+++ b/src/domain/tickets/templates/submodules/timesheet.sub.php
@@ -71,7 +71,7 @@
         foreach ($this->get('ticketHours') as $hours){
             $sum = $sum + $hours['summe'];
 
-            echo"labels.push('".date($this->__("language.dateformat"),  strtotime($hours['utc']))."');
+            echo"labels.push('".date("m/d/Y",  strtotime($hours['utc']))."');
                     ";
             echo"d2.push(".$sum.");
                     ";


### PR DESCRIPTION
Fixes #1185 

Chart.js does not do localization. So passing the date in a different form than the en_US format does not work.
Changed to en-US default format.