### PR TITLE
Add collaborator support to task assignment and UI (list + kanban)

### DIFF
--- a/app/Domain/Calendar/Repositories/Calendar.php
+++ b/app/Domain/Calendar/Repositories/Calendar.php
@@ -9,6 +9,7 @@ use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Db\Repository as RepositoryCore;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Core\Support\EntityRelationshipEnum;
 use Leantime\Core\Support\DateTimeHelper;
 use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Tickets\Services\Tickets;
@@ -309,7 +310,16 @@ class Calendar extends RepositoryCore
             ->select('id', 'headline', 'dateToFinish')
             ->where(function ($query) {
                 $query->where('userId', session('userdata.id'))
-                    ->orWhere('editorId', (string) session('userdata.id'));
+                    ->orWhere('editorId', (string) session('userdata.id'))
+                    ->orWhereExists(function ($subquery) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->where('zp_entity_relationship.entityB', session('userdata.id'));
+                    });
             })
             ->where('dateToFinish', '<>', '000-00-00 00:00:00')
             ->get();
@@ -323,7 +333,16 @@ class Calendar extends RepositoryCore
             ->select('id', 'headline', 'editFrom', 'editTo')
             ->where(function ($query) {
                 $query->where('userId', session('userdata.id'))
-                    ->orWhere('editorId', (string) session('userdata.id'));
+                    ->orWhere('editorId', (string) session('userdata.id'))
+                    ->orWhereExists(function ($subquery) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->where('zp_entity_relationship.entityB', session('userdata.id'));
+                    });
             })
             ->where('editFrom', '<>', '000-00-00 00:00:00')
             ->get();

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -475,6 +475,9 @@ class Projects
             if (isset($entity['editorId']) && (int) $entity['editorId'] === $userId) {
                 return true;
             }
+            if (isset($entity['collaborators']) && is_array($entity['collaborators']) && in_array($userId, array_map('intval', $entity['collaborators']), true)) {
+                return true;
+            }
             if (isset($entity['userId']) && (int) $entity['userId'] === $userId) {
                 return true;
             }
@@ -484,6 +487,9 @@ class Projects
             }
         } elseif (is_object($entity)) {
             if (isset($entity->editorId) && (int) $entity->editorId === $userId) {
+                return true;
+            }
+            if (isset($entity->collaborators) && is_array($entity->collaborators) && in_array($userId, array_map('intval', $entity->collaborators), true)) {
                 return true;
             }
             if (isset($entity->userId) && (int) $entity->userId === $userId) {

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -447,12 +447,6 @@ class Tickets
             $join->on('zp_tickets.projectId', '=', 'rup.projectId')
                 ->where('rup.userId', '=', $userId);
         })
-            ->leftJoin('zp_entity_relationship as er', function ($join) {
-                $join->on('er.entityAType', '=', $this->connection->raw("'Ticket'"))
-                    ->on('er.entityBType', '=', $this->connection->raw("'User'"))
-                    ->on('er.entityA', '=', 'zp_tickets.id')
-                    ->on('er.relationship', '=', $this->connection->raw("'".EntityRelationshipEnum::Collaborator->value."'"));
-            })
             ->where(function ($q) use ($clientId) {
                 $q->whereNotNull('rup.projectId')
                     ->orWhere('zp_projects.psettings', 'all')
@@ -489,7 +483,15 @@ class Tickets
             $userIds = explode(',', $searchCriteria['users']);
             $query->where(function ($q) use ($userIds) {
                 $q->whereIn('zp_tickets.editorId', $userIds)
-                    ->orWhereIn('er.entityB', $userIds);
+                    ->orWhereExists(function ($subquery) use ($userIds) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->whereIn('zp_entity_relationship.entityB', $userIds);
+                    });
             });
         }
 
@@ -672,12 +674,6 @@ class Tickets
                 $join->on('requestor.id', '=', $this->connection->raw((int) $requestorId));
             })
             ->leftJoin('zp_tickets as milestones', 'zp_tickets.milestoneid', '=', 'milestones.id')
-            ->leftJoin('zp_entity_relationship as er', function ($join) {
-                $join->on('er.entityAType', '=', $this->connection->raw("'Ticket'"))
-                    ->on('er.entityBType', '=', $this->connection->raw("'User'"))
-                    ->on('er.relationship', '=', $this->connection->raw("'Collaborator'"))
-                    ->on('er.entityA', '=', 'zp_tickets.id');
-            })
             ->where(function ($q) use ($requestorId, $clientId) {
                 $q->whereIn('zp_tickets.projectId', function ($subquery) use ($requestorId) {
                     $subquery->select('projectId')
@@ -699,7 +695,15 @@ class Tickets
         if (isset($userId) && $userId > 0) {
             $query->where(function ($q) use ($userId) {
                 $q->where('zp_tickets.editorId', (string) $userId)
-                    ->orWhere('er.entityB', $userId);
+                    ->orWhereExists(function ($subquery) use ($userId) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->where('zp_entity_relationship.entityB', $userId);
+                    });
             });
         }
 
@@ -764,7 +768,18 @@ class Tickets
             ->where('zp_tickets.type', '<>', 'milestone');
 
         if (isset($userId)) {
-            $query->where('zp_tickets.editorId', (string) $userId);
+            $query->where(function ($q) use ($userId) {
+                $q->where('zp_tickets.editorId', (string) $userId)
+                    ->orWhereExists(function ($subquery) use ($userId) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->where('zp_entity_relationship.entityB', $userId);
+                    });
+            });
         }
 
         $query->where(function ($q) use ($dateFrom, $dateTo) {
@@ -1129,7 +1144,18 @@ class Tickets
 
         if (isset($searchCriteria['users']) && $searchCriteria['users'] != '') {
             $userIds = explode(',', $searchCriteria['users']);
-            $query->whereIn('zp_tickets.editorId', $userIds);
+            $query->where(function ($q) use ($userIds) {
+                $q->whereIn('zp_tickets.editorId', $userIds)
+                    ->orWhereExists(function ($subquery) use ($userIds) {
+                        $subquery->selectRaw('1')
+                            ->from('zp_entity_relationship')
+                            ->whereColumn('zp_entity_relationship.entityA', 'zp_tickets.id')
+                            ->where('zp_entity_relationship.entityAType', 'Ticket')
+                            ->where('zp_entity_relationship.entityBType', 'User')
+                            ->where('zp_entity_relationship.relationship', EntityRelationshipEnum::Collaborator->value)
+                            ->whereIn('zp_entity_relationship.entityB', $userIds);
+                    });
+            });
         }
 
         if (isset($searchCriteria['milestone']) && $searchCriteria['milestone'] != '') {
@@ -1798,6 +1824,42 @@ class Tickets
             ->where('relationship', EntityRelationshipEnum::Collaborator->value)
             ->pluck('userId')
             ->toArray();
+    }
+
+    /**
+     * Retrieves collaborators for multiple tickets in a single query.
+     *
+     * @param  array<int, int|string>  $ticketIds
+     * @return array<int, array<int, int>>
+     */
+    public function getCollaboratorsByTicketIds(array $ticketIds): array
+    {
+        $ticketIds = array_values(array_filter(array_map('intval', $ticketIds)));
+
+        if (empty($ticketIds)) {
+            return [];
+        }
+
+        $rows = $this->connection->table('zp_entity_relationship')
+            ->select(['entityA', 'entityB'])
+            ->whereIn('entityA', $ticketIds)
+            ->where('entityAType', 'Ticket')
+            ->where('entityBType', 'User')
+            ->where('relationship', EntityRelationshipEnum::Collaborator->value)
+            ->orderBy('entityA')
+            ->orderBy('entityB')
+            ->get();
+
+        $collaboratorsByTicket = [];
+
+        foreach ($rows as $row) {
+            $ticketId = (int) $row->entityA;
+            $userId = (int) $row->entityB;
+            $collaboratorsByTicket[$ticketId] ??= [];
+            $collaboratorsByTicket[$ticketId][] = $userId;
+        }
+
+        return $collaboratorsByTicket;
     }
 
     /**

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -2812,6 +2812,7 @@ class Tickets
             $searchUrlString = '?'.http_build_query($this->getSetFilters($searchCriteria, true));
         }
 
+        $allTickets = $this->enrichGroupedTicketsWithCollaborators($allTickets);
         $allTickets = self::dispatchFilter('filterTickets', $allTickets);
 
         return [
@@ -2834,6 +2835,56 @@ class Tickets
             'sortOptions' => $sortOptions,
             'searchParams' => $searchUrlString,
         ];
+    }
+
+    /**
+     * Adds collaborator display metadata to grouped ticket collections used by list/kanban views.
+     *
+     * @param  array<string, array<string, mixed>>  $groupedTickets
+     * @return array<string, array<string, mixed>>
+     */
+    private function enrichGroupedTicketsWithCollaborators(array $groupedTickets): array
+    {
+        $ticketIds = [];
+
+        foreach ($groupedTickets as $group) {
+            foreach (($group['items'] ?? []) as $ticket) {
+                if (isset($ticket['id'])) {
+                    $ticketIds[] = (int) $ticket['id'];
+                }
+            }
+        }
+
+        if (empty($ticketIds)) {
+            return $groupedTickets;
+        }
+
+        $collaboratorsByTicket = $this->ticketRepository->getCollaboratorsByTicketIds($ticketIds);
+
+        foreach ($groupedTickets as &$group) {
+            foreach (($group['items'] ?? []) as &$ticket) {
+                $ticketId = (int) ($ticket['id'] ?? 0);
+                $editorId = (int) ($ticket['editorId'] ?? 0);
+                $collaboratorIds = $collaboratorsByTicket[$ticketId] ?? [];
+
+                // Do not duplicate the primary assignee in the collaborator UI stack.
+                if ($editorId > 0) {
+                    $collaboratorIds = array_values(array_filter(
+                        $collaboratorIds,
+                        fn ($userId) => (int) $userId !== $editorId
+                    ));
+                }
+
+                $ticket['collaborators'] = $collaboratorIds;
+                $ticket['collaboratorPreview'] = array_slice($collaboratorIds, 0, 2);
+                $ticket['collaboratorCount'] = count($collaboratorIds);
+                $ticket['collaboratorOverflow'] = max(0, count($collaboratorIds) - count($ticket['collaboratorPreview']));
+            }
+            unset($ticket);
+        }
+        unset($group);
+
+        return $groupedTickets;
     }
 
     /**

--- a/app/Domain/Tickets/Templates/showAll.tpl.php
+++ b/app/Domain/Tickets/Templates/showAll.tpl.php
@@ -263,11 +263,26 @@ $tpl->dispatchTplEvent('filters.beforeLefthandSectionClose');
                             <td data-order="<?= $row['editorFirstname'] != '' ? $tpl->escape($row['editorFirstname']) : $tpl->__('dropdown.not_assigned')?>">
                                 <div class="dropdown ticketDropdown userDropdown noBg show f-left">
                                     <a class="dropdown-toggle" href="javascript:void(0);" role="button" id="userDropdownMenuLink<?= $row['id']?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                                <span class="text">
+                                                                <span class="text" style="display:inline-flex; align-items:center; gap:6px;">
                                                                     <?php if ($row['editorFirstname'] != '') {
                                                                         echo "<span id='userImage".$row['id']."'><img src='".BASE_URL.'/api/users?profileImage='.$row['editorId']."' width='25' style='vertical-align: middle; margin-right:5px;'/></span><span id='user".$row['id']."'>".$tpl->escape($row['editorFirstname']).'</span>';
                                                                     } else {
                                                                         echo "<span id='userImage".$row['id']."'><img src='".BASE_URL."/api/users?profileImage=false' width='25' style='vertical-align: middle; margin-right:5px;'/></span><span id='user".$row['id']."'>".$tpl->__('dropdown.not_assigned').'</span>';
+                                                                    }
+
+                                                                    if (! empty($row['collaboratorPreview'])) {
+                                                                        echo "<span class='ticket-collaborators' style='display:inline-flex; align-items:center; margin-left:4px;'>";
+
+                                                                        foreach ($row['collaboratorPreview'] as $index => $collaboratorId) {
+                                                                            $offset = $index > 0 ? 'margin-left:-8px;' : '';
+                                                                            echo "<span class='ticket-collaborator-avatar' title='".$tpl->__('label.collaborators')."' style='display:inline-flex; width:20px; height:20px; border-radius:999px; border:2px solid var(--main-background-color, #fff); overflow:hidden; ".$offset."'><img src='".BASE_URL.'/api/users?profileImage='.$collaboratorId."' width='20' height='20' style='display:block; width:20px; height:20px;'/></span>";
+                                                                        }
+
+                                                                        if (($row['collaboratorOverflow'] ?? 0) > 0) {
+                                                                            echo "<span class='ticket-collaborator-more' title='".$tpl->__('label.collaborators')."' style='display:inline-flex; align-items:center; justify-content:center; min-width:20px; height:20px; padding:0 5px; margin-left:4px; border-radius:999px; background:var(--accent-color, #e9ecef); color:var(--secondary-font-color, #333); font-size:11px; line-height:20px;'>+".(int) $row['collaboratorOverflow'].'</span>';
+                                                                        }
+
+                                                                        echo '</span>';
                                                                     }?>
                                                                 </span>
                                         &nbsp;<i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/app/Domain/Tickets/Templates/showKanban.tpl.php
+++ b/app/Domain/Tickets/Templates/showKanban.tpl.php
@@ -323,12 +323,27 @@ $allTickets = $group['items'];
 
                                                 <div class="dropdown ticketDropdown userDropdown noBg show right lastDropdown dropRight">
                                                     <a class="dropdown-toggle f-left" href="javascript:void(0);" role="button" id="userDropdownMenuLink<?= $row['id']?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                        <span class="text">
+                                                        <span class="text" style="display:inline-flex; align-items:center;">
                                                             <?php
                                                             if ($row['editorFirstname'] != '') {
                                                                 echo "<span id='userImage".$row['id']."'><img src='".BASE_URL.'/api/users?profileImage='.$row['editorId']."' width='25' style='vertical-align: middle;'/></span>";
                                                             } else {
                                                                 echo "<span id='userImage".$row['id']."'><img src='".BASE_URL."/api/users?profileImage=false' width='25' style='vertical-align: middle;'/></span>";
+                                                            }
+
+                                                            if (! empty($row['collaboratorPreview'])) {
+                                                                echo "<span class='ticket-collaborators' style='display:inline-flex; align-items:center; margin-left:6px;'>";
+
+                                                                foreach ($row['collaboratorPreview'] as $index => $collaboratorId) {
+                                                                    $offset = $index > 0 ? 'margin-left:-8px;' : '';
+                                                                    echo "<span class='ticket-collaborator-avatar' title='".$tpl->__('label.collaborators')."' style='display:inline-flex; width:18px; height:18px; border-radius:999px; border:2px solid var(--main-background-color, #fff); overflow:hidden; ".$offset."'><img src='".BASE_URL.'/api/users?profileImage='.$collaboratorId."' width='18' height='18' style='display:block; width:18px; height:18px;'/></span>";
+                                                                }
+
+                                                                if (($row['collaboratorOverflow'] ?? 0) > 0) {
+                                                                    echo "<span class='ticket-collaborator-more' title='".$tpl->__('label.collaborators')."' style='display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:18px; padding:0 4px; margin-left:4px; border-radius:999px; background:var(--accent-color, #e9ecef); color:var(--secondary-font-color, #333); font-size:10px; line-height:18px;'>+".(int) $row['collaboratorOverflow'].'</span>';
+                                                                }
+
+                                                                echo '</span>';
                                                             }?>
                                                         </span>
                                                     </a>


### PR DESCRIPTION
## Description

This PR enhances task assignment by fully supporting multiple collaborators per task.

While the system already had partial support for collaborators using zp_entity_relationship, many parts of the application still relied solely on the primary assignee (editorId).

## What was done

### Backend improvements

- Standardized collaborator relationship usage using EntityRelationshipEnum::Collaborator->value
- Updated task queries to include:
  - primary assignee (editorId)
  - collaborators (via zp_entity_relationship)
- Applied changes to:
  - task search and listing
  - scheduled tasks
  - milestones
  - calendar views
- Extended notification involvement logic to include collaborators

### UI improvements

- Added collaborator display to:
  - task list view
  - kanban board
- Maintained primary assignee as the main avatar
- Displayed collaborators as stacked avatars with "+N" overflow
- Avoided duplication of primary assignee in collaborator list

## Type

- [x] Feature

## Result

Users can now:
- be assigned as collaborators to tasks
- see tasks where they are collaborators in "My Tasks"
- visualize collaborators directly in task cards

This improves collaboration while keeping the existing data model stable.