### PR TITLE
update OIDC to use json decoding by default

### DIFF
--- a/app/domain/oidc/services/class.oidc.php
+++ b/app/domain/oidc/services/class.oidc.php
@@ -200,8 +200,7 @@ class oidc {
                 $result = [];
                 parse_str($response->getBody()->getContents(), $result);
                 return $result;
-
-            case 'application/json':
+            default:
                 return json_decode($response->getBody()->getContents(), true);
         }
 


### PR DESCRIPTION
this is because this is the generally expected format, but sometimes its sent with additons like application/json+xyz or no type at all(in the case of azure)