### PR TITLE
A fix for mime types handling

### DIFF
--- a/app/Domain/Files/Controllers/Get.php
+++ b/app/Domain/Files/Controllers/Get.php
@@ -81,15 +81,19 @@ class Get extends Controller
                 $path_parts = pathinfo($fullPath);
 
                 if ($ext == 'pdf') {
+                    $mime_type = 'application/pdf';
                     header('Content-type: application/pdf');
                     header("Content-Disposition: inline; filename=\"" . $realName . "." . $ext . "\"");
                 } elseif ($ext == 'jpg' || $ext == 'jpeg' || $ext == 'gif' || $ext == 'png') {
+                    $mime_type = $mimes[$ext];
                     header('Content-type: ' . $mimes[$ext]);
                     header('Content-disposition: inline; filename="' . $realName . "." . $ext . '";');
                 } elseif ($ext == 'svg') {
+                    $mime_type = 'image/svg+xml';
                     header('Content-type: image/svg+xml');
                     header('Content-disposition: attachment; filename="' . $realName . "." . $ext . '";');
                 } else {
+                    $mime_type = 'application/octet-stream';
                     header("Content-type: application/octet-stream");
                     header("Content-Disposition: filename=\"" . $realName . "." . $ext . "\"");
                 }
@@ -102,7 +106,7 @@ class Get extends Controller
 
 
                 $oStreamResponse = new StreamedResponse();
-                $oStreamResponse->headers->set("Content-Type", $mimes[$ext] );
+                $oStreamResponse->headers->set("Content-Type", $mime_type );
                 $oStreamResponse->headers->set("Content-Length", $sFileSize);
                 $oStreamResponse->headers->set("ETag", $sEtag);
 


### PR DESCRIPTION
#### Link to ticket

Problem described on Discord, see: https://discord.com/channels/990001288026677318/1212409774092718090/1212409774092718090)

#### Description

Adding a docx files to a todo works fine, but trying to download it results in 500 with the following information:
```
ErrorException:
Warning: Undefined array key "docx"

  at /var/www/html/app/Domain/Files/Controllers/Get.php:105
  at Leantime\Domain\Files\Controllers\Get->getFileLocally('eb3d6a81e7906c4c96c151b0929a26bd', 'docx', 'ticket', 'badania swialo niebieskie_2 (1)')
     (/var/www/html/app/Domain/Files/Controllers/Get.php:55)
  at Leantime\Domain\Files\Controllers\Get->get(array('module' => 'ticket', 'encName' => 'eb3d6a81e7906c4c96c151b0929a26bd', 'ext' => 'docx', 'realName' => 'badania swialo niebieskie_2 (1)', 'act' => 'files.get'))
     (/var/www/html/app/Core/Controller.php:82)
  at Leantime\Core\Controller->executeActions('GET', array('module' => 'ticket', 'encName' => 'eb3d6a81e7906c4c96c151b0929a26bd', 'ext' => 'docx', 'realName' => 'badania swialo niebieskie_2 (1)', 'act' => 'files.get'))
     (/var/www/html/app/Core/Controller.php:49)
  at Leantime\Core\Controller->__construct(object(IncomingRequest), object(Template), object(Language))
  at ReflectionClass->newInstanceArgs(array(object(IncomingRequest), object(Template), object(Language)))
     (/var/www/html/vendor/illuminate/container/Container.php:929)
  at Illuminate\Container\Container->build('Leantime\\Domain\\Files\\Controllers\\Get')
     (/var/www/html/vendor/illuminate/container/Container.php:770)
  at Illuminate\Container\Container->resolve('Leantime\\Domain\\Files\\Controllers\\Get', array())
     (/var/www/html/vendor/illuminate/container/Container.php:706)
  at Illuminate\Container\Container->make('Leantime\\Domain\\Files\\Controllers\\Get')
     (/var/www/html/app/Core/Frontcontroller.php:130)
  at Leantime\Core\Frontcontroller::executeAction('files.get', array())
     (/var/www/html/app/Core/Frontcontroller.php:75)
  at Leantime\Core\Frontcontroller::dispatch()
     (/var/www/html/app/Core/HttpKernel.php:63)
  at Leantime\Core\HttpKernel->Leantime\Core\{closure}(object(IncomingRequest))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:141)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:116)
  at Illuminate\Pipeline\Pipeline->then(object(Closure))
     (/var/www/html/app/Core/HttpKernel.php:63)
  at Leantime\Core\HttpKernel->Leantime\Core\{closure}(object(IncomingRequest))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:141)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/CurrentProject.php:25)
  at Leantime\Core\Middleware\CurrentProject->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/Localization.php:48)
  at Leantime\Core\Middleware\Localization->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/Auth.php:88)
  at Leantime\Core\Middleware\Auth->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/Updated.php:37)
  at Leantime\Core\Middleware\Updated->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/Installed.php:55)
  at Leantime\Core\Middleware\Installed->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/app/Core/Middleware/InitialHeaders.php:22)
  at Leantime\Core\Middleware\InitialHeaders->handle(object(IncomingRequest), object(Closure))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:180)
  at Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(object(IncomingRequest))
     (/var/www/html/vendor/illuminate/pipeline/Pipeline.php:116)
  at Illuminate\Pipeline\Pipeline->then(object(Closure))
     (/var/www/html/app/Core/HttpKernel.php:64)
  at Leantime\Core\HttpKernel->handle(object(IncomingRequest))
     (/var/www/html/app/Core/Bootloader.php:303)
  at Leantime\Core\Bootloader->handleRequest()
     (/var/www/html/app/Core/Bootloader.php:173)
  at Leantime\Core\Bootloader->boot()
     (/var/www/html/public/index.php:18)  
```

This change fixes this.