### PR TITLE
Fixed helm chart services and deployment

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           env:
           - name: LEAN_DB_HOST
             value: {{ .Release.Name }}-mariadb
+          - name: LEAN_SESSION_SECURE
+            value: "{{ .Values.app.leanSessionSecure }}"
           - name: LEAN_DB_USER
             value: {{ .Values.mariadb.auth.username }}
           - name: LEAN_DB_PASSWORD
@@ -117,7 +119,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -12,7 +12,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
-  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -27,5 +29,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
-  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
 {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8080
       protocol: TCP
       name: http
   selector:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -26,12 +26,15 @@ persistence:
   # -- Sets the size of the PVs for Leantime's public and private userfiles
   size: 5Gi
   # -- Sets the storage class for Leantime's volumes
-  storageClass: "standard"
+  # -- empty will use system default
+  storageClass: ""
 
 # Application-specific environment variables
 app:
   # -- Sets the name for the instance
   sitename: "Leantime"
+  # -- Sets the cookie flag to only allow HTTPS transfer.
+  leanSessionSecure: "true"
   # -- Sets application language
   language: "en-US"
   # -- Sets the default Timezone


### PR DESCRIPTION
Changed service target port and container port to 8080 to match leantime image config.
Made the storageClass optionnal, Empty will use system default Added a configuration for the LEAN_SESSION_SECURE with true as default

### Description

*Please include a short description of the suggested change and the reasoning behind the approach you have chosen.*

### Link to ticket

*Please add a link to the GitHub issue being addressed by this change.*

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

*If your change affects the user interface, you should include a screenshot of the result with the pull request.*
