### PR TITLE
Password hash at User Repository level

### DIFF
--- a/app/command/class.addUserCommand.php
+++ b/app/command/class.addUserCommand.php
@@ -75,7 +75,7 @@ class addUserCommand extends Command
         }
         $user = array(
             "user" => $email,
-            "password" => password_hash($password, PASSWORD_DEFAULT),
+            "password" => $password,
             "role" => array_search($role, roles::getRoles()),
             "clientId" => $clientId,
             "firstname" => $firstName,

--- a/app/command/class.migrateCommand.php
+++ b/app/command/class.migrateCommand.php
@@ -78,7 +78,7 @@ class migrateCommand extends Command
 
                     $setupConfig = array(
                         "email" => $adminEmail,
-                        "password" => password_hash($adminPassword, PASSWORD_DEFAULT),
+                        "password" => $adminPassword,
                         "firstname" => $adminFirstName,
                         "lastname" => $adminLastName,
                         "company" => $companyName

--- a/app/domain/api/services/class.api.php
+++ b/app/domain/api/services/class.api.php
@@ -75,7 +75,7 @@ namespace leantime\domain\services;
             $values["user"] = $user;
             $values["lastname"] = '';
             $values["passwordClean"] = $password;
-            $values["password"] = password_hash($password, PASSWORD_DEFAULT);
+            $values["password"] = $password;
             $values["status"] = 'a';
             $values["clientId"] = '';
             $values["phone"] = '';

--- a/app/domain/auth/controllers/class.userInvite.php
+++ b/app/domain/auth/controllers/class.userInvite.php
@@ -82,7 +82,7 @@ namespace leantime\domain\controllers {
                             $user["lastname"] = $_POST["lastname"];
                             $user["status"] = "A";
                             $user["user"] =  $user["username"];
-                            $user["password"] = password_hash($_POST['password'], PASSWORD_DEFAULT);
+                            $user["password"] = $_POST['password'];
 
                             if ($this->usersService->editUser($user, $user["id"])) {
                                 $this->tpl->setNotification(

--- a/app/domain/install/controllers/class.index.php
+++ b/app/domain/install/controllers/class.index.php
@@ -74,7 +74,7 @@ namespace leantime\domain\controllers {
                                     $this->tpl->setNotification("notification.enter_company", "error");
                                     ;
                                 } else {
-                                    $values['password'] = password_hash($_POST['password'], PASSWORD_DEFAULT);
+                                    $values['password'] = $_POST['password'];
 
                                     if ($this->installRepo->setupDB($values)) {
                                         $this->tpl->setNotification(sprintf($this->language->__("notifications.installation_success"), BASE_URL), "success");

--- a/app/domain/users/controllers/class.editOwn.php
+++ b/app/domain/users/controllers/class.editOwn.php
@@ -148,7 +148,7 @@ namespace leantime\domain\controllers {
                     if (password_verify($_POST['currentPassword'], $values['password'])) {
                         if ($_POST['newPassword'] == $_POST['confirmPassword']) {
                             if ($this->userService->checkPasswordStrength($_POST['newPassword'])) {
-                                $values['password'] = password_hash($_POST['newPassword'], PASSWORD_DEFAULT);
+                                $values['password'] = $_POST['newPassword'];
                                 $this->userRepo->editOwn($values, $this->userId);
                                 $this->tpl->setNotification(
                                     $this->language->__("notifications.password_changed"),

--- a/app/domain/users/repositories/class.users.php
+++ b/app/domain/users/repositories/class.users.php
@@ -353,7 +353,7 @@ namespace leantime\domain\repositories {
             $stmn->bindValue(':wage', $values['wage'], PDO::PARAM_STR);
             $stmn->bindValue(':clientId', $values['clientId'], PDO::PARAM_STR);
             $stmn->bindValue(':id', $id, PDO::PARAM_STR);
-            $stmn->bindValue(':password', $values['password'], PDO::PARAM_STR);
+            $stmn->bindValue(':password', password_hash($values['password'], PASSWORD_DEFAULT), PDO::PARAM_STR);
 
             $result = $stmn->execute();
             $stmn->closeCursor();
@@ -433,7 +433,7 @@ namespace leantime\domain\repositories {
             $stmn->bindValue(':id', $id, PDO::PARAM_STR);
 
             if ($values['password'] != '') {
-                $stmn->bindValue(':password', $values['password'], PDO::PARAM_STR);
+                $stmn->bindValue(':password', password_hash($values['password'], PASSWORD_DEFAULT), PDO::PARAM_STR);
             }
 
             $stmn->execute();
@@ -485,7 +485,7 @@ namespace leantime\domain\repositories {
             $stmn->bindValue(':user', $values['user'], PDO::PARAM_STR);
             $stmn->bindValue(':role', $values['role'], PDO::PARAM_STR);
 
-            $stmn->bindValue(':password', $values['password'], PDO::PARAM_STR);
+            $stmn->bindValue(':password', password_hash($values['password'], PASSWORD_DEFAULT), PDO::PARAM_STR);
             $stmn->bindValue(':clientId', $values['clientId'], PDO::PARAM_INT);
 
             if (isset($values['source'])) {
@@ -627,7 +627,11 @@ namespace leantime\domain\repositories {
             $stmn->bindValue(':id2', $id, PDO::PARAM_STR);
 
             foreach ($params as $key => $value) {
-                $stmn->bindValue(':' . core\db::sanitizeToColumnString($key), $value, PDO::PARAM_STR);
+                $cleanKey = core\db::sanitizeToColumnString($key);
+                $val = $value;
+                if ($cleanKey == 'password')
+                    $val = password_hash($value, PASSWORD_DEFAULT);
+                $stmn->bindValue(':' . $cleanKey, $val, PDO::PARAM_STR);
             }
 
             $return = $stmn->execute();

--- a/app/domain/users/services/class.users.php
+++ b/app/domain/users/services/class.users.php
@@ -125,7 +125,7 @@ namespace leantime\domain\services {
             $tempPasswordVar =  Uuid::uuid4()->toString();
             $inviteCode = Uuid::uuid4()->toString();
 
-            $values['password'] = password_hash($tempPasswordVar, PASSWORD_DEFAULT);
+            $values['password'] = $tempPasswordVar;
             $values['status'] = "i";
             $values['pwReset'] = $inviteCode;
 
@@ -168,8 +168,6 @@ namespace leantime\domain\services {
          */
         public function addUser(array $values): bool|int
         {
-            //Hash password
-            $values['password'] = password_hash($values['password'], PASSWORD_DEFAULT);
             return $this->userRepo->addUser($values);
         }
 


### PR DESCRIPTION
Hi,
I found a case (editing a user via RPC call) where the password was not hashed properly.

I thought that it might be a good idea to simply have the hashing happen in the user repository, so that one doesn't have to remember about it.

I shouldn't have broken anything, but I haven't been able to test the code, so I highly advise  a review.

Thanks for the amazing software.