### PR TITLE
fix: title not populated (#3121)

### DIFF
--- a/app/Core/UI/ViewsServiceProvider.php
+++ b/app/Core/UI/ViewsServiceProvider.php
@@ -321,7 +321,7 @@ class ViewsServiceProvider extends LaravelViewServiceProvider
 
         app('blade.compiler')->directive(
             'dispatchFilter',
-            fn ($args) => "<?php \$tpl->dispatchTplFilter($args); ?>",
+            fn ($args) => "<?php echo \$tpl->dispatchTplFilter($args); ?>",
         );
 
         app('blade.compiler')->directive(


### PR DESCRIPTION
### Description

Fixes empty `<title>` tags. Root cause: the Blade directive for filters was defined without echoing its return value, so `@dispatchFilter('page_title', $sitename)` produced an empty title. Updated the `dispatchFilter` directive to echo the filter result so page titles (and any other filter-based content) now render correctly. No other template changes included.

Key change:
```php
app('blade.compiler')->directive(
    'dispatchFilter',
    fn ($args) => "<?php echo \$tpl->dispatchTplFilter($args); ?>",
);
```

Reasoning: Events are side-effect only (no echo). Filters are value transformers and must output their returned value. This aligns filter behavior with intended plugin extensibility.

### Link to ticket

Closes  #3121 

### Type

- [x] Fix

### Screenshot of the result
- mine post fix: <img width="798" height="160" alt="image" src="https://github.com/user-attachments/assets/d550c14d-5e35-431d-ad7d-244743228fb5" />
- demo site showing old issue: 
<img width="834" height="182" alt="image" src="https://github.com/user-attachments/assets/da5cc342-4a17-41ea-95d7-d36d72f6e59a" />

### Verification

1. Before: View page source → `<title></title>`
2. After: `<title>Leantime` (or configured sitename / plugin-modified value)

### Notes

- No risk of breaking silent side-effects; any code needing silence should use `@dispatchEvent`.
- Header template left untouched (still uses the directive form).
- Codesniffer and PHPStan validated