### PR TITLE
Feature/new leantime command to test email sending

### DIFF
--- a/app/command/class.testEmailCommand.php
+++ b/app/command/class.testEmailCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace leantime\command;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use leantime\core\mailer;
+
+class testEmailCommand extends Command
+{
+  protected static $defaultName = 'email:test';
+  protected static $defaultDescription = 'Sends an email to test system configuration';
+
+  protected function configure()
+  {
+    parent::configure();
+    $this->addOption('address', null, InputOption::VALUE_REQUIRED, "Recipient email address");
+  }
+
+  /**
+   * Execute the command
+   *
+   * @param  InputInterface  $input
+   * @param  OutputInterface $output
+   * @return int 0 if everything went fine, or an exit code.
+   */
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  { 
+    define('BASE_URL', "");
+    define('CURRENT_URL', "");
+    $io = new SymfonyStyle($input, $output);
+    
+    $address = $input->getOption('address');
+
+    if($address == '') {
+      $io->error("address parameter needs to be set");
+      return Command::INVALID;
+    } 
+
+    $config = \leantime\core\environment::getInstance();
+    
+    // force debug output from mailer subsystem
+    $config->debug = 1;
+    $mailer = new Mailer();
+
+    $io = new SymfonyStyle($input, $output);
+    $io->writeln('Sending a test email using current configuration');
+
+    $mailer = new Mailer();
+    $mailer->setSubject('Leantime email test');
+    $mailer->setHtml('This is a test of the leantime mailer configuration. If you have received this email, then the mail configuration is correct.');
+    $mailer->sendMail(Array($input->getOption('address')), 'Command-line test');
+
+    return Command::SUCCESS;
+  }
+}

--- a/app/core/class.mailer.php
+++ b/app/core/class.mailer.php
@@ -72,11 +72,11 @@ namespace leantime\core {
             //PHPMailer
             $this->mailAgent = new PHPMailer(false);
 
-            $this->mailAgent->CharSet = 'UTF-8';                    //Ensure UTF-8 is used for emails
+            $this->mailAgent->CharSet = 'UTF-8';                    // Ensure UTF-8 is used for emails
             //Use SMTP or php mail().
             if ($config->useSMTP === true) {
                 if ($config->debug) {
-                    $this->mailAgent->SMTPDebug = 2;                                  // Enable verbose debug output
+                    $this->mailAgent->SMTPDebug = 4;                // ensure all aspects (connection, TLS, SMTP, etc) are covered
                     $this->mailAgent->Debugoutput = function ($str, $level) {
 
                         error_log($level . ' ' . $str);

--- a/bin/leantime
+++ b/bin/leantime
@@ -10,10 +10,12 @@ require_once __DIR__ . '/../config/appSettings.php';
 use leantime\command\migrateCommand;
 use leantime\command\addUserCommand;
 use leantime\command\saveSettingCommand;
+use leantime\command\testEmailCommand;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
 $application->add(new addUserCommand());
 $application->add(new migrateCommand());
 $application->add(new saveSettingCommand());
+$application->add(new testEmailCommand());
 $application->run();


### PR DESCRIPTION
I was flummoxed with testing the email sending system and couldn't find an easy way to do it within the app without ending up with trouble, so I cooked up a rapid diagnosis command to add to the leantime command-line tool, and that allowed me to solve the issue, so I figured I would contribute it back.

It temporarily increases logging levels of the SMTP Mailer library to return as much debug feedback as possible.