### PR TITLE
Added check for plugin enabled on settings link

### DIFF
--- a/app/Domain/Plugins/Templates/partials/installed/plugincontrols.blade.php
+++ b/app/Domain/Plugins/Templates/partials/installed/plugincontrols.blade.php
@@ -8,7 +8,7 @@
         @endif
     </div>
     <div class="col-md-4" style="padding-top:10px; text-align:right;">
-        @if (file_exists(APP_ROOT . '/app/Plugins/' . $plugin->foldername . '/Controllers/Settings.php'))
+        @if ($plugin->enabled && file_exists(APP_ROOT . '/app/Plugins/' . $plugin->foldername . '/Controllers/Settings.php'))
         <a href="{{ BASE_URL }}/{{ $plugin->foldername }}/settings"><i class="fa fa-cog"></i> Settings</a>
         @endif
     </div>


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2389

#### Description

Shows "Settings" link only on *enabled* plugins.

#### Screenshot of the result

Before: 
![Screen Shot 2024-03-11 at 11 35 22](https://github.com/Leantime/leantime/assets/11267554/0a7d9bdf-b852-41a7-849d-ad86e5ef2eb7)

After:
![Screen Shot 2024-03-11 at 11 36 22](https://github.com/Leantime/leantime/assets/11267554/a0b771de-4ac2-4d03-966c-f02995a21a85)

#### Checklist

- [x] My code passes all test cases.
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

