### PR TITLE
Added milestone and tags to all timesheet view

### DIFF
--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -71,13 +71,16 @@ namespace Leantime\Domain\Timesheets\Repositories {
                         zp_user.lastname,
                         zp_tickets.id as ticketId,
                         zp_tickets.headline,
-                        zp_tickets.planHours
+                        zp_tickets.planHours,
+                        zp_tickets.tags,
+                        milestone.headline as milestone
                     FROM
                         zp_timesheets
                     LEFT JOIN zp_user ON zp_timesheets.userId = zp_user.id
                     LEFT JOIN zp_tickets ON zp_timesheets.ticketId = zp_tickets.id
                     LEFT JOIN zp_projects ON zp_tickets.projectId = zp_projects.id
                     LEFT JOIN zp_clients ON zp_projects.clientId = zp_clients.id
+                    LEFT JOIN zp_tickets milestone ON zp_tickets.milestoneid = milestone.id
                     WHERE
                         ((TO_SECONDS(zp_timesheets.workDate) >= TO_SECONDS(:dateFrom)) AND (TO_SECONDS(zp_timesheets.workDate) <= (TO_SECONDS(:dateTo))))";
 

--- a/app/Domain/Timesheets/Templates/showAll.tpl.php
+++ b/app/Domain/Timesheets/Templates/showAll.tpl.php
@@ -212,6 +212,8 @@ foreach ($__data as $var => $val) {
           <col class="con1"/>
           <col class="con0"/>
           <col class="con1"/>
+          <col class="con0"/>
+          <col class="con1"/>
     </colgroup>
     <thead>
         <tr>
@@ -225,6 +227,8 @@ foreach ($__data as $var => $val) {
             <th><?php echo $tpl->__('label.client'); ?></th>
             <th><?php echo $tpl->__('label.employee'); ?></th>
             <th><?php echo $tpl->__("label.type")?></th>
+            <th><?php echo $tpl->__("label.milestone") ?></th>
+            <th><?php echo $tpl->__("label.tags") ?></th>
             <th><?php echo $tpl->__('label.description'); ?></th>
             <th><?php echo $tpl->__('label.invoiced'); ?></th>
             <th><?php echo $tpl->__('label.invoiced_comp'); ?></th>
@@ -263,6 +267,10 @@ foreach ($__data as $var => $val) {
 
             <td><?php printf($tpl->__("text.full_name"), $tpl->escape($row["firstname"]), $tpl->escape($row['lastname'])); ?></td>
             <td><?php echo $tpl->__($tpl->get('kind')[$row['kind']]); ?></td>
+
+            <td><?php echo $tpl->escape($row["milestone"]); ?></td>
+            <td><?php echo $tpl->escape($row["tags"]); ?></td>
+
             <td><?php $tpl->e($row['description']); ?></td>
             <td data-order="<?php if ($row['invoicedEmpl'] == '1') {
                 echo format($row['invoicedEmplDate'])->date();


### PR DESCRIPTION
Added milestone and tags column to all timesheet view (which also exports them in the CVS export, which then can be used to make pivot-tables using these fields).

![Screenshot from 2024-02-01 14-58-10](https://github.com/Leantime/leantime/assets/111397/5c6cc101-8326-40bc-865f-20cae5d17e28)
