### PR TITLE
Bug - Fix kanban milestone tag overflow out of the card

### DIFF
--- a/app/Domain/Tickets/Templates/showKanban.tpl.php
+++ b/app/Domain/Tickets/Templates/showKanban.tpl.php
@@ -208,7 +208,7 @@ if ($numberofColumns > 0) {
 
                                                     <div class="dropdown ticketDropdown milestoneDropdown colorized show firstDropdown" >
                                                         <a style="background-color:<?=$tpl->escape($row['milestoneColor'])?>" class="dropdown-toggle f-left  label-default milestone" href="javascript:void(0);" role="button" id="milestoneDropdownMenuLink<?=$row['id']?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                            <span class="text"><?php
+                                                            <span class="text" title="<?php $row['milestoneid'] != "" && $row['milestoneid'] != 0 && $tpl->e($row['milestoneHeadline']) ?>"><?php
                                                             if ($row['milestoneid'] != "" && $row['milestoneid'] != 0) {
                                                                 $tpl->e($row['milestoneHeadline']);
                                                             } else {

--- a/public/assets/css/components/kanban.css
+++ b/public/assets/css/components/kanban.css
@@ -389,3 +389,24 @@ body .maincontent .priority-text-5 a:link {
 .kanbanLane a {
     font-size: var(--base-font-size);
 }
+
+.kanbanBoard .ticketDropdown.show {
+    width: 100%;
+}
+
+.maincontentinner .kanbanBoard .ticketDropdown > a,
+.maincontentinner .kanbanBoard .ticketDropdown > a:link
+{
+    display: flex;
+    width: 100%;
+    align-items: center;
+}
+
+.maincontentinner .kanbanBoard .ticketDropdown > a > span,
+.maincontentinner .kanbanBoard .ticketDropdown > a:link > span
+{
+    display: inline-block;
+    overflow: hidden;
+    width: calc(100% - 10px);
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Description
On the Kanban show page, there is an issue with long timeline names causing the text to overflow from the card. This problem persists across all browsers

## Motivation and Context
This is causing issues with Kanban Styles. I included some new styles for milestone into the kanban section, also, added a new title tag to allow the user see the full text information

## How Has This Been Tested?

-  Go to any project
- Create a new milestone with long text
- Set this milestone to any task
- See the kanban view page

## Screenshots (if appropriate):

<img width="589" alt="image" src="https://github.com/Leantime/leantime/assets/645526/6a9fa9e5-c587-4e0b-951e-eac46274c20b">


## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Browser tested

- [x] Chrome
- [x] Safari
- [x] Firefox

## Screenshot solution
<img width="530" alt="image" src="https://github.com/Leantime/leantime/assets/645526/5f1aa18e-777c-4c16-aae1-740694a409f4">
<img width="403" alt="image" src="https://github.com/Leantime/leantime/assets/645526/b030ed2c-bde3-47b0-a2bb-aecd8ea6b345">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~~- [ ] My change requires a change to the documentation.~~
~~- [ ] I have updated the documentation accordingly.~~