### PR TITLE
Conditional change password by edituser 

### DIFF
--- a/app/domain/users/controllers/class.editUser.php
+++ b/app/domain/users/controllers/class.editUser.php
@@ -72,7 +72,6 @@ namespace leantime\domain\controllers {
                             'hours' => ($_POST['hours'] ?? $row['hours']),
                             'wage' => ($_POST['wage'] ?? $row['wage']),
                             'clientId' => ($_POST['client'] ?? $row['clientId']),
-                            'password' => ($row['password']),
                             'source' =>  $row['source'],
                             'pwReset' => $row['pwReset']
                         );

--- a/app/domain/users/repositories/class.users.php
+++ b/app/domain/users/repositories/class.users.php
@@ -328,7 +328,12 @@ namespace leantime\domain\repositories {
          */
         public function editUser(array $values, $id)
         {
-
+            if ($values['password'] != '') {
+                $chgPW = " password = :password, ";
+            } else {
+                $chgPW = "";
+            }
+            
             $query = "UPDATE `zp_user` SET
 				firstname = :firstname,
 				lastname = :lastname,
@@ -338,8 +343,8 @@ namespace leantime\domain\repositories {
 				role = :role,
 				hours = :hours,
 				wage = :wage,
-				clientId = :clientId,
-				password = :password
+                " . $chgPW . "
+				clientId = :clientId
 			 WHERE id = :id LIMIT 1";
 
             $stmn = $this->db->database->prepare($query);
@@ -353,7 +358,9 @@ namespace leantime\domain\repositories {
             $stmn->bindValue(':wage', $values['wage'], PDO::PARAM_STR);
             $stmn->bindValue(':clientId', $values['clientId'], PDO::PARAM_STR);
             $stmn->bindValue(':id', $id, PDO::PARAM_STR);
-            $stmn->bindValue(':password', password_hash($values['password'], PASSWORD_DEFAULT), PDO::PARAM_STR);
+            if ($values['password'] != '') {
+                $stmn->bindValue(':password', password_hash($values['password'], PASSWORD_DEFAULT), PDO::PARAM_STR);
+            }
 
             $result = $stmn->execute();
             $stmn->closeCursor();


### PR DESCRIPTION
Hi,
I was facing issue when editing a user from an Owner account. This was leading to a password change (due to a double hashing of password) and the modified user was not anymore able to connect. This is probably a side effect of the PR #1636 

I made some checks to not update the password if not provided to editUser function and removed the value from the editform.

I was not able to do extended check, so it this change has to be taken with care