### PR TITLE
Clear out previously defined sections in web.config to resolve 500 on /

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -15,6 +15,7 @@
         </rewrite>
         <defaultDocument>
             <files>
+                <clear />
                 <add value="index.php" />
             </files>
         </defaultDocument>


### PR DESCRIPTION
### Description

Without doing this, 500's occur when browsing to the root directory - navigating to something other than `/` works as expected however. Tested on IIS 10, may require additional testing though.

### Link to ticket

n/a

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

n/a
