### PR TITLE
Update Tickets.php to include zp_tickets.userId in simpleTicketQuery

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -635,6 +635,7 @@ namespace Leantime\Domain\Tickets\Repositories {
                     IF(zp_tickets.type <> "", zp_tickets.type, "task") AS type,
                     zp_tickets.status,
                     zp_tickets.tags,
+                    zp_tickets.userId,
                     zp_tickets.editorId,
                     zp_tickets.dependingTicketId,
                     zp_tickets.milestoneid,


### PR DESCRIPTION
#### Link to ticket

None

#### Description

In most of other get ticket methods, zp_tickets.userId is included, but not in this simpleTicketQuery. It doesn't make sense.

#### Screenshot of the result

If your change affects the user interface, you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
