### PR TITLE
Download files issue when using OIDC login provider

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -4,6 +4,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Str;
 use Illuminate\View\Factory;
 use Leantime\Core\Application;
+use Leantime\Core\AppSettings;
 use Leantime\Core\Bootloader;
 use Leantime\Core\Language;
 use Leantime\Core\Support\Build;
@@ -51,7 +52,9 @@ if (! function_exists('bootstrap_minimal_app')) {
     function bootstrap_minimal_app(): Application
     {
         $app = app()::setInstance(new Application())::setHasBeenBootstrapped();
-        return Bootloader::getInstance($app)->getApplication();
+        $app_inst = Bootloader::getInstance($app)->getApplication();
+        $app_inst->make(AppSettings::class)->loadSettings();
+        return $app_inst;
     }
 }
 


### PR DESCRIPTION
Hello !

There is currently an issue with the file download script which returns the "No Access" image for file downloads when the users are logged in through an OIDC provider.

This seems to be related to the fact that the download script does not load the full application, and some settings are missing.

This patch loads the app settings in the bootstrap_minimal_app function.

This has been tested and is working on a production instance with OIDC login.

I don't know if this is the best way to implement this. Tell me if there are changes to do.

Thanks !

Best regards