### PR TITLE
fix: Ensure sessions folder exists before putting files into it

### DIFF
--- a/app/Core/Providers/Session.php
+++ b/app/Core/Providers/Session.php
@@ -27,6 +27,17 @@ class Session extends ServiceProvider
 
             } else {
 
+                // Ensure session base path exists:
+                if (! is_dir(storage_path('framework/sessions')) && ! mkdir(
+                    $concurrentDirectory = storage_path('framework/sessions'),
+                    0755,
+                    true
+                ) && ! is_dir(
+                    $concurrentDirectory
+                )) {
+                    throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+                }
+
                 $sessionDir = storage_path('framework/sessions/'.get_domain_key());
 
                 // domain key was created as file. Let's remove that


### PR DESCRIPTION
### Description

Fixes issue where sessions folder doesn't exist after system update. Ensures sessions folder is created before adding sessions

### Link to ticket

#2993 2993

### Type

- [x ] Fix
- [ ] Feature
- [ ] Cleanup 

