### PR TITLE
ITKDev: Added session to API users

### DIFF
--- a/app/Domain/Api/Services/Api.php
+++ b/app/Domain/Api/Services/Api.php
@@ -3,10 +3,12 @@
 namespace Leantime\Domain\Api\Services;
 
 use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Api\Repositories\Api as ApiRepository;
+use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 use RangeException;
 
@@ -18,18 +20,22 @@ class Api
 
     private UserRepository $userRepo;
 
+    private Auth $authService;
+
     private ?array $error = null;
 
     /**
      * @api
      */
-    public function __construct(ApiRepository $apiRepository, UserRepository $userRepo)
+    public function __construct(ApiRepository $apiRepository, UserRepository $userRepo, Auth $authService)
     {
         $this->apiRepository = $apiRepository;
         $this->userRepo = $userRepo;
+        $this->authService = $authService;
     }
 
     /**
+     * @throws BindingResolutionException
      * @api
      */
     public function getAPIKeyUser(string $apiKey): bool|array
@@ -54,6 +60,7 @@ class Api
 
         if ($apiUser) {
             if (password_verify($key, $apiUser['password'])) {
+                $this->authService->setUserSession($apiUser);
                 return $apiUser;
             }
         }

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -1342,7 +1342,7 @@ namespace Leantime\Domain\Tickets\Services {
                     ];
                     $notification->entity = $values;
                     $notification->module = 'tickets';
-                    $notification->projectId = session('currentProject');
+                    $notification->projectId = $values['projectId'] ?? session('currentProject');
                     $notification->subject = $subject;
                     $notification->authorId = session('userdata.id');
                     $notification->message = $message;


### PR DESCRIPTION
### Description

The code base have been change to only support ticket creation when user have an session but this is not the case to API users. So this initialize an session for API users and fixes ticket create.

### Link to ticket

No ticket.

### Type

- [ ] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

N/A
