### PR TITLE
Fixing template for new sprint creation

### DIFF
--- a/app/Domain/Sprints/Templates/sprintdialog.tpl.php
+++ b/app/Domain/Sprints/Templates/sprintdialog.tpl.php
@@ -23,18 +23,16 @@ if (isset($currentSprint->id)) {
     <label><?=$tpl->__('label.project') ?></label>
     <select name="projectId">
         <?php foreach($allAssignedprojects as $project) { ?>
-        <option value="<?=$project['id'] ?>"
-            <?php foreach($allAssignedprojects as $project) { ?>
-                <option value="<?=$project['id'] ?>"
+            <option value="<?=$project['id'] ?>"
                     <?php
-                    if($currentSprint->projectId == $project['id']) {
+                    if(isset($currentSprint)) {
+                        if($currentSprint->projectId == $project['id']) {
                         echo "selected";
+			}
                     }else if( $_SESSION['currentProject'] == $project['id']){
                         echo "selected";
                     }
                     ?>
-                ><?=$tpl->escape($project["name"]); ?></option>
-            <?php } ?>
         ><?=$tpl->escape($project["name"]); ?></option>
         <?php } ?>
     </select><br />


### PR DESCRIPTION
#### Link to ticket

No ticket spotted... i rand into the bug and just fixed it.

#### Description

When using the button "create sprint" the produced html is buggy and lead to wrong project assignation if the default choice is not made.

![image](https://github.com/Leantime/leantime/assets/434725/f51392fa-9d32-47c9-b02e-947519bcf634)


#### Screenshot of the result

There is no visible difference except the list does not show projects twice any more and the projects id are correctly associated with project names.

#### Checklist

N/A

#### Additional comments or questions

The change made consists in removing the duplicate foreach loop on select. It was probably just a copy paste made twice.