### PR TITLE
LDAP: Cleanup unused parameters

### DIFF
--- a/app/core/class.defaultConfiguration.php
+++ b/app/core/class.defaultConfiguration.php
@@ -63,11 +63,7 @@ class config
     public $ldapType = 'OL';                              //Select the correct directory type. Currently Supported: OL - OpenLdap, AD - Active Directory
     public $ldapHost = '';                                //FQDN
     public $ldapPort = 389;                               //Default Port
-    public $baseDn = '';                                  //Base DN, example: DC=example,DC=com
     public $ldapDn = '';                                  //Location of users, example: CN=users,DC=example,DC=com
-    public $ldapUserDomain = '';                          //Domain after ldap, example @example.com
-    public $bindUser = '';                                //ldap user that can search directory. (Should be read only)
-    public $bindPassword = '';
     //Default ldap keys in your directory.
     //Works for OL
     public $ldapKeys = '{

--- a/app/core/class.environment.php
+++ b/app/core/class.environment.php
@@ -89,9 +89,7 @@ class environment
             $this->ldapType = $this->environmentHelper("LEAN_LDAP_LDAP_TYPE", $defaultConfiguration->ldapType ?? '');
             $this->ldapHost = $this->environmentHelper("LEAN_LDAP_HOST", $defaultConfiguration->ldapHost ?? '');
             $this->ldapPort = $this->environmentHelper("LEAN_LDAP_PORT", $defaultConfiguration->ldapPort ?? '');
-            $this->baseDn = $this->environmentHelper("LEAN_LDAP_BASE_DN", $defaultConfiguration->baseDn ?? '');
             $this->ldapDn = $this->environmentHelper("LEAN_LDAP_DN", $defaultConfiguration->ldapDn ?? '') ;
-            $this->ldapUserDomain = $this->environmentHelper("LEAN_LDAP_USER_DOMAIN", $defaultConfiguration->ldapUserDomain ?? '');
             $this->ldapKeys = $this->environmentHelper("LEAN_LDAP_KEYS", $defaultConfiguration->ldapKeys ?? '');
             $this->ldapLtGroupAssignments = $this->environmentHelper("LEAN_LDAP_GROUP_ASSIGNMENT", $defaultConfiguration->ldapLtGroupAssignments ?? '') ;
             $this->ldapDefaultRoleKey = $this->environmentHelper("LEAN_LDAP_DEFAULT_ROLE_KEY", $defaultConfiguration->ldapDefaultRoleKey ?? '');

--- a/app/domain/auth/services/class.auth.php
+++ b/app/domain/auth/services/class.auth.php
@@ -205,7 +205,6 @@ namespace leantime\domain\services {
 
                 if ($ldap->connect() && $ldap->bind($username, $password)) {
                     //Update username to include domain
-                    //$usernameWDomain = $ldap->extractLdapFromUsername($username)."".$ldap->userDomain;
                     $usernameWDomain = $ldap->getEmail($username);
                     //Get user
                     $user = $this->userRepo->getUserByEmail($usernameWDomain);

--- a/app/domain/ldap/services/class.ldap.php
+++ b/app/domain/ldap/services/class.ldap.php
@@ -10,9 +10,7 @@ class ldap
     private $ldapConnection;
     private $host;
     private $port;
-    private $baseDn; //Base DN for domain
     private $ldapDn; //DN where users are located (including baseDn)
-    public $userDomain;
     private $ldapKeys = array(
         "username" => "uid",
         "groups" => "memberof",
@@ -58,11 +56,9 @@ class ldap
 
             //Prepare and map in case we want to get the config from somewhere else in the future
             $this->host = $this->config->ldapHost;
-            $this->baseDn = $this->config->baseDn;
             $this->ldapDn = $this->config->ldapDn;
             $this->defaultRoleKey = $this->config->ldapDefaultRoleKey;
             $this->port = $this->config->ldapPort;
-            $this->userDomain = $this->config->ldapUserDomain;
             $this->ldapLtGroupAssignments = json_decode(trim(preg_replace('/\s+/', '', $this->config->ldapLtGroupAssignments)));
             $this->ldapKeys = $this->settingsRepo->getSetting('companysettings.ldap.ldapKeys') ? json_decode($this->settingsRepo->getSetting('companysettings.ldap.ldapKeys')) : json_decode(trim(preg_replace('/\s+/', '', $this->config->ldapKeys)));
             $this->directoryType = $this->config->ldapType;
@@ -202,8 +198,6 @@ class ldap
         if ($this->config->debug) {
             error_log("LEANTIME: Testing the logging\n");
 
-            //$uname = $this->extractLdapFromUsername($username)."".$this->userDomain;
-            //$uname = str_replace("@","AT", $uname);
             error_log("LEANTIME: >>>Attributes Begin>>>>>>\n");
             error_log("LEANTIME: fn $firstname", 0);
             error_log("LEANTIME: sn $lastname", 0);

--- a/config/configuration.sample.php
+++ b/config/configuration.sample.php
@@ -4,7 +4,8 @@
 
 namespace leantime\core;
 
-class config {
+class config
+{
     /* General */
 
     public $sitename = 'Leantime';                        //Name of your site, can be changed later
@@ -64,11 +65,7 @@ class config {
     public $ldapType = 'OL';                              //Select the correct directory type. Currently Supported: OL - OpenLdap, AD - Active Directory
     public $ldapHost = '';                                //FQDN
     public $ldapPort = 389;                               //Default Port
-    public $baseDn = '';                                  //Base DN, example: DC=example,DC=com
     public $ldapDn = '';                                  //Location of users, example: CN=users,DC=example,DC=com
-    public $ldapUserDomain = '';                          //Domain after ldap, example @example.com
-    public $bindUser = '';                                //ldap user that can search directory. (Should be read only)
-    public $bindPassword = '';
     //Default ldap keys in your directory.
     //Works for OL
     public $ldapKeys = '{
@@ -120,5 +117,4 @@ class config {
           }
         }';
     public $ldapDefaultRoleKey = 20;           //Default Leantime Role on creation. (set to editor)
-
 }


### PR DESCRIPTION
Removes LDAP parameters from configuration that are unused and could mislead users.

Signed-off-by: Silvio Gissi <silvio@gissilabs.com>