### PR TITLE
Restore getRequestURI to appsettings

### DIFF
--- a/config/appSettings.php
+++ b/config/appSettings.php
@@ -60,6 +60,29 @@ namespace leantime\core {
             }
 
         }
+        
+        public function getRequestURI($baseURL = "")
+        {
+
+            //$_SERVER['REQUEST_URI'] will include the subfolder if one is set. Let's make sure to take it out
+            if ($baseURL != "") {
+                $trimmedBaseURL = rtrim($baseURL, "/");
+                $baseURLParts = explode("/", $trimmedBaseURL);
+
+                //We only need to update Request URI if we have a subfolder install
+                if (is_array($baseURLParts) && count($baseURLParts) == 4) {
+                    //0: http, 1: "", 2: domain.com 3: subfolder
+                    $subfolderName = $baseURLParts[3];
+
+                    //Remove subfoldername from Request URI
+                    $requestURI = preg_replace('/^\/' . $subfolderName . '/', '', $_SERVER['REQUEST_URI']);
+
+                    return $requestURI;
+                }
+            }
+
+            return $_SERVER['REQUEST_URI'];
+        }
 
 
     }


### PR DESCRIPTION
this is because its being used in places in the system(index.php), and post upgrade caused an error. We should clean up its usage first. I also think we need to push out a new version