### PR TITLE
Update type declaration for id parameter in JSON RPC response

### DIFF
--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -368,14 +368,14 @@ class Jsonrpc extends Controller
      *
      * @see https://jsonrpc.org/specification#response_object
      */
-    private function returnResponse(?array $returnValue, ?string $id = null): Response
+    private function returnResponse(?array $returnValue, int|string|null $id = null): Response
     {
         /**
          * No IDs imply notification and MUST not be responded to
          *
          * @see https://jsonrpc.org/specification#notification
          */
-        if ($id == null) {
+        if ($id === null) {
             return new Response;
         }
 


### PR DESCRIPTION
### Description

Includes `int` (number) in the allowed id types in the JSON RPC response (cf. https://www.jsonrpc.org/specification#response_object)

### Link to ticket

https://github.com/Leantime/leantime/issues/3063

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

*If your change affects the user interface, you should include a screenshot of the result with the pull request.*
