### PR TITLE
2356: Fixed typo in parameter name

### DIFF
--- a/app/Core/ConsoleKernel.php
+++ b/app/Core/ConsoleKernel.php
@@ -138,7 +138,7 @@ class ConsoleKernel implements ConsoleKernelContract
             // filter by active plugins
             ->filter(fn ($command) => in_array(
                 Str::of($command)->after('Plugins/')->before('/Command')->toString(),
-                array_map(fn ($plugin) => $plugin->foldername, $this->getApplication()->make(PluginsService::class)->getAllPlugins(enabled: true)),
+                array_map(fn ($plugin) => $plugin->foldername, $this->getApplication()->make(PluginsService::class)->getAllPlugins(enabledOnly: true)),
             ));
 
         $commands = collect(Arr::flatten($_SESSION['commands']))


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2356

#### Description

Fixes typo in parameter name.

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

