### PR TITLE
1620: remove -22px, as it pushed the pop-up out of the browser

### DIFF
--- a/public/assets/css/components/nav.css
+++ b/public/assets/css/components/nav.css
@@ -436,16 +436,12 @@ a.barmenu:hover {
     background: var(--light-layered-background);
 }
 
-
-
-
 .headmenu {
     list-style: none;
 }
 
 .headmenu .dropdown-menu {
     margin: 0;
-    left:-22px;
 }
 
 


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/1620

#### Description

- Remove negative positioning (and some whitespace)

#### Screenshot of the result

**From**

<img width="655" alt="image" src="https://github.com/Leantime/leantime/assets/15377965/92fce3ca-a8f3-4d9c-ab13-367520a6f7eb">

**To**

<img width="596" alt="image" src="https://github.com/Leantime/leantime/assets/15377965/60c0aad1-e66c-48a8-9994-3c61a4c4c550">

#### Additional comments or questions

The failing test seem unrelated.
