### PR TITLE
cli: fix crash when running commands

### DIFF
--- a/app/Core/Console/ConsoleKernel.php
+++ b/app/Core/Console/ConsoleKernel.php
@@ -151,7 +151,7 @@ class ConsoleKernel implements ConsoleKernelContract
                 array_map(fn ($plugin) => $plugin->foldername, $this->getApplication()->make(PluginsService::class)->getAllPlugins(enabledOnly: true)),
             )));
 
-        $commands = collect(Arr::flatten(session("commands")))
+        $commands = collect(Arr::flatten(Cache::store('installation')->many(["commands.core", "commands.plugins"])))
             ->map(fn ($path) => $this->getApplication()->getNamespace() . Str::of($path)->remove([APP_ROOT . '/app/', APP_ROOT . '/custom/'])->replace(['/', '.php'], ['\\', ''])->toString());
 
         /**


### PR DESCRIPTION
The commands are cached in cache store and not in session object.

Fixes #2710

### Description

Long ago this was in _SESSION. Then, it moved to session() and now it's in the Cache

### Link to ticket

https://github.com/Leantime/leantime/issues/2710

### Type

- [ X ] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

No change in UI