### PR TITLE
fix: accessibility, view system, and composer improvements from phase-0

### DIFF
--- a/app/Core/UI/ViewsServiceProvider.php
+++ b/app/Core/UI/ViewsServiceProvider.php
@@ -62,11 +62,10 @@ class ViewsServiceProvider extends LaravelViewServiceProvider
 
             $factory = $this->createFactory($resolver, $finder, $app['events']);
 
-            // Backwards compatible view engine resolver
+            // Legacy template extensions — still needed for plugins with .tpl.php/.sub.php/.inc.php
             array_map(fn ($ext) => $factory->addExtension($ext, 'php'), ['inc.php', 'sub.php', 'tpl.php']);
 
-            // reprioritize blade
-            // Use blade engine for all things blade
+            // Use blade engine for all things blade (registered last to take priority)
             $factory->addExtension('blade.php', 'blade');
 
             // We will also set the container instance on this view environment since the
@@ -411,6 +410,7 @@ class ViewsServiceProvider extends LaravelViewServiceProvider
 
         $storePaths = $domainPaths
             ->merge($pluginPaths)
+            ->merge(['globals' => APP_ROOT.'/app/Views/Templates'])
             ->merge(['global' => APP_ROOT.'/app/Views/Templates'])
             ->merge(['__components' => $this->app['config']->get('view.compiled')])
             ->all();

--- a/app/Views/Composers/App.php
+++ b/app/Views/Composers/App.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller\Frontcontroller as FrontcontrollerCore;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\UI\Composer;
+use Leantime\Core\UI\Theme;
 use Leantime\Domain\Menu\Repositories\Menu;
 
 class App extends Composer
@@ -18,9 +19,12 @@ class App extends Composer
 
     private Menu $menuRepo;
 
-    public function init(Menu $menuRepo): void
+    private Theme $themeCore;
+
+    public function init(Menu $menuRepo, Theme $themeCore): void
     {
         $this->menuRepo = $menuRepo;
+        $this->themeCore = $themeCore;
     }
 
     /**
@@ -39,8 +43,10 @@ class App extends Composer
         $announcement = self::dispatch_filter('appAnnouncement', $announcement);
 
         return [
+            'module' => strtolower(FrontcontrollerCore::getModuleName()),
             'section' => $menuType,
             'appAnnouncement' => $announcement,
+            'themeBgUrl' => $this->themeCore->getBackgroundImage(),
         ];
     }
 }

--- a/app/Views/Composers/Header.php
+++ b/app/Views/Composers/Header.php
@@ -85,6 +85,8 @@ class Header extends Composer
             'accents' => [
                 $this->themeCore->getPrimaryColor(),
                 $this->themeCore->getSecondaryColor(),
+                false,  // accent3 uses CSS default
+                false,  // accent4 uses CSS default
             ],
             'themeBg' => $this->themeCore->getBackgroundImage(),
             'themeOpacity' => $backgroundOpacity,

--- a/app/Views/Templates/sections/header.blade.php
+++ b/app/Views/Templates/sections/header.blade.php
@@ -3,7 +3,7 @@
 <meta name="requestId" content="{{ \Illuminate\Support\Str::random(4) }}">
 <meta name="description" content="{{ $sitename }}">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-touch-fullscreen" content="yes">
 <meta name="theme-color" content="{{ $primaryColor }}">


### PR DESCRIPTION
## Summary

Independent improvements extracted from the phase-0 modernization branch. Each change creates a noop diff reduction when the feature branch eventually merges. All are low-risk and independently valuable.

This is PR 4 of the phase-0 modernization series.

## Changes

### Accessibility
- **Remove `maximum-scale=1.0` from viewport meta** — This restriction prevents users with low vision from zooming the page, violating WCAG 2.1 SC 1.4.4 (Resize Text). One-line change in `header.blade.php`.

### View system
- **Add `globals` alias in ViewsServiceProvider** — Registers `app/Views/Templates` under both `global` (existing) and `globals` (new) aliases. This enables `<x-globals::componentName>` syntax used by the new Blade component library in the modernization branch. Purely additive — existing `<x-global::...>` syntax continues to work.
- **Update comments** — Clarify legacy extension support and blade priority registration.

### App composer
- **Pass `module` to app layout** — Exposes `strtolower(FrontcontrollerCore::getModuleName())` as a template variable. This enables a `data-module` attribute on `<body>` for domain-specific JS lazy-loading (used by the Vite migration).
- **Pass `themeBgUrl` to app layout** — Moves background image URL resolution from inline template logic to the composer, following the composer pattern.

### Header composer
- **Add accent3/4 to accents array** — Adds `false` entries for accent3 and accent4 in the accents array. These use CSS defaults from the theme files (added in PR #3290). The `false` value means "use CSS default, don't override via inline style."

## Verification
- PHPStan: **PASS** (0 errors)
- Laravel Pint: **PASS** (1376 files)
- `getModuleName()` exists on Frontcontroller (line 384)
- `getBackgroundImage()` exists on Theme class (already used by Header composer)