### PR TITLE
Fix syntax for Referrer-Policy header assignment

### DIFF
--- a/app/Core/Middleware/InitialHeaders.php
+++ b/app/Core/Middleware/InitialHeaders.php
@@ -55,7 +55,7 @@ class InitialHeaders
                 'X-Frame-Options' => 'SAMEORIGIN',
                 'X-XSS-Protection' => '1; mode=block',
                 'X-Content-Type-Options' => 'nosniff',
-                'Referrer-Policy', 'same-origin',
+                'Referrer-Policy' => 'same-origin',
                 'Access-Control-Allow-Origin' => BASE_URL,
                 'Cache-Control' => 'no-cache, no-store, must-revalidate',
                 'Pragma' => 'no-cache',


### PR DESCRIPTION
while testing i noticed the odd http headers in the response, 0: Referrer-Policy
1: same-origin
on investigation i found the cause to be a typo app/Core/Middleware/InitialHeaders.php replacing the , with => now shows the correct header Referrer-Policy: same-origin

### Description

This looks like a basic typo in the code resulting in malformed headers in response.

### Link to ticket

I did not create a ticket

### Type

- [X] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

HTTP/1.1 302 Found
Date: Wed, 01 Apr 2026 14:06:00 GMT
Server: Apache/2.4.63 (Oracle Linux Server) OpenSSL/3.5.1
X-Powered-By: PHP/8.3.29
Cache-Control: no-cache, private
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
**Referrer-Policy: same-origin**
Access-Control-Allow-Origin: https://leantime.testing.local
Pragma: no-cache
Content-Security-Policy: default-src 'self' 'unsafe-inline';base-uri 'self';;script-src 'self' 'unsafe-inline' 'unsafe-eval' unpkg.com;font-src 'self'  data: unpkg.com;img-src * 'self' *.leantime.io *.amazonaws.com data: blob: marketplace.localhost;frame-src 'self' *.google.com *.microsoft.com *.live.com *.sharepoint.com *.officeapps.live.com *.figma.com *.miro.com *.youtube.com *.youtube-nocookie.com player.vimeo.com *.vimeo.com *.loom.com *.airtable.com *.typeform.com form.typeform.com calendly.com codepen.io *.codesandbox.io;frame-ancestors 'self' *.google.com *.microsoft.com *.live.com
Set-Cookie: leantime_session=Kt2INDpOkp23c7Q149VMzcNFpY0SGAOMvUJ8y48I; expires=Wed, 01 Apr 2026 22:06:00 GMT; Max-Age=28800; path=/; httponly; samesite=lax
Location: https://leantime.testing.local/auth/login
Content-Type: text/html; charset=utf-8
