### PR TITLE
Project list avatar - html based

### DIFF
--- a/app/Domain/Menu/Templates/partials/projectLink.blade.php
+++ b/app/Domain/Menu/Templates/partials/projectLink.blade.php
@@ -3,11 +3,7 @@
        data-tippy-content='{{ $project["name"] }}'
     @endif >
     <span class='projectAvatar'>
-        @if(isset($projectTypeAvatars[$project["type"]]) && $projectTypeAvatars[$project["type"]] != "avatar")
-            <span class="{{ $projectTypeAvatars[$project["type"]] }}"></span>
-        @else
-            <img src='{{ BASE_URL }}/api/projects?projectAvatar={{ $project["id"] }}&v={{  format($project['modified'])->timestamp() }}' />
-        @endif
+       <span class="projectAvatar-text">{{ substr($project["name"], 0, 2) }}</span>
     </span>
     <span class='projectName'>
         @if($project["clientName"] != '')

--- a/public/assets/css/components/nav.css
+++ b/public/assets/css/components/nav.css
@@ -284,6 +284,14 @@ a.barmenu:hover {
     background:var(--element-gradient);
 }
 
+.projectselector .projectAvatar .projectAvatar-text {
+    margin: auto;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 14px;
+    letter-spacing: 1px;
+}
+
 .headmenu .projectselector .projectAvatar img {
     width:30px;
     height:30px;


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

This PR is a proposal for an alternative and simpler way to generate project avatars.

When loading the front-page, a get-request for each project is made to get the avatar for the project list in the header. In my test case, having 48 projects, the 48 simultaneous get-requests slowed each page load by over 50%.

Since the generated avatar svg is quite simple and consists of two letters, i thought that a way to go, or a simple short-term solution were to generate these avatars using HTML. 

#### Screenshot of the result

<img width="408" alt="Screenshot 2024-07-02 at 16 38 06" src="https://github.com/Leantime/leantime/assets/106669866/5a4f020c-ab77-46f1-b816-ed8ca78459a8">

#### Checklist

- [ ] My code passes all test cases.
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass the requirements on the checklist, you should add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer, please add them here.
