### PR TITLE
Update README.md for newer mysql version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Leantime is an open source project management system for non-project manager.<br
 ### ❗System Requirements ###
 
 * PHP 8.1+
-* MySQL 5.7+
+* MySQL 8.0+
 * Apache or Nginx (IIS works with some modifications)
 * PHP Extensions: 
 * * mysql, mbstring, GD, exif, pcntl, bcmath, opcache, ldap


### PR DESCRIPTION
Changed the requirements from MySQL 5.7+ to MySQL 8.0+ 
MySQL 5.7 is not supported anymore by Oracle since 2023-10-31 and will not get any security updates. 
We should not encourage our users to use old and insecure software.

MySQL 8.0 is the lowest version that is still supported by Oracle and is a LTS release 
(Generic support until 2025-04-30 and extended until 2026-04-30)