### PR TITLE
Addressing issue regarding timezone change

### DIFF
--- a/app/Core/Support/DateTimeHelper.php
+++ b/app/Core/Support/DateTimeHelper.php
@@ -293,19 +293,16 @@ class DateTimeHelper
         $dateTime = trim($dateTime);
 
         if ($this->isValidDateString($dateTime)) {
-            $fromDateTimeZone = new \DateTimeZone($fromTz);
+            $fromDateTimeZone = new DateTimeZone($fromTz);
 
             //If it is an API Request, don't do any formatting, return ATOM in target tz
             if ($this->apiRequest->isApiRequest()) {
                 $utcDate = new DateTime($dateTime, $fromDateTimeZone);
                 return is_object($utcDate) ? $utcDate->format(DateTime::ATOM) : false;
             }
+            $timestamp = DateTime::createFromFormat($fromFormat, $dateTime, new DateTimeZone($toTz));
 
-            $timestamp = DateTime::createFromFormat($fromFormat, $dateTime, $fromDateTimeZone);
-
-            if (is_object($timestamp)) {
-                $toTimezone = new \DateTimeZone($toTz);
-                $timestamp->setTimezone($toTimezone);
+            if ($timestamp instanceof DateTime) {
                 return $timestamp->format($toFormat);
             }
         }


### PR DESCRIPTION
TLDR: 
Core/Support/DateTimeHelper:281 - convertDateTime()
converts 05/02/2024 00:00:00 to 2024-02-04 23:00:00 when converting from UTC to Europe/Copenhagen, slowly but surely shifting the dates when rendering the timesheet overview calendar.

<img width="345" alt="Screenshot 2024-02-12 at 16 22 25" src="https://github.com/Leantime/leantime/assets/106669866/04cfae63-aeb4-4659-a950-79923cc1a7b6">

As of version 3.0.6, being in the Europe/Copenhagen timezone, navigating the "My Timesheets" page by jumping from week to week caused some issues in the table layout.

When navigating backwards one week, then forward one week multiple times, this happens:
(Notice how Monday the 12th Febuary becomes wednesday and then friday)

Initial:
<img width="1423" alt="Screenshot 2024-02-12 at 16 18 13" src="https://github.com/Leantime/leantime/assets/106669866/b7d7cc8e-ea9a-4f2f-9f64-d28ccad63267">

Backward 1 week:
<img width="1422" alt="Screenshot 2024-02-12 at 16 18 18" src="https://github.com/Leantime/leantime/assets/106669866/0e0cceb9-ca62-4e8e-9af3-3d1885f809d2">

Forward 1 week:
<img width="1428" alt="Screenshot 2024-02-12 at 16 18 24" src="https://github.com/Leantime/leantime/assets/106669866/d189f911-f4c5-4f74-8009-69b990b9de16">

Backward 1 week:
<img width="1421" alt="Screenshot 2024-02-12 at 16 18 29" src="https://github.com/Leantime/leantime/assets/106669866/39ce36d0-2e77-4e06-97a4-b913d0e7d874">

Forward 1 week:
<img width="1423" alt="Screenshot 2024-02-12 at 16 18 35" src="https://github.com/Leantime/leantime/assets/106669866/44f0a0f7-1ad6-494d-83bb-7b825f80415f">
