### PR TITLE
remove sub-url install as default from .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,7 +1,7 @@
 RewriteEngine On
 
 #Uncomment and update if Leantime runs in a subfolder
-RewriteBase /leantime/
+#RewriteBase /leantime/
 
 RewriteRule ^/?$ index.php?act=dashboard.show
 RewriteRule ^([^/\.]+)/?$ index.php?act=$1 [QSA]


### PR DESCRIPTION
this is to prevent confused users and dysfunctional docker images