### PR TITLE
fix: add slack logo prevent CSP policy error

### DIFF
--- a/app/Domain/Projects/Templates/showProject.blade.php
+++ b/app/Domain/Projects/Templates/showProject.blade.php
@@ -266,7 +266,7 @@
                     <h4 class="widgettitle title-light"><span class="fa fa-leaf"></span>Slack</h4>
                     <div class="row">
                         <div class="col-md-3">
-                            <img src="https://cdn.cdnlogo.com/logos/s/52/slack.svg" width="200" />
+                            <img src="<?=BASE_URL ?>/dist/images/slack.svg" width="200"/>
                         </div>
 
                         <div class="col-md-5">

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -67,6 +67,7 @@
     "/dist/images/logo.png": "/dist/images/logo.png",
     "/dist/images/logo.svg": "/dist/images/logo.svg",
     "/dist/images/mattermost-logoHorizontal.png": "/dist/images/mattermost-logoHorizontal.png",
+    "/dist/images/slack.svg": "/dist/images/slack.svg",
     "/dist/images/next.gif": "/dist/images/next.gif",
     "/dist/images/onboarding/canvasScreen.png": "/dist/images/onboarding/canvasScreen.png",
     "/dist/images/onboarding/ideaScreen.png": "/dist/images/onboarding/ideaScreen.png",


### PR DESCRIPTION
### Description
Slack logo in the Integrations page is not loaded because of CSP Policy, this PR will solve that issue.

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

Before changes
![Screenshot from 2024-10-13 14-52-42](https://github.com/user-attachments/assets/5b5905f8-7771-4f2b-80a1-32816e9246d0)

After changes
![Screenshot from 2024-10-13 14-55-56](https://github.com/user-attachments/assets/93100977-9109-41bb-bd42-aa7386555ab6)

