### PR TITLE
Fix Broken Links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ We love your input! We want to make contributing to this project as easy and tra
 ## We Develop with Github
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
-Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+## We Use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests.
@@ -53,4 +53,4 @@ People *love* thorough bug reports. I'm not even kidding.
 We are using the [PSR-12 coding style](https://www.php-fig.org/psr/psr-12/) for PHP. 
 
 ## References
-This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md)
+This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebookarchive/draft-js/blob/5dd99d327066f5f0b30b95ab95770822cff1ac65/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ We love your input! We want to make contributing to this project as easy and tra
 - Translating files
 - Becoming a maintainer
 
-## We Develop with Github
-We use github to host code, to track issues and feature requests, as well as accept pull requests.
+## We Develop with GitHub
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
-Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
+## We Use [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests.
@@ -25,14 +25,14 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 Developers who wish to contribute code to be considered for inclusion in Leantime must first complete a Contributor License Agreement (CLA).
 We use CLA assistant to manage signatures. You will be asked to sign the CLA with your first pull request. Subsequent pull requests will not require additional signatures. Please keep in mind that:
 - If you are an individual writing the code on your own time and you're SURE you are the sole owner of any intellectual property you contribute, you can sign the license as an individual contributor
-- If you are writing the code as part of your job, or if there is any possibility that your employers might think they own any intellectual property you create, then you should reach out to us at support@leantime.io for a Corporate Contributor Licence Agreement (this will allow any employee at your company to contribute without having to sign individual CLAs).
+- If you are writing the code as part of your job, or if there is any possibility that your employers might think they own any intellectual property you create, then you should reach out to us at support@leantime.io for a Corporate Contributor License Agreement (this will allow any employee at your company to contribute without having to sign individual CLAs).
 
-## Report bugs using Github's [issues]([https://github.com/Leantime/leantime/issues](https://github.com/Leantime/leantime/issues))
+## Report bugs using GitHub's [issues]([https://github.com/Leantime/leantime/issues](https://github.com/Leantime/leantime/issues))
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Leantime/leantime/issues); it's that easy!
 
 ## Translations
 We use Crowdin to manage our translations. Please update translations in [this project](https://crowdin.com/project/leantime)
-At this point we will stop accepting PRs into the language files directly as this is causing issues with the crowdin sync process. 
+At this point we will stop accepting PRs into the language files directly as this is causing issues with the Crowdin sync process. 
 
 ## Write bug reports with detail, background, and sample code
 [This is an example](http://stackoverflow.com/q/12488905/180626) of a bug report, and we have modeled the issue templates after that. Here's [another example from Craig Hockenberry](http://www.openradar.me/11905408), an app developer whom I greatly respect.


### PR DESCRIPTION
Fixes the following issues:
- GitHub Flow documentation has moved (the old link is redirecting to the GitHub Docs homepage) [Old Link](https://guides.github.com/introduction/flow/index.html) | [New Link](https://docs.github.com/en/get-started/quickstart/github-flow)
- The link to the Draft.js contributing guidelines was pointing to a specific ref that appears to not exist anymore (I replaced it with the most recent ref, which was committed much earlier than Leantime's CONTRIBUTING.md was created, so I assume that's the most relevant version) [Old Link](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md) | [New Link](https://github.com/facebookarchive/draft-js/blob/5dd99d327066f5f0b30b95ab95770822cff1ac65/CONTRIBUTING.md)

Also fixes a typo and makes the capitalization of some company names more consistent