### PR TITLE
Set init value of $_SESSION['currentProject'] to 0 instead of ''

### DIFF
--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -603,7 +603,7 @@ namespace Leantime\Domain\Projects\Services {
                 return;
             }
 
-            $_SESSION['currentProject'] = '';
+            $_SESSION['currentProject'] = 0;
 
             //If last project setting is set use that
             $lastProject = $this->settingsRepo->getSetting("usersettings." . $_SESSION['userdata']['id'] . ".lastProject");


### PR DESCRIPTION
#### Link to ticket
This PR closes this issue https://github.com/Leantime/leantime/issues/2366
#### Description

The dashbaord page is crashing with 500 error because the init value of $_SESSION['currentProject'] is an empty string. Setting the init value to 0 solved the problem. The check in the getProject method didn't prevent the issue because it is checking on null
![image](https://github.com/Leantime/leantime/assets/119036273/7e2e8601-ef15-4190-a258-cdd1b3de4a3e)


