### PR TITLE
fix: pseudo element on overlay took over click events on dark mode

### DIFF
--- a/public/assets/css/components/structure.css
+++ b/public/assets/css/components/structure.css
@@ -369,6 +369,7 @@ body {
     background-repeat:no-repeat;
     background-position:center;
     background-attachment: fixed;
+    pointer-events: none !important;
 }
 
 .rightpanel.personal:before {
@@ -381,6 +382,21 @@ body {
 
 .rightpanel.company:before {
 
+}
+
+.rightpanel {
+    padding-top:50px;
+}
+
+.rightpanel::after {
+    clear: both;
+    content: '';
+    display: block;
+    pointer-events: none !important;
+}
+
+.overlay::after {
+    pointer-events: none !important;
 }
 
 
@@ -429,15 +445,7 @@ body {
     text-shadow: 0px 1px 3px var(--primary-font-color);
 }
 
-.rightpanel {
-    padding-top:50px;
-}
 
-.rightpanel:after {
-    clear: both;
-    content: '';
-    display: block;
-}
 
 .pageheader {
     padding: 0px 15px;

--- a/public/theme/default/css/dark.css
+++ b/public/theme/default/css/dark.css
@@ -173,11 +173,11 @@
 
 }
 
-.rightpanel:before {
+.rightpanel::before {
     opacity:0.9;
 }
 
-.overlay:after {
+.overlay::after {
     content:"";
     position: fixed;
     top: 0px;


### PR DESCRIPTION
### Description

Pseudo element on overlay used to darken the background takes over dropdown events in header. 
Thank you to Discord User _strangecameleon_ for debugging this with me! 

### Link to ticket

*Please add a link to the GitHub issue being addressed by this change.*

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 
