### PR TITLE
Fix 500 on client detail page: undefined constant generalComment

### DIFF
--- a/app/Domain/Clients/Templates/showClient.blade.php
+++ b/app/Domain/Clients/Templates/showClient.blade.php
@@ -25,7 +25,7 @@
 
             <ul>
                 <li><a href="#clientDetails">{!! __('label.client_details') !!}</a></li>
-                <li><a href="#comment">{!! sprintf(__('tabs.discussion_with_count'), count($submodules.generalComment)) !!}</a></li>
+                <li><a href="#comment">{!! sprintf(__('tabs.discussion_with_count'), count($submodules['generalComment'] ?? [])) !!}</a></li>
                 <li><a href="#files">{!! sprintf(__('tabs.files_with_count'), count($files)) !!}</a></li>
             </ul>
 


### PR DESCRIPTION
## Problem
Opening a client's detail page (`/clients/showClient/{id}`) returns a 500 on PHP 8. The client record saves fine; rendering its detail view fatals. Same symptom as #3407.
## Root cause
`app/Domain/Clients/Templates/showClient.blade.php` (line 28):
count($submodules.generalComment)
1. `$submodules.generalComment` uses `.` (concatenation) instead of array access. On PHP 8 the bareword `generalComment` is read as an undefined constant → fatal Error.
2. `$submodules` is also not passed to this view (regressed in the Blade migration,#3362), so array access alone still throws `Undefined variable $submodules`.  
 <details>
  <summary>Stack trace (PHP 8.3 — paths redacted)</summary>
 Before the fix:
      production.ERROR: Undefined constant "generalComment"
      (View: app/Domain/Clients/Templates/showClient.blade.php)
      at <app>/storage/framework/views/<compiled>.php:28
  After correcting the `.` to array access, the unpassed variable surfaces:
      production.ERROR: Undefined variable $submodules
 (View: app/Domain/Clients/Templates/showClient.blade.php) at <app>/storage/framework/views/<compiled>.php:28
  Both originate at showClient.blade.php line 28.
  </details>
## Fix
count($submodules['generalComment'] ?? [])
Correct array access plus a null-coalescing guard so the page renders. The discussion tab count shows 0 until `$submodules` is supplied by the controller (the comments themselves still load via the `comments::submodules.generalComment` include).
## Notes
A more complete fix would pass `$submodules` from the Clients controller so the count is accurate. happy to follow up if preferred. Tested on v3.8.0 / PHP 8.3.
Fixes #3407