### PR TITLE
Update sample.env

### DIFF
--- a/config/sample.env
+++ b/config/sample.env
@@ -100,7 +100,7 @@ LEAN_LDAP_KEYS="{
 #        \"department\":\"department\"
 #      }"
 
-LEAN_LDAP_DEFAULT_ROLE_KEY = 20;                   # Default Leantime Role on creation. (set to editor)
+LEAN_LDAP_DEFAULT_ROLE_KEY = 20                   # Default Leantime Role on creation. (set to editor)
 
 # Default role assignments upon first login.
 # optional - Can be updated later in user settings for each user


### PR DESCRIPTION
The semicolon at the end of the LEAN_LDAP_DEFAULT_ROLE_KEY will cause any LDAP users permissions to fail if they do not match any assignment rules in LEAN_LDAP_GROUP_ASSIGNMENT.

### Description

*Please include a short description of the suggested change and the reasoning behind the approach you have chosen.*

### Link to ticket

*Please add a link to the GitHub issue being addressed by this change.*

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

*If your change affects the user interface, you should include a screenshot of the result with the pull request.*
