### PR TITLE
fix: 6 high-impact bugs — PDO crash, commenter role, Wiki Postgres, Ideas canvasId, Kanban scroll

### DIFF
--- a/app/Core/Configuration/laravelConfig.php
+++ b/app/Core/Configuration/laravelConfig.php
@@ -575,24 +575,43 @@ return [
                 ],
                 'engine' => 'InnoDB',
                 'sslmode' => env('LEAN_DB_SSLMODE', ''),
-                'options' => extension_loaded('pdo_mysql') ? array_filter([
-                    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('LEAN_DB_MYSQL_ATTR_SSL_VERIFY_SERVER', false),
-                    PDO::MYSQL_ATTR_SSL_KEY => env('LEAN_DB_MYSQL_ATTR_SSL_KEY'),
-                    PDO::MYSQL_ATTR_SSL_CERT => env('LEAN_DB_MYSQL_ATTR_SSL_CERT'),
-                    PDO::MYSQL_ATTR_SSL_CA => env('LEAN_DB_MYSQL_ATTR_SSL_CA'),
-                    PDO::ATTR_EMULATE_PREPARES => true,
-                    // Connection pooling and management options
-                    PDO::ATTR_PERSISTENT => env('LEAN_DB_PERSISTENT_CONNECTIONS', true),
-                    PDO::ATTR_TIMEOUT => env('LEAN_DB_CONNECTION_TIMEOUT', 30),
-                    PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-                    PDO::MYSQL_ATTR_FOUND_ROWS => true,
-                    // Connection limits and timeouts
-                    PDO::MYSQL_ATTR_INIT_COMMAND => sprintf(
-                        'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci, @@session.wait_timeout = %d, @@session.interactive_timeout = %d',
-                        env('LEAN_DB_IDLE_TIMEOUT', 3600),
-                        env('LEAN_DB_IDLE_TIMEOUT', 3600)
-                    ),
-                ]) : [],
+                'options' => (function () {
+                    if (! extension_loaded('pdo_mysql')) {
+                        return [];
+                    }
+
+                    // Start with generic PDO options (always available)
+                    $options = [
+                        PDO::ATTR_EMULATE_PREPARES => true,
+                        PDO::ATTR_PERSISTENT => env('LEAN_DB_PERSISTENT_CONNECTIONS', true),
+                        PDO::ATTR_TIMEOUT => env('LEAN_DB_CONNECTION_TIMEOUT', 30),
+                    ];
+
+                    // MySQL-specific constants may be absent on some PHP builds
+                    // (e.g. cPanel/EasyApache), so guard each with defined() (#3371)
+                    $mysqlOptions = [
+                        'MYSQL_ATTR_SSL_VERIFY_SERVER_CERT' => env('LEAN_DB_MYSQL_ATTR_SSL_VERIFY_SERVER', false),
+                        'MYSQL_ATTR_SSL_KEY' => env('LEAN_DB_MYSQL_ATTR_SSL_KEY'),
+                        'MYSQL_ATTR_SSL_CERT' => env('LEAN_DB_MYSQL_ATTR_SSL_CERT'),
+                        'MYSQL_ATTR_SSL_CA' => env('LEAN_DB_MYSQL_ATTR_SSL_CA'),
+                        'MYSQL_ATTR_USE_BUFFERED_QUERY' => true,
+                        'MYSQL_ATTR_FOUND_ROWS' => true,
+                        'MYSQL_ATTR_INIT_COMMAND' => sprintf(
+                            'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci, @@session.wait_timeout = %d, @@session.interactive_timeout = %d',
+                            env('LEAN_DB_IDLE_TIMEOUT', 3600),
+                            env('LEAN_DB_IDLE_TIMEOUT', 3600)
+                        ),
+                    ];
+
+                    foreach ($mysqlOptions as $constName => $value) {
+                        $fqn = "PDO::{$constName}";
+                        if (defined($fqn) && $value !== null) {
+                            $options[constant($fqn)] = $value;
+                        }
+                    }
+
+                    return array_filter($options, fn ($v) => $v !== null && $v !== '');
+                })(),
             ],
             'pgsql' => [
                 'driver' => 'pgsql',

--- a/app/Domain/Comments/Js/commentsController.js
+++ b/app/Domain/Comments/Js/commentsController.js
@@ -2,13 +2,17 @@ leantime.commentsController = (function () {
 
     var enableCommenterForms = function () {
 
-        jQuery(".commentBox").show();
+        // Show the "Add new comment" toggler that makeInputReadonly may have hidden
+        jQuery("[class^='mainToggler']").show();
 
-        //Hide reply comment boxes
-        jQuery("#comments .replies .commentBox").hide();
+        // Show reply-level comment boxes (legacy .commentBox class only).
+        // Do NOT show commentBox-{hash} containers — those are the "new comment"
+        // forms that start hidden and open on-demand via toggleCommentBoxes().
+        jQuery(".commentBox").show();
+        jQuery(".replies .commentBox").hide();
         jQuery(".deleteComment, .replyButton").show();
 
-        // Enable Tiptap editors
+        // Enable Tiptap editors in comment areas
         jQuery(".commentReply .tiptap-wrapper").each(function() {
             var editorEl = jQuery(this).find('.tiptap-editor')[0];
             if (editorEl && window.leantime && window.leantime.tiptapController) {
@@ -20,11 +24,12 @@ leantime.commentsController = (function () {
         });
         jQuery(".commentReply .tiptap-toolbar").show();
 
-        jQuery(".commenterFields input").prop("readonly", false);
-        jQuery(".commenterFields input").prop("disabled", false);
-
-        jQuery(".commenterFields textarea").prop("readonly", false);
-        jQuery(".commenterFields textarea").prop("disabled", false);
+        // Re-enable form controls in all comment areas (both legacy .commentBox
+        // and hashed commentBox-{hash} containers) without changing visibility (#3194)
+        jQuery(".commenterFields, .commentBox, [class*='commentBox-']")
+            .find("input, textarea, button, select")
+            .prop("readonly", false)
+            .prop("disabled", false);
 
     };
 

--- a/app/Domain/Ideas/Controllers/IdeaDialog.php
+++ b/app/Domain/Ideas/Controllers/IdeaDialog.php
@@ -145,7 +145,7 @@ class IdeaDialog extends Controller
         if (isset($params['changeItem'])) {
             if (isset($params['itemId']) && $params['itemId'] != '') {
                 if (isset($params['description']) === true) {
-                    $currentCanvasId = (int) session('currentIdeaCanvas');
+                    $currentCanvasId = (int) ($params['canvasId'] ?? session('currentIdeaCanvas'));
 
                     $id = $params['itemId'];
                     $canvasItem = [
@@ -222,7 +222,7 @@ class IdeaDialog extends Controller
                 }
             } else {
                 if (isset($_POST['description']) === true) {
-                    $currentCanvasId = (int) session('currentIdeaCanvas');
+                    $currentCanvasId = (int) ($params['canvasId'] ?? session('currentIdeaCanvas'));
 
                     $canvasItem = [
                         'box' => $params['box'],

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -52,7 +52,10 @@ class Wiki extends Canvas
             )
             ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
             ->leftJoin('zp_user', 'zp_canvas_items.author', '=', 'zp_user.id')
-            ->leftJoin('zp_tickets AS milestone', 'milestone.id', '=', 'zp_canvas_items.milestoneId')
+            ->leftJoin('zp_tickets AS milestone', function ($join) {
+                $join->on('zp_canvas_items.milestoneId', '=',
+                    $this->dbConnection->raw($this->dbHelper->castAs($this->dbHelper->wrapColumn('milestone.id'), 'text')));
+            })
             ->where('zp_canvas.projectId', $projectId)
             ->where('zp_canvas_items.box', 'article');
 
@@ -166,7 +169,6 @@ class Wiki extends Canvas
     {
         return $this->dbConnection->table('zp_canvas')
             ->where('id', $wikiId)
-            ->limit(1)
             ->update(['title' => $wiki->title]) >= 0;
     }
 
@@ -184,7 +186,7 @@ class Wiki extends Canvas
             'status' => $article->status,
             'created' => date('Y-m-d'),
             'modified' => date('Y-m-d'),
-            'sortIndex' => '10',
+            'sortindex' => '10',
         ]);
 
         return (string) $id;
@@ -194,7 +196,6 @@ class Wiki extends Canvas
     {
         return $this->dbConnection->table('zp_canvas_items')
             ->where('id', $article->id)
-            ->limit(1)
             ->update([
                 'title' => $article->title,
                 'description' => $article->description,
@@ -211,7 +212,6 @@ class Wiki extends Canvas
     {
         $this->dbConnection->table('zp_canvas_items')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 
@@ -223,7 +223,6 @@ class Wiki extends Canvas
 
         $this->dbConnection->table('zp_canvas')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 

--- a/public/assets/css/components/kanban.css
+++ b/public/assets/css/components/kanban.css
@@ -39,8 +39,8 @@
     box-sizing: border-box;
     height:auto;
     padding: 0 6px;
-    flex: 1 1 0;  /* Equal width columns regardless of content */
-    min-width:150px;
+    flex: 1 0 0;  /* Equal width columns, no shrink below min-width (#3394) */
+    min-width:200px;
 }
 
 .column:first-child {
@@ -551,6 +551,7 @@ body .maincontent .priority-text-5 a:link {
     width:100%;
     display:flex;
     padding-bottom: 20px;
+    overflow-x: auto;
 }
 
 /* Note: Swimlane auto-height overrides are at the top of this file */


### PR DESCRIPTION
## Summary

Fixes 6 open GitHub bug reports in a single batch. All changes are small and contained — no architectural changes.

### #3371 — PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT crashes shared hosting
- **Root cause**: `laravelConfig.php` references MySQL-specific PDO constants without `defined()` guards. Some cPanel/EasyApache PHP builds load pdo_mysql without these constants, causing a fatal error on all pages.
- **Fix**: Guard each MySQL-specific constant with `defined()` using spread operator to conditionally include.
- **File**: `app/Core/Configuration/laravelConfig.php`

### #3194, #3186 — Commenter role cannot comment (Save/Reply buttons disabled)
- **Root cause**: `makeInputReadonly()` disables all inputs in the modal container (including comment form buttons). `enableCommenterForms()` only re-enabled elements inside `.commenterFields` but not inside `.commentBox` reply boxes. Also used stale `#comments` and `#mainToggler` ID selectors that don't match the hash-based class names in the comment template.
- **Fix**: Updated `enableCommenterForms()` to re-enable all form elements in both `.commenterFields` and `.commentBox` areas, and use attribute selectors that match hash-based class names.
- **File**: `app/Domain/Comments/Js/commentsController.js`

### #3382 — Wiki `sortIndex` casing breaks article creation on Postgres
- **Root cause**: `createArticle()` uses `'sortIndex'` (camelCase) but schema defines `sortindex` (lowercase). MySQL is case-insensitive; Postgres is not.
- **Fix**: `'sortIndex'` → `'sortindex'`
- **File**: `app/Domain/Wiki/Repositories/Wiki.php`

### #3383 — Wiki milestone JOIN type mismatch crashes Postgres
- **Root cause**: `getArticle()` does a plain `leftJoin` comparing `milestone.id` (BIGINT) with `milestoneId` (VARCHAR). Postgres rejects the implicit type coercion. Sibling repos (Canvas, Ideas, Goalcanvas) all use `DatabaseHelper::castAs()`.
- **Fix**: Applied the same closure-form JOIN with `castAs()` used by the parent Canvas repository.
- **Bonus**: Removed `->limit(1)` from `updateWiki()`, `updateArticle()`, `delArticle()`, and `delWiki()` — same Postgres-breaking pattern fixed for Projects in #3393.
- **File**: `app/Domain/Wiki/Repositories/Wiki.php`

### #3181 — Ideas saved with canvasId 0 (invisible after creation)
- **Root cause**: POST handler reads `canvasId` exclusively from session, ignoring the form-submitted value. If the session is stale or empty, canvasId defaults to 0.
- **Fix**: Prefer form-submitted `$params['canvasId']` with session as fallback (both create and update paths).
- **File**: `app/Domain/Ideas/Controllers/IdeaDialog.php`

### #3394 — Kanban board with 8+ columns cannot scroll horizontally
- **Root cause**: `.sortableTicketList .row-fluid` uses `display: flex` with `width: 100%` but no overflow handling. Columns use `flex-shrink: 1` allowing them to compress below usable widths.
- **Fix**: Added `overflow-x: auto` to the flex container and changed columns to `flex-shrink: 0` with `min-width: 200px`.
- **File**: `public/assets/css/components/kanban.css`

## Files Changed

| File | Change |
|------|--------|
| `app/Core/Configuration/laravelConfig.php` | Guard MySQL PDO constants with `defined()` |
| `app/Domain/Comments/Js/commentsController.js` | Fix `enableCommenterForms()` selectors and re-enable scope |
| `app/Domain/Ideas/Controllers/IdeaDialog.php` | Prefer form canvasId over session |
| `app/Domain/Wiki/Repositories/Wiki.php` | Fix sortindex casing, milestone JOIN cast, remove limit(1) |
| `public/assets/css/components/kanban.css` | Add horizontal scroll support for many columns |

## Test plan
- [ ] Verify Leantime installs/runs on a PHP build without `PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` (e.g. cPanel shared hosting)
- [ ] Log in as a Commenter role user, open a ticket, verify Save/Reply comment buttons are enabled
- [ ] Create a wiki article on Postgres, verify no error (sortindex)
- [ ] View a wiki article with milestone on Postgres, verify no 500 (JOIN cast)
- [ ] Create an idea on the Ideas board, verify it appears (canvasId != 0)
- [ ] Add 10+ status columns to a Kanban board, verify horizontal scrolling works

Closes #3371, closes #3194, closes #3186, closes #3382, closes #3383, closes #3181, closes #3394

🤖 Generated with [Claude Code](https://claude.com/claude-code)