### PR TITLE
2403 Added en-US translation

### DIFF
--- a/app/Language/en-US.ini
+++ b/app/Language/en-US.ini
@@ -578,6 +578,8 @@ text.no_plugins_activated = "☕  No plugins activated"
 text.comments = "Comments"
 text.num_comments = "<span class='fa fa-regular fa-comments'></span> %1$s Comments"
 text.full_name = "%1$s %2$s"
+text.full_lean_canvas_helper_content = "The full research board will guide you through the entire process of idea validation.<br/>On this page, you'll once again address your customer segment, problem, solution (but don't worry, if you've already filled this out on the simple board, you'll see it again here!).<br/>From there, you'll switch to Clear Value Proposition (What Makes Your Idea Better Than Other Offerings?),<br/>Sales Channels (How Do Customers Get Your Solution?)<br/>Revenue Streams (How does your solution make money?)<br/>Cost Structure (How Much Is Your Solution Worth?)
+Key Metrics (How Do You Measure Success?)<br/>and unfair advantage (What helps you stand out against the competition?)<br/>Answering these questions is designed to drive success, mitigate failures, and allow you to track and validate your assumptions.<br/>Lean is about eliminating waste and working to build products, stores, and solutions that your customers need."
 text.no_files = "No files uploaded yet"
 text.here_are_news = "News from your Leantime projects"
 text.create_new_content = "Create your first article."


### PR DESCRIPTION
#### Link to ticket
Please add a link to the GitHub issue being addressed by this change.
#2403 

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

Dropping in the en-US translation of `text.full_lean_canvas_helper_content` in app/Language/de-DE_informal.ini into app/Language/en-US.ini

Ideally, the fullLeanCanvas modal will display that description instead of the token `text.full_lean_canvas_helper_content` when en-US is the default language.
