### PR TITLE
Fix cropped textbox content effected by rounder textbox border.

### DIFF
--- a/app/Domain/Projects/Templates/newProject.tpl.php
+++ b/app/Domain/Projects/Templates/newProject.tpl.php
@@ -93,13 +93,13 @@ $project = $tpl->get('project');
                                 <div>
                                     <label><?php echo $tpl->__('label.project_start'); ?></label>
                                     <div class="">
-                                        <input type="text" class="dates dateFrom" style="width:90px;" name="start" autocomplete="off"
+                                        <input type="text" class="dates dateFrom" style="width:100px;" name="start" autocomplete="off"
                                                value="<?php echo $project['start']; ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
 
                                     </div>
                                     <label ><?php echo $tpl->__('label.project_end'); ?></label>
                                     <div class="">
-                                        <input type="text" class="dates dateTo" style="width:90px;" name="end" autocomplete="off"
+                                        <input type="text" class="dates dateTo" style="width:100px;" name="end" autocomplete="off"
                                                value="<?php echo $project['end']; ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
 
                                     </div>

--- a/app/Domain/Projects/Templates/showProject.tpl.php
+++ b/app/Domain/Projects/Templates/showProject.tpl.php
@@ -400,7 +400,7 @@ $state = $tpl->get('state');
                                         </div>
                                         <div class="col-md-1">
                                             <label><?=$tpl->__("label.sortindex") ?></label>
-                                            <input type="text" name="labelSort-<?=$key?>" class="sorter" id="labelSort-<?=$key ?>" value="<?=$tpl->escape($ticketStatus['sortKey']);?>" style="width:30px;"/>
+                                            <input type="text" name="labelSort-<?=$key?>" class="sorter" id="labelSort-<?=$key ?>" value="<?=$tpl->escape($ticketStatus['sortKey']);?>" style="width:40px;"/>
                                         </div>
                                         <div class="col-md-2">
                                             <label><?=$tpl->__("label.label") ?></label>
@@ -474,7 +474,7 @@ $state = $tpl->get('state');
         </div>
         <div class="col-md-1">
             <label><?=$tpl->__("label.sortindex") ?></label>
-            <input type="text" name="labelSort-XXNEWKEYXX" class="sorter" id="labelSort-XXNEWKEYXX" value="" style="width:30px;"/>
+            <input type="text" name="labelSort-XXNEWKEYXX" class="sorter" id="labelSort-XXNEWKEYXX" value="" style="width:40px;"/>
         </div>
         <div class="col-md-2">
             <label><?=$tpl->__("label.label") ?></label>

--- a/app/Domain/Projects/Templates/showProject.tpl.php
+++ b/app/Domain/Projects/Templates/showProject.tpl.php
@@ -400,7 +400,7 @@ $state = $tpl->get('state');
                                         </div>
                                         <div class="col-md-1">
                                             <label><?=$tpl->__("label.sortindex") ?></label>
-                                            <input type="text" name="labelSort-<?=$key?>" class="sorter" id="labelSort-<?=$key ?>" value="<?=$tpl->escape($ticketStatus['sortKey']);?>" style="width:40px;"/>
+                                            <input type="text" name="labelSort-<?=$key?>" class="sorter" id="labelSort-<?=$key ?>" value="<?=$tpl->escape($ticketStatus['sortKey']);?>" style="width:50px;"/>
                                         </div>
                                         <div class="col-md-2">
                                             <label><?=$tpl->__("label.label") ?></label>
@@ -474,7 +474,7 @@ $state = $tpl->get('state');
         </div>
         <div class="col-md-1">
             <label><?=$tpl->__("label.sortindex") ?></label>
-            <input type="text" name="labelSort-XXNEWKEYXX" class="sorter" id="labelSort-XXNEWKEYXX" value="" style="width:40px;"/>
+            <input type="text" name="labelSort-XXNEWKEYXX" class="sorter" id="labelSort-XXNEWKEYXX" value="" style="width:50px;"/>
         </div>
         <div class="col-md-2">
             <label><?=$tpl->__("label.label") ?></label>

--- a/app/Domain/Projects/Templates/submodules/projectDetails.sub.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.sub.php
@@ -120,13 +120,13 @@ $menuTypes = $tpl->get('menuTypes');
 
                         <label class="control-label"><?php echo $tpl->__('label.project_start'); ?></label>
                         <div class="">
-                            <input type="text" class="dates" style="width:90px;" name="start" autocomplete="off"
+                            <input type="text" class="dates" style="width:100px;" name="start" autocomplete="off"
                                    value="<?php echo format($project['start'])->date(); ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
 
                         </div>
                         <label class="control-label"><?php echo $tpl->__('label.project_end'); ?></label>
                         <div class="">
-                            <input type="text" class="dates" style="width:90px;" name="end" autocomplete="off"
+                            <input type="text" class="dates" style="width:100px;" name="end" autocomplete="off"
                                    value="<?php echo format($project['end'])->date(); ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
 
                         </div>

--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.sub.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.sub.php
@@ -308,7 +308,7 @@ $ticketTypes = $tpl->get('ticketTypes');
                     <div class="form-group">
                         <label class=" control-label"><?php echo $tpl->__('label.due_date'); ?></label>
                         <div class="">
-                            <input type="text" class="dates" style="width:90px;" id="deadline" autocomplete="off"
+                            <input type="text" class="dates" style="width:100px;" id="deadline" autocomplete="off"
                                    value="<?=format($ticket->dateToFinish)->date(); ?>"
                                    name="dateToFinish" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
 
@@ -321,7 +321,7 @@ $ticketTypes = $tpl->get('ticketTypes');
                     <div class="form-group">
                         <label class=" control-label"><?php echo $tpl->__('label.working_date_from'); ?></label>
                         <div class="">
-                            <input type="text" class="editFrom" style="width:90px;" name="editFrom" autocomplete="off"
+                            <input type="text" class="editFrom" style="width:100px;" name="editFrom" autocomplete="off"
                                    value="<?=format($ticket->editFrom)->date(); ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
                             <input type="time" class="timepicker" style="width:120px;" id="timeFrom" autocomplete="off"
                                    value="<?=format($ticket->editFrom)->time24(); ?>"
@@ -332,7 +332,7 @@ $ticketTypes = $tpl->get('ticketTypes');
                     <div class="form-group">
                         <label class=" control-label"><?php echo $tpl->__('label.working_date_to'); ?></label>
                         <div class="">
-                            <input type="text" class="editTo" style="width:90px;" name="editTo" autocomplete="off"
+                            <input type="text" class="editTo" style="width:100px;" name="editTo" autocomplete="off"
                                    value="<?=format($ticket->editTo)->date() ?>" placeholder="<?=$tpl->__('language.dateformat') ?>"/>
                             <input type="time" class="timepicker" style="width:120px;" id="timeTo" autocomplete="off"
                                    value="<?=format($ticket->editTo)->time24() ?>"


### PR DESCRIPTION
**Description**

This PR provide fix of textbox size in leantime v3 for the new leantime UI that comes with rounder textbox border. This result in some of the textbox contents were cropped out. Please refer to screen capture below

- Project to-do status sort order textbox (existing status and add new status)

Before
![image](https://github.com/Leantime/leantime/assets/11164699/66c7bdc5-fe8e-44c5-88f0-9d8be71a67e2)

After
![image](https://github.com/Leantime/leantime/assets/11164699/4dd3d3c2-b34c-4353-92bb-7a4ac3c8bdd4)


- Date textbox (new project, project detail, ticker detail)

Before
![image](https://github.com/Leantime/leantime/assets/11164699/1df5b38f-51c4-4157-bfb3-8f3f80acd2bc)


After
![image](https://github.com/Leantime/leantime/assets/11164699/04dd963e-1ebb-4b1a-8d78-4ad0a77a827c)
