### PR TITLE
Fix JSON RPC acceptance tests

### DIFF
--- a/tests/Acceptance/API/ApiCest.php
+++ b/tests/Acceptance/API/ApiCest.php
@@ -77,6 +77,30 @@ class ApiCest
         $I->seeResponseMatchesJsonType([
             'jsonrpc' => 'string',
             'result' => 'array',
+            'id' => 'integer',
+        ]);
+    }
+
+    #[Group('api')]
+    #[Depends('createAPIKey')]
+    public function testJsonRpcEndpointStringId(AcceptanceTester $I)
+    {
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->haveHttpHeader('x-api-key', $this->apiKey);
+
+        $I->sendPost('/api/jsonrpc', [
+            'jsonrpc' => '2.0',
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
+            'id' => 'one',
+        ]);
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'jsonrpc' => 'string',
+            'result' => 'array',
             'id' => 'string',
         ]);
     }


### PR DESCRIPTION
### Description

Fixes acceptance tests that broke in https://github.com/Leantime/leantime/pull/3064.

> [!NOTE]
> [The “pint” check](https://github.com/Leantime/leantime/actions/runs/16164821085/job/45624135644?pr=3066) now fails so further cleanup is needed (in another pull request). 

### Link to ticket

Follow-up on https://github.com/Leantime/leantime/issues/3063

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 
