### PR TITLE
make MarketplacePlugin model properties nullable for PHP 8.x

### DIFF
--- a/app/Core/Support/Build.php
+++ b/app/Core/Support/Build.php
@@ -128,6 +128,20 @@ class Build
         } elseif (method_exists($this->object, 'set'.$key)) {
             $property->{'set'.$key}($value);
         } else {
+            if ($value === null && property_exists($property, $key)) {
+                $reflection = new \ReflectionProperty($property, $key);
+                $type = $reflection->getType();
+                if ($type !== null && ! $type->allowsNull()) {
+                    $value = match ($type->getName()) {
+                        'string' => '',
+                        'int'    => 0,
+                        'float'  => 0.0,
+                        'bool'   => false,
+                        'array'  => [],
+                        default  => null,
+                    };
+                }
+            }
             $property->$key = $value;
         }
     }

--- a/app/Domain/Plugins/Models/MarketplacePlugin.php
+++ b/app/Domain/Plugins/Models/MarketplacePlugin.php
@@ -6,23 +6,23 @@ use Leantime\Domain\Plugins\Contracts\PluginDisplayStrategy;
 
 class MarketplacePlugin implements PluginDisplayStrategy
 {
-    public string $identifier = '';
+    public ?string $identifier = '';
 
-    public string $name = '';
+    public ?string $name = '';
 
-    public string $excerpt = '';
+    public ?string $excerpt = '';
 
-    public string $description = '';
+    public ?string $description = '';
 
-    public string $imageUrl = '';
+    public ?string $imageUrl = '';
 
-    public string $vendorDisplayName = '';
+    public ?string $vendorDisplayName = '';
 
     public int $vendorId = 0;
 
-    public string $vendorEmail = '';
+    public ?string $vendorEmail = '';
 
-    public string $marketplaceUrl = '';
+    public ?string $marketplaceUrl = '';
 
     public ?string $startingPrice = null;
 
@@ -36,17 +36,17 @@ class MarketplacePlugin implements PluginDisplayStrategy
 
     public ?int $reviewCount = null;
 
-    public string $type = 'marketplace';
+    public ?string $type = 'marketplace';
 
     public array $reviews = [];
 
-    public string $marketplaceId = '';
+    public ?string $marketplaceId = '';
 
     public array $compatibility = [];
 
-    public string $version = '';
+    public ?string $version = '';
 
-    public string $icon = '';
+    public ?string $icon = '';
 
     public array $categories = [];
 


### PR DESCRIPTION
### Description

The Leantime marketplace API returns null for several fields (e.g. excerpt,
vendorId) that were declared as non-nullable typed properties in
MarketplacePlugin.php. PHP 8.0+ strictly enforces typed property assignments
and throws a TypeError on null assignment, causing an HTTP 500 for any
marketplace interaction.

This patch:
1. Makes all API-sourced scalar properties nullable in MarketplacePlugin.php,
   consistent with the four properties ($startingPrice, $calculatedMonthlyPrice,
   $license, $rating) that were already correctly declared as ?string.
2. Adds a defensive null coercion in Build.php::setValue() using ReflectionProperty
   so all models hydrated from external API data are protected systemically.

Confirmed broken on PHP 8.4 (bare-metal PHP-FPM) and PHP 8.x (Docker).
PHP 7.x silently accepted null assignment, masking this bug.

### Link to ticket

https://github.com/Leantime/leantime/issues/3342

also: https://github.com/Leantime/leantime/issues/3336

closed patch PR: https://github.com/Leantime/leantime/pull/3343

### Type

- [X] Fix
