### PR TITLE
Fix: Added autofocus to 2fa verify HTML field

### DIFF
--- a/app/Domain/TwoFA/Templates/verify.tpl.php
+++ b/app/Domain/TwoFA/Templates/verify.tpl.php
@@ -19,7 +19,7 @@ $redirectUrl = $tpl->get("redirectUrl");
         <div class="">
             <input type="text" name="twoFA_code" id="twoFA_code" class="form-control"
                    placeholder="<?php echo $tpl->language->__("label.twoFACode"); ?>"
-                   value=""/>
+                   value="" autofocus/>
         </div>
         <div class="">
             <div class="forgotPwContainer">


### PR DESCRIPTION
Hi

Very minor fix to sets focus on the 2FA verify field and thereby removes the need for that extra click one forgets before entering the numbers form ones 2FA app.

![Screenshot from 2024-01-26 14-31-40](https://github.com/Leantime/leantime/assets/111397/c418ca0d-7c1a-4632-95eb-13a8615d1433)
