### PR TITLE
Handle date(time) parameters in API requests

### DIFF
--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -307,7 +307,6 @@ class Jsonrpc extends Controller
                 }
 
                 try {
-                    // @TODO: this is override in linge 318 before the casted value here is used?
                     $filtered_parameters[$position] = cast($params[$name], $type->getName());
                 } catch (\Throwable $e) {
                     error_log($e);
@@ -315,7 +314,9 @@ class Jsonrpc extends Controller
                 }
             }
 
-            $filtered_parameters[$position] = $params[$name];
+            if (!isset($filtered_parameters[$position])) {
+                $filtered_parameters[$position] = $params[$name];
+            }
         }
 
         // make sure it is in the right order

--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -368,13 +368,12 @@ class Jsonrpc extends Controller
     {
 
         //TODO: And FYI. json_encode cannot encode throwable. https://github.com/pmjones/throwable-properties
-        //For now we'll just return the message
         return $this->tpl->displayJson([
             'jsonrpc' => '2.0',
             'error' => [
                 'code' => $errorcode,
                 'message' => $errorMessage,
-                'data' => $additional_info->getMessage(),
+                'data' => $additional_info instanceof \Throwable ? $additional_info->getMessage() : $additional_info,
             ],
             'id' => $id,
         ]);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\View\Factory;
 use Leantime\Core\Application;
@@ -7,11 +9,11 @@ use Leantime\Core\AppSettings;
 use Leantime\Core\Bootloader;
 use Leantime\Core\Language;
 use Leantime\Core\Support\Build;
+use Leantime\Core\Support\Cast;
+use Leantime\Core\Support\DateTimeHelper;
 use Leantime\Core\Support\Format;
 use Leantime\Core\Support\FromFormat;
-use Leantime\Core\Support\Cast;
 use Leantime\Core\Support\Mix;
-use Carbon\Carbon;
 
 
 if (! function_exists('app')) {
@@ -232,6 +234,11 @@ if (! function_exists('cast')) {
 
         if (enum_exists($classOrType)) {
             return Cast::castEnum($source, $classOrType);
+        }
+
+        // Convert string to date if required.
+        if (is_string($source) && is_a($classOrType, CarbonInterface::class, true)) {
+            return new DateTimeHelper($source);
         }
 
         return (new Cast($source))->castTo($classOrType, $constructParams, $mappings);


### PR DESCRIPTION
#### Link to ticket

https://github.com/Leantime/leantime/issues/2397

#### Description

* Handles converting date(time) strings in API requests to `Carbon` objects if needed.

#### Checklist

- [x] My code passes all test cases.
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

Also contains a small improvement in the API request error reporting: https://github.com/Leantime/leantime/pull/2398/commits/ac400e9357f993e6db6e137ab0429ee71075fdd2

The actual conversion from string to `Carbon` object is performed in the [`cast` function](https://github.com/ITK-Leantime/leantime/blob/ac400e9357f993e6db6e137ab0429ee71075fdd2/app/helpers.php#L254-L257). It may be more appropriate to do it in [`Cast::castTo`](https://github.com/Leantime/leantime/blob/7a0856dd66a0e5c88e4dc6a4fbaae22cbaadea80/app/Core/Support/Cast.php#L33), but that would require letting the `Cast` constructor accept a `string` type argument in addition to the already allowed types (`array|object`) and further changes to handle a string in the rest of the class.