### PR TITLE
Fix case sensitivity in secondary color setting

### DIFF
--- a/app/Core/UI/Theme.php
+++ b/app/Core/UI/Theme.php
@@ -985,7 +985,7 @@ class Theme
                 session(['usersettings.colors.secondaryColor' => $this->config->secondaryColor]);
             }
 
-            $secondaryColor = $this->settingsRepo->getSetting('companysettings.secondaryColor');
+            $secondaryColor = $this->settingsRepo->getSetting('companysettings.secondarycolor');
             if ($secondaryColor !== false) {
                 session(['usersettings.colors.secondaryColor' => $secondaryColor]);
             }


### PR DESCRIPTION
the setting string was incorrectly capitalised,

companysettings.secondaryColor shoudl be companysettings.secondarycolor

### Description

Another small typo i noticed while initially setting up and trying (and failing) to set company colours.

### Link to ticket

No ticket

### Type

- [X] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

<img width="416" height="125" alt="image" src="https://github.com/user-attachments/assets/e44d772a-4964-425e-a444-249c0aff0945" />
