### PR TITLE
Improved Slack and Mattermost notifications

### DIFF
--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -7,8 +7,9 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use League\HTMLToMarkdown\HtmlConverter;
 use Leantime\Core\Language as LanguageCore;
-use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Leantime\Domain\Tickets\Services\Tickets;
 
 /**
  *
@@ -75,8 +76,7 @@ class Messengers
      */
     private function slackWebhook(NotificationModel $notification): bool
     {
-
-        $slackWebhookURL = $this->settingsRepo->getSetting("projectsettings." . $notification->projectId . ".slackWebhookURL");
+        $slackWebhookURL = $this->settingsRepo->getSetting("projectsettings.{$notification->projectId}.slackWebhookURL");
 
         if ($slackWebhookURL !== "" && $slackWebhookURL !== false) {
             $message = $this->prepareMessage($notification);
@@ -96,7 +96,8 @@ class Messengers
 
                 return true;
             } catch (GuzzleException $e) {
-                error_log($e);
+                error_log($e->getMessage());
+
                 return false;
             }
         }
@@ -112,15 +113,14 @@ class Messengers
     private function mattermostWebhook(NotificationModel $notification): bool
     {
 
-        $mattermostWebhookURL = $this->settingsRepo->getSetting("projectsettings." . $notification->projectId . ".mattermostWebhookURL");
+        $mattermostWebhookURL = $this->settingsRepo->getSetting("projectsettings.{$notification->projectId}.mattermostWebhookURL");
 
-        if ($mattermostWebhookURL !== "" && $mattermostWebhookURL !== false) {
+        if ($mattermostWebhookURL !== '' && $mattermostWebhookURL !== false) {
             $message = $this->prepareMessage($notification);
-
 
             $data = array(
                 'username' => "Leantime",
-                "icon_url" => '',
+                'icon_url' => '',
                 'text' => '',
                 'attachments' => $message,
             );
@@ -134,7 +134,7 @@ class Messengers
 
                 return true;
             } catch (Exception $e) {
-                error_log($e);
+                error_log($e->getMessage());
 
                 return false;
             }
@@ -150,8 +150,7 @@ class Messengers
      */
     private function zulipWebhook(NotificationModel $notification): bool
     {
-
-        $zulipWebhookSerialized = $this->settingsRepo->getSetting("projectsettings." . $notification->projectId . ".zulipHook");
+        $zulipWebhookSerialized = $this->settingsRepo->getSetting("projectsettings.{$notification->projectId}.zulipHook");
 
         if ($zulipWebhookSerialized !== false && $zulipWebhookSerialized !== "") {
             $zulipWebhook = unserialize($zulipWebhookSerialized);
@@ -166,9 +165,9 @@ class Messengers
             }
 
             $data = array(
-                "type" => "stream",
-                "to" => $zulipWebhook['zulipStream'],
-                "topic" => $zulipWebhook['zulipTopic'],
+                'type' => 'stream',
+                'to' => $zulipWebhook['zulipStream'],
+                'topic' => $zulipWebhook['zulipTopic'],
                 'content' => $prepareChatMessage,
             );
 
@@ -188,7 +187,7 @@ class Messengers
 
                 return true;
             } catch (GuzzleException $e) {
-                error_log($e);
+                error_log($e->getMessage());
 
                 return false;
             }
@@ -207,8 +206,8 @@ class Messengers
         $converter = false;
 
         for ($i = 1; 3 >= $i; $i++) {
-            $discordWebhookURL = $this->settingsRepo->getSetting('projectsettings.' . $notification->projectId . '.discordWebhookURL' . $i);
-            if ($discordWebhookURL !== "" && $discordWebhookURL !== false) {
+            $discordWebhookURL = $this->settingsRepo->getSetting("projectsettings.{$notification->projectId}.discordWebhookURL.{$i}");
+            if ($discordWebhookURL !== '' && $discordWebhookURL !== false) {
                 if (!$converter) {
                     $converter = new HtmlConverter();
                 }
@@ -255,12 +254,14 @@ class Messengers
                 ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
                 try {
-                    $response = $this->httpClient->post($discordWebhookURL, [
+                    $this->httpClient->post($discordWebhookURL, [
                         'body' => $data_string,
                         'headers' => ['Content-Type' => 'application/json'],
                     ]);
                 } catch (GuzzleException $e) {
-                    error_log($e);
+                    error_log($e->getMessage());
+
+                    return false;
                 }
             }
         }
@@ -274,27 +275,30 @@ class Messengers
      */
     public function prepareMessage(NotificationModel $notification): array
     {
-
-
-
-        $prepareChatMessage = $notification->message;
-        if ($notification->url !== false) {
-            $prepareChatMessage .= " <" . $notification->url['url'] . "|" . $notification->url['text'] . ">";
+        $ticketService = app()->make(Tickets::class);
+        if (is_array($notification->entity)) {
+            $headline = $notification->entity['headline'];
+            $status = $notification->entity['status'];
+        } else {
+            $headline = $notification->entity->headline;
+            $status = $notification->entity->status;
         }
-
+        $statusLabelsArray = $ticketService->getStatusLabels($notification->projectId);
         $message = array(
-        [
-            'fallback' => $notification->subject,
-            'pretext'  => $notification->subject,
-            'color'    => '#1b75bb',
-            'fields'   => array(
-                [
-                    'title' => $this->language->__("headlines.project_with_name") . " " . $this->projectName,
-                    'value' => $prepareChatMessage,
-                    'short' => false,
-                ],
-            ),
-        ],
+            [
+                'color'    => '#1b75bb',
+                'fallback' => $notification->message,
+                'pretext'  => $notification->message,
+                'title' => $headline,
+                'title_link' => $notification->url['url'],
+                'fields'   => array(
+                    [
+                        'title' => $this->language->__("headlines.project_with_name") . ' ' . $this->projectName,
+                        'value' => $this->language->__("label.todo_status") . ': ' . $statusLabelsArray[$status]['name'],
+                        'short' => false,
+                    ],
+                ),
+            ],
         );
 
         return $message;


### PR DESCRIPTION
The current Slack and Mattermost notifications were not sending much information. For example, when moving a card, it just said "Task was updated", but nothing else was shown. So I tried Trello's integrations and updated the Leantime with more information. Previous notifications were like this (Spanish):

![screenshot1](https://github.com/Leantime/leantime/assets/6916591/2d0f7ba6-2559-418e-9fd3-055eab78b248)

To this:

![screenshot2](https://github.com/Leantime/leantime/assets/6916591/b1c5559c-f1be-474a-846c-dd045f9953ae)

So, now:
- The summary just shows what happened, without the ticket ID
- The clickable area is just the task name
- The project is shown in bold
- The status of the card is shown below

More information may be added easily, but I don't think a client, for example, needs to know the priority or other internal labels.

Here you can also see a comment:

![screenshot3](https://github.com/Leantime/leantime/assets/6916591/d38460b1-49fb-4246-b356-dc1b6b6ef6d7)

And the same goes for Mattermost:

![screenshot4](https://github.com/Leantime/leantime/assets/6916591/a872f864-80f9-4ac1-bb85-4ed987d0ac69)
