### PR TITLE
Timesheet fixes - retry - part II

### DIFF
--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -157,7 +157,7 @@ namespace Leantime\Domain\Tickets\Controllers {
 
             $this->tpl->assign("timesheetValues", array(
                 "kind" => "",
-                "date" => Carbon::now('UTC')->startOfDay(),
+                "date" => Carbon::now($_SESSION['usersettings.timezone'])->startOfDay()->setTimezone('UTC'),
                 "hours" => "",
                 "description" => "",
             ));

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -157,7 +157,7 @@ namespace Leantime\Domain\Tickets\Controllers {
 
             $this->tpl->assign("timesheetValues", array(
                 "kind" => "",
-                "date" => Carbon::now($_SESSION['usersettings.timezone'])->startOfDay()->setTimezone('UTC'),
+                "date" => Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC'),
                 "hours" => "",
                 "description" => "",
             ));

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Tickets\Controllers {
 
+    use Carbon\Carbon;
     use Illuminate\Contracts\Container\BindingResolutionException;
     use Leantime\Core\Controller;
     use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -154,7 +155,12 @@ namespace Leantime\Domain\Tickets\Controllers {
 
             $this->tpl->assign('onTheClock', $this->timesheetService->isClocked($_SESSION["userdata"]["id"]));
 
-            $this->tpl->assign("timesheetValues", array("kind" => "", "date" => date($this->language->__("language.dateformat")), "hours" => "", "description" => ""));
+            $this->tpl->assign("timesheetValues", array(
+                "kind" => "",
+                "date" => Carbon::now('UTC')->startOfDay(),
+                "hours" => "",
+                "description" => "",
+            ));
 
             //TODO: Refactor thumbnail generation in file manager
             $this->tpl->assign('imgExtensions', array('jpg', 'jpeg', 'png', 'gif', 'psd', 'bmp', 'tif', 'thm', 'yuv'));
@@ -164,6 +170,7 @@ namespace Leantime\Domain\Tickets\Controllers {
 
             $response = $this->tpl->displayPartial('tickets.showTicketModal');
             $response->headers->set('HX-Trigger', 'ticketUpdate');
+
             return $response;
         }
 

--- a/app/Domain/Tickets/Templates/submodules/timesheet.sub.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.sub.php
@@ -35,7 +35,7 @@ $currentPay = $tpl->get('userHours') * $userInfo['wage'];
                     </span>
 
                     <label for="timesheetdate"><?php echo $tpl->__('label.date') ?>:</label>
-                    <input type="text" id="timesheetdate" name="date" class="dates" value="<?php echo format($values['date'])->date() ?>" /><br/>
+                    <input type="text" id="timesheetdate" name="date" class="dates" value="<?php echo format($values['date'], 'short') ?>" /><br/>
 
                     <label for="hours"><?php echo $tpl->__('label.hours') ?></label>
                     <span class="field">

--- a/app/Domain/Timesheets/Controllers/AddTime.php
+++ b/app/Domain/Timesheets/Controllers/AddTime.php
@@ -191,6 +191,7 @@ class AddTime extends Controller
             $this->tpl->assign('allProjects', $this->timesheetsRepo->getAll());
             $this->tpl->assign('allTickets', $this->timesheetsRepo->getAll());
             $this->tpl->assign('kind', $this->timesheetsRepo->kind);
+
             return $this->tpl->display('timesheets.addTime');
         } else {
             return $this->tpl->display('errors.error403', responseCode: 403);

--- a/app/Domain/Timesheets/Controllers/AddTime.php
+++ b/app/Domain/Timesheets/Controllers/AddTime.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
@@ -92,54 +93,54 @@ class AddTime extends Controller
                     $values['ticket'] = $tempArr[1];
                 }
 
-                if (isset($_POST['kind']) && $_POST['kind'] != '') {
+                if (!empty($_POST['kind'])) {
                     $values['kind'] = ($_POST['kind']);
                 }
 
-                if (isset($_POST['date']) && $_POST['date'] != '') {
-                    $values['date'] = format($_POST['date'])->isoDateStart();
+                if (!empty($_POST['date'])) {
+                    $values['date'] = (new Carbon($_POST['date'], $_SESSION['usersettings.timezone']))->setTimezone('UTC');
                 }
 
-                if (isset($_POST['hours']) && $_POST['hours'] != '') {
+                if (!empty($_POST['hours'])) {
                     $values['hours'] = ($_POST['hours']);
                 }
 
-                if (isset($_POST['invoicedEmpl']) && $_POST['invoicedEmpl'] != '') {
+                if (!empty($_POST['invoicedEmpl'])) {
                     if ($_POST['invoicedEmpl'] == 'on') {
                         $values['invoicedEmpl'] = 1;
                     }
 
-                    if (isset($_POST['invoicedEmplDate']) && $_POST['invoicedEmplDate'] != '') {
-                        $values['invoicedEmplDate'] = format($_POST['invoicedEmplDate'])->isoDateMid();
+                    if (!empty($_POST['invoicedEmplDate'])) {
+                        $values['invoicedEmplDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                     }
                 }
 
-                if (isset($_POST['invoicedComp']) && $_POST['invoicedComp'] != '') {
+                if (!empty($_POST['invoicedComp'])) {
                     if (Auth::userIsAtLeast(Roles::$manager)) {
                         if ($_POST['invoicedComp'] == 'on') {
                             $values['invoicedComp'] = 1;
                         }
 
-                        if (isset($_POST['invoicedCompDate']) && $_POST['invoicedCompDate'] != '') {
-                            $values['invoicedCompDate'] = format($_POST['invoicedCompDate'])->isoDateMid();
+                        if (!empty($_POST['invoicedCompDate'])) {
+                            $values['invoicedCompDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                         }
                     }
                 }
 
-                if (isset($_POST['paid']) && $_POST['paid'] != '') {
+                if (!empty($_POST['paid'])) {
                     if (Auth::userIsAtLeast(Roles::$manager)) {
                         if ($_POST['paid'] == 'on') {
                             $values['paid'] = 1;
                         }
 
-                        if (isset($_POST['paidDate']) && $_POST['paidDate'] != '') {
-                            $values['paidDate'] = format($_POST['paidDate'])->isoDateMid();
+                        if (!empty($_POST['paidDate'])) {
+                            $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                         }
                     }
                 }
 
 
-                if (isset($_POST['description']) && $_POST['description'] != '') {
+                if (!empty($_POST['description'])) {
                     $values['description'] = ($_POST['description']);
                 }
 

--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -96,7 +96,10 @@ class EditTime extends Controller
                         }
 
                         if (isset($_POST['date']) && $_POST['date'] != '') {
-                            $values['date'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['date'], 'UTC');
+                            $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['date'], $_SESSION['usersettings.timezone']);
+                            $date->setTimezone('UTC');
+                            $values['date'] = $date;
+
                         }
 
                         if (isset($_POST['hours']) && $_POST['hours'] != '') {
@@ -114,9 +117,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedEmplDate']) && $_POST['invoicedEmplDate'] != '') {
-                                    $values['invoicedEmplDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], 'UTC')->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date->setTimezone('UTC');
+                                    $values['invoicedEmplDate'] = $date;
                                 } else {
-                                    $values['invoicedEmplDate'] = Carbon::now('UTC')->midDay();
+                                    $values['invoicedEmplDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
                                 }
                             } else {
                                 $values['invoicedEmpl'] = 0;
@@ -129,9 +134,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedCompDate']) && $_POST['invoicedCompDate'] != '') {
-                                    $values['invoicedCompDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], 'UTC')->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date->setTimezone('UTC');
+                                    $values['invoicedCompDate'] = $date;
                                 } else {
-                                    $values['invoicedCompDate'] = Carbon::now('UTC')->midDay();
+                                    $values['invoicedCompDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
                                 }
                             } else {
                                 $values['invoicedComp'] = 0;
@@ -144,9 +151,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['paidDate']) && $_POST['paidDate'] != '') {
-                                    $values['paidDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], 'UTC')->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date->setTimezone('UTC');
+                                    $values['paidDate'] = $date;
                                 } else {
-                                    $values['paidDate'] = Carbon::now('UTC')->midDay();
+                                    $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
                                 }
                             } else {
                                 $values['paid'] = 0;

--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -117,11 +117,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedEmplDate']) && $_POST['invoicedEmplDate'] != '') {
-                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['invoicedEmplDate'] = $date;
                                 } else {
-                                    $values['invoicedEmplDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
+                                    $values['invoicedEmplDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                                 }
                             } else {
                                 $values['invoicedEmpl'] = 0;
@@ -134,11 +134,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedCompDate']) && $_POST['invoicedCompDate'] != '') {
-                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['invoicedCompDate'] = $date;
                                 } else {
-                                    $values['invoicedCompDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
+                                    $values['invoicedCompDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                                 }
                             } else {
                                 $values['invoicedComp'] = 0;
@@ -151,11 +151,11 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['paidDate']) && $_POST['paidDate'] != '') {
-                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], $_SESSION['usersettings.timezone'])->midDay();
+                                    $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['paidDate'] = $date;
                                 } else {
-                                    $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])->midDay()->setTimezone('UTC');
+                                    $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
                                 }
                             } else {
                                 $values['paid'] = 0;

--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Carbon\Carbon;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
@@ -18,6 +19,10 @@ class EditTime extends Controller
     private TimesheetRepository $timesheetsRepo;
     private ProjectRepository $projects;
     private TicketRepository $tickets;
+
+    // This is the date we get back from the database, when no date has been sat. This is somewhat a hack and should
+    // be looked into.
+    const EMPTY_DATE = '0000-00-00 00:00:00';
 
     /**
      * init - initialize private variables
@@ -50,28 +55,33 @@ class EditTime extends Controller
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
 
         $info = '';
-        //Only admins and employees
+        // Only admins and employees
         if (Auth::userIsAtLeast(Roles::$editor)) {
             if (isset($_GET['id']) === true) {
                 $id = ($_GET['id']);
 
                 $timesheet = $this->timesheetsRepo->getTimesheet($id);
 
+                // Date validation.
+                $timesheet['invoicedEmplDate'] = $timesheet['invoicedEmplDate'] == self::EMPTY_DATE ? 'now' : $timesheet['invoicedEmplDate'];
+                $timesheet['invoicedCompDate'] = $timesheet['invoicedCompDate'] == self::EMPTY_DATE ? 'now' : $timesheet['invoicedCompDate'];
+                $timesheet['paidDate'] = $timesheet['paidDate'] == self::EMPTY_DATE ? 'now' : $timesheet['paidDate'];
+
                 $values = array(
                     'id' => $id,
                     'userId' => $timesheet['userId'],
                     'ticket' => $timesheet['ticketId'],
                     'project' => $timesheet['projectId'],
-                    'date' => $timesheet['workDate'],
+                    'date' => new Carbon($timesheet['workDate'], 'UTC'),
                     'kind' => $timesheet['kind'],
                     'hours' => $timesheet['hours'],
                     'description' => $timesheet['description'],
                     'invoicedEmpl' => $timesheet['invoicedEmpl'],
                     'invoicedComp' => $timesheet['invoicedComp'],
-                    'invoicedEmplDate' => $timesheet['invoicedEmplDate'],
-                    'invoicedCompDate' => $timesheet['invoicedCompDate'],
+                    'invoicedEmplDate' => new Carbon($timesheet['invoicedEmplDate'], 'UTC'),
+                    'invoicedCompDate' => new Carbon($timesheet['invoicedCompDate'], 'UTC'),
                     'paid' => $timesheet['paid'],
-                    'paidDate' => $timesheet['paidDate'],
+                    'paidDate' => new Carbon($timesheet['paidDate'], 'UTC'),
                 );
 
                 if (Auth::userIsAtLeast(Roles::$manager) || $_SESSION['userdata']['id'] == $values['userId']) {
@@ -86,9 +96,7 @@ class EditTime extends Controller
                         }
 
                         if (isset($_POST['date']) && $_POST['date'] != '') {
-                            $timestamp = date_create_from_format($this->language->__("language.dateformat"), $_POST['date']);
-
-                            $values['date'] = format($_POST['date'])->isoDateMid();
+                            $values['date'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['date'], 'UTC');
                         }
 
                         if (isset($_POST['hours']) && $_POST['hours'] != '') {
@@ -106,9 +114,9 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedEmplDate']) && $_POST['invoicedEmplDate'] != '') {
-                                    $values['invoicedEmplDate'] = format($_POST['invoicedEmplDate'])->isoDateMid();
+                                    $values['invoicedEmplDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], 'UTC')->midDay();
                                 } else {
-                                    $values['invoicedEmplDate'] = date("Y-m-d");
+                                    $values['invoicedEmplDate'] = Carbon::now('UTC')->midDay();
                                 }
                             } else {
                                 $values['invoicedEmpl'] = 0;
@@ -121,9 +129,9 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['invoicedCompDate']) && $_POST['invoicedCompDate'] != '') {
-                                    $values['invoicedCompDate'] = format($_POST['invoicedCompDate'])->isoDateMid();
+                                    $values['invoicedCompDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], 'UTC')->midDay();
                                 } else {
-                                    $values['invoicedCompDate'] = date("Y-m-d");
+                                    $values['invoicedCompDate'] = Carbon::now('UTC')->midDay();
                                 }
                             } else {
                                 $values['invoicedComp'] = 0;
@@ -136,16 +144,15 @@ class EditTime extends Controller
                                 }
 
                                 if (isset($_POST['paidDate']) && $_POST['paidDate'] != '') {
-                                    $values['paidDate'] = format($_POST['paidDate'])->isoDateMid();
+                                    $values['paidDate'] = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], 'UTC')->midDay();
                                 } else {
-                                    $values['paidDate'] = date("Y-m-d");
+                                    $values['paidDate'] = Carbon::now('UTC')->midDay();
                                 }
                             } else {
                                 $values['paid'] = 0;
                                 $values['paidDate'] = '';
                             }
                         }
-
 
                         if ($values['ticket'] != '' && $values['project'] != '') {
                             if ($values['kind'] != '') {
@@ -156,21 +163,26 @@ class EditTime extends Controller
 
                                         $timesheetUpdated = $this->timesheetsRepo->getTimesheet($id);
 
+                                        // Date validation.
+                                        $timesheetUpdated['invoicedEmplDate'] = $timesheetUpdated['invoicedEmplDate'] == self::EMPTY_DATE ? 'now' : $timesheetUpdated['invoicedEmplDate'];
+                                        $timesheetUpdated['invoicedCompDate'] = $timesheetUpdated['invoicedCompDate'] == self::EMPTY_DATE ? 'now' : $timesheetUpdated['invoicedCompDate'];
+                                        $timesheetUpdated['paidDate'] = $timesheetUpdated['paidDate'] == self::EMPTY_DATE ? 'now' : $timesheetUpdated['paidDate'];
+
                                         $values = array(
                                             'id' => $id,
                                             'userId' => $timesheetUpdated['userId'],
                                             'ticket' => $timesheetUpdated['ticketId'],
                                             'project' => $timesheetUpdated['projectId'],
-                                            'date' => $timesheetUpdated['workDate'],
+                                            'date' => new Carbon($timesheetUpdated['workDate'], 'UTC'),
                                             'kind' => $timesheetUpdated['kind'],
                                             'hours' => $timesheetUpdated['hours'],
                                             'description' => $timesheetUpdated['description'],
                                             'invoicedEmpl' => $timesheetUpdated['invoicedEmpl'],
                                             'invoicedComp' => $timesheetUpdated['invoicedComp'],
-                                            'invoicedEmplDate' => $timesheetUpdated['invoicedEmplDate'],
-                                            'invoicedCompDate' => $timesheetUpdated['invoicedCompDate'],
+                                            'invoicedEmplDate' => new Carbon($timesheetUpdated['invoicedEmplDate'], 'UTC'),
+                                            'invoicedCompDate' => new Carbon($timesheetUpdated['invoicedCompDate'], 'UTC'),
                                             'paid' => $timesheetUpdated['paid'],
-                                            'paidDate' => $timesheetUpdated['paidDate'],
+                                            'paidDate' => new Carbon($timesheetUpdated['paidDate'], 'UTC'),
                                         );
                                     } else {
                                         $this->tpl->setNotification('notifications.time_logged_error_no_hours', 'error');
@@ -186,13 +198,13 @@ class EditTime extends Controller
                         }
                     }
 
-
                     $this->tpl->assign('values', $values);
 
                     $this->tpl->assign('info', $info);
                     $this->tpl->assign('allProjects', $this->projects->getAll());
                     $this->tpl->assign('allTickets', $this->tickets->getAll());
                     $this->tpl->assign('kind', $this->timesheetsRepo->kind);
+
                     return $this->tpl->displayPartial('timesheets.editTime');
                 } else {
                     return $this->tpl->displayPartial('errors.error403');

--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -86,37 +86,36 @@ class EditTime extends Controller
 
                 if (Auth::userIsAtLeast(Roles::$manager) || $_SESSION['userdata']['id'] == $values['userId']) {
                     if (isset($_POST['saveForm']) === true) {
-                        if (isset($_POST['tickets']) && $_POST['tickets'] != '') {
+                        if (!empty($_POST['tickets'])) {
                             $values['project'] = (int) $_POST['projects'];
                             $values['ticket'] = (int) $_POST['tickets'];
                         }
 
-                        if (isset($_POST['kind']) && $_POST['kind'] != '') {
+                        if (!empty($_POST['kind'])) {
                             $values['kind'] = ($_POST['kind']);
                         }
 
-                        if (isset($_POST['date']) && $_POST['date'] != '') {
+                        if (!empty($_POST['date'])) {
                             $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['date'], $_SESSION['usersettings.timezone']);
                             $date->setTimezone('UTC');
                             $values['date'] = $date;
-
                         }
 
-                        if (isset($_POST['hours']) && $_POST['hours'] != '') {
+                        if (!empty($_POST['hours'])) {
                             $values['hours'] = (float)($_POST['hours']);
                         }
 
-                        if (isset($_POST['description']) && $_POST['description'] != '') {
+                        if (!empty($_POST['description'])) {
                             $values['description'] = ($_POST['description']);
                         }
 
                         if (Auth::userIsAtLeast(Roles::$manager)) {
-                            if (isset($_POST['invoicedEmpl']) && $_POST['invoicedEmpl'] != '') {
+                            if (!empty($_POST['invoicedEmpl'])) {
                                 if ($_POST['invoicedEmpl'] == 'on') {
                                     $values['invoicedEmpl'] = 1;
                                 }
 
-                                if (isset($_POST['invoicedEmplDate']) && $_POST['invoicedEmplDate'] != '') {
+                                if (!empty($_POST['invoicedEmplDate'])) {
                                     $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedEmplDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['invoicedEmplDate'] = $date;
@@ -128,12 +127,12 @@ class EditTime extends Controller
                                 $values['invoicedEmplDate'] = '';
                             }
 
-                            if (isset($_POST['invoicedComp']) && $_POST['invoicedComp'] != '') {
+                            if (!empty($_POST['invoicedComp'])) {
                                 if ($_POST['invoicedComp'] == 'on') {
                                     $values['invoicedComp'] = 1;
                                 }
 
-                                if (isset($_POST['invoicedCompDate']) && $_POST['invoicedCompDate'] != '') {
+                                if (!empty($_POST['invoicedCompDate'])) {
                                     $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['invoicedCompDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['invoicedCompDate'] = $date;
@@ -145,17 +144,17 @@ class EditTime extends Controller
                                 $values['invoicedCompDate'] = '';
                             }
 
-                            if (isset($_POST['paid']) && $_POST['paid'] != '') {
+                            if (!empty($_POST['paid'])) {
                                 if ($_POST['paid'] == 'on') {
                                     $values['paid'] = 1;
                                 }
 
-                                if (isset($_POST['paidDate']) && $_POST['paidDate'] != '') {
+                                if (!empty($_POST['paidDate'])) {
                                     $date = Carbon::createFromFormat($this->language->__("language.dateformat"), $_POST['paidDate'], $_SESSION['usersettings.timezone']);
                                     $date->setTimezone('UTC');
                                     $values['paidDate'] = $date;
                                 } else {
-                                    $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC');
+                                    $values['paidDate'] = Carbon::now($_SESSION['usersettings.timezone'])   ->setTimezone('UTC');
                                 }
                             } else {
                                 $values['paid'] = 0;

--- a/app/Domain/Timesheets/Controllers/ShowAll.php
+++ b/app/Domain/Timesheets/Controllers/ShowAll.php
@@ -86,14 +86,18 @@ class ShowAll extends Controller
             $userId = intval(strip_tags($_POST['userId']));
         }
 
-        $dateFrom = Carbon::now('UTC')->startOfMonth();
+        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateFrom'])) {
-            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], 'UTC')->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date->setTimezone('UTC');
+            $dateFrom = $date;
         }
 
-        $dateTo = Carbon::now('UTC')->endOfMonth();
+        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateTo'])) {
-            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], 'UTC')->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date->setTimezone('UTC');
+            $dateTo = $date;
         }
 
         if (isset($_POST['invEmpl'])) {

--- a/app/Domain/Timesheets/Controllers/ShowAll.php
+++ b/app/Domain/Timesheets/Controllers/ShowAll.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Carbon\Carbon;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
@@ -73,35 +74,29 @@ class ShowAll extends Controller
             $this->timesheetsService->updateInvoices($invEmpl, $invComp, $paid);
         }
 
-        $invEmplCheck = '0';
         $invCompCheck = '0';
-
-        $projectFilter =  "";
-        $dateFromMk = mktime(0, 0, 0, date("m"), '1', date("Y"));
-        $dateToMk = mktime(0, 0, 0, date("m"), date("t"), date("Y"));
-
-        $dateFrom = date("Y-m-d", $dateFromMk);
-        $dateTo = date("Y-m-d", $dateToMk);
         $kind = 'all';
         $userId = null;
 
-        if (isset($_POST['kind']) && $_POST['kind'] != '') {
+        if (!empty($_POST['kind'])) {
             $kind = strip_tags($_POST['kind']);
         }
 
-        if (isset($_POST['userId']) && $_POST['userId'] != '') {
+        if (!empty($_POST['userId'])) {
             $userId = intval(strip_tags($_POST['userId']));
         }
 
-        if (isset($_POST['dateFrom']) && $_POST['dateFrom'] != '') {
-            $dateFrom = format($_POST['dateFrom'])->isoDate();
+        $dateFrom = Carbon::now('UTC')->startOfMonth();
+        if (!empty($_POST['dateFrom'])) {
+            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], 'UTC')->startOfDay();
         }
 
-        if (isset($_POST['dateTo']) && $_POST['dateTo'] != '') {
-            $dateTo = format($_POST['dateTo'])->isoDateEnd();
+        $dateTo = Carbon::now('UTC')->endOfMonth();
+        if (!empty($_POST['dateTo'])) {
+            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], 'UTC')->startOfDay();
         }
 
-        if (isset($_POST['invEmpl']) === true) {
+        if (isset($_POST['invEmpl'])) {
             $invEmplCheck = $_POST['invEmpl'];
 
             if ($invEmplCheck == 'on') {
@@ -113,7 +108,7 @@ class ShowAll extends Controller
             $invEmplCheck = '0';
         }
 
-        if (isset($_POST['invComp']) === true) {
+        if (isset($_POST['invComp'])) {
             $invCompCheck = ($_POST['invComp']);
 
             if ($invCompCheck == 'on') {
@@ -123,7 +118,7 @@ class ShowAll extends Controller
             }
         }
 
-        if (isset($_POST['paid']) === true) {
+        if (isset($_POST['paid'])) {
             $paidCheck = ($_POST['paid']);
 
             if ($paidCheck == 'on') {
@@ -136,27 +131,13 @@ class ShowAll extends Controller
         }
 
         $projectFilter = "";
-        if (isset($_POST['project']) && $_POST['project'] != '') {
+        if (!empty($_POST['project'])) {
             $projectFilter = strip_tags($_POST['project']);
         }
 
         $clientId = -1;
-        if (isset($_POST['clientId']) && $_POST['clientId'] != '') {
+        if (!empty($_POST['clientId'])) {
             $clientId = strip_tags($_POST['clientId']);
-        }
-
-        if (isset($_POST['export'])) {
-            $values = array(
-                'project' => $projectFilter,
-                'clientId' => $clientId,
-                'kind' => $kind,
-                'userId' => $userId,
-                'dateFrom' => $dateFrom,
-                'dateTo' => $dateTo,
-                'invEmplCheck' => $invEmplCheck,
-                'invCompCheck' => $invCompCheck,
-            );
-            $this->timesheetsService->export($values);
         }
 
         $user = app()->make(UserRepository::class);
@@ -176,7 +157,18 @@ class ShowAll extends Controller
         $this->tpl->assign('projectFilter', $projectFilter);
         $this->tpl->assign('clientFilter', $clientId);
         $this->tpl->assign('allClients', $this->clientService->getAll());
-        $this->tpl->assign('allTimesheets', $this->timesheetsService->getAll((int)$projectFilter, $kind, $dateFrom, $dateTo, $userId, $invEmplCheck, $invCompCheck, '-1', $paidCheck, $clientId));
+        $this->tpl->assign('allTimesheets', $this->timesheetsService->getAll(
+            $dateFrom,
+            $dateTo,
+            (int)$projectFilter,
+            $kind,
+            $userId,
+            $invEmplCheck,
+            $invCompCheck,
+            '-1',
+            $paidCheck,
+            $clientId
+        ));
 
         return $this->tpl->display('timesheets.showAll');
     }

--- a/app/Domain/Timesheets/Controllers/ShowAll.php
+++ b/app/Domain/Timesheets/Controllers/ShowAll.php
@@ -88,14 +88,14 @@ class ShowAll extends Controller
 
         $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateFrom'])) {
-            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone']);
             $date->setTimezone('UTC');
             $dateFrom = $date;
         }
 
         $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateTo'])) {
-            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone']);
             $date->setTimezone('UTC');
             $dateTo = $date;
         }

--- a/app/Domain/Timesheets/Controllers/ShowAll.php
+++ b/app/Domain/Timesheets/Controllers/ShowAll.php
@@ -86,14 +86,14 @@ class ShowAll extends Controller
             $userId = intval(strip_tags($_POST['userId']));
         }
 
-        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
+        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->startOfMonth();
         if (!empty($_POST['dateFrom'])) {
             $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone']);
             $date->setTimezone('UTC');
             $dateFrom = $date;
         }
 
-        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
+        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->endOfMonth();
         if (!empty($_POST['dateTo'])) {
             $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone']);
             $date->setTimezone('UTC');
@@ -123,7 +123,7 @@ class ShowAll extends Controller
         }
 
         if (isset($_POST['paid'])) {
-            $paidCheck = ($_POST['paid']);
+            $paidCheck = $_POST['paid'];
 
             if ($paidCheck == 'on') {
                 $paidCheck = '1';

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -3,6 +3,7 @@
 namespace Leantime\Domain\Timesheets\Controllers;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
@@ -62,7 +63,9 @@ class ShowMy extends Controller
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
 
         // Use UTC here as all data stored in the database should be UTC (start in user's timezone and convert to UTC).
-        $fromData = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->startOfWeek();
+        // The front end javascript is hardcode to start the week on mondays, so we use that here too.
+        $fromData = Carbon::now($_SESSION['usersettings.timezone'])->startOfWeek(CarbonInterface::MONDAY);
+        $fromData->setTimezone('UTC');
 
         $kind = 'all';
         if (isset($_POST['search'])) {

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -61,14 +61,16 @@ class ShowMy extends Controller
     {
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
 
-        // Use UTC here as all data stored in the database should be UTC.
-        $fromData = Carbon::now('UTC')->startOfWeek();
+        // Use UTC here as all data stored in the database should be UTC (start in user's timezone and convert to UTC).
+        $fromData = Carbon::now($_SESSION['usersettings.timezone'])->startOfWeek()->setTimezone('UTC');
 
         $kind = 'all';
         if (isset($_POST['search'])) {
             // User date comes is in user date format and user timezone. Change it to utc.
             if (!empty($_POST['startDate'])) {
-                $fromData = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['startDate'], 'UTC')->startOfDay();
+                $date =  Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['startDate'], $_SESSION['usersettings.timezone'])->startOfDay();
+                $date->setTimezone('UTC');
+                $fromData = $date;
             }
         }
 
@@ -113,7 +115,8 @@ class ShowMy extends Controller
             if (count($tempData) === 4) {
                 $ticketId = $tempData[0];
                 $isNewEntry = 'new' === $tempData[1];
-                $currentDate = new Carbon(str_replace('_', ' ', $tempData[2]));
+                $currentDate = new Carbon(str_replace('_', ' ', $tempData[2]), $_SESSION['usersettings.timezone']);
+                $currentDate->setTimezone('UTC');
                 $hours = $dateEntry;
                 $kind = $tempData[3];
 

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -2,13 +2,14 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
-use DateTime;
+use Carbon\Carbon;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 use Leantime\Domain\Auth\Services\Auth;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,7 +19,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ShowMy extends Controller
 {
-    private TimesheetRepository $timesheetsRepo;
+    private timesheetService $timesheetService;
+    private TimesheetRepository $timesheetRepo;
     private ProjectRepository $projects;
     private TicketRepository $tickets;
     private UserRepository $userRepo;
@@ -26,7 +28,8 @@ class ShowMy extends Controller
     /**
      * init - initialze private variables
      *
-     * @param TimesheetRepository $timesheetsRepo
+     * @param TimesheetService    $timesheetService
+     * @param TimesheetRepository $timesheetRepo
      * @param ProjectRepository   $projects
      * @param TicketRepository    $tickets
      * @param UserRepository      $userRepo
@@ -34,12 +37,14 @@ class ShowMy extends Controller
      * @return void
      */
     public function init(
-        TimesheetRepository $timesheetsRepo,
+        TimesheetService $timesheetService,
+        TimesheetRepository $timesheetRepo,
         ProjectRepository $projects,
         TicketRepository $tickets,
         UserRepository $userRepo
     ): void {
-        $this->timesheetsRepo = $timesheetsRepo;
+        $this->timesheetService = $timesheetService;
+        $this->timesheetRepo = $timesheetRepo;
         $this->projects = $projects;
         $this->tickets = $tickets;
         $this->userRepo = $userRepo;
@@ -56,37 +61,35 @@ class ShowMy extends Controller
     {
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
 
-        // Start with user monday 00:00 of this week in user timezone.
-        $dateStart = new \DateTime('Monday this week', new \DateTimeZone($_SESSION['usersettings.timezone']));
-
-        // Change to UTC for processing
-        $dateStart->setTimezone(new \DateTimeZone("UTC"));
-        $dateFrom = $dateStart->format("Y-m-d H:i:s");
+        // Use UTC here as all data stored in the database should be UTC.
+        $fromData = Carbon::now('UTC')->startOfWeek();
 
         $kind = 'all';
-
-        if (isset($_POST['search']) === true) {
-            // User date comes is in user date format and user timezone. change to utc and iso
-            if (isset($_POST['startDate']) === true && $_POST['startDate'] != "") {
-                $dateFrom = format($_POST['startDate'])->isoDate();
+        if (isset($_POST['search'])) {
+            // User date comes is in user date format and user timezone. Change it to utc.
+            if (!empty($_POST['startDate'])) {
+                $fromData = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['startDate'], 'UTC')->startOfDay();
             }
         }
 
-        if (isset($_POST['saveTimeSheet']) === true) {
+        if (isset($_POST['saveTimeSheet'])) {
             $this->saveTimeSheet($_POST);
-
             $this->tpl->setNotification('Timesheet successfully updated', 'success');
         }
 
-        $myTimesheets = $this->timesheetsRepo->getWeeklyTimesheets(-1, $dateFrom, $_SESSION['userdata']['id']);
+        $myTimesheets = $this->timesheetService->getWeeklyTimesheets(-1, $fromData, $_SESSION['userdata']['id']);
 
-        // Ensure we assume this is UTC
-        $dateFromDate = new \DateTime($dateFrom, new \DateTimeZone("UTC"));
-        $this->tpl->assign('dateFrom', $dateFromDate);
+        $this->tpl->assign('dateFrom', $fromData);
         $this->tpl->assign('actKind', $kind);
-        $this->tpl->assign('kind', $this->timesheetsRepo->kind);
-        $this->tpl->assign('allProjects', $this->projects->getUserProjects(userId: $_SESSION["userdata"]["id"], projectTypes: "project"));
-        $this->tpl->assign('allTickets', $this->tickets->getUsersTickets($_SESSION["userdata"]["id"], -1));
+        $this->tpl->assign('kind', $this->timesheetRepo->kind);
+        $this->tpl->assign('allProjects', $this->projects->getUserProjects(
+            userId: $_SESSION["userdata"]["id"],
+            projectTypes: "project"
+        ));
+        $this->tpl->assign('allTickets', $this->tickets->getUsersTickets(
+            id: $_SESSION["userdata"]["id"],
+            limit: -1
+        ));
         $this->tpl->assign('allTimesheets', $myTimesheets);
 
         return $this->tpl->display('timesheets.showMy');
@@ -96,48 +99,45 @@ class ShowMy extends Controller
      * @param array $postData
      *
      * @return void
+     *
      * @throws BindingResolutionException
      */
     public function saveTimeSheet(array $postData): void
     {
-        $ticketId = "";
-        $currentTimesheetId = -1;
         $userinfo = $this->userRepo->getUser($_SESSION["userdata"]["id"]);
 
         foreach ($postData as $key => $dateEntry) {
-            // Receiving a string of
-            // TICKET ID | New or existing timesheetID | Current Date | Type of booked hours
+            // The temp data should contain four parts, spectated by "|":
+            // TICKET ID | new or existing | Current Date (user format) | Type of booked hours
             $tempData = explode("|", $key);
-
-            if (count($tempData) == 4) {
+            if (count($tempData) === 4) {
                 $ticketId = $tempData[0];
-                $isCurrentTimesheetEntry = $tempData[1];
-                $currentDate = $tempData[2];
+                $isNewEntry = 'new' === $tempData[1];
+                $currentDate = new Carbon(str_replace('_', ' ', $tempData[2]));
                 $hours = $dateEntry;
+                $kind = $tempData[3];
 
                 // No ticket ID set, ticket id comes from form fields
                 if ($ticketId == "new") {
                     $ticketId = $postData["ticketId"];
                     $kind = $postData["kindId"];
-                } else {
-                    $kind = $tempData[3];
                 }
 
                 $values = array(
                     "userId" => $_SESSION["userdata"]["id"],
                     "ticket" => $ticketId,
-                    "date" => format($currentDate)->isoDate(),
+                    "date" => $currentDate,
                     "hours" => $hours,
                     "kind" => $kind,
                     "rate" => $userinfo["wage"],
                 );
 
-                if ($isCurrentTimesheetEntry == "new") {
-                    if ($values["hours"] > 0) {
-                        $this->timesheetsRepo->simpleInsert($values);
+                if ($isNewEntry) {
+                    if ($hours > 0) {
+                        $this->timesheetRepo->simpleInsert($values);
                     }
                 } else {
-                    $this->timesheetsRepo->updateHours($values);
+                    $this->timesheetRepo->updateHours($values);
                 }
             }
         }

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -122,8 +122,7 @@ class ShowMy extends Controller
                     $currentDate = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $tempData[2], $_SESSION['usersettings.timezone']);
                     $currentDate->setTimeFrom(Carbon::now($_SESSION['usersettings.timezone']));
                     $currentDate->setTimezone('UTC');
-                }
-                else {
+                } else {
                     // To update existing entries, the timesheet date was saved in the front end.
                     $currentDate = new Carbon(str_replace('_', ' ', $tempData[2]), 'UTC');
                 }

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -65,7 +65,7 @@ class ShowMy extends Controller
         // Use UTC here as all data stored in the database should be UTC (start in user's timezone and convert to UTC).
         // The front end javascript is hardcode to start the week on mondays, so we use that here too.
         $fromData = Carbon::now($_SESSION['usersettings.timezone'])->startOfWeek(CarbonInterface::MONDAY);
-        $fromData->setTimezone('UTC');
+        $fromData->setTimeFrom(Carbon::now($_SESSION['usersettings.timezone']))->setTimezone('UTC');
 
         $kind = 'all';
         if (isset($_POST['search'])) {

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -68,9 +68,8 @@ class ShowMy extends Controller
         if (isset($_POST['search'])) {
             // User date comes is in user date format and user timezone. Change it to utc.
             if (!empty($_POST['startDate'])) {
-                $date =  Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['startDate'], $_SESSION['usersettings.timezone']);
-                $date->setTimezone('UTC');
-                $fromData = $date;
+                $fromData =  Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['startDate'], $_SESSION['usersettings.timezone']);
+                $fromData->setTimezone('UTC');
             }
         }
 

--- a/app/Domain/Timesheets/Controllers/ShowMyList.php
+++ b/app/Domain/Timesheets/Controllers/ShowMyList.php
@@ -43,14 +43,18 @@ class ShowMyList extends Controller
             $kind = ($_POST['kind']);
         }
 
-        $dateFrom = Carbon::now('UTC')->startOfMonth();
+        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateFrom'])) {
-            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], 'UTC')->startOfDay();
+            // Time posted from the front end is in the user's timezone.
+            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $dateFrom->setTimezone('UTC');
         }
 
-        $dateTo = Carbon::now('UTC')->endOfMonth();
+        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateTo'])) {
-            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], 'UTC')->startOfDay();
+            // Time posted from the front end is in the user's timezone.
+            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $dateTo->setTimezone('UTC');
         }
 
         $this->tpl->assign('dateFrom', $dateFrom);

--- a/app/Domain/Timesheets/Controllers/ShowMyList.php
+++ b/app/Domain/Timesheets/Controllers/ShowMyList.php
@@ -46,14 +46,14 @@ class ShowMyList extends Controller
         $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateFrom'])) {
             // Time posted from the front end is in the user's timezone.
-            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone']);
             $dateFrom->setTimezone('UTC');
         }
 
         $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
         if (!empty($_POST['dateTo'])) {
             // Time posted from the front end is in the user's timezone.
-            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone']);
             $dateTo->setTimezone('UTC');
         }
 

--- a/app/Domain/Timesheets/Controllers/ShowMyList.php
+++ b/app/Domain/Timesheets/Controllers/ShowMyList.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Carbon\Carbon;
 use Leantime\Core\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
@@ -22,10 +23,7 @@ class ShowMyList extends Controller
      */
     public function init(TimesheetService $timesheetService): void
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         $this->timesheetService = $timesheetService;
-
         $_SESSION['lastPage'] = BASE_URL . "/timesheets/showMyList";
     }
 
@@ -38,30 +36,37 @@ class ShowMyList extends Controller
      */
     public function run(): Response
     {
-        $projectFilter =  $_SESSION['currentProject'];
-        $dateFrom = mktime(0, 0, 0, date("m"), '1', date("Y"));
-        $dateTo = mktime(0, 0, 0, date("m"), date("t"), date("Y"));
-        $dateFrom = date("Y-m-d 00:00:00", $dateFrom);
-        $dateTo = date("Y-m-d 00:00:00", $dateTo);
-        $kind = 'all';
+        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
 
-        if (isset($_POST['kind']) && $_POST['kind'] != '') {
+        $kind = 'all';
+        if (!empty($_POST['kind'])) {
             $kind = ($_POST['kind']);
         }
 
-        if (isset($_POST['dateFrom']) && $_POST['dateFrom'] != '') {
-            $dateFrom =  format($_POST['dateFrom'])->isoDate();
+        $dateFrom = Carbon::now('UTC')->startOfMonth();
+        if (!empty($_POST['dateFrom'])) {
+            $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], 'UTC')->startOfDay();
         }
 
-        if (isset($_POST['dateTo']) && $_POST['dateTo'] != '') {
-            $dateTo =  format($_POST['dateTo'])->isoDateEnd();
+        $dateTo = Carbon::now('UTC')->endOfMonth();
+        if (!empty($_POST['dateTo'])) {
+            $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], 'UTC')->startOfDay();
         }
 
         $this->tpl->assign('dateFrom', $dateFrom);
         $this->tpl->assign('dateTo', $dateTo);
         $this->tpl->assign('actKind', $kind);
         $this->tpl->assign('kind', $this->timesheetService->getLoggableHourTypes());
-        $this->tpl->assign('allTimesheets', $this->timesheetService->getAll(-1, $kind, $dateFrom, $dateTo, $_SESSION['userdata']['id'], 0, 0, "-1", 0));
+        $this->tpl->assign('allTimesheets', $this->timesheetService->getAll(
+            dateFrom: $dateFrom,
+            dateTo: $dateTo,
+            projectId: -1,
+            kind: $kind,
+            userId: $_SESSION['userdata']['id'],
+            invEmpl: 0,
+            invComp: 0,
+            paid: 0
+        ));
 
         return $this->tpl->display('timesheets.showMyList');
     }

--- a/app/Domain/Timesheets/Controllers/ShowMyList.php
+++ b/app/Domain/Timesheets/Controllers/ShowMyList.php
@@ -43,14 +43,14 @@ class ShowMyList extends Controller
             $kind = ($_POST['kind']);
         }
 
-        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->startOfMonth()->setTimezone('UTC');
+        $dateFrom = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->startOfMonth();
         if (!empty($_POST['dateFrom'])) {
             // Time posted from the front end is in the user's timezone.
             $dateFrom = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateFrom'], $_SESSION['usersettings.timezone']);
             $dateFrom->setTimezone('UTC');
         }
 
-        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->endOfMonth()->setTimezone('UTC');
+        $dateTo = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->endOfMonth();
         if (!empty($_POST['dateTo'])) {
             // Time posted from the front end is in the user's timezone.
             $dateTo = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'], $_POST['dateTo'], $_SESSION['usersettings.timezone']);

--- a/app/Domain/Timesheets/Js/timesheetsController.js
+++ b/app/Domain/Timesheets/Js/timesheetsController.js
@@ -3,9 +3,6 @@ leantime.timesheetsController = (function () {
 
     var initTimesheetsTable = function (groupBy) {
         jQuery(document).ready(function () {
-            var size = 100;
-            var columnIndex = false;
-
             var allTimesheets = jQuery("#allTimesheetsTable").DataTable({
                 "language": {
                     "decimal":        leantime.i18n.__("datatables.decimal"),
@@ -60,10 +57,9 @@ leantime.timesheetsController = (function () {
                                 }
                             }
                         }
-                },
-                    {
-                        extend: 'colvis',
-                        columns: ':not(.noVis)'
+                }, {
+                    extend: 'colvis',
+                    columns: ':not(.noVis)'
                 }
                 ]
             }).container().appendTo(jQuery('#tableButtons'));
@@ -91,7 +87,6 @@ leantime.timesheetsController = (function () {
                     }
                 },
                 afterShowCont: function () {
-
                     jQuery(".editTimeModal").nyroModal(canvasoptions);
                 },
                 beforeClose: function () {
@@ -109,6 +104,5 @@ leantime.timesheetsController = (function () {
     return {
         initTimesheetsTable:initTimesheetsTable,
         initEditTimeModal:initEditTimeModal,
-
     };
 })();

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -303,8 +303,9 @@ class Timesheets extends Repository
 
         $call->prepare($query);
 
-        $call->bindValue(':dateStart1', $fromDate);
-        $call->bindValue(':dateStart2', $fromDate);
+        $startOfDay = $fromDate->format('Y-m-d');
+        $call->bindValue(':dateStart1', $startOfDay);
+        $call->bindValue(':dateStart2', $startOfDay);
         $call->bindValue(':userId', $userId, PDO::PARAM_INT);
 
         if ($projectId > 0) {
@@ -806,7 +807,7 @@ class Timesheets extends Repository
         $call->bindValue(':ticketId', $ticketId);
         $call->bindValue(':sessionId', $_SESSION['userdata']['id']);
         $call->bindValue(':hoursWorked', $hoursWorked);
-        $call->bindValue(':workDate', (new Carbon($inTimestamp, $_SESSION['usersettings.timezone']))->startOfDay()->setTimezone('UTC'));
+        $call->bindValue(':workDate', (new Carbon($inTimestamp, $_SESSION['usersettings.timezone']))->setTimezone('UTC'));
 
         $call->execute();
 

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -631,7 +631,7 @@ class Timesheets extends Repository
         $values = $call->fetchAll();
         $returnValues = array();
         if (count($values) > 0) {
-            $startDate = (Carbon::createFromFormat('Y-m-d', $values[0]['utc'], 'UTC'))->startOfMonth();
+            $startDate = Carbon::createFromFormat('Y-m-d', $values[0]['utc'], 'UTC')->startOfMonth();
             $endDate = Carbon::createFromFormat('Y-m-d', last($values)['utc'], 'UTC');
 
             $range = CarbonPeriod::since($startDate)->days(1)->until($endDate);
@@ -647,7 +647,7 @@ class Timesheets extends Repository
                 $returnValues[$row['utc']]["summe"] = $row['summe'];
             }
         } else {
-            $utc = Carbon::now('utc')->format('Y-m-d');
+            $utc = Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC')->format('Y-m-d');
             $returnValues[$utc] = [
               'utc' => $utc,
               'summe' => 0,
@@ -806,7 +806,7 @@ class Timesheets extends Repository
         $call->bindValue(':ticketId', $ticketId);
         $call->bindValue(':sessionId', $_SESSION['userdata']['id']);
         $call->bindValue(':hoursWorked', $hoursWorked);
-        $call->bindValue(':workDate', (new Carbon($inTimestamp, 'UTC'))->startOfDay());
+        $call->bindValue(':workDate', (new Carbon($inTimestamp, $_SESSION['usersettings.timezone']))->startOfDay()->setTimezone('UTC'));
 
         $call->execute();
 
@@ -851,7 +851,7 @@ class Timesheets extends Repository
             $onTheClock["since"] = $results[0]["punchIn"];
             $onTheClock["headline"] = $results[0]["headline"];
             $start_date = new Carbon($results[0]["punchIn"], 'UTC');
-            $since_start = $start_date->diff(Carbon::now('UTC'));
+            $since_start = $start_date->diff(Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC'));
 
             $r = $since_start->format('%H:%I');
 

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -742,34 +742,45 @@ class Timesheets extends Repository
     public function updateInvoices(array $invEmpl, array $invComp = [], array $paid = []): bool
     {
         foreach ($invEmpl as $row1) {
-            $query = "UPDATE zp_timesheets SET invoicedEmpl = 1, invoicedEmplDate = DATE(NOW()) WHERE id = :id ";
+            $query = "UPDATE zp_timesheets
+                      SET invoicedEmpl = 1,
+                          invoicedEmplDate = :date
+                      WHERE id = :id ";
 
             $invEmplCall = $this->dbcall(func_get_args(), ['dbcall_key' => 'inv_empl']);
             $invEmplCall->prepare($query);
             $invEmplCall->bindValue(':id', $row1);
+            $invEmplCall->bindValue(':date', Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC'));
             $invEmplCall->execute();
 
             unset($invEmplCall);
         }
 
         foreach ($invComp as $row2) {
-            $query2 = "UPDATE zp_timesheets SET invoicedComp = 1, invoicedCompDate = DATE(NOW()) WHERE id = :id ";
+            $query2 = "UPDATE zp_timesheets
+                       SET invoicedComp = 1,
+                           invoicedCompDate = :date
+                       WHERE id = :id ";
 
             $invCompCall = $this->dbcall(func_get_args(), ['dbcall_key' => 'inv_comp']);
             $invCompCall->prepare($query2);
             $invCompCall->bindValue(':id', $row2);
+            $invCompCall->bindValue(':date', Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC'));
             $invCompCall->execute();
 
             unset($invCompCall);
         }
 
         foreach ($paid as $row3) {
-            $query3 = "UPDATE zp_timesheets SET paid = 1, paidDate = DATE(NOW()) WHERE id = :id ";
+            $query3 = "UPDATE zp_timesheets
+                       SET paid = 1,
+                           paidDate = :date
+                       WHERE id = :id ";
 
             $paidCol = $this->dbcall(func_get_args(), ['dbcall_key' => 'paid']);
             $paidCol->prepare($query3);
             $paidCol->bindValue(':id', $row3);
-
+            $paidCol->bindValue(':date', Carbon::now($_SESSION['usersettings.timezone'])->setTimezone('UTC'));
             $paidCol->execute();
 
             unset($paidCol);

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -375,8 +375,8 @@ class Timesheets extends Repository
         $call->bindValue(':userId', $values['userId']);
         $call->bindValue(':ticket', $values['ticket']);
         $call->bindValue(':kind', $values['kind']);
-        $call->bindValue(':dateStart', $values['date']->startOfDay());
-        $call->bindValue(':dateEnd', $values['date']->endOfDay());
+        $call->bindValue(':dateStart', $values['date']->copy()->startOfDay());
+        $call->bindValue(':dateEnd', $values['date']->copy()->endOfDay());
 
         $timesheets = $call->fetchAll();
         if (!empty($timesheets)) {
@@ -386,7 +386,8 @@ class Timesheets extends Repository
                 zp_timesheets
             SET
                 hours = :hours,
-                description = :description
+                description = :description,
+                workDate = :newWorkDate
             WHERE
                 userId = :userId
                 AND ticketId = :ticketId
@@ -401,6 +402,7 @@ class Timesheets extends Repository
             $call->prepare($query);
             $call->bindValue(':hours', $timesheet['hours'] + $values['hours']);
             $call->bindValue(':description', $values['description'] . '\n' . '--' . '\n\n' . $timesheet['description']);
+            $call->bindValue(':newWorkDate', $values['date']);
             $call->bindValue(':workDate', $timesheet['workDate']);
             $call->bindValue(':userId', $values['userId']);
             $call->bindValue(':ticketId', $values['ticket']);

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -436,7 +436,7 @@ class Timesheets extends Repository
                 :invoicedCompDate,
                 :rate,
                 :paid,
-                :paidDate;
+                :paidDate
             ) ON DUPLICATE KEY UPDATE
                  hours = hours + :hours,
                  description = CONCAT(:date, '\n', :description, '\n', '--', '\n\n', description)";

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -400,7 +400,7 @@ class Timesheets extends Repository
 
             $call->prepare($query);
             $call->bindValue(':hours', $timesheet['hours'] + $values['hours']);
-            $call->bindValue(':description',  $values['description'] . '\n' . '--' . '\n\n' . $timesheet['description']);
+            $call->bindValue(':description', $values['description'] . '\n' . '--' . '\n\n' . $timesheet['description']);
             $call->bindValue(':workDate', $timesheet['workDate']);
             $call->bindValue(':userId', $values['userId']);
             $call->bindValue(':ticketId', $values['ticket']);
@@ -408,8 +408,7 @@ class Timesheets extends Repository
             $call->bindValue(':workDate', $timesheet['workDate']);
 
             $call->execute();
-        }
-        else {
+        } else {
             $query = "INSERT INTO zp_timesheets (
                 userId,
                 ticketId,

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -97,6 +97,7 @@ class Timesheets
 
         if (!empty($params['date'])) {
             $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], $_SESSION['usersettings.timezone']);
+            $date->setTimeFrom(Carbon::now($_SESSION['usersettings.timezone']));
             $date->setTimezone('UTC');
             $values['date'] = $date;
         }

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Timesheets\Services;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Domain\Tickets\Models\Tickets;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 
 /**
@@ -12,6 +14,15 @@ use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 class Timesheets
 {
     private TimesheetRepository $timesheetsRepo;
+
+    public array $kind = array(
+        'GENERAL_BILLABLE' => 'label.general_billable',
+        'GENERAL_NOT_BILLABLE' => 'label.general_not_billable',
+        'PROJECTMANAGEMENT' => 'label.projectmanagement',
+        'DEVELOPMENT' => 'label.development',
+        'BUGFIXING_NOT_BILLABLE' => 'label.bugfixing_not_billable',
+        'TESTING' => 'label.testing',
+    );
 
     /**
      * @param TimesheetRepository $timesheetsRepo
@@ -85,7 +96,7 @@ class Timesheets
         }
 
         if (!empty($params['date'])) {
-            $values['date'] = format($params['date'])->isoDate();
+            $values['date'] = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], 'UTC')->startOfDay();
         }
 
         if (!empty($params['hours'])) {
@@ -143,11 +154,11 @@ class Timesheets
     }
 
     /**
-     * @param $ticket
+     * @param Tickets $ticket
      *
      * @return int|mixed
      */
-    public function getRemainingHours($ticket): mixed
+    public function getRemainingHours(Tickets $ticket): mixed
     {
         $totalHoursLogged = $this->getSumLoggedHoursForTicket($ticket->id);
         $planHours = $ticket->planHours;
@@ -181,10 +192,10 @@ class Timesheets
     }
 
     /**
+     * @param Carbon   $dateFrom
+     * @param Carbon   $dateTo
      * @param int      $projectId
      * @param string   $kind
-     * @param string   $dateFrom
-     * @param string   $dateTo
      * @param int|null $userId
      * @param string   $invEmpl
      * @param string   $invComp
@@ -194,7 +205,7 @@ class Timesheets
      *
      * @return array|false
      */
-    public function getAll(int $projectId = -1, string $kind = 'all', string $dateFrom = '0000-01-01 00:00:00', string $dateTo = '9999-12-24 00:00:00', ?int $userId = null, string $invEmpl = '1', string $invComp = '1', string $ticketFilter = '-1', string $paid = '1', string $clientId = '-1'): array|false
+    public function getAll(Carbon $dateFrom, Carbon $dateTo, int $projectId = -1, string $kind = 'all', ?int $userId = null, string $invEmpl = '1', string $invComp = '1', string $ticketFilter = '-1', string $paid = '1', string $clientId = '-1'): array|false
     {
         return $this->timesheetsRepo->getAll(
             id: $projectId,
@@ -211,6 +222,24 @@ class Timesheets
     }
 
     /**
+     * @param int    $projectId
+     * @param Carbon $fromDate
+     * @param int    $userId
+     *
+     * @return array
+     */
+    public function getWeeklyTimesheets(int $projectId, Carbon $fromDate, int $userId = 0): array
+    {
+        return $this->timesheetsRepo->getWeeklyTimesheets(
+            projectId: $projectId,
+            fromDate: $fromDate,
+            userId: $userId
+        );
+    }
+
+    /**
+     * @TODO: Function is currently not used by core.
+     *
      * @param array $values
      *
      * @return void

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -96,7 +96,7 @@ class Timesheets
         }
 
         if (!empty($params['date'])) {
-            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], $_SESSION['usersettings.timezone']);
             $date->setTimezone('UTC');
             $values['date'] = $date;
         }

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -96,7 +96,9 @@ class Timesheets
         }
 
         if (!empty($params['date'])) {
-            $values['date'] = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], 'UTC')->startOfDay();
+            $date = Carbon::createFromFormat($_SESSION['usersettings.language.date_format'] ?? 'Y-m-d', $params['date'], $_SESSION['usersettings.timezone'])->startOfDay();
+            $date->setTimezone('UTC');
+            $values['date'] = $date;
         }
 
         if (!empty($params['hours'])) {

--- a/app/Domain/Timesheets/Templates/editTime.tpl.php
+++ b/app/Domain/Timesheets/Templates/editTime.tpl.php
@@ -13,21 +13,18 @@ $values = $tpl->get('values');
         jQuery(".ticket-select").chosen();
 
         jQuery(".project-select").change(function () {
-
             jQuery(".ticket-select").removeAttr("selected");
             jQuery(".ticket-select").val("");
             jQuery(".ticket-select").trigger("liszt:updated");
 
             jQuery(".ticket-select option").show();
             jQuery("#ticketSelect .chosen-results li").show();
+
             var selectedValue = jQuery(this).find("option:selected").val();
             jQuery("#ticketSelect .chosen-results li").not(".project_" + selectedValue).hide();
-
-
-        });
+       });
 
         jQuery(".ticket-select").change(function () {
-
             var selectedValue = jQuery(this).find("option:selected").attr("data-value");
             jQuery(".project-select option[value=" + selectedValue + "]").attr("selected", "selected");
             jQuery(".project-select").trigger("liszt:updated");
@@ -50,11 +47,8 @@ $values = $tpl->get('values');
                 weekHeader: leantime.i18n.__("language.weekHeader"),
             });
         });
-
     });
-
 </script>
-
 
 <?php echo $tpl->displayNotification() ?>
 
@@ -104,7 +98,7 @@ $values = $tpl->get('values');
 
 </select><br />
 <label for="date"><?php echo $tpl->__('label.date')?></label> <input type="text" autocomplete="off"
-    id="datepicker" name="date" value="<?php echo format($values['date'])->dateUtc(); ?>" size="7" />
+    id="datepicker" name="date" value="<?php echo format($values['date'], 'short'); ?>" size="7" />
 <br />
 <label for="hours"><?php echo $tpl->__('label.hours')?></label> <input
     type="text" id="hours" name="hours"
@@ -126,7 +120,7 @@ $values = $tpl->get('values');
 
             <?php echo $tpl->__('label.date') ?>&nbsp;<input type="text" autocomplete="off"
                                                   id="invoicedEmplDate" name="invoicedEmplDate"
-                                                  value="<?php echo format($values['invoicedEmplDate'])->date(); ?>"
+                                                  value="<?php echo format($values['invoicedEmplDate'], 'short'); ?>"
                                                   size="7"/><br/>
 
 
@@ -141,7 +135,7 @@ $values = $tpl->get('values');
         <?php echo $tpl->__('label.date') ?>&nbsp;<input type="text" autocomplete="off"
                                                       id="invoicedCompDate"
                                                       name="invoicedCompDate"
-                                                      value="<?php echo format($values['invoicedCompDate'])->date(); ?>"
+                                                      value="<?php echo format($values['invoicedCompDate'], 'short'); ?>"
                                                       size="7"/><br/>
 
         <br/>
@@ -155,7 +149,7 @@ $values = $tpl->get('values');
         <?php echo $tpl->__('label.date') ?>&nbsp;<input type="text" autocomplete="off"
                                                           id="paidDate"
                                                           name="paidDate"
-                                                          value="<?php echo format($values['paidDate'])->date(); ?>"
+                                                          value="<?php echo format($values['paidDate'], 'short'); ?>"
                                                           size="7"/><br/>
     <?php } ?>
 

--- a/app/Domain/Timesheets/Templates/partials/stopwatch.blade.php
+++ b/app/Domain/Timesheets/Templates/partials/stopwatch.blade.php
@@ -3,14 +3,10 @@
     <li class='timerHeadMenu' id='timerHeadMenu' hx-get="{{BASE_URL}}/timesheets/stopwatch/get-status" hx-trigger="timerUpdate from:body">
 
     @if ($onTheClock !== false|null)
-
-
-
             <a
                 href='javascript:void(0);'
                 class='dropdown-toggle'
                 data-toggle='dropdown'
-
             >{!! sprintf(
                     __('text.timer_on_todo'),
                     $onTheClock['totalTime'],
@@ -34,10 +30,7 @@
                     >{!! __('links.stop_timer') !!}</a>
                 </li>
             </ul>
-
     @endif
-
     </li>
-
 @endif
 

--- a/app/Domain/Timesheets/Templates/showAll.tpl.php
+++ b/app/Domain/Timesheets/Templates/showAll.tpl.php
@@ -6,27 +6,24 @@ foreach ($__data as $var => $val) {
 }
 ?>
 <script type="text/javascript">
-
     jQuery(document).ready(function(){
-
         jQuery("#checkAllEmpl").change(function(){
             jQuery(".invoicedEmpl").prop('checked', jQuery(this).prop("checked"));
-            if(jQuery(this).prop("checked") == true){
+            if (jQuery(this).prop("checked") == true) {
                 jQuery(".invoicedEmpl").attr("checked", "checked");
                 jQuery(".invoicedEmpl").parent().addClass("checked");
-            }else{
+            } else {
                 jQuery(".invoicedEmpl").removeAttr("checked");
                 jQuery(".invoicedEmpl").parent().removeClass("checked");
             }
-
         });
 
         jQuery("#checkAllComp").change(function(){
             jQuery(".invoicedComp").prop('checked', jQuery(this).prop("checked"));
-            if(jQuery(this).prop("checked") == true){
+            if (jQuery(this).prop("checked") == true) {
                 jQuery(".invoicedComp").attr("checked", "checked");
                 jQuery(".invoicedComp").parent().addClass("checked");
-            }else{
+            } else {
                 jQuery(".invoicedComp").removeAttr("checked");
                 jQuery(".invoicedComp").parent().removeClass("checked");
             }
@@ -34,10 +31,10 @@ foreach ($__data as $var => $val) {
 
         jQuery("#checkAllPaid").change(function(){
             jQuery(".paid").prop('checked', jQuery(this).prop("checked"));
-            if(jQuery(this).prop("checked") == true){
+            if (jQuery(this).prop("checked") == true) {
                 jQuery(".paid").attr("checked", "checked");
                 jQuery(".paid").parent().addClass("checked");
-            }else{
+            } else {
                 jQuery(".paid").removeAttr("checked");
                 jQuery(".paid").parent().removeClass("checked");
             }
@@ -49,283 +46,273 @@ foreach ($__data as $var => $val) {
             leantime.timesheetsController.initEditTimeModal();
         <?php } ?>
 
-
         leantime.dateController.initDateRangePicker(".dateFrom", ".dateTo", 1)
-
     });
-
-
 </script>
 
+<!-- page header -->
 <div class="pageheader">
-
-
     <div class="pageicon"><span class="fa-solid fa-business-time"></span></div>
-            <div class="pagetitle">
-
-                <h1><?php echo $tpl->__("headlines.all_timesheets") ?></h1>
-            </div>
-        </div><!--pageheader-->
-
-        <div class="maincontent">
-            <div class="maincontentinner">
-
-
-
-<form action="<?=BASE_URL ?>/timesheets/showAll" method="post" id="form" name="form">
-
-    <div class="pull-right">
-
-        <div id="tableButtons" style="display:inline-block"></div>
-
+        <div class="pagetitle">
+        <h1><?php echo $tpl->__("headlines.all_timesheets") ?></h1>
     </div>
-    <div class="clearfix"></div>
-    <div class="headtitle" style="">
-
-    <table cellpadding="10" cellspacing="0" width="90%" class="table dataTable filterTable">
-
-        <tr>
-            <td>
-                <label for="clients"><?php echo $tpl->__('label.client'); ?></label>
-                <select name="clientId">
-                    <option value="-1"><?php echo strip_tags($tpl->__("menu.all_clients")) ?></option>
-                    <?php foreach ($tpl->get('allClients') as $client) {?>
-                        <option value="<?=$client['id'] ?>"
-                            <?php if ($tpl->get('clientFilter') == $client['id']) {
-                                echo "selected='selected'";
-                            } ?>><?=$tpl->escape($client['name'])?></option>
-                    <?php } ?>
-                </select>
-            </td>
-            <td>
-                <label for="projects"><?php echo $tpl->__('label.project'); ?></label>
-                <select name="project" style="max-width:120px;">
-                    <option value="-1"><?php echo strip_tags($tpl->__("menu.all_projects")) ?></option>
-                    <?php foreach ($tpl->get('allProjects') as $project) {?>
-                        <option value="<?=$project['id'] ?>"
-                            <?php if ($tpl->get('projectFilter') == $project['id']) {
-                                echo "selected='selected'";
-                            } ?>><?=$tpl->escape($project['name'])?></option>
-                    <?php } ?>
-                </select>
-            </td>
-            <td><label for="dateFrom"><?php echo $tpl->__('label.date_from'); ?></label>
-                <input type="text" id="dateFrom" class="dateFrom"  name="dateFrom" autocomplete="off"
-                value="<?php echo format($tpl->get('dateFrom'))->date(); ?>" size="5" style="max-width:100px; margin-bottom:10px"/></td>
-            <td><label for="dateTo"><?php echo $tpl->__('label.date_to'); ?></label>
-                <input type="text" id="dateTo" class="dateTo" name="dateTo" autocomplete="off"
-                value="<?php echo format($tpl->get('dateTo'))->date(); ?>" size="5" style="max-width:100px; margin-bottom:10px" /></td>
-            <td>
-            <label for="userId"><?php echo $tpl->__("label.employee"); ?></label>
-            <select name="userId" id="userId" onchange="submit();" style="max-width:120px;">
-                <option value="all"><?php echo $tpl->__("label.all_employees"); ?></option>
-
-                <?php foreach ($tpl->get('employees') as $row) {
-                    echo'<option value="' . $row['id'] . '"';
-                    if ($row['id'] == $tpl->get('employeeFilter')) {
-                        echo' selected="selected" ';
-                    }
-                    echo'>' . sprintf($tpl->__('text.full_name'), $tpl->escape($row['firstname']), $tpl->escape($row['lastname'])) . '</option>';
-                }
-                ?>
-            </select>
-            </td>
-            <td>
-            <label for="kind"><?php echo $tpl->__("label.type")?></label>
-            <select id="kind" name="kind" onchange="submit();" style="max-width:120px;">
-                <option value="all"><?php echo $tpl->__("label.all_types"); ?></option>
-                <?php foreach ($tpl->get('kind') as $key => $row) {
-                    echo'<option value="' . $key . '"';
-                    if ($key == $tpl->get('actKind')) {
-                        echo ' selected="selected"';
-                    }
-                    echo'>' . $tpl->__($row) . '</option>';
-                }
-                ?>
-
-            </select> </td>
-            <td>
-
-            <input type="checkbox" value="on" name="invEmpl" id="invEmpl" onclick="submit();"
-                <?php
-                if ($tpl->get('invEmpl') == '1') {
-                    echo ' checked="checked"';
-                }
-                ?>
-            /><label for="invEmpl"><?php echo $tpl->__("label.invoiced"); ?></label></td>
-            <td>
-
-            <input type="checkbox" value="on" name="invComp" id="invComp" onclick="submit();"
-                <?php
-                if ($tpl->get('invComp') == '1') {
-                    echo ' checked="checked"';
-                }
-                ?>
-            /><label for="invEmpl"><?php echo $tpl->__("label.invoiced_comp"); ?></label>
-            </td>
-
-            <td>
-
-                <input type="checkbox" value="on" name="paid" id="paid" onclick="submit();"
-                    <?php
-                    if ($tpl->get('paid') == '1') {
-                        echo ' checked="checked"';
-                    }
-                    ?>
-                /><label for="paid"><?php echo $tpl->__("label.paid"); ?></label>
-            </td>
-            <td>
-                <input type="hidden" name='filterSubmit' value="1"/>
-                <input type="submit" value="<?php echo $tpl->__('buttons.search')?>" class="reload" />
-            </td>
-        </tr>
-
-</table>
-
 </div>
-<table cellpadding="0" cellspacing="0" border="0" class="table table-bordered display" id="allTimesheetsTable">
-    <colgroup>
-          <col class="con0" width="100px"/>
-          <col class="con1" />
-          <col class="con0"/>
-          <col class="con1" />
-          <col class="con0"/>
-          <col class="con1" />
-          <col class="con0"/>
-          <col class="con1" />
-          <col class="con0"/>
-          <col class="con1" />
-          <col class="con0"/>
-          <col class="con1"/>
-          <col class="con0"/>
-          <col class="con1"/>
-          <col class="con0"/>
-          <col class="con1"/>
-    </colgroup>
-    <thead>
-        <tr>
-            <th><?php echo $tpl->__('label.id'); ?></th>
-            <th><?php echo $tpl->__('label.date'); ?></th>
-            <th><?php echo $tpl->__('label.hours'); ?></th>
-            <th><?php echo $tpl->__('label.plan_hours'); ?></th>
-            <th><?php echo $tpl->__('label.difference'); ?></th>
-            <th><?php echo $tpl->__('label.ticket'); ?></th>
-            <th><?php echo $tpl->__('label.project'); ?></th>
-            <th><?php echo $tpl->__('label.client'); ?></th>
-            <th><?php echo $tpl->__('label.employee'); ?></th>
-            <th><?php echo $tpl->__("label.type")?></th>
-            <th><?php echo $tpl->__("label.milestone") ?></th>
-            <th><?php echo $tpl->__("label.tags") ?></th>
-            <th><?php echo $tpl->__('label.description'); ?></th>
-            <th><?php echo $tpl->__('label.invoiced'); ?></th>
-            <th><?php echo $tpl->__('label.invoiced_comp'); ?></th>
-            <th><?php echo $tpl->__('label.paid'); ?></th>
-        </tr>
+<!-- page header -->
 
-    </thead>
-    <tbody>
 
-    <?php
+<div class="maincontent">
+    <div class="maincontentinner">
+        <form action="<?php echo BASE_URL ?>/timesheets/showAll" method="post" id="form" name="form">
 
-    $sum = 0;
-    $billableSum = 0;
+            <div class="pull-right">
+                <div id="tableButtons" style="display:inline-block"></div>
+            </div>
+            <div class="clearfix"></div>
+            <div class="headtitle" style="">
 
-    foreach ($tpl->get('allTimesheets') as $row) {
-        $sum = $sum + $row['hours'];?>
-        <tr>
-            <td data-order="<?=$tpl->e($row['id']); ?>">
-                    <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                    <a href="<?=BASE_URL?>/timesheets/editTime/<?=$row['id']?>" class="editTimeModal">#<?=$row['id'] . " - " . $tpl->__('label.edit'); ?> </a>
-                    <?php } else { ?>
-                    #<?=$row['id']?>
-                    <?php } ?>
-            </td>
-            <td data-order="<?=$tpl->escape($row['workDate']); ?>">
-                    <?php echo format($row['workDate'])->date(); ?>
-            </td>
-            <td data-order="<?php $tpl->e($row['hours']); ?>"><?php $tpl->e($row['hours']); ?></td>
-            <td data-order="<?php $tpl->e($row['planHours']); ?>"><?php $tpl->e($row['planHours']); ?></td>
-                <?php $diff = $row['planHours'] - $row['hours']; ?>
-            <td data-order="<?=$diff; ?>"><?php echo $diff; ?></td>
-            <td data-order="<?=$tpl->e($row['headline']); ?>"><a href="#/tickets/showTicket/<?php echo $row['ticketId']; ?>"><?php $tpl->e($row['headline']); ?></a></td>
+            <table cellpadding="10" cellspacing="0" width="90%" class="table dataTable filterTable">
+                <tr>
+                    <td>
+                        <label for="clients"><?php echo $tpl->__('label.client'); ?></label>
+                        <select name="clientId">
+                            <option value="-1"><?php echo strip_tags($tpl->__("menu.all_clients")) ?></option>
+                            <?php foreach ($tpl->get('allClients') as $client) {?>
+                                <option value="<?=$client['id'] ?>"
+                                    <?php if ($tpl->get('clientFilter') == $client['id']) {
+                                        echo "selected='selected'";
+                                    } ?>><?=$tpl->escape($client['name'])?></option>
+                            <?php } ?>
+                        </select>
+                    </td>
+                    <td>
+                        <label for="projects"><?php echo $tpl->__('label.project'); ?></label>
+                        <select name="project" style="max-width:120px;">
+                            <option value="-1"><?php echo strip_tags($tpl->__("menu.all_projects")) ?></option>
+                            <?php foreach ($tpl->get('allProjects') as $project) {?>
+                                <option value="<?=$project['id'] ?>"
+                                    <?php if ($tpl->get('projectFilter') == $project['id']) {
+                                        echo "selected='selected'";
+                                    } ?>><?=$tpl->escape($project['name'])?></option>
+                            <?php } ?>
+                        </select>
+                    </td>
+                    <td>
+                        <label for="dateFrom"><?php echo $tpl->__('label.date_from'); ?></label>
+                        <input type="text" id="dateFrom" class="dateFrom"  name="dateFrom" autocomplete="off"
+                        value="<?php echo format($tpl->get('dateFrom'), 'short'); ?>" size="5" style="max-width:100px; margin-bottom:10px"/></td>
+                    <td>
+                        <label for="dateTo"><?php echo $tpl->__('label.date_to'); ?></label>
+                        <input type="text" id="dateTo" class="dateTo" name="dateTo" autocomplete="off"
+                        value="<?php echo format($tpl->get('dateTo'), 'short'); ?>" size="5" style="max-width:100px; margin-bottom:10px" /></td>
+                    <td>
+                    <label for="userId"><?php echo $tpl->__("label.employee"); ?></label>
+                        <select name="userId" id="userId" onchange="submit();" style="max-width:120px;">
+                            <option value="all"><?php echo $tpl->__("label.all_employees"); ?></option>
 
-            <td data-order="<?=$tpl->e($row['name']); ?>"><a href="<?=BASE_URL ?>/projects/showProject/<?php echo $row['projectId']; ?>"><?php $tpl->e($row['name']); ?></a></td>
-            <td data-order="<?=$tpl->e($row['clientName']); ?>"><a href="<?=BASE_URL ?>/clients/showClient/<?php echo $row['clientId']; ?>"><?php $tpl->e($row['clientName']); ?></a></td>
+                            <?php foreach ($tpl->get('employees') as $row) {
+                                echo'<option value="' . $row['id'] . '"';
+                                if ($row['id'] == $tpl->get('employeeFilter')) {
+                                    echo' selected="selected" ';
+                                }
+                                echo'>' . sprintf($tpl->__('text.full_name'), $tpl->escape($row['firstname']), $tpl->escape($row['lastname'])) . '</option>';
+                            }
+                            ?>
+                        </select>
+                    </td>
+                    <td>
+                        <label for="kind"><?php echo $tpl->__("label.type")?></label>
+                        <select id="kind" name="kind" onchange="submit();" style="max-width:120px;">
+                            <option value="all"><?php echo $tpl->__("label.all_types"); ?></option>
+                            <?php foreach ($tpl->get('kind') as $key => $row) {
+                                echo'<option value="' . $key . '"';
+                                if ($key == $tpl->get('actKind')) {
+                                    echo ' selected="selected"';
+                                }
+                                echo'>' . $tpl->__($row) . '</option>';
+                            }
+                            ?>
 
-            <td><?php printf($tpl->__("text.full_name"), $tpl->escape($row["firstname"]), $tpl->escape($row['lastname'])); ?></td>
-            <td><?php echo $tpl->__($tpl->get('kind')[$row['kind']]); ?></td>
+                        </select>
+                    </td>
+                    <td>
+                        <input type="checkbox" value="on" name="invEmpl" id="invEmpl" onclick="submit();"
+                            <?php
+                            if ($tpl->get('invEmpl') == '1') {
+                                echo ' checked="checked"';
+                            }
+                            ?>
+                        />
+                        <label for="invEmpl"><?php echo $tpl->__("label.invoiced"); ?></label>
+                    </td>
+                    <td>
+                        <input type="checkbox" value="on" name="invComp" id="invComp" onclick="submit();"
+                            <?php
+                            if ($tpl->get('invComp') == '1') {
+                                echo ' checked="checked"';
+                            }
+                            ?>
+                        />
+                        <label for="invEmpl"><?php echo $tpl->__("label.invoiced_comp"); ?></label>
+                    </td>
 
-            <td><?php echo $tpl->escape($row["milestone"]); ?></td>
-            <td><?php echo $tpl->escape($row["tags"]); ?></td>
+                    <td>
+                        <input type="checkbox" value="on" name="paid" id="paid" onclick="submit();"
+                            <?php
+                            if ($tpl->get('paid') == '1') {
+                                echo ' checked="checked"';
+                            }
+                            ?>
+                        />
+                        <label for="paid"><?php echo $tpl->__("label.paid"); ?></label>
+                    </td>
+                    <td>
+                        <input type="hidden" name='filterSubmit' value="1"/>
+                        <input type="submit" value="<?php echo $tpl->__('buttons.search')?>" class="reload" />
+                    </td>
+                </tr>
+            </table>
+            </div>
 
-            <td><?php $tpl->e($row['description']); ?></td>
-            <td data-order="<?php if ($row['invoicedEmpl'] == '1') {
-                echo format($row['invoicedEmplDate'])->date();
-                            }?>"><?php if ($row['invoicedEmpl'] == '1') {
+            <table cellpadding="0" cellspacing="0" border="0" class="table table-bordered display" id="allTimesheetsTable">
+                <colgroup>
+                      <col class="con0" width="100px"/>
+                      <col class="con1" />
+                      <col class="con0"/>
+                      <col class="con1" />
+                      <col class="con0"/>
+                      <col class="con1" />
+                      <col class="con0"/>
+                      <col class="con1" />
+                      <col class="con0"/>
+                      <col class="con1" />
+                      <col class="con0"/>
+                      <col class="con1"/>
+                      <col class="con0"/>
+                      <col class="con1"/>
+                      <col class="con0"/>
+                      <col class="con1"/>
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th><?php echo $tpl->__('label.id'); ?></th>
+                        <th><?php echo $tpl->__('label.date'); ?></th>
+                        <th><?php echo $tpl->__('label.hours'); ?></th>
+                        <th><?php echo $tpl->__('label.plan_hours'); ?></th>
+                        <th><?php echo $tpl->__('label.difference'); ?></th>
+                        <th><?php echo $tpl->__('label.ticket'); ?></th>
+                        <th><?php echo $tpl->__('label.project'); ?></th>
+                        <th><?php echo $tpl->__('label.client'); ?></th>
+                        <th><?php echo $tpl->__('label.employee'); ?></th>
+                        <th><?php echo $tpl->__("label.type")?></th>
+                        <th><?php echo $tpl->__("label.milestone") ?></th>
+                        <th><?php echo $tpl->__("label.tags") ?></th>
+                        <th><?php echo $tpl->__('label.description'); ?></th>
+                        <th><?php echo $tpl->__('label.invoiced'); ?></th>
+                        <th><?php echo $tpl->__('label.invoiced_comp'); ?></th>
+                        <th><?php echo $tpl->__('label.paid'); ?></th>
+                    </tr>
+
+                </thead>
+                <tbody>
+
+                <?php
+
+                $sum = 0;
+                $billableSum = 0;
+
+                foreach ($tpl->get('allTimesheets') as $row) {
+                    $sum = $sum + $row['hours'];?>
+                    <tr>
+                        <td data-order="<?=$tpl->e($row['id']); ?>">
+                                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                                <a href="<?=BASE_URL?>/timesheets/editTime/<?=$row['id']?>" class="editTimeModal">#<?=$row['id'] . " - " . $tpl->__('label.edit'); ?> </a>
+                                <?php } else { ?>
+                                #<?=$row['id']?>
+                                <?php } ?>
+                        </td>
+                        <td data-order="<?=$tpl->escape($row['workDate']); ?>">
+                                <?php echo format($row['workDate'])->date(); ?>
+                        </td>
+                        <td data-order="<?php $tpl->e($row['hours']); ?>"><?php $tpl->e($row['hours']); ?></td>
+                        <td data-order="<?php $tpl->e($row['planHours']); ?>"><?php $tpl->e($row['planHours']); ?></td>
+                            <?php $diff = $row['planHours'] - $row['hours']; ?>
+                        <td data-order="<?=$diff; ?>"><?php echo $diff; ?></td>
+                        <td data-order="<?=$tpl->e($row['headline']); ?>"><a href="#/tickets/showTicket/<?php echo $row['ticketId']; ?>"><?php $tpl->e($row['headline']); ?></a></td>
+
+                        <td data-order="<?=$tpl->e($row['name']); ?>"><a href="<?=BASE_URL ?>/projects/showProject/<?php echo $row['projectId']; ?>"><?php $tpl->e($row['name']); ?></a></td>
+                        <td data-order="<?=$tpl->e($row['clientName']); ?>"><a href="<?=BASE_URL ?>/clients/showClient/<?php echo $row['clientId']; ?>"><?php $tpl->e($row['clientName']); ?></a></td>
+
+                        <td><?php printf($tpl->__("text.full_name"), $tpl->escape($row["firstname"]), $tpl->escape($row['lastname'])); ?></td>
+                        <td><?php echo $tpl->__($tpl->get('kind')[$row['kind']]); ?></td>
+
+                        <td><?php echo $tpl->escape($row["milestone"]); ?></td>
+                        <td><?php echo $tpl->escape($row["tags"]); ?></td>
+
+                        <td><?php $tpl->e($row['description']); ?></td>
+                        <td data-order="<?php if ($row['invoicedEmpl'] == '1') {
+                            echo format($row['invoicedEmplDate'])->date();
+                                        }?>"><?php if ($row['invoicedEmpl'] == '1') {
     ?> <?php echo format($row['invoicedEmplDate'])->date(); ?>
+                                        <?php } else { ?>
+                                            <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                                <input type="checkbox" name="invoicedEmpl[]" class="invoicedEmpl"
+                            value="<?php echo $row['id']; ?>" /> <?php
+                                            } ?><?php
+                                        } ?></td>
+                        <td data-order="<?php if ($row['invoicedComp'] == '1') {
+                            echo format($row['invoicedCompDate'])->date();
+                                        }?>">
+
+                            <?php if ($row['invoicedComp'] == '1') {?>
+                                <?php echo format($row['invoicedCompDate'])->date(); ?>
                             <?php } else { ?>
                                 <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                    <input type="checkbox" name="invoicedEmpl[]" class="invoicedEmpl"
-                value="<?php echo $row['id']; ?>" /> <?php
-                                } ?><?php
-                            } ?></td>
-            <td data-order="<?php if ($row['invoicedComp'] == '1') {
-                echo format($row['invoicedCompDate'])->date();
-                            }?>">
+                                <input type="checkbox" name="invoicedComp[]" class="invoicedComp" value="<?php echo $row['id']; ?>" />
+                                <?php } ?>
+                            <?php } ?>
+                        </td>
+                        <td data-order="<?php if ($row['paid'] == '1') {
+                            echo format($row['paidDate'])->date();
+                                        }?>">
 
-                <?php if ($row['invoicedComp'] == '1') {?>
-                    <?php echo format($row['invoicedCompDate'])->date(); ?>
-                <?php } else { ?>
-                    <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                    <input type="checkbox" name="invoicedComp[]" class="invoicedComp" value="<?php echo $row['id']; ?>" />
-                    <?php } ?>
+                            <?php if ($row['paid'] == '1') {?>
+                                <?php echo format($row['paidDate'])->date(); ?>
+                            <?php } else { ?>
+                                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                                    <input type="checkbox" name="paid[]" class="paid" value="<?php echo $row['id']; ?>" />
+                                <?php } ?>
+                            <?php } ?>
+                        </td>
+                    </tr>
                 <?php } ?>
-            </td>
-            <td data-order="<?php if ($row['paid'] == '1') {
-                echo format($row['paidDate'])->date();
-                            }?>">
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="2"><strong><?php echo $tpl->__("label.total_hours")?></strong></td>
+                        <td colspan="10"><strong><?php echo $sum; ?></strong></td>
 
-                <?php if ($row['paid'] == '1') {?>
-                    <?php echo format($row['paidDate'])->date(); ?>
-                <?php } else { ?>
-                    <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                        <input type="checkbox" name="paid[]" class="paid" value="<?php echo $row['id']; ?>" />
-                    <?php } ?>
-                <?php } ?>
-            </td>
-        </tr>
-    <?php } ?>
-    </tbody>
-    <tfoot>
-        <tr>
-            <td colspan="2"><strong><?php echo $tpl->__("label.total_hours")?></strong></td>
-            <td colspan="10"><strong><?php echo $sum; ?></strong></td>
-
-            <td>
-                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                <input type="submit" class="button" value="<?php echo $tpl->__('buttons.save'); ?>" name="saveInvoice" />
-                <?php } ?>
-            </td>
-            <td>
-                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                <input type="checkbox" id="checkAllEmpl" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?></td>
-                <?php } ?>
-            <td>
-                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                <input type="checkbox"  id="checkAllComp" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?>
-                <?php } ?>
-            </td>
-            <td>
-                <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
-                    <input type="checkbox"  id="checkAllPaid" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?>
-                <?php } ?>
-            </td>
-        </tr>
-    </tfoot>
-</table>
-
-</form>
-
-
-            </div>
-        </div>
+                        <td>
+                            <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                            <input type="submit" class="button" value="<?php echo $tpl->__('buttons.save'); ?>" name="saveInvoice" />
+                            <?php } ?>
+                        </td>
+                        <td>
+                            <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                            <input type="checkbox" id="checkAllEmpl" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?></td>
+                            <?php } ?>
+                        <td>
+                            <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                            <input type="checkbox"  id="checkAllComp" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?>
+                            <?php } ?>
+                        </td>
+                        <td>
+                            <?php if ($login::userIsAtLeast($roles::$manager)) { ?>
+                                <input type="checkbox"  id="checkAllPaid" style="vertical-align: baseline;"/> <?php echo $tpl->__('label.select_all')?>
+                            <?php } ?>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </form>
+    </div>
+</div>

--- a/app/Domain/Timesheets/Templates/showMy.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMy.tpl.php
@@ -184,14 +184,15 @@ jQuery(document).ready(function(){
  });
 </script>
 
+<!-- page header -->
 <div class="pageheader">
-
     <div class="pageicon"><span class="fa-regular fa-clock"></span></div>
     <div class="pagetitle">
         <h5><?php echo $tpl->__('headline.overview'); ?></h5>
         <h1><?php echo $tpl->__('headline.my_timesheets'); ?></h1>
     </div>
-</div><!--pageheader-->
+</div>
+<!-- page header -->
 
 <div class="maincontent">
     <div class="maincontentinner">
@@ -199,14 +200,14 @@ jQuery(document).ready(function(){
         echo $tpl->displayNotification();
         ?>
 
-
-
-        <form action="<?=BASE_URL ?>/timesheets/showMy" method="post" id="timesheetList">
+        <form action="<?php echo BASE_URL ?>/timesheets/showMy" method="post" id="timesheetList">
             <div class="btn-group viewDropDown pull-right">
-                <button class="btn dropdown-toggle" data-toggle="dropdown"><?=$tpl->__("links.week_view") ?> <?=$tpl->__("links.view") ?></button>
+                <button class="btn dropdown-toggle" data-toggle="dropdown">
+                    <?php echo $tpl->__("links.week_view") ?> <?=$tpl->__("links.view") ?>
+                </button>
                 <ul class="dropdown-menu">
-                    <li><a href="<?=BASE_URL?>/timesheets/showMy" class="active"><?=$tpl->__("links.week_view") ?></a></li>
-                    <li><a href="<?=BASE_URL?>/timesheets/showMyList" ><?=$tpl->__("links.list_view") ?></a></li>
+                    <li><a href="<?php echo BASE_URL ?>/timesheets/showMy" class="active"><?php echo $tpl->__("links.week_view") ?></a></li>
+                    <li><a href="<?php echo BASE_URL ?>/timesheets/showMyList" ><?php echo $tpl->__("links.list_view") ?></a></li>
                 </ul>
             </div>
             <div class="pull-left" style="padding-left:5px; margin-top:-3px;">
@@ -214,16 +215,11 @@ jQuery(document).ready(function(){
                 <div class="padding-top-sm">
                     <span><?php echo $tpl->__('label.week_from')?></span>
                     <a href="javascript:void(0)" style="font-size:16px;" id="prevWeek"><i class="fa fa-chevron-left"></i></a>
-                    <input type="text" class="week-picker" name="startDate" autocomplete="off" id="startDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?=format($tpl->get("dateFrom"))->date() ?>" style="margin-top:5px;"/> <?php echo $tpl->__('label.until'); ?>
-                    <input type="text" class="week-picker" name="endDate" autocomplete="off" id="endDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?=format($tpl->get("dateFrom")->add(new DateInterval('P6D')))->date() ?>" style="margin-top:6px;"/>
+                    <input type="text" class="week-picker" name="startDate" autocomplete="off" id="startDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?php echo format($tpl->get("dateFrom"), 'short') ?>" style="margin-top:5px;"/>
+                    <?php echo $tpl->__('label.until'); ?>
+                    <input type="text" class="week-picker" name="endDate" autocomplete="off" id="endDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?php echo format($tpl->get("dateFrom")->copy()->add(6, 'days'), 'short') ?>" style="margin-top:6px;"/>
                     <a href="javascript:void(0)" style="font-size:16px;" id="nextWeek"><i class="fa fa-chevron-right"></i></a>
                     <input type="hidden" name="search" value="1" />
-
-                    <?php
-                        //Return date to beginning
-                        $tpl->get("dateFrom")->sub(new DateInterval('P6D'));
-                    ?>
-
                 </div>
 
             </div>
@@ -244,187 +240,90 @@ jQuery(document).ready(function(){
                 </colgroup>
                 <thead>
                 <?php
-
-                $dateFromHeader = clone $tpl->get("dateFrom");
-                $currentDate = format($dateFromHeader)->date();
-                $days = explode(',', $tpl->__('language.dayNamesShort'));
-                $todayObject = new \DateTime('now', new \DateTimeZone("UTC"));
-                $today = format($todayObject)->date();
-
+                    $dateFromHeader = $tpl->get("dateFrom")->copy();
+                    $days = explode(',', $tpl->__('language.dayNamesShort'));
+                    // Make the first day of week monday, by shifting sunday to the back of the array.
+                    $days[] = array_shift($days);
                 ?>
                 <tr>
                     <th><?php echo $tpl->__('label.client_product')?></th>
                     <th><?php echo $tpl->__('subtitles.todo')?></th>
                     <th><?php echo $tpl->__('label.type')?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[1]?><br /><?php echo $currentDate;
-                    $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[2]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[3]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[4]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[5]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[6]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $days[0]?><br /><?php echo $currentDate;
-                        $currentDate = format($dateFromHeader->add(new DateInterval('P1D')))->date(); ?></th>
-                    <th class="<?php if ($today == $currentDate) {
-                        echo "active";
-                               } ?>"><?php echo $tpl->__('label.total')?></th>
+                    <?php foreach ($days as $day) { ?>
+                        <th class="<?php if ($dateFromHeader->isToday()) {
+                            echo "active";
+                                   } ?>"><?php echo $day ?><br />
+                            <?php
+                                echo format($dateFromHeader, 'short');
+                                $dateFromHeader->add('1', 'day');
+                            ?>
+                        </th>
+                    <?php } ?>
+                    <th><?php echo $tpl->__('label.total')?></th>
                 </tr>
                 </thead>
                 <tbody>
                     <?php
-                        $sumMon = 0;
-                        $sumTu = 0;
-                        $sumWe = 0;
-                        $sumTh = 0;
-                        $sumFr = 0;
-                        $sumSa = 0;
-                        $sumSu = 0;
+                        // @todo: move all this calculations into the service the timesheets class.
+                        $rowKeys = [
+                           "hoursMonday",
+                           "hoursTuesday",
+                           "hoursWednesday",
+                           "hoursThursday",
+                           "hoursFriday",
+                           "hoursSaturday",
+                           "hoursSunday",
+                        ];
+                        $totalHours = [];
+                        foreach ($rowKeys as $key) {
+                            $totalHours[$key] = 0;
+                        }
 
-                    foreach ($tpl->get('allTimesheets') as $timeRow) {
+                        foreach ($tpl->get('allTimesheets') as $timeRow) {
+                            // Calculate totals.
+                            $rowSum = 0;
+                            foreach ($rowKeys as $key) {
+                                $totalHours[$key] += $timeRow[$key];
+                                $rowSum += $timeRow[$key];
+                            }
 
-                        $sumMon = $timeRow["hoursMonday"] + $sumMon;
-                        $sumTu = $timeRow["hoursTuesday"] + $sumTu;
-                        $sumWe = $timeRow["hoursWednesday"] + $sumWe;
-                        $sumTh = $timeRow["hoursThursday"] + $sumTh;
-                        $sumFr = $timeRow["hoursFriday"] + $sumFr;
-                        $sumSa = $timeRow["hoursSaturday"] + $sumSa;
-                        $sumSu = $timeRow["hoursSunday"] + $sumSu;
+                            $timesheetId = "new";
 
-                        $dateFrom = clone $tpl->get("dateFrom");
+                            $workDatesArray = explode(",", $timeRow["workDates"]);
+                            $workDatesArray = array_map(function ($item) {
+                                return format($item)->date();
+                            }, $workDatesArray);
 
-                        $timesheetId = "new";
-
-                        $workDatesArray = explode(",", $timeRow["workDates"]);
-                        $workDatesArray = array_map(function($item){ return format($item)->date(); }, $workDatesArray);
-
-                        $rowSum = $timeRow["hoursMonday"] + $timeRow["hoursTuesday"] + $timeRow["hoursWednesday"] + $timeRow["hoursThursday"] + $timeRow["hoursFriday"] + $timeRow["hoursSaturday"] + $timeRow["hoursSunday"];
-
-                        ?>
+                            /** @var \Carbon\Carbon $currentDate */
+                            $currentDate = $tpl->get("dateFrom")->copy();
+                            ?>
 
                         <tr class="gradeA timesheetRow">
                             <td width="14%"><?php $tpl->e($timeRow["clientName"]); ?> // <?php $tpl->e($timeRow["name"]); ?></td>
                             <td width="14%"><?php $tpl->e($timeRow["headline"]); ?></td>
                             <td width="10%"><?php echo $tpl->__($tpl->get('kind')[$timeRow['kind']]); ?></td>
-                            <?php $currentDate = format($dateFrom)->date(); ?>
-                            <td width="7%" class="rowMo <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>" <?php if ($today == $currentDate) {
-                                                        echo"active";
-                                                        } ?>><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursMonday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowTu <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursTuesday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowWe <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursWednesday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowTh <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursThursday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowFr <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursFriday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowSa <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursSaturday"]; ?>" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowSu <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="<?php echo $timeRow["workDates"]; ?> hourCell" name="<?php echo $timeRow["ticketId"];?>|<?php if (
-                                                            in_array(
-                                                                $currentDate,
-                                                                $workDatesArray
-                                                            )
-                                                        ) {
-                                                            echo "existing";
-                                                        } else {
-                                                            echo "new";
-                                                        }?>|<?php echo $currentDate; ?>|<?php echo $timeRow["kind"];?>" value="<?php echo $timeRow["hoursSunday"]; ?>" /></td>
-                            <td width="7%" class="rowSum <?php if ($today == $currentDate) {
-                                echo"active";
-                                                         } ?>"><strong><?php echo $rowSum; ?></strong></td>
-                        </tr>
 
-                    <?php } ?>
+                            <?php foreach ($rowKeys as $key) { ?>
+                                <td width="7%" class="rowMo <?php if ($currentDate->isToday()) {
+                                    echo"active";
+                                                            } ?>">
+                                    <input type="text"
+                                           class="hourCell"
+                                           name="<?php echo $timeRow["ticketId"]; ?>|<?php echo $timeRow[$key] > 0 ? "existing" : "new"; ?>|<?php echo $timeRow['workDate'] ?>|<?php echo $timeRow["kind"];?>"
+                                           value="<?php echo $timeRow[$key]; ?>"
+                                    />
+                                </td>
+                                <?php $currentDate->add('1', 'day');  ?>
+                            <?php } ?>
+
+                            <td width="7%" class="rowSum?>"><strong><?php echo $rowSum; ?></strong></td>
+                        </tr>
+                        <?php } ?>
+
+                    <!-- Row to add new time registration -->
                     <?php
-                        $dateFrom = clone $tpl->get("dateFrom");
+                        /** @var \Carbon\Carbon $currentDate */
+                        $currentDate = $tpl->get("dateFrom")->copy();
                     ?>
                         <tr class="gradeA timesheetRow">
                             <td width="14%">
@@ -480,59 +379,32 @@ jQuery(document).ready(function(){
                                         <?php }?>
                                     </select>
                             </td>
-                            <?php $currentDate = format($dateFrom)->date(); ?>
-                            <td width="7%" class="rowMo <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowTu <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowWe <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowTh <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowFr <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowSa <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <?php $currentDate = format($dateFrom->add(new DateInterval('P1D')))->date(); ?>
-                            <td width="7%" class="rowSu <?php if ($today == $currentDate) {
-                                echo"active";
-                                                        } ?>"><input type="text" class="hourCell" name="new|new|<?php  echo $currentDate ?>|GENERAL_BILLABLE" value="0" /></td>
-                            <td width="7%" class="rowSum "><strong>0</strong></td>
+
+                            <?php foreach ($days as $day) { ?>
+                                <td width="7%" class="rowMo <?php if ($currentDate->isToday()) {
+                                    echo "active";
+                                                            } ?>">
+                                    <input type="text" class="hourCell" name="new|new|<?php echo $currentDate->startOfDay() ?>|GENERAL_BILLABLE" value="0" />
+                                </td>
+                                <?php $currentDate->add('1', 'day'); ?>
+                            <?php } ?>
                         </tr>
                 </tbody>
 
                 <tfoot>
                     <tr style="font-weight:bold;">
                         <td colspan="3"><?php echo $tpl->__('label.total')?></td>
-                        <td id="sumMo"><?php echo $sumMon; ?></td>
-                        <td id="sumTu"><?php echo $sumTu; ?></td>
-                        <td id="sumWe"><?php echo $sumWe; ?></td>
-                        <td id="sumTh"><?php echo $sumTh; ?></td>
-                        <td id="sumFr"><?php echo $sumFr; ?></td>
-                        <td id="sumSa"><?php echo $sumSa; ?></td>
-                        <td id="sumSu"><?php echo $sumSu; ?></td>
-                        <td id="finalSum"><?php echo ($sumMon + $sumTu + $sumWe + $sumTh + $sumFr + $sumSa + $sumSu); ?></td>
+                        <?php foreach ($rowKeys as $key) { ?>
+                            <td id="<?php echo $key ?>"><?php echo $totalHours[$key]; ?></td>
+                        <?php } ?>
+                        <td id="finalSum"><?php echo array_sum($totalHours); ?></td>
                     </tr>
                 </tfoot>
             </table>
             <div class="right">
                 <input type="submit" name="saveTimeSheet" value="Save"/>
             </div>
-
             <div class="clearall"></div>
-
         </form>
-
     </div>
 </div>

--- a/app/Domain/Timesheets/Templates/showMy.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMy.tpl.php
@@ -288,6 +288,13 @@ jQuery(document).ready(function(){
 
                             $timesheetId = "new";
 
+
+                            $workDatesArray = [];
+                            foreach (explode(",", $timeRow["workDates"]) as $workDate) {
+                                $date = new \Carbon\Carbon($workDate, 'UTC');
+                                $workDatesArray[format($date, 'short')] = $date;
+                             }
+
                             /** @var \Carbon\Carbon $currentDate */
                             $currentDate = $tpl->get("dateFrom")->copy();
                             ?>
@@ -303,7 +310,7 @@ jQuery(document).ready(function(){
                                                             } ?>">
                                     <input type="text"
                                            class="hourCell"
-                                           name="<?php echo $timeRow["ticketId"]; ?>|<?php echo $timeRow[$key] > 0 ? "existing" : "new"; ?>|<?php echo $timeRow[$key] > 0 ? $timeRow['workDate'] : format($currentDate, 'short') ?>|<?php echo $timeRow["kind"];?>"
+                                           name="<?php echo $timeRow["ticketId"]; ?>|<?php echo $timeRow[$key] > 0 ? "existing" : "new"; ?>|<?php echo $timeRow[$key] > 0 ? $workDatesArray[format($currentDate, 'short')] : format($currentDate, 'short') ?>|<?php echo $timeRow["kind"];?>"
                                            value="<?php echo $timeRow[$key]; ?>"
                                     />
                                 </td>

--- a/app/Domain/Timesheets/Templates/showMy.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMy.tpl.php
@@ -289,11 +289,6 @@ jQuery(document).ready(function(){
 
                             $timesheetId = "new";
 
-                            $workDatesArray = explode(",", $timeRow["workDates"]);
-                            $workDatesArray = array_map(function ($item) {
-                                return format($item)->date();
-                            }, $workDatesArray);
-
                             /** @var \Carbon\Carbon $currentDate */
                             $currentDate = $tpl->get("dateFrom")->copy();
                             ?>
@@ -309,7 +304,7 @@ jQuery(document).ready(function(){
                                                             } ?>">
                                     <input type="text"
                                            class="hourCell"
-                                           name="<?php echo $timeRow["ticketId"]; ?>|<?php echo $timeRow[$key] > 0 ? "existing" : "new"; ?>|<?php echo $timeRow['workDate'] ?>|<?php echo $timeRow["kind"];?>"
+                                           name="<?php echo $timeRow["ticketId"]; ?>|<?php echo $timeRow[$key] > 0 ? "existing" : "new"; ?>|<?php echo $timeRow[$key] > 0 ? $timeRow['workDate'] : format($currentDate, 'short') ?>|<?php echo $timeRow["kind"];?>"
                                            value="<?php echo $timeRow[$key]; ?>"
                                     />
                                 </td>
@@ -384,7 +379,7 @@ jQuery(document).ready(function(){
                                 <td width="7%" class="rowMo <?php if ($currentDate->isToday()) {
                                     echo "active";
                                                             } ?>">
-                                    <input type="text" class="hourCell" name="new|new|<?php echo $currentDate->startOfDay() ?>|GENERAL_BILLABLE" value="0" />
+                                    <input type="text" class="hourCell" name="new|new|<?php echo format($currentDate, 'short') ?>|GENERAL_BILLABLE" value="0" />
                                 </td>
                                 <?php $currentDate->add('1', 'day'); ?>
                             <?php } ?>

--- a/app/Domain/Timesheets/Templates/showMy.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMy.tpl.php
@@ -133,8 +133,7 @@ jQuery(document).ready(function(){
         var dateFormat = inst.settings.dateFormat || jQuery.datepicker._defaults.dateFormat;
         jQuery('#startDate').val(jQuery.datepicker.formatDate(dateFormat, startDate, inst.settings));
         jQuery('#endDate').val(jQuery.datepicker.formatDate(dateFormat, endDate, inst.settings));
-       jQuery("#timesheetList").submit();
-
+        jQuery("#timesheetList").submit();
     });
 
     jQuery(".timesheetTable input").change(function(){
@@ -156,25 +155,25 @@ jQuery(document).ready(function(){
 
                 var currentClass = jQuery(this).parent().attr('class');
 
-                if(currentClass.indexOf("rowMo") > -1){ colSumMo = colSumMo + currentValue; }
-                if(currentClass.indexOf("rowTu") > -1){ colSumTu = colSumTu + currentValue; }
-                if(currentClass.indexOf("rowWe") > -1){ colSumWe = colSumWe + currentValue;  }
-                if(currentClass.indexOf("rowTh") > -1){ colSumTh = colSumTh + currentValue; }
-                if(currentClass.indexOf("rowFr") > -1){ colSumFr = colSumFr + currentValue;  }
-                if(currentClass.indexOf("rowSa") > -1){ colSumSa = colSumSa + currentValue;  }
-                if(currentClass.indexOf("rowSu") > -1){ colSumSu = colSumSu + currentValue;  }
+                if(currentClass.indexOf("rowMon") > -1){ colSumMo = colSumMo + currentValue; }
+                if(currentClass.indexOf("rowTue") > -1){ colSumTu = colSumTu + currentValue; }
+                if(currentClass.indexOf("rowWed") > -1){ colSumWe = colSumWe + currentValue;  }
+                if(currentClass.indexOf("rowThu") > -1){ colSumTh = colSumTh + currentValue; }
+                if(currentClass.indexOf("rowFri") > -1){ colSumFr = colSumFr + currentValue;  }
+                if(currentClass.indexOf("rowSat") > -1){ colSumSa = colSumSa + currentValue;  }
+                if(currentClass.indexOf("rowSun") > -1){ colSumSu = colSumSu + currentValue;  }
             });
 
             jQuery(this).find(".rowSum strong").text(rowSum);
         });
 
-        jQuery("#sumMo").text(colSumMo.toFixed(2));
-        jQuery("#sumTu").text(colSumTu.toFixed(2));
-        jQuery("#sumWe").text(colSumWe.toFixed(2));
-        jQuery("#sumTh").text(colSumTh.toFixed(2));
-        jQuery("#sumFr").text(colSumFr.toFixed(2));
-        jQuery("#sumSa").text(colSumSa.toFixed(2));
-        jQuery("#sumSu").text(colSumSu.toFixed(2));
+        jQuery("#sumMon").text(colSumMo.toFixed(2));
+        jQuery("#sumTue").text(colSumTu.toFixed(2));
+        jQuery("#sumWed").text(colSumWe.toFixed(2));
+        jQuery("#sumThu").text(colSumTh.toFixed(2));
+        jQuery("#sumFri").text(colSumFr.toFixed(2));
+        jQuery("#sumSat").text(colSumSa.toFixed(2));
+        jQuery("#sumSun").text(colSumSu.toFixed(2));
 
         var finalSum = colSumMo + colSumTu + colSumWe + colSumTh + colSumFr + colSumSa + colSumSu;
         var roundedSum = Math.round((finalSum)*100)/100;
@@ -298,9 +297,9 @@ jQuery(document).ready(function(){
                             <td width="14%"><?php $tpl->e($timeRow["headline"]); ?></td>
                             <td width="10%"><?php echo $tpl->__($tpl->get('kind')[$timeRow['kind']]); ?></td>
 
-                            <?php foreach ($rowKeys as $key) { ?>
-                                <td width="7%" class="rowMo <?php if ($currentDate->isToday()) {
-                                    echo"active";
+                            <?php foreach ($rowKeys as $i => $key) { ?>
+                                <td width="7%" class="row<?php echo $days[$i]; ?><?php if ($currentDate->isToday()) {
+                                    echo " active";
                                                             } ?>">
                                     <input type="text"
                                            class="hourCell"
@@ -311,7 +310,7 @@ jQuery(document).ready(function(){
                                 <?php $currentDate->add('1', 'day');  ?>
                             <?php } ?>
 
-                            <td width="7%" class="rowSum?>"><strong><?php echo $rowSum; ?></strong></td>
+                            <td width="7%" class="rowSum"><strong><?php echo $rowSum; ?></strong></td>
                         </tr>
                         <?php } ?>
 
@@ -322,7 +321,7 @@ jQuery(document).ready(function(){
                     ?>
                         <tr class="gradeA timesheetRow">
                             <td width="14%">
-                                <div class="form-group">
+                                <div class="form-group" id="projectSelect">
                                     <select data-placeholder="<?php echo $tpl->__('input.placeholders.choose_project')?>" style="" class="project-select" >
                                         <option value=""></option>
                                         <?php foreach ($tpl->get('allProjects') as $projectRow) { ?>
@@ -376,8 +375,8 @@ jQuery(document).ready(function(){
                             </td>
 
                             <?php foreach ($days as $day) { ?>
-                                <td width="7%" class="rowMo <?php if ($currentDate->isToday()) {
-                                    echo "active";
+                                <td width="7%" class="row<?php echo $day?><?php if ($currentDate->isToday()) {
+                                    echo " active";
                                                             } ?>">
                                     <input type="text" class="hourCell" name="new|new|<?php echo format($currentDate, 'short') ?>|GENERAL_BILLABLE" value="0" />
                                 </td>

--- a/app/Domain/Timesheets/Templates/showMy.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMy.tpl.php
@@ -214,7 +214,7 @@ jQuery(document).ready(function(){
                 <div class="padding-top-sm">
                     <span><?php echo $tpl->__('label.week_from')?></span>
                     <a href="javascript:void(0)" style="font-size:16px;" id="prevWeek"><i class="fa fa-chevron-left"></i></a>
-                    <input type="text" class="week-picker" name="startDate" autocomplete="off" id="startDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?php echo format($tpl->get("dateFrom"), 'short') ?>" style="margin-top:5px;"/>
+                    <input type="text" class="week-picker" name="startDate" autocomplete="off" id="startDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?php echo format($tpl->get("dateFrom")->copy(), 'short') ?>" style="margin-top:5px;"/>
                     <?php echo $tpl->__('label.until'); ?>
                     <input type="text" class="week-picker" name="endDate" autocomplete="off" id="endDate" placeholder="<?php echo $tpl->__('language.dateformat')?>" value="<?php echo format($tpl->get("dateFrom")->copy()->add(6, 'days'), 'short') ?>" style="margin-top:6px;"/>
                     <a href="javascript:void(0)" style="font-size:16px;" id="nextWeek"><i class="fa fa-chevron-right"></i></a>

--- a/app/Domain/Timesheets/Templates/showMyList.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMyList.tpl.php
@@ -7,38 +7,44 @@ foreach ($__data as $var => $val) {
 }
 ?>
 
-
+<!-- page header -->
 <div class="pageheader">
-
-
     <div class="pageicon"><span class="fa-regular fa-clock"></span></div>
     <div class="pagetitle">
         <h5><?php echo $tpl->__('headline.overview'); ?></h5>
         <h1><?php echo $tpl->__("headline.my_timesheets") ?></h1>
     </div>
-</div><!--pageheader-->
+</div>
+<!-- page header -->
+
 
 <div class="maincontent">
     <div class="maincontentinner">
-
         <?php
         echo $tpl->displayNotification();
         ?>
 
-
-        <form action="<?=BASE_URL ?>/timesheets/showMyList" method="post" id="form" name="form">
-
+        <form action="<?php echo BASE_URL ?>/timesheets/showMyList" method="post" id="form" name="form">
             <div class="filterWrapper tw-relative">
-                <a onclick="jQuery('.filterBar').toggle();" class="btn btn-default pull-left"><?=$tpl->__("links.filter") ?> (1)</a>
+                <a onclick="jQuery('.filterBar').toggle();" class="btn btn-default pull-left"><?php echo $tpl->__("links.filter") ?> (1)</a>
                 <div class="filterBar" style="display:none; top:30px;">
 
                     <div class="filterBoxLeft">
                         <label for="dateFrom"><?php echo $tpl->__('label.date_from'); ?> <?php echo $tpl->__('label.date_to'); ?></label>
-                        <input type="text" id="dateFrom" class="dateFrom"  name="dateFrom"
-                               value="<?php echo format($tpl->get('dateFrom'))->date(); ?>" style="margin-bottom:10px; width:90px; float:left; margin-right:10px"/>
-                        <input type="text" id="dateTo" class="dateTo" name="dateTo"
-                               value="<?php echo format($tpl->get('dateTo'))->date(); ?>" style="margin-bottom:10px; width:90px" />
+                        <input type="text"
+                               id="dateFrom"
+                               class="dateFrom"
+                               name="dateFrom"
+                               value="<?php echo format($tpl->get('dateFrom'), 'short'); ?>"
+                               style="margin-bottom:10px; width:90px; float:left; margin-right:10px"/>
+                        <input type="text"
+                               id="dateTo"
+                               class="dateTo"
+                               name="dateTo"
+                               value="<?php echo format($tpl->get('dateTo'), 'short'); ?>"
+                               style="margin-bottom:10px; width:90px" />
                     </div>
+
                     <div class="filterBoxLeft">
                         <label for="kind"><?php echo $tpl->__("label.type")?></label>
                         <select id="kind" name="kind" onchange="submit();">
@@ -77,8 +83,6 @@ foreach ($__data as $var => $val) {
 
             <div class="clearfix"></div>
 
-
-
             <table cellpadding="0" cellspacing="0" border="0" class="table table-bordered display" id="allTimesheetsTable">
                 <colgroup>
                       <col class="con0" width="100px"/>
@@ -92,7 +96,7 @@ foreach ($__data as $var => $val) {
                       <col class="con0"/>
                       <col class="con1" />
                       <col class="con0"/>
-                        <col class="con1"/>
+                      <col class="con1"/>
                 </colgroup>
                 <thead>
                     <tr>
@@ -122,43 +126,64 @@ foreach ($__data as $var => $val) {
                 foreach ($tpl->get('allTimesheets') as $row) {
                     $sum = $sum + $row['hours'];?>
                     <tr>
-                        <td data-order="<?=$tpl->e($row['id']); ?>"> <a href="<?=BASE_URL?>/timesheets/editTime/<?=$row['id']?>" class="editTimeModal">#<?=$row['id'] . " - " . $tpl->__('label.edit'); ?> </a></td>
+                        <td data-order="<?php echo $tpl->e($row['id']); ?>">
+                            <a href="<?=BASE_URL?>/timesheets/editTime/<?php echo $row['id']?>" class="editTimeModal">#<?php echo $row['id'] . " - " . $tpl->__('label.edit'); ?> </a></td>
                         <td data-order="<?php echo format($row['workDate'])->date(); ?>">
-                                            <?php echo format($row['workDate'])->date(); ?>
+                            <?php echo format($row['workDate'])->date(); ?>
                         </td>
-                        <td data-order="<?php $tpl->e($row['hours']); ?>"><?php $tpl->e($row['hours'] ?: 0); ?></td>
-                        <td data-order="<?php $tpl->e($row['planHours']); ?>"><?php $tpl->e($row['planHours'] ?: 0); ?></td>
-                                        <?php $diff = ($row['planHours'] ?: 0) - ($row['hours'] ?: 0); ?>
-                        <td data-order="<?=$diff; ?>"><?php echo $diff; ?></td>
-                        <td data-order="<?=$tpl->e($row['headline']); ?>"><a href="#/tickets/showTicket/<?php echo $row['ticketId']; ?>"><?php $tpl->e($row['headline']); ?></a></td>
+                        <td data-order="<?php $tpl->e($row['hours']); ?>">
+                            <?php $tpl->e($row['hours'] ?: 0); ?>
+                        </td>
+                        <td data-order="<?php $tpl->e($row['planHours']); ?>">
+                            <?php $tpl->e($row['planHours'] ?: 0); ?>
+                        </td>
+                        <td data-order="<?php echo $diff; ?>">
+                            <?php $diff = ($row['planHours'] ?: 0) - ($row['hours'] ?: 0); ?>
+                            <?php echo $diff; ?>
+                        </td>
+                        <td data-order="<?php echo $tpl->e($row['headline']); ?>">
+                            <a href="#/tickets/showTicket/<?php echo $row['ticketId']; ?>"><?php $tpl->e($row['headline']); ?></a>
+                        </td>
 
-                        <td data-order="<?=$tpl->e($row['name']); ?>"><a href="<?=BASE_URL ?>/projects/showProject/<?php echo $row['projectId']; ?>"><?php $tpl->e($row['name']); ?></a></td>
-                        <td><?php sprintf($tpl->__('text.full_name'), $tpl->escape($row['firstname']), $tpl->escape($row['lastname'])); ?></td>
-                        <td><?php echo $tpl->__($tpl->get('kind')[$row['kind']]); ?></td>
-                        <td><?php $tpl->e($row['description']); ?></td>
+                        <td data-order="<?php echo $tpl->e($row['name']); ?>">
+                            <a href="<?php echo BASE_URL ?>/projects/showProject/<?php echo $row['projectId']; ?>"><?php $tpl->e($row['name']); ?></a>
+                        </td>
+                        <td>
+                            <?php sprintf($tpl->__('text.full_name'), $tpl->escape($row['firstname']), $tpl->escape($row['lastname'])); ?>
+                        </td>
+                        <td>
+                            <?php echo $tpl->__($tpl->get('kind')[$row['kind']]); ?>
+                        </td>
+                        <td>
+                            <?php $tpl->e($row['description']); ?>
+                        </td>
                         <td data-order="<?php if ($row['invoicedEmpl'] == '1') {
                             echo format($row['invoicedEmplDate'])->date();
-                                        }?>"><?php if ($row['invoicedEmpl'] == '1') {
-    ?> <?php echo format($row['invoicedEmplDate'])->date(); ?>
-                                        <?php } else {
-                                            echo $tpl->__("label.pending");
-                                        } ?></td>
+                                        }?>">
+                            <?php if ($row['invoicedEmpl'] == '1') {
+                                echo format($row['invoicedEmplDate'])->date();
+                            } else {
+                                echo $tpl->__("label.pending");
+                            } ?>
+                        </td>
                         <td data-order="<?php if ($row['invoicedComp'] == '1') {
                             echo format($row['invoicedCompDate'])->date();
                                         }?>">
                             <?php if ($row['invoicedComp'] == '1') {
-                                ?> <?php echo format($row['invoicedCompDate'])->date(); ?>
-                            <?php } else {
+                                echo format($row['invoicedCompDate'])->date();
+                            } else {
                                 echo $tpl->__("label.pending");
-                            } ?></td>
+                            } ?>
+                        </td>
                         <td data-order="<?php if ($row['paid'] == '1') {
                             echo format($row['paidDate'])->date();
                                         }?>">
                             <?php if ($row['paid'] == '1') {
-                                ?> <?php echo format($row['paidDate'])->date(); ?>
-                            <?php } else {
+                                echo format($row['paidDate'])->date();
+                            } else {
                                 echo $tpl->__("label.pending");
-                            } ?></td>
+                            } ?>
+                        </td>
                     </tr>
                 <?php } ?>
                 </tbody>
@@ -167,8 +192,6 @@ foreach ($__data as $var => $val) {
                         <td></td>
                         <td colspan="1"><strong><?php echo $tpl->__("label.total_hours")?></strong></td>
                         <td colspan="11"><strong><?php echo $sum; ?></strong></td>
-
-
                     </tr>
                 </tfoot>
             </table>
@@ -177,11 +200,9 @@ foreach ($__data as $var => $val) {
 </div>
 
 <script type="text/javascript">
-
     jQuery(document).ready(function(){
         leantime.timesheetsController.initTimesheetsTable();
         leantime.timesheetsController.initEditTimeModal();
         leantime.dateController.initDateRangePicker(".dateFrom", ".dateTo", 1);
     });
-
 </script>

--- a/app/Domain/Timesheets/Templates/showMyList.tpl.php
+++ b/app/Domain/Timesheets/Templates/showMyList.tpl.php
@@ -128,8 +128,8 @@ foreach ($__data as $var => $val) {
                     <tr>
                         <td data-order="<?php echo $tpl->e($row['id']); ?>">
                             <a href="<?=BASE_URL?>/timesheets/editTime/<?php echo $row['id']?>" class="editTimeModal">#<?php echo $row['id'] . " - " . $tpl->__('label.edit'); ?> </a></td>
-                        <td data-order="<?php echo format($row['workDate'])->date(); ?>">
-                            <?php echo format($row['workDate'])->date(); ?>
+                        <td data-order="<?php echo format((new Carbon\Carbon($row['workDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short'); ?>">
+                            <?php echo format((new Carbon\Carbon($row['workDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short'); ?>
                         </td>
                         <td data-order="<?php $tpl->e($row['hours']); ?>">
                             <?php $tpl->e($row['hours'] ?: 0); ?>
@@ -158,28 +158,28 @@ foreach ($__data as $var => $val) {
                             <?php $tpl->e($row['description']); ?>
                         </td>
                         <td data-order="<?php if ($row['invoicedEmpl'] == '1') {
-                            echo format($row['invoicedEmplDate'])->date();
+                            echo format((new Carbon\Carbon($row['invoicedEmplDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                                         }?>">
                             <?php if ($row['invoicedEmpl'] == '1') {
-                                echo format($row['invoicedEmplDate'])->date();
+                                echo format((new Carbon\Carbon($row['invoicedEmplDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                             } else {
                                 echo $tpl->__("label.pending");
                             } ?>
                         </td>
                         <td data-order="<?php if ($row['invoicedComp'] == '1') {
-                            echo format($row['invoicedCompDate'])->date();
+                            echo format((new Carbon\Carbon($row['invoicedCompDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                                         }?>">
                             <?php if ($row['invoicedComp'] == '1') {
-                                echo format($row['invoicedCompDate'])->date();
+                                echo format((new Carbon\Carbon($row['invoicedCompDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                             } else {
                                 echo $tpl->__("label.pending");
                             } ?>
                         </td>
                         <td data-order="<?php if ($row['paid'] == '1') {
-                            echo format($row['paidDate'])->date();
+                            echo format((new Carbon\Carbon($row['paidDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                                         }?>">
                             <?php if ($row['paid'] == '1') {
-                                echo format($row['paidDate'])->date();
+                                echo format((new Carbon\Carbon($row['paidDate'], 'UTC'))->setTimeZone($_SESSION['usersettings.timezone']), 'short');
                             } else {
                                 echo $tpl->__("label.pending");
                             } ?>

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,18 +1,16 @@
 <?php
 
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Str;
 use Illuminate\View\Factory;
 use Leantime\Core\Application;
 use Leantime\Core\AppSettings;
 use Leantime\Core\Bootloader;
-use Leantime\Core\HtmxRequest;
-use Leantime\Core\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\Support\Build;
 use Leantime\Core\Support\Format;
 use Leantime\Core\Support\Cast;
 use Leantime\Core\Support\Mix;
+use Carbon\Carbon;
 
 if (! function_exists('app')) {
     /**
@@ -205,10 +203,25 @@ if (! function_exists('format')) {
      * @param string|int|float|DateTime|null $value
      * @param string|int|float|DateTime|null $value2
      *
-     * @return Format
+     * @return Format|string
      */
-    function format(string|int|float|null|\DateTime $value, string|int|float|null|\DateTime $value2 =null): Format
+    function format(string|int|float|null|\DateTime $value, string|int|float|null|\DateTime $value2 =null): Format|string
     {
+        // @TODO: This is an hack that should be fixed when all date handling is moved into carbon. This is not the best
+        //        solution, but will work for now.
+        if ($value instanceof Carbon) {
+            $value->setTimezone($_SESSION['usersettings.timezone'] ?? 'UTC');
+
+            $language = app()->make(Language::class);
+            $format = match ($value2) {
+                'short' => $_SESSION['usersettings.language.date_format'] ?? $language->__("language.dateformat"),
+                'long' => ($_SESSION['usersettings.language.date_format'] ?? $language->__("language.dateformat")) . ' ' . $_SESSION['usersettings.language.time_format'],
+                default => $value2 ?? 'Y-m-d',
+            };
+
+            return $value->format($format);
+        }
+
         if ($value instanceof \DateTime) {
             $value = $value->format("Y-m-d H:i:s");
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -205,7 +205,7 @@ if (! function_exists('format')) {
      *
      * @return Format|string
      */
-    function format(string|int|float|null|\DateTime $value, string|int|float|null|\DateTime $value2 =null): Format|string
+    function format(string|int|float|null|\DateTime|Carbon $value, string|int|float|null|\DateTime $value2 =null): Format|string
     {
         // @TODO: This is an hack that should be fixed when all date handling is moved into carbon. This is not the best
         //        solution, but will work for now.

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "illuminate/pipeline": "^9.52",
         "illuminate/cache": "^9.52",
         "symfony/cache": "^6.3",
-        "nikic/php-parser": "^4.17"
+        "nikic/php-parser": "^4.17",
+        "nesbot/carbon": "^2.72"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f32ebf9033e9823dfafffd8ced83085",
+    "content-hash": "eabd2d0ad66d9b7e30d5722b487dcc8b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2836,16 +2836,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.72.1",
+            "version": "2.72.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78"
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/0c6fd108360c562f6e4fd1dedb8233b423e91c83",
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83",
                 "shasum": ""
             },
             "require": {
@@ -2939,7 +2939,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-08T23:47:49+00:00"
+            "time": "2024-01-25T10:35:09+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -10941,6 +10941,7 @@
         "php": "^8.1",
         "ext-ldap": "*",
         "ext-pdo": "*",
+        "ext-zip": "*",
         "ext-fileinfo": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2322

#### Description

Look into timezone handling and the conversion of dates. 

* Switched to using carbon (https://carbon.nesbot.com)  for date handling in timesheets
* Ensure date are in UTC in all PHP code and first converted on display in UI to local timezone and format.
* Added helper to `format()` to help during transition to carbon (as this is only change in timesheets for now)
* Ensure newly create and user provided dates are converted to UTC (and not created as UTC)

#### Screenshot of the result

N/A

#### Checklist

- [x] My code passes all test cases.
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

Tests can be found in https://github.com/Leantime/leantime/pull/2377