### PR TITLE
Fix toogle issue for current project menu

### DIFF
--- a/app/Domain/Menu/Templates/Submodules/projectSelector.sub.php
+++ b/app/Domain/Menu/Templates/Submodules/projectSelector.sub.php
@@ -74,7 +74,7 @@ use Leantime\Core\Eventhelpers;
                                             echo " hideGroup ";
                                         }
 
-                                        echo "'><a href='#' onclick='leantime.menuController.toggleClientList(\"" . $projectRow['clientId'] . "\", this)' class='open'><i class=\"fas fa-angle-down\"></i>" . $tpl->escape($projectRow['clientName']) . " </li>";
+                                        echo "'><a href='#' onclick='leantime.menuController.toggleClientList(\"" . $projectRow['clientId'] . "\", this)' class='closed'><i class=\"fas fa-angle-right\"></i>" . $tpl->escape($projectRow['clientName']) . " </li>";
                                     }
 
                                     echo"<li class='projectGroup-" . $projectRow['parent'] . " hideGroup clientId-" . $projectRow['parent'] . "-" . $projectRow['clientId'] . "";


### PR DESCRIPTION
## Description
For the sidebar, when you click the name project options, the list of “projects” show the icon as it was opened and you have to click twice to see the list for each client.

## Motivation and Context
This issue is causing bad UI/UX experience


## How Has This Been Tested?
[Leantime.webm](https://github.com/Leantime/leantime/assets/645526/493d709d-194e-4e24-8b8b-547ceed201b3)


## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Browser tested

- [x] Chrome
- [x] Safari
- [x] Firefox

## Video solution
 
[Leantime (1).webm](https://github.com/Leantime/leantime/assets/645526/fc029dcd-f09d-48b1-9a18-bbee520774b2)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~~- [ ] My change requires a change to the documentation.~~
~~- [ ] I have updated the documentation accordingly.~~