### PR TITLE
Order Wiki headers

### DIFF
--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -131,7 +131,7 @@ class Wiki extends Canvas
 
 				WHERE canvasId = :canvasId
 				  AND box = 'article' AND (status = 'published' OR (status = 'draft' AND author = :authorId) )
-				ORDER BY parent DESC, sortindex DESC";
+				ORDER BY parent, title";
 
         $stmn = $this->db->database->prepare($query);
         $stmn->bindValue(':canvasId', $canvasId, PDO::PARAM_INT);


### PR DESCRIPTION
### Description

This is a rapid fix from the discussion 
https://github.com/Leantime/leantime/discussions/2370

While it doesn't fully addresses the request (manually ordering of wiki headers) it orders alpabetically both the wiki tree (without changes to the original code) and the voices inside the "parent" combobox.

I saw that you already have a "sortindex" field in the table, so probably you are already working on it, but in hte meanwhile it can put a bit of order in managing wikis.

The combobox avoids that a circular reference can be created by hiding the current wiki page and all its children.

I nearly don't know PHP (I programmed it for a while when version 4 came out) so the code is probably less than ideal.

Hope this helps.

### Link to ticket

[*Please add a link to the GitHub issue being addressed by this change.*
](https://github.com/Leantime/leantime/discussions/2370)

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result


![image](https://github.com/user-attachments/assets/288efc0a-690a-4ec3-8ebc-6ed849b1f23a)

![image](https://github.com/user-attachments/assets/b4c6f197-bb0c-4e07-929e-1f1a345be343)
