### PR TITLE
Fix label OR in form login template

### DIFF
--- a/app/Domain/Auth/Templates/login.blade.php
+++ b/app/Domain/Auth/Templates/login.blade.php
@@ -74,8 +74,10 @@ $redirectUrl = $tpl->get('redirectUrl');
     <?php if ($tpl->get('oidcEnabled')) { ?>
         <?php $tpl->dispatchTplEvent('beforeOidcButton'); ?>
         <div class="">
-            <br /><center class="uppercase"><?php echo $tpl->language->__("label.or"); ?></center><br />
-            
+            <?php if (false === $tpl->get('noLoginForm')) { ?>
+                <br /><center class="uppercase"><?php echo $tpl->language->__("label.or"); ?></center><br />
+            <?php } ?>
+
             <x-global::forms.button onclick="window.location.href = '{{ BASE_URL }}/oidc/login'" content-role="primary" name="oidclogin" class="w-full">
                 {{ $tpl->language->__('buttons.oidclogin') }}
             </x-global::forms.button>


### PR DESCRIPTION
### Description

hide `label.or` when oidc is enabled with noLoginForm is true

before:
![Screenshot from 2024-10-12 22-53-15](https://github.com/user-attachments/assets/0ebcc134-17e6-43ff-8544-28f3c477a2ad)

after:
![Screenshot from 2024-10-12 22-58-25](https://github.com/user-attachments/assets/066f3fc3-0a28-4820-995e-ae9b1ce32c12)


### Type

- [x ] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

*If your change affects the user interface, you should include a screenshot of the result with the pull request.*
