### PR TITLE
Fix three bugs: isset on null param, redundant limit(1), malformed URL

### DIFF
--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -808,7 +808,6 @@ class Projects
     {
         $this->connection->table('zp_projects')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
 
         $this->connection->table('zp_tickets')

--- a/app/Domain/Users/Controllers/EditUser.php
+++ b/app/Domain/Users/Controllers/EditUser.php
@@ -73,7 +73,7 @@ class EditUser extends Controller
 
             ];
 
-            if (isset($_GET['resendInvite']) && $row !== false) {
+            if (array_key_exists('resendInvite', $_GET) && $row !== false) {
                 if (! session()->exists('lastInvite.'.$values['id']) ||
                     session('lastInvite.'.$values['id']) < time() - 240) {
                     session(['lastInvite.'.$values['id'] => time()]);

--- a/app/Domain/Users/Templates/editOwn.blade.php
+++ b/app/Domain/Users/Templates/editOwn.blade.php
@@ -103,7 +103,7 @@
                             </div>
                             <div class="col-md-4">
                                 <div class="center">
-                                    <img src='{{ BASE_URL }}/api/users?profileImage={{ $user['id'] }}?v={{ format($user['modified'])->timestamp() }}'  class='profileImg tw-rounded-full' alt='Profile Picture' id="previousImage"/>
+                                    <img src='{{ BASE_URL }}/api/users?profileImage={{ $user['id'] }}&v={{ format($user['modified'])->timestamp() }}'  class='profileImg tw-rounded-full' alt='Profile Picture' id="previousImage"/>
                                     <div id="profileImg">
                                     </div>
 


### PR DESCRIPTION
Three small bug fixes:

**1. #3391 — isset() on null-normalized query param**
EditUser controller used `isset($_GET["resendInvite"])` but Leantime normalizes empty query params (`?resendInvite`) to null. Changed to `array_key_exists("resendInvite", $_GET)` so the invite branch executes.

**2. #3384 — LIMIT 1 on DELETE breaks Postgres**
`deleteProject()` used `->limit(1)` which is MySQL-only. Since `id` is a primary key, the limit is redundant. Removed it.

**3. #3381 — `?v=` instead of `&v=` in profile image URL**
editOwn.blade.php used `?v=` as the second query parameter separator, breaking the image on Postgres (malformed SQL) and silently wrong on MySQL.