### PR TITLE
feat(api): JSON-RPC migration — Users JSON endpoints

### DIFF
--- a/app/Domain/Help/Js/helperRepository.js
+++ b/app/Domain/Help/Js/helperRepository.js
@@ -6,23 +6,8 @@ leantime.helperRepository = (function () {
 
     var updateUserModalSettings = function (module, permanent = false) {
 
-        jQuery.ajax(
-            {
-                type: 'PATCH',
-                url: leantime.appUrl + '/api/users',
-                data:
-                {
-                    settings: module,
-                    permanent: permanent ? 1 : 0,
-                    patchModalSettings: 1
-                }
-            }
-        ).done(
-            function () {
-                    //This is easier for now and MVP. Later this needs to be refactored to reload the list of tickets async
-
-            }
-        );
+        leantime.rpc('Users.Users.saveModalDismissal', { modalKey: module, permanent: !!permanent })
+            .catch(function (e) { console.error('Could not save modal setting', e); });
 
     };
 

--- a/app/Domain/Users/Js/usersRepository.js
+++ b/app/Domain/Users/Js/usersRepository.js
@@ -27,22 +27,8 @@ leantime.usersRepository = (function () {
 
     var updateUserViewSettings = function (module, value) {
 
-        jQuery.ajax(
-            {
-                type: 'PATCH',
-                url: leantime.appUrl + '/api/users',
-                data:
-                {
-                    patchViewSettings : module,
-                    value: value
-                }
-            }
-        ).done(
-            function () {
-                    //This is easier for now and MVP. Later this needs to be refactored to reload the list of tickets async
-
-            }
-        );
+        leantime.rpc('Users.Users.updateUserSettings', { category: 'views', setting: module, value: value })
+            .catch(function (e) { console.error('Could not save view setting', e); });
 
     };
 

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -482,7 +482,9 @@ class Users
      *
      * @throws BindingResolutionException
      *
-     * @api
+     * @internal Not exposed via JSON-RPC (projectId is unscoped). The JSON-RPC
+     *           entry point is searchProjectUsers(), which scopes the result to
+     *           a project the caller can actually access.
      */
     public function getUsersWithProjectAccess(?int $currentUser = null, int $projectId = 0): array
     {
@@ -539,6 +541,36 @@ class Users
         }
 
         return [];
+    }
+
+    /**
+     * Authorized JSON-RPC entry point: list users with access to a project,
+     * optionally filtered by a search query (used by the @mention autocomplete).
+     *
+     * Resolves to the current project when no id is given. Project access is
+     * enforced by getUsersWithProjectAccess() (which returns [] when the session
+     * user is not assigned to the project), so a caller cannot enumerate the
+     * users of a project they aren't part of.
+     *
+     * @param  int|null  $projectId  Project id, or null for the current project
+     * @param  string  $query  Optional case-insensitive substring filter
+     * @return array<int, array<string, mixed>> Matching users (empty when no access)
+     *
+     * @api
+     */
+    public function searchProjectUsers(?int $projectId = null, string $query = ''): array
+    {
+        $projectId = $projectId ?? (int) session('currentProject');
+
+        $users = $this->getUsersWithProjectAccess(projectId: $projectId);
+
+        if ($query === '') {
+            return $users;
+        }
+
+        return array_values(
+            array_filter($users, static fn (array $user) => stripos(implode(' ', $user), $query) !== false)
+        );
     }
 
     /**

--- a/public/assets/js/app/core/tiptap/extensions/mention.js
+++ b/public/assets/js/app/core/tiptap/extensions/mention.js
@@ -67,25 +67,10 @@ const LeantimeMention = Mention.extend({
  */
 function fetchUsers(query) {
     return new Promise(function(resolve, reject) {
-        var url = leantime.appUrl + '/api/users?' +
-            'projectUsersAccess=current' +
-            (query ? '&query=' + encodeURIComponent(query) : '');
-
-        fetch(url, {
-            method: 'GET',
-            credentials: 'include',
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'application/json'
-            }
-        })
-        .then(function(response) {
-            if (!response.ok) throw new Error('Failed to fetch users');
-            return response.json();
-        })
+        leantime.rpc('Users.Users.searchProjectUsers', { query: query || '' })
         .then(function(data) {
             // Transform API response to mention format
-            var users = data.map(function(user) {
+            var users = (data || []).map(function(user) {
                 return {
                     id: user.id,
                     label: (user.firstname + ' ' + user.lastname).trim(),

--- a/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
+++ b/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
@@ -303,4 +303,42 @@ class UsersServiceTest extends TestCase
         $this->assertSame('user_exists', $result);
         $this->assertSame(0, $editCalls, 'A duplicate email must not be persisted');
     }
+
+    // ---------------------------------------------------------------------
+    // searchProjectUsers() — JSON-RPC entry for the @mention autocomplete.
+    // ---------------------------------------------------------------------
+
+    public function test_search_project_users_filters_by_query(): void
+    {
+        session(['userdata' => ['id' => 1], 'currentProject' => 5]);
+
+        $projectRepository = $this->make(ProjectRepository::class, [
+            'isUserAssignedToProject' => fn () => true,
+            'getProject' => fn () => ['psettings' => 'restricted', 'clientId' => 0],
+            'getUsersAssignedToProject' => fn () => [
+                ['id' => 1, 'firstname' => 'Alice'],
+                ['id' => 2, 'firstname' => 'Bob'],
+            ],
+        ]);
+
+        $users = $this->makeService($this->make(UserRepository::class), ['projectRepository' => $projectRepository])
+            ->searchProjectUsers(5, 'alice');
+
+        $this->assertCount(1, $users);
+        $this->assertSame('Alice', $users[0]['firstname']);
+    }
+
+    public function test_search_project_users_returns_empty_without_project_access(): void
+    {
+        session(['userdata' => ['id' => 1], 'currentProject' => 5]);
+
+        $projectRepository = $this->make(ProjectRepository::class, [
+            'isUserAssignedToProject' => fn () => false,
+        ]);
+
+        $users = $this->makeService($this->make(UserRepository::class), ['projectRepository' => $projectRepository])
+            ->searchProjectUsers(5);
+
+        $this->assertSame([], $users);
+    }
 }


### PR DESCRIPTION
## Summary

Migrates the **JSON** parts of `/api/users` to JSON-RPC. Note: **`/api/projects` has no JSON callers** — every reference is the `projectAvatar` binary endpoint — so Projects is handled entirely by the upcoming **endpoint-relocation** batch, not here.

## Changes
- **@mention autocomplete** (tiptap `mention.js`): `/api/users?projectUsersAccess=current&query=` → new `@api Users\Services\Users::searchProjectUsers(?projectId, query)`. Defaults to the current project, **scopes** the result to a project the caller can access (`getUsersWithProjectAccess` returns `[]` for non-members), and applies the query filter server-side.
- **De-`@api`'d** the raw `getUsersWithProjectAccess` (unscoped `projectId`) so it's no longer directly JSON-RPC-callable; `searchProjectUsers` is the scoped entry point.
- **View settings** (`usersRepository.updateUserViewSettings`) → `Users.Users.updateUserSettings` (session-scoped, own settings).
- **Modal dismissal** (`helperRepository.updateUserModalSettings`) → `Users.Users.saveModalDismissal`.

## Out of scope (next batch — relocation)
The binary `profileImage` GET + photo-upload POST on `/api/users`, and the `projectAvatar` GET on `/api/projects`, stay for now. The relocation batch moves them to the Users / Projects domains and then deletes the `Api/Users` + `Api/Projects` controllers, along with StaticAsset/I18n → Core, file/logo uploads → Files/Setting.

## Verification
- ✅ phpstan 0 errors · Pint clean · `node --check` clean · no remaining JSON `/api/users` callers
- ✅ 363 unit tests pass, incl. 2 new (`searchProjectUsers` query filter + no-access → empty)

## Test plan
- [ ] CI: phpstan, pint, unit, build, acceptance
- [ ] Smoke: @mention autocomplete in the editor (lists project users, filters as you type, and a non-member can't enumerate another project's users), saving a view setting (e.g. list/table toggle persists), dismissing a "permanent" modal stays dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)