### PR TITLE
Update Comments.php to fix ticket comment notification url

### DIFF
--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -83,6 +83,7 @@ namespace Leantime\Domain\Comments\Services {
                             $subject = sprintf($this->language->__("email_notifications.new_comment_todo_with_type_subject"), $this->language->__("label." . strtolower($entity->type)), $entity->id, $entity->headline);
                             $message = sprintf($this->language->__("email_notifications.new_comment_todo_with_type_message"), $_SESSION["userdata"]["name"], $this->language->__("label." . strtolower($entity->type)), $entity->headline, $values['text']);
                             $linkLabel = $this->language->__("email_notifications.new_comment_todo_cta");
+                            $currentUrl = BASE_URL . "#/tickets/showTicket/" . $entity->id;
                             break;
                         case "project":
                             $subject = sprintf($this->language->__("email_notifications.new_comment_project_subject"), $entityId, $entity['name']);


### PR DESCRIPTION
#### Link to ticket

None

#### Description

Before change, the comment notification includes a url to the task such as `https://leantime.io/tickets/showTicket/325&projectId=10`

It is not working because it lacks `#/`

It should be `https://leantime.io/#/tickets/showTicket/325&projectId=10`

Without this change, the link doesn't lead the user to the task but leads to something like `https://leantime.io/tickets/showKanban?showTicketModal=325`. In this case, the task window does not pop up.

#### Screenshot of the result

If your change affects the user interface, you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
