### PR TITLE
Action/version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Universal Version Bump
-        uses: ./
+        uses: taj54/universal-version-bump@v0.13.2
         with:
           release_type: ${{ inputs.release_type }}
           target_platform: 'custom'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,14 +27,14 @@ jobs:
           fetch-depth: 0
 
       - name: Universal Version Bump
-        uses: taj54/universal-version-bump@v0.13.2
+        uses: taj54/universal-version-bump@v0.13.3
         with:
           release_type: ${{ inputs.release_type }}
           target_platform: 'custom'
           bump_targets: |
             [
               { "path": "package.json", "variable": "version" },
-              { "path": "app\core\Configuration\AppSettings.php", "variable": "$appVersion" }
+              { "path": "app\core\Configuration\AppSettings.php", "variable": "appVersion" }
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,40 @@
+name: Version Bump
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Select version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Universal Version Bump
+        uses: ./
+        with:
+          release_type: ${{ inputs.release_type }}
+          target_platform: 'custom'
+          bump_targets: |
+            [
+              { "path": "package.json", "variable": "version" },
+              { "path": "app\core\Configuration\AppSettings.php", "variable": "$appVersion" }
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This PR introduces a **manual version bump workflow** using GitHub Actions.  
It allows maintainers to trigger version bumps (`patch`, `minor`, `major`) directly from the **Actions tab**, ensuring consistency across `package.json`, PHP class files, and other defined targets.  

The workflow leverages [`taj54/universal-version-bump`](https://github.com/taj54/universal-version-bump) for multi-language support.

### Link to ticket

#3110 

### Type

- [ ] Fix
- [x] Feature
- [ ] Cleanup 

### Screenshot of the result

N/A — no UI impact, workflow only.

### Checklist

- [x] Workflow can be triggered manually via `workflow_dispatch`.
- [x] Bump type can be selected (`patch`, `minor`, `major`).
- [x] Version is updated consistently across configured files.
