### PR TITLE
fix incorrect symbol in the translation for zh-CN

### DIFF
--- a/app/Language/zh-CN.ini
+++ b/app/Language/zh-CN.ini
@@ -608,7 +608,7 @@ text.discord_instructions="此集成会将更新通知发布到您选择的频�
 text.no_conclusion_yet="<i>暂无结论</i>"
 text.no_users_assigned_to_this_client="尚未将任何成员分配给此客户。在<a href='/users/showAll'>此处</a>新增和分配成员"
 text.confirm_delete_timesheet="是否要删除此时间表？"
-text.timer_on_todo="<span class='head-icon fa fa-stop'></span>为％2$s启动%1$s计时器"
+text.timer_on_todo="<span class='head-icon fa fa-stop'></span>为%2$s启动%1$s计时器"
 text.these_are_system_wide_settings="这些是系统范围的设置，将影响您的 Leantime 的外观。"
 text.company_name_helper="将出现在页面标题和电子邮件中"
 text.advanced_boards_helper_content="这里是追踪创意产生、生长和成熟的地方。<br/>将创意卡片从一列移动到下一列，可以反映它们的当前状态。<br/>这是研究开发原型的好地方，并且您可以在开始实施之前，就与部分客户验证这些原型。"


### PR DESCRIPTION
#### Description

Wrong % symbol is used, causing failure of text rendering.

#### Screenshot of the result

![image](https://github.com/Leantime/leantime/assets/26152437/e647b131-6542-4e6e-a2cd-eb16884fc850)

#### Checklist
Translation only. 

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
