### PR TITLE
Plugin settings minor markup fix

### DIFF
--- a/app/Domain/Plugins/Templates/partials/installed/plugincontrols.blade.php
+++ b/app/Domain/Plugins/Templates/partials/installed/plugincontrols.blade.php
@@ -8,7 +8,7 @@
         @endif
     </div>
     <div class="col-md-4" style="padding-top:10px; text-align:right;">
-        @if (file_exists(APP_ROOT . '/app/Plugins/' . $plugin->foldername . '/Controllers/Settings.php')) {?>
+        @if (file_exists(APP_ROOT . '/app/Plugins/' . $plugin->foldername . '/Controllers/Settings.php'))
         <a href="{{ BASE_URL }}/{{ $plugin->foldername }}/settings"><i class="fa fa-cog"></i> Settings</a>
         @endif
     </div>


### PR DESCRIPTION
Minor markup fix in plugin settings:

**Before**:
![Screenshot from 2024-02-01 20-03-19](https://github.com/Leantime/leantime/assets/111397/e525f17c-aae5-4aa4-a385-7adeb17db4d5)

**After**:
![Screenshot from 2024-02-01 20-03-24](https://github.com/Leantime/leantime/assets/111397/42a3b57e-fbb3-4c82-b92c-a4074b323fd1)
