### PR TITLE
Issue 2392

### DIFF
--- a/.idea/leantime-oss.iml
+++ b/.idea/leantime-oss.iml
@@ -96,6 +96,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/http-kernel" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php83" />
       <excludeFolder url="file://$MODULE_DIR$/app/Plugins/CustomFields/vendor/composer" />
+      <excludeFolder url="file://$MODULE_DIR$/cache" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/Domain/Menu/Services/Menu.php
+++ b/app/Domain/Menu/Services/Menu.php
@@ -121,8 +121,8 @@ class Menu
 
         $projectType = "project";
         $project = [];
-        if (isset($_SESSION['currentProject'])) {
-            $project = $this->projectService->getProject($_SESSION['currentProject']);
+        if ($currentProjectId = $this->projectService->getCurrentProjectId()) {
+            $project = $this->projectService->getProject($currentProjectId);
 
             $projectType = ($project !== false && isset($project['type']))
                 ? $project['type']

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -627,6 +627,17 @@ namespace Leantime\Domain\Projects\Services {
         }
 
         /**
+         * Get current project id or 0 if no current project is set.
+         *
+         * @return int
+         */
+        public function getCurrentProjectId(): int
+        {
+            // Make sure that we never return a value less than 0.
+            return max(0, (int) ($_SESSION['currentProject'] ?? 0));
+        }
+
+        /**
          * @param $projectId
          * @return bool
          * @throws BindingResolutionException


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2392

#### Description

Adds a `getCurrentProjectId` function in `Leantime\Domain\Projects\Services\Projects` and uses it instead of `$_SESSION['currentProject']` in select places (the ones calling [Projects::getProject()](https://github.com/Leantime/leantime/blob/6635c4d3bb5b65adff5ea877eb6273b13784b0a9/app/Domain/Projects/Services/Projects.php#L101)).

#### Checklist

- [x] My code passes all test cases.
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.
