### PR TITLE
Fix OIDC bugs

### DIFF
--- a/app/Domain/Oidc/Controllers/Callback.php
+++ b/app/Domain/Oidc/Controllers/Callback.php
@@ -31,7 +31,7 @@ class Callback extends Controller
         } catch (\Exception $e) {
             $this->tpl->setNotification($e->getMessage(), 'danger', 'oidc_error');
 
-            return Frontcontroller::redirect(BASE_URL.'/oidc/login');
+            return Frontcontroller::redirect(BASE_URL.'/auth/login');
         }
     }
 }

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -153,10 +153,14 @@ class Oidc
         //echo '<pre>' . print_r($tokens, true) . '</pre>';
         if (isset($tokens['id_token'])) {
             $userInfo = $this->decodeJWT($tokens['id_token']);
-        } elseif (isset($tokens['access_token'])) {
+        }
+
+        if ($userInfo == null && isset($tokens['access_token'])) {
             //falback to OAuth userinfo endpoint
             $userInfo = $this->pollUserInfo($tokens['access_token']);
-        } else {
+        }
+
+        if ((!isset($tokens['access_token'])) && (!isset($tokens['access_token']))) {
             $this->displayError('oidc.error.unsupportedToken');
         }
 


### PR DESCRIPTION
### Description
This PR solves several bug fixes when using OIDC with Leantime. Notably, i've resolved issues related to:
- Ensuring get userinfo oauth2 endpoint is called when the decodeJWT function fails
- Returning to the `/auth/login` URL in case the callback service fails, thereby preventing infinite redirect loops.

These changes will resolve the issue of infinite redirect loops experienced by users who integrate Leantime with Keycloak.

### Type

- [x] Fix
- [ ] Feature
- [x] Cleanup 
