### PR TITLE
fix(clients): show accurate discussion count on client detail page

### DIFF
--- a/app/Domain/Clients/Templates/showClient.blade.php
+++ b/app/Domain/Clients/Templates/showClient.blade.php
@@ -25,7 +25,7 @@
 
             <ul>
                 <li><a href="#clientDetails">{!! __('label.client_details') !!}</a></li>
-                <li><a href="#comment">{!! sprintf(__('tabs.discussion_with_count'), count($submodules['generalComment'] ?? [])) !!}</a></li>
+                <li><a href="#comment">{!! sprintf(__('tabs.discussion_with_count'), count($comments)) !!}</a></li>
                 <li><a href="#files">{!! sprintf(__('tabs.files_with_count'), count($files)) !!}</a></li>
             </ul>
 


### PR DESCRIPTION
## Context
Follow-up to #3423.

#3423 fixed the 500 on `/clients/showClient/{id}` (PHP 8 fatal from `count($submodules.generalComment)` — `.` concatenation + undefined constant, plus an undefined `$submodules` variable). The merged fix guards it with `count($submodules['generalComment'] ?? [])`, which stops the fatal but, as the PR author noted, leaves the Discussion tab permanently showing **"(0)"** because `$submodules` is never passed to the view (regressed in the Blade migration #3362).

## Change
The Clients controller already supplies the comments: `ShowClient::getClientPageData()` assigns `$comments` via `CommentService::getComments('client', $id)`. So count that directly:

```diff
- count($submodules['generalComment'] ?? [])
+ count($comments)
```

This shows the real comment count and drops the dependency on the missing `$submodules` variable entirely. It mirrors how Tickets and Wiki compute their tab counts (`count($comments)` / `numComments`).

## Scope
I swept all ~469 Blade and legacy `.tpl.php` templates for the same dot-as-array-access bug class — it was isolated to this one line, no other occurrences.

## Testing
Open a client detail page (`/clients/showClient/{id}`) with and without comments; the Discussion tab now reflects the actual count instead of always "(0)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)