### PR TITLE
Fix content-disposition header

### DIFF
--- a/app/Domain/Files/Controllers/Get.php
+++ b/app/Domain/Files/Controllers/Get.php
@@ -95,7 +95,7 @@ class Get extends Controller
                 } else {
                     $mime_type = 'application/octet-stream';
                     header("Content-type: application/octet-stream");
-                    header("Content-Disposition: filename=\"" . $realName . "." . $ext . "\"");
+                    header("Content-Disposition: attachment; filename=\"" . $realName . "." . $ext . "\"");
                 }
 
 


### PR DESCRIPTION
For downloads with unknown file types (like xls, zip), the content is displayed inline in Chrome. Works fine in Firefox without this change.

#### Link to ticket

No ticket. Reported on Cloudron forum at https://forum.cloudron.io/topic/11347/issue-with-file-opening-downloading-in-leantime-application

#### Description

content-disposition is not set correctly for chrome browser when downloading unknown file types

#### Screenshot of the result

No change in UI

#### Checklist

I have only tested this change locally on Cloudron and have not run the tests.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
