### PR TITLE
#1505 #1528 Fix: Email notifications about changes are sent to the change owner.

### DIFF
--- a/app/domain/projects/services/class.projects.php
+++ b/app/domain/projects/services/class.projects.php
@@ -135,7 +135,7 @@ namespace leantime\domain\services {
             //Only users that actually want to be notified and are active
             foreach ($users as $user) {
                 if ($user["notifications"] != 0 && strtolower($user["status"]) == 'a') {
-                    $to[] = $user["username"];
+                    $to[] = $user["id"];
                 }
             }
 


### PR DESCRIPTION

Correct usage of the 'notifyProjectUsers' method with the line 'return $user != $notification->authorId;', see: https://github.com/Leantime/leantime/blob/98f0bb4af4763c44a007942e6b8d6c40b79b3a1f/app/domain/projects/services/class.projects.php#L171 