### PR TITLE
fix: Resend Invite button silently no-ops due to isset(null) check

### DIFF
--- a/app/Domain/Users/Controllers/EditUser.php
+++ b/app/Domain/Users/Controllers/EditUser.php
@@ -73,7 +73,7 @@ class EditUser extends Controller
 
             ];
 
-            if (isset($_GET['resendInvite']) && $row !== false) {
+            if (array_key_exists('resendInvite', $_GET) && $row !== false) {
                 if (! session()->exists('lastInvite.'.$values['id']) ||
                     session('lastInvite.'.$values['id']) < time() - 240) {
                     session(['lastInvite.'.$values['id'] => time()]);

--- a/app/Domain/Users/Templates/editUser.tpl.php
+++ b/app/Domain/Users/Templates/editUser.tpl.php
@@ -82,7 +82,7 @@ $projects = $tpl->get('relations');
                                 <input type="text" id="inviteURL" value="<?= BASE_URL ?>/auth/userInvite/<?= $values['pwReset'] ?>" />
                                 <button class="btn btn-primary" onclick="leantime.snippets.copyUrl('inviteURL');"><?= $tpl->__('links.copy_url') ?></button>
                             </div>
-                            <a href="<?= BASE_URL?>/users/editUser/<?= $values['id'] ?>?resendInvite" class="btn btn-default" style="margin-left:5px;"><i class="fa fa-envelope"></i> <?= $tpl->__('buttons.resend_invite') ?></a>
+                            <a href="<?= BASE_URL?>/users/editUser/<?= $values['id'] ?>?resendInvite=1" class="btn btn-default" style="margin-left:5px;"><i class="fa fa-envelope"></i> <?= $tpl->__('buttons.resend_invite') ?></a>
                         </div>
                         <?php } ?>
                         <div class="clearfix"></div>


### PR DESCRIPTION
### Description

The "Resend Invite" button on the edit-user page renders as `?resendInvite` with no value. The framework normalizes empty-string GET params to `null`. The controller's `isset($_GET['resendInvite'])` guard returns `false` for null, so the resend branch never executes and no email is queued — the button appears to succeed but is dead on every click.

Two-part fix:

1. **`app/Domain/Users/Controllers/EditUser.php`** — `isset()` → `array_key_exists()`. The semantically correct check for "is this key in the request" regardless of value. Fixes the root cause; any caller using bare `?resendInvite` now works.

2. **`app/Domain/Users/Templates/editUser.tpl.php`** — `?resendInvite` → `?resendInvite=1`. Defense in depth against future framework changes.

Either change alone fixes the user-visible bug; both make it resilient.

### Link to ticket

Closes #3391

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup

### Screenshot of the result

No UI change — only behavior. Verified locally on Leantime 3.7.3 (PHP 8.4.21, Apache + PHP-FPM):

- **Before**: click → 200 OK, no postfix activity in `journalctl -u postfix`, no email.
- **After**: click → postfix log shows `relay=smtp.resend.com:587 ... status=sent`, recipient receives invite within ~1 sec.

### Local verification

- `php -l` on both files: ✅ no syntax errors
- `vendor/bin/pint --test` on both files: ✅ PASS
- PHPStan: attempted locally but hit a bootstrap conflict (loading `public/index.php` causes Leantime CLI to take over the Symfony Console app and clobber PHPStan's `analyse` command). Maintainers' CI should run cleanly in Docker. The diff is semantically a no-op for static analysis (`array_key_exists` and `isset` both return `bool`, with no type-narrowing differences for downstream code).