### PR TITLE
Fixed typo in timesheets showAll template

### DIFF
--- a/app/Domain/Timesheets/Templates/showAll.tpl.php
+++ b/app/Domain/Timesheets/Templates/showAll.tpl.php
@@ -83,7 +83,7 @@ foreach ($__data as $var => $val) {
                                     } ?>><?= $tpl->escape($client['name'])?></option>
                             <?php } ?>
                         </select>
-                    </td
+                    </td>
                     <td>
                         <label for="projects"><?php echo $tpl->__('label.project'); ?></label>
                         <select name="project" style="max-width:120px;">


### PR DESCRIPTION
### Description

As of my recent PR https://github.com/Leantime/leantime/pull/3093
I made a mistake, not closing a td-tag, causing the "projects" filter td to be rendered outside of its table.

This PR serves to fix that. I apologize for the inconvenience.

### Link to ticket

N/A

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

Before:
<img width="1386" height="159" alt="Screenshot 2025-08-19 at 12 15 57" src="https://github.com/user-attachments/assets/1a269478-809c-411d-a474-ff444c6d26a1" />

After:
<img width="1390" height="96" alt="Screenshot 2025-08-19 at 12 16 09" src="https://github.com/user-attachments/assets/5ab6c262-24f8-4cab-8909-ce563e4b3c5f" />


*If your change affects the user interface, you should include a screenshot of the result with the pull request.*
