### PR TITLE
Add Retry-After header to support standard ratelimit response expectations

### DIFF
--- a/app/Core/Middleware/RequestRateLimiter.php
+++ b/app/Core/Middleware/RequestRateLimiter.php
@@ -125,6 +125,7 @@ class RequestRateLimiter
             'X-RateLimit-Remaining' => $this->limiter->retriesLeft($key, $limit),
             'X-RateLimit-Retry-After' => $this->limiter->availableIn($key),
             'X-RateLimit-Limit' => $this->limiter->attempts($key),
+            'Retry-After' => $this->limiter->availableIn($key),
         ];
     }
 }


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Along with the newly added x-ratelimit headers, "Retry-After" needs to be added as it is a standard and sometimes expected.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
