### PR TITLE
fix: resolve timezone crash in EditTime controller

### DIFF
--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -147,9 +147,9 @@ class EditTime extends Controller
                                 }
 
                                 if (! empty($_POST['paidDate'])) {
-                                    $date = dtHelper()->parseUserDateTime($_POST['paidDate'], 'start')->formatDateTimeForDb();
+                                    $date = dtHelper()->parseUserDateTime($_POST['paidDate'], 'start');
                                     $date->setTimezone('UTC');
-                                    $values['paidDate'] = $date;
+                                    $values['paidDate'] = $date->formatDateTimeForDb();
                                 } else {
                                     $values['paidDate'] = dtHelper()->userNow()->formatDateTimeForDb();
                                 }


### PR DESCRIPTION
### Description

This PR resolves a critical 500 Error (Call to a member function setTimezone() on string) in the EditTime controller.

The issue occurred because the formatDateTimeForDb() method was being called before the setTimezone() method. In PHP, formatDateTimeForDb() returns a string, while setTimezone() must be called on a DateTime object.

The chosen approach reorders these operations to ensure the timezone is adjusted while the variable is still a DateTime object, then formats it for database storage as the final step.


### Link to ticket

Fixes #3248

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result
<img width="998" height="713" alt="Screenshot 2026-02-18 at 14 09 42" src="https://github.com/user-attachments/assets/a89c732d-bbe4-4b9b-808c-072f8f3c5386" />
