### PR TITLE
Added plugin commands

### DIFF
--- a/app/Command/AbstractPluginCommand.php
+++ b/app/Command/AbstractPluginCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Leantime\Command;
+
+use Leantime\Domain\Plugins\Models\InstalledPlugin;
+use Leantime\Domain\Plugins\Services\Plugins;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class AbstractPluginCommand
+ */
+abstract class AbstractPluginCommand extends Command
+{
+    protected InputInterface $input;
+    protected SymfonyStyle $io;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected readonly Plugins $plugins
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the command
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @return int 0 if everything went fine, or an exit code.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->io = new SymfonyStyle($input, $output);
+
+        return $this->executeCommand();
+    }
+
+    /**
+     * Execute the actual command.
+     *
+     * @return int
+     */
+    abstract protected function executeCommand(): int;
+
+    /**
+     * Asks a confirmation question.
+     *
+     * @param string $question
+     * @return bool
+     */
+    protected function confirm(string $question): bool
+    {
+        return $this->io->confirm($question, !$this->input->isInteractive());
+    }
+
+    /**
+     * @return array|InstalledPlugin[]
+     */
+    protected function getAllPlugins(): array
+    {
+        return array_values(
+            array_merge(
+                $this->plugins->getAllPlugins() ?: [],
+                $this->plugins->discoverNewPlugins(),
+            )
+        );
+    }
+
+    /**
+     * @return InstalledPlugin
+     */
+    protected function getPlugin(string $name): InstalledPlugin
+    {
+        foreach ($this->getAllPlugins() as $plugin) {
+            if ($name === $plugin->name) {
+                return $plugin;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Invalid plugin name: %s', $name));
+    }
+}

--- a/app/Command/DisablePluginCommand.php
+++ b/app/Command/DisablePluginCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Leantime\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class DisablePluginCommand
+ *
+ * This class represents a command that disables plugins.
+ */
+#[AsCommand(
+    name: 'plugin:disable',
+    description: 'Disable a plugin',
+)]
+class DisablePluginCommand extends AbstractPluginCommand
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return int
+     */
+    protected function executeCommand(): int
+    {
+        $name = $this->input->getArgument('plugin');
+        $plugin = $this->getPlugin($name);
+
+        if (!isset($plugin->id)) {
+            throw new RuntimeException(sprintf('Plugin %s is not installed', $plugin->name));
+        }
+
+        if (!$plugin->enabled) {
+            throw new RuntimeException(sprintf('Plugin %s is not enabled', $plugin->name));
+        }
+
+        if (!$this->confirm(sprintf('Disable plugin %s', $plugin->name))) {
+            return Command::SUCCESS;
+        }
+
+        return $this->plugins->disablePlugin($plugin->id) ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/app/Command/EnablePluginCommand.php
+++ b/app/Command/EnablePluginCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Leantime\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class EnablePluginCommand
+ *
+ * This class represents a command that enables plugins.
+ */
+#[AsCommand(
+    name: 'plugin:enable',
+    description: 'Enable a plugin',
+)]
+class EnablePluginCommand extends AbstractPluginCommand
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return int
+     */
+    protected function executeCommand(): int
+    {
+        $name = $this->input->getArgument('plugin');
+        $plugin = $this->getPlugin($name);
+
+        if (!isset($plugin->id)) {
+            throw new RuntimeException(sprintf('Plugin %s is not installed', $plugin->name));
+        }
+
+        if ($plugin->enabled) {
+            throw new RuntimeException(sprintf('Plugin %s is already enabled', $plugin->name));
+        }
+
+        if (!$this->confirm(sprintf('Enable plugin %s', $plugin->name))) {
+            return Command::SUCCESS;
+        }
+
+        return $this->plugins->enablePlugin($plugin->id) ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/app/Command/InstallPluginCommand.php
+++ b/app/Command/InstallPluginCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Leantime\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class InstallPluginCommand
+ *
+ * This class represents a command that installs plugins.
+ */
+#[AsCommand(
+    name: 'plugin:install',
+    description: 'Install a plugin',
+)]
+class InstallPluginCommand extends AbstractPluginCommand
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     *  @return int
+     */
+    protected function executeCommand(): int
+    {
+        $name = $this->input->getArgument('plugin');
+        $plugin = $this->getPlugin($name);
+
+        if (!isset($plugin->foldername)) {
+            throw new RuntimeException(sprintf('Plugin %s cannot be installed', $plugin->name));
+        }
+
+        if (!$this->confirm(sprintf('Install plugin %s', $plugin->name))) {
+            return Command::SUCCESS;
+        }
+
+        return $this->plugins->installPlugin($plugin->foldername) ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/app/Command/ListPluginCommand.php
+++ b/app/Command/ListPluginCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Leantime\Command;
+
+use Leantime\Domain\Plugins\Models\InstalledPlugin;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Symfony\Component\String\u;
+
+/**
+ * Class ListPluginCommand
+ *
+ * This class represents a command that lists all plugins.
+ */
+#[AsCommand(
+    name: 'plugin:list',
+    description: 'List all plugins',
+)]
+final class ListPluginCommand extends AbstractPluginCommand
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->addOption('order-by', null, InputOption::VALUE_REQUIRED, 'Plugin order', 'name');
+        $this->addOption('installed', null, InputOption::VALUE_REQUIRED, 'Filter plugins on installed status');
+        $this->addOption('enabled', null, InputOption::VALUE_REQUIRED, 'Filter plugins on enabled status');
+        $this->setHelp(<<<'EOL'
+Examples
+
+Show all plugins:
+
+    bin/leantime plugin:list
+
+Show only installed plugins:
+
+    bin/leantime plugin:list --installed=true
+
+Show only non-installed plugins:
+
+    bin/leantime plugin:list --installed=false
+
+Show only enabled plugins:
+
+    bin/leantime plugin:list --enabled=true
+
+Show plugins that are both installed and enabled:
+
+    bin/leantime plugin:list --installed=true --enabled=true
+
+EOL);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return int
+     */
+    protected function executeCommand(): int
+    {
+        $plugins = $this->getAllPlugins();
+
+        // Filter by “installed" if requested.
+        $installed = $this->input->getOption('installed');
+        if (null !== $installed) {
+            $installed = null === $installed || filter_var($installed, FILTER_VALIDATE_BOOLEAN);
+            $plugins = array_filter($plugins, fn (InstalledPlugin $p) => !($installed xor isset($p->id)));
+        }
+
+        // Filter by “enabled" if requested.
+        $enabled = $this->input->getOption('enabled');
+        if (null !== $enabled) {
+            $enabled = null === $enabled || filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
+            $plugins = array_filter($plugins, fn (InstalledPlugin $p) => !($enabled xor $p->enabled));
+        }
+
+        $orderBy = $this->input->getOption('order-by');
+        usort($plugins, static fn (InstalledPlugin $p0, InstalledPlugin $p1) => ($p0->{$orderBy} ?? null) <=> ($p1->{$orderBy} ?? null));
+
+        foreach ($plugins as $plugin) {
+            $this->io->definitionList(
+                // Pad name to line up with wrapped description.
+                ['Name' => u($plugin->name)->padEnd(60)],
+                ['Description' => u($plugin->description)->wordwrap(60)],
+                ['Installed' => isset($plugin->id) ? 'yes' : 'no'],
+                ['Enabled' => $plugin->enabled ? 'yes' : 'no'],
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Command/RemovePluginCommand.php
+++ b/app/Command/RemovePluginCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Leantime\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class RemovePluginCommand
+ *
+ * This class represents a command that removes plugins.
+ */
+#[AsCommand(
+    name: 'plugin:remove',
+    description: 'Remove a plugin',
+)]
+class RemovePluginCommand extends AbstractPluginCommand
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return int
+     */
+    protected function executeCommand(): int
+    {
+        $name = $this->input->getArgument('plugin');
+        $plugin = $this->getPlugin($name);
+
+        if (!isset($plugin->id)) {
+            throw new RuntimeException(sprintf('Plugin %s is not installed', $plugin->name));
+        }
+
+        if (!$this->confirm(sprintf('Remove plugin %s', $plugin->name))) {
+            return Command::SUCCESS;
+        }
+
+        return $this->plugins->removePlugin($plugin->id) ? Command::SUCCESS : Command::FAILURE;
+    }
+}


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2363

#### Description

Adds commands to manage plugins:

```sh
$ bin/leantime
…
 plugin
  plugin:disable        Disable a plugin
  plugin:enable         Enable a plugin
  plugin:install        Install a plugin
  plugin:list           List all plugins
  plugin:remove         Remove a plugin
```

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.
