### PR TITLE
prevent OIDC header capitalization errors

### DIFF
--- a/app/domain/oidc/services/class.oidc.php
+++ b/app/domain/oidc/services/class.oidc.php
@@ -189,7 +189,11 @@ class oidc {
                 'client_secret' => $this->clientSecret
             ]
         ]);
-        $contentType = $response->getHeaders()['Content-Type'][0];
+        $headerArray = [];
+        foreach($response->getHeaders() as $header => $values) {
+            $headerArray[strtolower($header)] = $values;
+        }
+        $contentType = array_pop($headerArray['content-type']);
         switch($contentType) {
             case 'application/x-www-form-urlencoded; charset=utf-8':
             case 'application/x-www-form-urlencoded':


### PR DESCRIPTION
Hi,
someone contacted me because their OIDC-Connection wasn‘t working.

The header key is case sensitive, but shouldn‘t be. So I just turn copy them all to lower space and then check their value.