### PR TITLE
fix(db): Fix zp_entity_relationship table migration issues

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.6.0';
 
-    public string $dbVersion = '3.4.11';
+    public string $dbVersion = '3.4.12';
 }


### PR DESCRIPTION
## Summary

Fixes database migration issues where the `zp_entity_relationship` table doesn't exist or has incorrect schema, causing errors like:
- `Table 'zp_entity_relationship' doesn't exist`
- Dashboard and tickets pages failing to load

## Problem

The migration had several issues:
1. **Original migration (update_sql_20115)** created `zp_entity_relationships` (plural) with typo `enitityA`
2. **Fresh install SQL** creates `zp_entity_relationship` (singular) with correct `entityA`
3. **Migration update_sql_30410** tried to fix the typo but assumed the singular table exists
4. **Users who already ran broken 30410** had it marked as complete, so fixes to 30410 wouldn't help them

## Solution

- Improved `update_sql_30410()` for new users who haven't run it yet
- Added new `update_sql_30412()` migration for users who already ran the broken version
- Updated `dbVersion` to `3.4.12`

The new migration handles all scenarios:
1. Renames plural table (`zp_entity_relationships`) to singular if it exists
2. Creates table with correct schema if missing entirely
3. Fixes column typo (`enitityA` → `entityA`) if present

## Test plan

- [ ] Fresh install: Table created with correct schema
- [ ] Upgrade from old version with plural table: Table renamed and column fixed
- [ ] User who already ran broken 30410: New migration 30412 fixes the issues
- [ ] Dashboard loads without errors
- [ ] Tickets page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)