### PR TITLE
docs: remove duplicated PHP Extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,27 +92,6 @@ Built with ADHD, dyslexia and autism in mind. 🧠<br />
 * SimpleXML
 <br /><br />
 
-
-Ctype PHP Extension
-cURL PHP Extension
-DOM PHP Extension
-Fileinfo PHP Extension
-Filter PHP Extension
-Hash PHP Extension
-Mbstring PHP Extension
-OpenSSL PHP Extension
-PCRE PHP Extension
-PDO PHP Extension
-Session PHP Extension
-Tokenizer PHP Extension
-XML PHP Extension
-
-
-
-
-
-
-
 ### ️⚡️ Installation (Production) ###
 
 There are two main ways to install LeanTime for production. The first of which is to install all needed pieces of the system locally. The second is to use the officially supported Docker image.


### PR DESCRIPTION
### Description

- there is already a formatted list [directly above this paragraph](https://github.com/Leantime/leantime/tree/03d36dd8ff2df63c25172afc7252d76bb5c8f1be?tab=readme-ov-file#system-requirements)
  - https://github.com/Leantime/leantime/commit/5f01410766218631ccb47e3697bc58dbdbe3dd0b seemed to have accidentally partially duplicated the list

### Link to ticket

n/a

### Type

- [ ] Fix
- [ ] Feature
- [x] Cleanup 

### Screenshot of the result

Screenshot of README with the duplicated list/paragraph removed:
<img width="913" height="956" alt="Screenshot 2025-08-26 at 7 16 45 PM" src="https://github.com/user-attachments/assets/99b22740-151c-47ab-b161-039d720f61cb" />


### Misc Notes

You might be interested in adding [a `<details>` spoiler tag](https://gist.github.com/jbsulli/03df3cdce94ee97937ebda0ffef28287) to put the list behind a dropdown; I can make that change if desired, but left this PR as a clean fix
