### PR TITLE
Fix LDAP AD login without domain (using only user ID).

### DIFF
--- a/app/Domain/Ldap/Services/Ldap.php
+++ b/app/Domain/Ldap/Services/Ldap.php
@@ -141,14 +141,17 @@ class Ldap
             if ($this->directoryType == 'AD') {
                 $usernameDN = $username;
 
-                $bind = ldap_bind($this->ldapConnection, $usernameDN, $passwordBind);
+                if (str_contains($usernameDN, '@')) {
+                    $bind = ldap_bind($this->ldapConnection, $usernameDN, $passwordBind);
+                } else {
+                    $bind = ldap_bind($this->ldapConnection, $usernameDN . "@" . $this->ldapDomain, $passwordBind);
+                }
+
                 if ($bind) {
                     return true;
                 }
-
-                $bind = ldap_bind($this->ldapConnection, $usernameDN . "@" . $this->ldapDomain, $passwordBind);
-                //OL requires distinguished name login
             } else {
+                //OL requires distinguished name login
                 $usernameDN = $this->ldapKeys->username . "=" . $username . "," . $this->ldapDn;
 
                 $bind = ldap_bind($this->ldapConnection, $usernameDN, $passwordBind);


### PR DESCRIPTION
#### Description

The  Problem:
Even if you set a domain for the LEAN_LDAP_LDAP_DOMAIN environment variable, you will not be able to login using only the user ID, you can only login using the full form, user@domain.

**Example login entry:**

*Before changes:*
* "user@domain", result Login
* "user", result ```Error 500```

*After changes:*
* "user@domain", result OK
* "user", result OK

**Type**
[X] Fix
[] Feature
[] Cleanup