### PR TITLE
Improved update check

### DIFF
--- a/app/Core/Middleware/Updated.php
+++ b/app/Core/Middleware/Updated.php
@@ -31,7 +31,10 @@ class Updated
             session(["dbVersion" => $dbVersion]);
         }
 
-        session(["isUpdated" => $dbVersion == $settingsDbVersion]);
+        $dbVersionInt = $this->getVersionInt($dbVersion);
+        $settingsDbVersionInt = $this->getVersionInt($settingsDbVersion);
+
+        session(["isUpdated" => $dbVersionInt >= $settingsDbVersionInt]);
 
         if (session("isUpdated")) {
             return $next($request);
@@ -63,5 +66,18 @@ class Updated
         $route = BASE_URL . "/install/update";
         $route = self::dispatch_filter("redirectroute", $route);
         return $frontController::redirect($route);
+    }
+
+    private function getVersionInt($version)
+    {
+            $versionArray = explode(".", $version);
+            if (is_array($versionArray) && count($versionArray) == 3) {
+                $major = $versionArray[0];
+                $minor = str_pad($versionArray[1], 2, "0", STR_PAD_LEFT);
+                $patch = str_pad($versionArray[2], 2, "0", STR_PAD_LEFT);
+                $newDBVersion = $major . $minor . $patch;
+                return $newDBVersion;
+            }
+            return false;
     }
 }


### PR DESCRIPTION
#### Description

If a db was updated but had to be downgraded later on the update check in the middleware prevented the app from registering valid version. This is now fixed


### Type

[x] Fix
[] Feature
[] Cleanup 

