### PR TITLE
New user email queue bug

### DIFF
--- a/app/Domain/Queue/Repositories/Queue.php
+++ b/app/Domain/Queue/Repositories/Queue.php
@@ -48,10 +48,15 @@ namespace Leantime\Domain\Queue\Repositories {
                 } elseif (filter_var($recipient, FILTER_VALIDATE_EMAIL)) {
                     $theuser = $this->users->getUserByEmail($recipient);
                 } else {
-                    return;
+                    //skip invalid users
+                    continue;
                 }
-                // TODO : exit if no user was found ?
-                // Low risk but still it could be deleted in the meantime
+
+                //User might not be set because it's a new user
+                if (!$theuser) {
+                    continue;
+                }
+
                 $userId = $theuser['id'];
                 $userEmail = $theuser['username'];
                 $msghash = md5($thedate . $subject . $message . $userEmail . $projectId);


### PR DESCRIPTION
#### Description
New users are set to invited while the email queue will only look for active users. This causes a 500 

#### Link to ticket

#2698

### Type

[x] Fix
[] Feature
[] Cleanup 

