### PR TITLE
fix: Value Proposition Canvas 500 (Undefined variable $currentCanvas) (#3402)

### DIFF
--- a/app/Domain/Canvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Canvas/Controllers/EditCanvasItem.php
@@ -120,6 +120,7 @@ class EditCanvasItem extends Controller
         $this->tpl->assign('canvasTypes', $this->canvasRepo->getCanvasTypes());
         $this->tpl->assign('statusLabels', $this->canvasRepo->getStatusLabels());
         $this->tpl->assign('dataLabels', $this->canvasRepo->getDataLabels());
+        $this->tpl->assign('currentCanvas', (int) session('current'.strtoupper(static::CANVAS_NAME).'Canvas'));
 
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas'.'.canvasDialog');
     }
@@ -337,6 +338,7 @@ class EditCanvasItem extends Controller
             $this->tpl->assign('canvasItem', $value);
         }
         $this->tpl->assign('comments', $comments);
+        $this->tpl->assign('currentCanvas', (int) session('current'.strtoupper(static::CANVAS_NAME).'Canvas'));
 
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas'.'.canvasDialog');
     }

--- a/app/Domain/Valuecanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Valuecanvas/Templates/canvasDialog.blade.php
@@ -1,5 +1,6 @@
 @php
     $canvasName = 'value';
+    $currentCanvas = $currentCanvas ?? '';
 
     $hiddenStatusLabels = $statusLabels ?? [];
     $statusLabels = $statusLabels ?? $hiddenStatusLabels;


### PR DESCRIPTION
## Summary

Fixes #3402 — opening or editing items on a **Project Value Board** (Value Proposition Canvas) throws a 500: `Undefined variable $currentCanvas`.

## Root cause

The canvas item modal (`canvasDialog`) reads `$currentCanvas` to populate a hidden `canvasId` field, but `Canvas\Controllers\EditCanvasItem` **never assigned it**.

- The **base** `canvas::canvasDialog` guards against this with `$currentCanvas = $currentCanvas ?? ''`.
- The 15 simple canvas variants are 1-line `@include('canvas::canvasDialog', …)` stubs, so they inherit the guard and don't crash.
- **Valuecanvas is the lone exception** — during the Blade migration it kept its *own* full `canvasDialog.blade.php` (it needs value-canvas-specific label translations), and that copy uses `{{ $currentCanvas }}` **without the guard** → hard 500.
- Goalcanvas also has its own dialog but its controller already assigns `currentCanvas`, so it was unaffected.

Note: item→board association was never actually broken — the POST handler resolves the board id from `session('current{NAME}Canvas')`, not the posted field. This was purely a missing template variable.

## Changes

- `Canvas\Controllers\EditCanvasItem` — assign `currentCanvas` from the session board id in `get()` and `post()`, so the hidden field is populated for **every** canvas variant (robust fix).
- `Valuecanvas/Templates/canvasDialog.blade.php` — add the defensive `$currentCanvas ?? ''` guard to match the base template.

## Testing

- PHP lint: clean
- Laravel Pint: passes
- Manual: open a Project Value Board → add/edit an item → modal opens with no 500; new items persist and attach to the current board. Smoke-tested a stub variant (Lean Canvas) for no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)