### PR TITLE
refactor(blueprints): native Laravel controllers, drop the dispatch bridge

### DIFF
--- a/app/Domain/Blueprints/Controllers/ApiCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ApiCanvas.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
@@ -17,56 +19,32 @@ use Symfony\Component\HttpFoundation\Response;
  * Provides the API endpoint used by the blueprintsController.js for inline
  * status, relates, and user dropdown updates on the canvas board.
  */
-class ApiCanvas extends Controller
+class ApiCanvas
 {
-    private BlueprintsRepository $blueprintsRepo;
+    private string $canvasSlug;
 
-    private TemplateRegistry $templateRegistry;
-
-    private ProjectRepository $projects;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * init - resolve dependencies and determine the canvas slug from request.
+     * __construct - resolve dependencies and determine the canvas slug from request.
      *
+     * @param  IncomingRequest  $request  Incoming request
+     * @param  Template  $tpl  Template handler
+     * @param  Language  $language  Language handler
      * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  TemplateRegistry  $templateRegistry  Template registry
      * @param  ProjectRepository  $projects  Project repository (for access checks)
+     * @param  TemplateRegistry  $templateRegistry  Template registry
      */
-    public function init(
-        BlueprintsRepository $blueprintsRepo,
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private BlueprintsRepository $blueprintsRepo,
+        private ProjectRepository $projects,
         TemplateRegistry $templateRegistry,
-        ProjectRepository $projects
-    ): void {
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->templateRegistry = $templateRegistry;
-        $this->projects = $projects;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
-    }
-
-    /**
-     * get - handle GET requests (not implemented).
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function get(array $params): Response
-    {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
-    }
-
-    /**
-     * post - handle POST requests (not implemented).
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function post(array $params): Response
-    {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
@@ -74,21 +52,21 @@ class ApiCanvas extends Controller
      *
      * Supports updating status, relates, and author fields on individual
      * canvas items via AJAX calls from the board view dropdowns.
-     *
-     * @param  array<string, mixed>  $params  Request parameters (must include 'id')
      */
-    public function patch(array $params): Response
+    public function patch(): Response
     {
+        $data = $this->request->getRequestParams();
+
         if ($this->template === null) {
             return $this->tpl->displayJson(['status' => 'Unknown canvas type'], 404);
         }
 
-        if (! isset($params['id'])) {
+        if (! isset($data['id'])) {
             return $this->tpl->displayJson(['status' => 'failure'], 400);
         }
 
         // Verify the item exists and the user has access to its project before patching.
-        $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $params['id']);
+        $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
         if ($canvasItem === false) {
             return $this->tpl->displayJson(['status' => 'not found'], 404);
         }
@@ -104,20 +82,10 @@ class ApiCanvas extends Controller
         }
 
         // patchCanvasItem returns false when no allowlisted columns are present — a client error.
-        if (! $this->blueprintsRepo->patchCanvasItem((int) $params['id'], $params)) {
+        if (! $this->blueprintsRepo->patchCanvasItem((int) $data['id'], $data)) {
             return $this->tpl->displayJson(['status' => 'no valid fields to update'], 400);
         }
 
         return $this->tpl->displayJson(['status' => 'ok']);
-    }
-
-    /**
-     * delete - handle DELETE requests (not implemented).
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function delete(array $params): Response
-    {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
     }
 }

--- a/app/Domain/Blueprints/Controllers/BoardDialog.php
+++ b/app/Domain/Blueprints/Controllers/BoardDialog.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
 use Leantime\Core\Mailer as MailerCore;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
@@ -20,44 +22,40 @@ use Symfony\Component\HttpFoundation\Response;
  * Replaces the old per-variant Canvas\Controllers\BoardDialog subclasses.
  * The canvas type slug comes from a GET parameter instead of a class constant.
  */
-class BoardDialog extends Controller
+class BoardDialog
 {
-    private ProjectService $projectService;
+    private string $canvasSlug;
 
-    private BlueprintsRepository $blueprintsRepo;
-
-    private TemplateRegistry $templateRegistry;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * init - resolve dependencies and determine the canvas slug from request.
+     * __construct - resolve dependencies and determine the canvas slug from request.
      *
+     * @param  IncomingRequest  $request  Incoming request
+     * @param  Template  $tpl  Template engine
+     * @param  Language  $language  Language service
      * @param  ProjectService  $projectService  Project service
      * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
-    public function init(
-        ProjectService $projectService,
-        BlueprintsRepository $blueprintsRepo,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->projectService = $projectService;
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private ProjectService $projectService,
+        private BlueprintsRepository $blueprintsRepo,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - display the create/edit board dialog.
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Current board id
      */
-    public function get(array $params): Response
+    public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -66,8 +64,8 @@ class BoardDialog extends Controller
         $currentCanvasId = '';
         $canvasTitle = '';
 
-        if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
+        if ($id !== null) {
+            $currentCanvasId = (int) $id;
             $singleCanvas = $this->blueprintsRepo->getSingleCanvas($currentCanvasId, $this->template->getDatabaseType());
             $canvasTitle = $singleCanvas[0]['title'] ?? '';
             session([$this->template->getSessionKey() => $currentCanvasId]);
@@ -79,9 +77,9 @@ class BoardDialog extends Controller
     /**
      * post - handle create/edit board submissions.
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Current board id
      */
-    public function post(array $params): Response
+    public function post(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -91,7 +89,7 @@ class BoardDialog extends Controller
         $sessionKey = $this->template->getSessionKey();
         $basePath = '/blueprints/'.$this->canvasSlug;
 
-        $currentCanvasId = isset($params['id']) ? (int) $params['id'] : '';
+        $currentCanvasId = ($id !== null && $id !== '') ? (int) $id : '';
         $canvasTitle = '';
         if (is_int($currentCanvasId) && $currentCanvasId > 0) {
             $singleCanvas = $this->blueprintsRepo->getSingleCanvas($currentCanvasId, $canvasType);
@@ -100,11 +98,11 @@ class BoardDialog extends Controller
         }
 
         // Add Canvas
-        if (isset($params['newCanvas'])) {
-            if (isset($params['canvastitle']) && ! empty($params['canvastitle'])) {
-                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $params['canvastitle'], $canvasType)) {
+        if ($this->request->has('newCanvas')) {
+            if ($this->request->has('canvastitle') && ! empty($this->request->input('canvastitle'))) {
+                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $this->request->input('canvastitle'), $canvasType)) {
                     $values = [
-                        'title' => $params['canvastitle'],
+                        'title' => $this->request->input('canvastitle'),
                         'author' => session('userdata.id'),
                         'projectId' => session('currentProject'),
                     ];
@@ -148,10 +146,10 @@ class BoardDialog extends Controller
         }
 
         // Edit Canvas
-        if (isset($params['editCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
-            if (isset($params['canvastitle']) && ! empty($params['canvastitle'])) {
-                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $params['canvastitle'], $canvasType)) {
-                    $this->blueprintsRepo->updateCanvas(['title' => $params['canvastitle'], 'id' => $currentCanvasId]);
+        if ($this->request->has('editCanvas') && is_int($currentCanvasId) && $currentCanvasId > 0) {
+            if ($this->request->has('canvastitle') && ! empty($this->request->input('canvastitle'))) {
+                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $this->request->input('canvastitle'), $canvasType)) {
+                    $this->blueprintsRepo->updateCanvas(['title' => $this->request->input('canvastitle'), 'id' => $currentCanvasId]);
 
                     $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 

--- a/app/Domain/Blueprints/Controllers/DelCanvas.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvas.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
@@ -16,42 +18,34 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * DelCanvas controller - handles canvas board deletion.
  *
- * Replaces the old per-variant Canvas\Controllers\DelCanvas subclasses.
- * The canvas type slug comes from a GET parameter instead of a class constant.
+ * Native Laravel controller: route-bound actions, the {canvasSlug}/{id} path segments
+ * arrive via the route (canvasSlug resolved in the constructor, id as a typed action arg),
+ * and request input is read from the injected IncomingRequest instead of the legacy
+ * merged-$params argument and superglobals.
  */
-class DelCanvas extends Controller
+class DelCanvas
 {
-    private BlueprintsRepository $blueprintsRepo;
+    private string $canvasSlug;
 
-    private TemplateRegistry $templateRegistry;
+    private ?CanvasTemplate $template;
 
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
-
-    /**
-     * init - resolve dependencies and determine the canvas slug from request.
-     *
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  TemplateRegistry  $templateRegistry  Template registry
-     */
-    public function init(
-        BlueprintsRepository $blueprintsRepo,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private BlueprintsRepository $blueprintsRepo,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - display the delete confirmation dialog.
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Board id from the route
      */
-    public function get(array $params): Response
+    public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -67,9 +61,9 @@ class DelCanvas extends Controller
     /**
      * post - process the board deletion.
      *
-     * @param  array<string, mixed>  $params  Request parameters (expects 'id')
+     * @param  string|null  $id  Board id from the route
      */
-    public function post(array $params): Response
+    public function post(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -80,8 +74,8 @@ class DelCanvas extends Controller
         $canvasType = $this->template->getDatabaseType();
         $sessionKey = $this->template->getSessionKey();
 
-        if (isset($params['del']) && isset($params['id']) && (int) $params['id'] > 0) {
-            $id = (int) $params['id'];
+        if ($this->request->has('del') && (int) $id > 0) {
+            $id = (int) $id;
             $this->blueprintsRepo->deleteCanvas($id);
 
             $allCanvas = $this->blueprintsRepo->getAllCanvas(session('currentProject'), $canvasType);

--- a/app/Domain/Blueprints/Controllers/DelCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvasItem.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
@@ -16,42 +18,29 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * DelCanvasItem controller - handles canvas item deletion.
  *
- * Replaces the old per-variant Canvas\Controllers\DelCanvasItem subclasses.
- * The canvas type slug comes from a GET parameter instead of a class constant.
+ * Native Laravel controller: route-bound actions, the {canvasSlug}/{id} path segments
+ * arrive via the route (canvasSlug resolved in the constructor, id as a typed action arg),
+ * and request input is read from the injected IncomingRequest instead of the legacy
+ * merged-$params argument and superglobals.
  */
-class DelCanvasItem extends Controller
+class DelCanvasItem
 {
-    private BlueprintsRepository $blueprintsRepo;
+    private string $canvasSlug;
 
-    private TemplateRegistry $templateRegistry;
+    private ?CanvasTemplate $template;
 
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
-
-    /**
-     * init - resolve dependencies and determine the canvas slug from request.
-     *
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  TemplateRegistry  $templateRegistry  Template registry
-     */
-    public function init(
-        BlueprintsRepository $blueprintsRepo,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private BlueprintsRepository $blueprintsRepo,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
-    /**
-     * get - display the item delete confirmation dialog.
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function get(array $params): Response
+    public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -64,12 +53,7 @@ class DelCanvasItem extends Controller
         return $this->tpl->displayPartial('blueprints.delCanvasItem');
     }
 
-    /**
-     * post - process the canvas item deletion.
-     *
-     * @param  array<string, mixed>  $params  Request parameters (expects 'id')
-     */
-    public function post(array $params): Response
+    public function post(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -77,8 +61,8 @@ class DelCanvasItem extends Controller
 
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
 
-        if (isset($params['del']) && isset($params['id']) && (int) $params['id'] > 0) {
-            $id = (int) $params['id'];
+        if ($this->request->has('del') && (int) $id > 0) {
+            $id = (int) $id;
             $this->blueprintsRepo->delCanvasItem($id);
 
             $this->tpl->setNotification(

--- a/app/Domain/Blueprints/Controllers/EditCanvasComment.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasComment.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
@@ -22,33 +24,20 @@ use Symfony\Component\HttpFoundation\Response;
  * EditCanvasComment controller - handles the comment-focused editing view for canvas items.
  *
  * Replaces the old per-variant Canvas\Controllers\EditCanvasComment subclasses.
- * The canvas type slug comes from a GET parameter instead of a class constant.
+ * The canvas type slug comes from the route instead of a class constant.
  */
-class EditCanvasComment extends Controller
+class EditCanvasComment
 {
-    private TicketRepository $ticketRepo;
+    private string $canvasSlug;
 
-    private CommentRepository $commentsRepo;
-
-    private SprintService $sprintService;
-
-    private TicketService $ticketService;
-
-    private ProjectService $projectService;
-
-    private BlueprintsRepository $blueprintsRepo;
-
-    private BlueprintsService $blueprintsService;
-
-    private TemplateRegistry $templateRegistry;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * init - resolve dependencies and determine the canvas slug from request.
+     * __construct - resolve dependencies and determine the canvas slug from request.
      *
+     * @param  IncomingRequest  $request  Incoming request
+     * @param  Template  $tpl  Template engine
+     * @param  Language  $language  Language service
      * @param  TicketRepository  $ticketRepo  Ticket repository
      * @param  CommentRepository  $commentsRepo  Comment repository
      * @param  SprintService  $sprintService  Sprint service
@@ -58,37 +47,35 @@ class EditCanvasComment extends Controller
      * @param  BlueprintsService  $blueprintsService  Blueprints service
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
-    public function init(
-        TicketRepository $ticketRepo,
-        CommentRepository $commentsRepo,
-        SprintService $sprintService,
-        TicketService $ticketService,
-        ProjectService $projectService,
-        BlueprintsRepository $blueprintsRepo,
-        BlueprintsService $blueprintsService,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->ticketRepo = $ticketRepo;
-        $this->commentsRepo = $commentsRepo;
-        $this->sprintService = $sprintService;
-        $this->ticketService = $ticketService;
-        $this->projectService = $projectService;
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->blueprintsService = $blueprintsService;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private TicketRepository $ticketRepo,
+        private CommentRepository $commentsRepo,
+        private SprintService $sprintService,
+        private TicketService $ticketService,
+        private ProjectService $projectService,
+        private BlueprintsRepository $blueprintsRepo,
+        private BlueprintsService $blueprintsService,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - handle GET requests for the comment editing view.
      *
-     * @param  array<string, mixed>  $params  Request parameters
-     * @return Response|void
+     * @param  string|null  $id  Canvas item id from the route
      */
-    public function get(array $params)
+    public function get(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -98,10 +85,10 @@ class EditCanvasComment extends Controller
         $statusLabels = $this->blueprintsService->getTranslatedStatusLabels($this->template);
         $relatesLabels = $this->blueprintsService->getTranslatedRelatesLabels($this->template);
 
-        if (isset($params['id'])) {
+        if (isset($data['id'])) {
             // Delete comment
-            if (isset($params['delComment']) === true) {
-                $commentId = (int) ($params['delComment']);
+            if (isset($data['delComment']) === true) {
+                $commentId = (int) ($data['delComment']);
                 $this->commentsRepo->deleteComment($commentId);
                 $this->tpl->setNotification(
                     $this->language->__('notifications.comment_deleted'),
@@ -110,7 +97,7 @@ class EditCanvasComment extends Controller
                 );
             }
 
-            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $params['id']);
+            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
 
             if ($canvasItem) {
                 $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
@@ -122,8 +109,8 @@ class EditCanvasComment extends Controller
                 return $this->tpl->displayPartial('errors.error404');
             }
         } else {
-            if (isset($params['type'])) {
-                $type = strip_tags($params['type']);
+            if (isset($data['type'])) {
+                $type = strip_tags($data['type']);
             } else {
                 $type = array_key_first($canvasTypes);
             }
@@ -155,11 +142,15 @@ class EditCanvasComment extends Controller
     /**
      * post - handle POST requests for updating canvas items and adding comments.
      *
-     * @param  array<string, mixed>  $params  Request parameters
-     * @return Response|void
+     * @param  string|null  $id  Canvas item id from the route
      */
-    public function post(array $params)
+    public function post(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -168,33 +159,33 @@ class EditCanvasComment extends Controller
         $sessionKey = $this->template->getSessionKey();
         $basePath = '/blueprints/'.$this->canvasSlug;
 
-        if (isset($params['changeItem'])) {
-            if (isset($params['itemId']) && $params['itemId'] != '') {
-                if (isset($params['description']) && ! empty($params['description'])) {
+        if (isset($data['changeItem'])) {
+            if (isset($data['itemId']) && $data['itemId'] != '') {
+                if (isset($data['description']) && ! empty($data['description'])) {
                     $currentCanvasId = (int) session($sessionKey);
 
                     $canvasItem = [
-                        'box' => $params['box'],
+                        'box' => $data['box'],
                         'author' => session('userdata.id'),
-                        'description' => $params['description'],
-                        'status' => $params['status'],
-                        'relates' => $params['relates'],
-                        'assumptions' => $params['assumptions'],
-                        'data' => $params['data'],
-                        'conclusion' => $params['conclusion'],
-                        'itemId' => $params['itemId'],
-                        'id' => $params['itemId'],
+                        'description' => $data['description'],
+                        'status' => $data['status'],
+                        'relates' => $data['relates'],
+                        'assumptions' => $data['assumptions'],
+                        'data' => $data['data'],
+                        'conclusion' => $data['conclusion'],
+                        'itemId' => $data['itemId'],
+                        'id' => $data['itemId'],
                         'canvasId' => $currentCanvasId,
-                        'milestoneId' => $params['milestoneId'],
+                        'milestoneId' => $data['milestoneId'],
                         'dependentMilstone' => '',
                     ];
 
                     $this->blueprintsRepo->editCanvasItem($canvasItem);
 
-                    $comments = $this->commentsRepo->getComments($commentModule, $params['itemId']);
+                    $comments = $this->commentsRepo->getComments($commentModule, $data['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
                         $commentModule,
-                        $params['itemId']
+                        $data['itemId']
                     ));
                     $this->tpl->assign('comments', $comments);
 
@@ -206,7 +197,7 @@ class EditCanvasComment extends Controller
 
                     $notification = app()->make(NotificationModel::class);
                     $notification->url = [
-                        'url' => BASE_URL.$basePath.'/editCanvasComment/'.(int) $params['itemId'],
+                        'url' => BASE_URL.$basePath.'/editCanvasComment/'.(int) $data['itemId'],
                         'text' => $this->language->__('email_notifications.canvas_item_update_cta'),
                     ];
                     $notification->entity = $canvasItem;
@@ -223,23 +214,23 @@ class EditCanvasComment extends Controller
 
                     $this->projectService->notifyProjectUsers($notification);
 
-                    return Frontcontroller::redirect(BASE_URL.$basePath.'/editCanvasComment/'.$params['itemId']);
+                    return Frontcontroller::redirect(BASE_URL.$basePath.'/editCanvasComment/'.$data['itemId']);
                 } else {
                     $this->tpl->setNotification($this->language->__('notification.please_enter_element_title'), 'error');
                 }
             } else {
-                if (isset($_POST['description']) && ! empty($_POST['description'])) {
+                if (isset($data['description']) && ! empty($data['description'])) {
                     $currentCanvasId = (int) session($sessionKey);
 
                     $canvasItem = [
-                        'box' => $params['box'],
+                        'box' => $data['box'],
                         'author' => session('userdata.id'),
-                        'description' => $params['description'],
-                        'status' => $params['status'],
-                        'relates' => $params['relates'],
-                        'assumptions' => $params['assumptions'],
-                        'data' => $params['data'],
-                        'conclusion' => $params['conclusion'],
+                        'description' => $data['description'],
+                        'status' => $data['status'],
+                        'relates' => $data['relates'],
+                        'assumptions' => $data['assumptions'],
+                        'data' => $data['data'],
+                        'conclusion' => $data['conclusion'],
                         'canvasId' => $currentCanvasId,
                     ];
 
@@ -250,14 +241,14 @@ class EditCanvasComment extends Controller
                     $canvasTypes = $this->blueprintsService->getTranslatedBoxes($this->template);
 
                     $this->tpl->setNotification(
-                        ($canvasTypes[$params['box']]['title'] ?? $params['box']).' successfully created',
+                        ($canvasTypes[$data['box']]['title'] ?? $data['box']).' successfully created',
                         'success',
                         strtoupper($this->canvasSlug).'canvasitem_created'
                     );
 
                     $notification = app()->make(NotificationModel::class);
                     $notification->url = [
-                        'url' => BASE_URL.$basePath.'/editCanvasComment/'.(int) ($params['itemId'] ?? $id),
+                        'url' => BASE_URL.$basePath.'/editCanvasComment/'.(int) ($data['itemId'] ?? $id),
                         'text' => $this->language->__('email_notifications.canvas_item_update_cta'),
                     ];
                     $notification->entity = $canvasItem;
@@ -287,14 +278,14 @@ class EditCanvasComment extends Controller
             }
         }
 
-        if (isset($params['comment']) === true) {
-            $itemId = (int) ($_GET['id'] ?? 0);
+        if (isset($data['comment']) === true) {
+            $itemId = (int) ($data['id'] ?? 0);
             $values = [
-                'text' => $params['text'],
+                'text' => $data['text'],
                 'date' => date('Y-m-d H:i:s'),
                 'userId' => (session('userdata.id')),
                 'moduleId' => $itemId,
-                'commentParent' => ($params['father']),
+                'commentParent' => ($data['father']),
             ];
 
             $this->commentsRepo->addComment($values, $commentModule);
@@ -325,7 +316,7 @@ class EditCanvasComment extends Controller
             return Frontcontroller::redirect(BASE_URL.$basePath.'/editCanvasComment/'.$itemId);
         }
 
-        $itemId = (int) ($_GET['id'] ?? 0);
+        $itemId = (int) ($data['id'] ?? 0);
         $this->tpl->assign('id', $itemId);
         $this->tpl->assign('canvasTypes', $this->blueprintsService->getTranslatedBoxes($this->template));
         $this->tpl->assign('canvasItem', $this->blueprintsRepo->getSingleCanvasItem($itemId));
@@ -333,18 +324,4 @@ class EditCanvasComment extends Controller
 
         return $this->tpl->displayPartial('blueprints.canvasComment');
     }
-
-    /**
-     * put - handle PUT requests.
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function put(array $params): void {}
-
-    /**
-     * delete - handle DELETE requests.
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function delete(array $params): void {}
 }

--- a/app/Domain/Blueprints/Controllers/EditCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasItem.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
@@ -22,60 +21,57 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * EditCanvasItem controller - handles viewing and editing a single canvas item.
  *
- * Replaces the old per-variant Canvas\Controllers\EditCanvasItem subclasses.
- * The canvas type slug comes from a GET parameter instead of a class constant.
+ * Native Laravel controller: route-bound actions, the {canvasSlug}/{id} path segments
+ * arrive via the route (canvasSlug resolved in the constructor, id as a typed action arg),
+ * and request input is read from the injected IncomingRequest instead of the legacy
+ * merged-$params argument and superglobals.
  */
-class EditCanvasItem extends Controller
+class EditCanvasItem
 {
-    private TicketService $ticketService;
+    private string $canvasSlug;
 
-    private ProjectService $projectService;
-
-    private CommentRepository $commentsRepo;
-
-    private BlueprintsRepository $blueprintsRepo;
-
-    private BlueprintsService $blueprintsService;
-
-    private TemplateRegistry $templateRegistry;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * __construct - resolve dependencies that need to be available before init().
+     * __construct - resolve dependencies and the canvas template for the requested slug.
      *
-     * @param  IncomingRequest  $incomingRequest  Incoming HTTP request
+     * @param  IncomingRequest  $request  Incoming HTTP request
      * @param  Template  $tpl  Template engine
      * @param  Language  $language  Language service
+     * @param  TicketService  $ticketService  Ticket service
+     * @param  ProjectService  $projectService  Project service
+     * @param  CommentRepository  $commentsRepo  Comments repository
+     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
+     * @param  BlueprintsService  $blueprintsService  Blueprints service
+     * @param  TemplateRegistry  $templateRegistry  Canvas template registry
      */
     public function __construct(
-        IncomingRequest $incomingRequest,
-        Template $tpl,
-        Language $language
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private TicketService $ticketService,
+        private ProjectService $projectService,
+        private CommentRepository $commentsRepo,
+        private BlueprintsRepository $blueprintsRepo,
+        private BlueprintsService $blueprintsService,
+        TemplateRegistry $templateRegistry,
     ) {
-        $this->ticketService = app()->make(TicketService::class);
-        $this->projectService = app()->make(ProjectService::class);
-        $this->commentsRepo = app()->make(CommentRepository::class);
-        $this->blueprintsRepo = app()->make(BlueprintsRepository::class);
-        $this->blueprintsService = app()->make(BlueprintsService::class);
-        $this->templateRegistry = app()->make(TemplateRegistry::class);
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
-
-        parent::__construct($incomingRequest, $tpl, $language);
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - handle GET requests for viewing/editing a canvas item.
      *
-     * @param  array<string, mixed>  $params  Request parameters
-     * @return Response|void
+     * @param  string|null  $id  Canvas item id
      */
-    public function get(array $params)
+    public function get(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -85,21 +81,21 @@ class EditCanvasItem extends Controller
         $statusLabels = $this->blueprintsService->getTranslatedStatusLabels($this->template);
         $relatesLabels = $this->blueprintsService->getTranslatedRelatesLabels($this->template);
 
-        if (isset($params['id'])) {
+        if (isset($data['id'])) {
             // Delete comment
-            if (isset($params['delComment'])) {
-                $commentId = (int) ($params['delComment']);
+            if (isset($data['delComment'])) {
+                $commentId = (int) ($data['delComment']);
                 $this->commentsRepo->deleteComment($commentId);
                 $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
             }
 
             // Delete milestone relationship
-            if (isset($params['removeMilestone'])) {
-                $this->blueprintsRepo->patchCanvasItem((int) $params['id'], ['milestoneId' => '']);
+            if (isset($data['removeMilestone'])) {
+                $this->blueprintsRepo->patchCanvasItem((int) $data['id'], ['milestoneId' => '']);
                 $this->tpl->setNotification($this->language->__('notifications.milestone_detached'), 'success');
             }
 
-            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $params['id']);
+            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
 
             if ($canvasItem) {
                 $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
@@ -111,8 +107,8 @@ class EditCanvasItem extends Controller
                 return $this->tpl->displayPartial('errors.error404');
             }
         } else {
-            if (isset($params['type'])) {
-                $type = strip_tags($params['type']);
+            if (isset($data['type'])) {
+                $type = strip_tags($data['type']);
             } else {
                 $type = array_key_first($canvasTypes);
             }
@@ -155,11 +151,15 @@ class EditCanvasItem extends Controller
     /**
      * post - handle POST requests for creating/updating canvas items and comments.
      *
-     * @param  array<string, mixed>  $params  Request parameters
-     * @return Response|void
+     * @param  string|null  $id  Canvas item id
      */
-    public function post(array $params)
+    public function post(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -168,56 +168,56 @@ class EditCanvasItem extends Controller
         $sessionKey = $this->template->getSessionKey();
         $basePath = '/blueprints/'.$this->canvasSlug;
 
-        if (isset($params['changeItem'])) {
-            if (isset($params['itemId']) && ! empty($params['itemId'])) {
-                if (isset($params['description']) && ! empty($params['description'])) {
+        if (isset($data['changeItem'])) {
+            if (isset($data['itemId']) && ! empty($data['itemId'])) {
+                if (isset($data['description']) && ! empty($data['description'])) {
                     $currentCanvasId = (int) session($sessionKey);
 
                     $canvasItem = [
-                        'box' => $params['box'],
+                        'box' => $data['box'],
                         'author' => session('userdata.id'),
-                        'description' => $params['description'],
-                        'status' => $params['status'],
-                        'relates' => $params['relates'],
-                        'assumptions' => $params['assumptions'],
-                        'data' => $params['data'],
-                        'conclusion' => $params['conclusion'],
-                        'itemId' => $params['itemId'],
+                        'description' => $data['description'],
+                        'status' => $data['status'],
+                        'relates' => $data['relates'],
+                        'assumptions' => $data['assumptions'],
+                        'data' => $data['data'],
+                        'conclusion' => $data['conclusion'],
+                        'itemId' => $data['itemId'],
                         'canvasId' => $currentCanvasId,
-                        'milestoneId' => $params['milestoneId'],
+                        'milestoneId' => $data['milestoneId'],
                         'dependentMilstone' => '',
-                        'id' => $params['itemId'],
+                        'id' => $data['itemId'],
                     ];
 
-                    if (isset($params['newMilestone']) && $params['newMilestone'] != '') {
-                        $params['headline'] = $params['newMilestone'];
-                        $params['tags'] = '#ccc';
-                        $params['editFrom'] = dtHelper()->userNow()->formatDateForUser();
-                        $params['editTo'] = dtHelper()->userNow()->addDays(7)->formatDateForUser();
-                        $params['dependentMilestone'] = '';
-                        $id = $this->ticketService->quickAddMilestone($params);
+                    if (isset($data['newMilestone']) && $data['newMilestone'] != '') {
+                        $data['headline'] = $data['newMilestone'];
+                        $data['tags'] = '#ccc';
+                        $data['editFrom'] = dtHelper()->userNow()->formatDateForUser();
+                        $data['editTo'] = dtHelper()->userNow()->addDays(7)->formatDateForUser();
+                        $data['dependentMilestone'] = '';
+                        $id = $this->ticketService->quickAddMilestone($data);
 
                         if ($id !== false) {
                             $canvasItem['milestoneId'] = $id;
                         }
                     }
-                    if (isset($params['existingMilestone']) && $params['existingMilestone'] != '') {
-                        $canvasItem['milestoneId'] = $params['existingMilestone'];
+                    if (isset($data['existingMilestone']) && $data['existingMilestone'] != '') {
+                        $canvasItem['milestoneId'] = $data['existingMilestone'];
                     }
 
                     $this->blueprintsRepo->editCanvasItem($canvasItem);
 
-                    $comments = $this->commentsRepo->getComments($commentModule, $params['itemId']);
+                    $comments = $this->commentsRepo->getComments($commentModule, $data['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
                         $commentModule,
-                        $params['itemId']
+                        $data['itemId']
                     ));
                     $this->tpl->assign('comments', $comments);
 
                     $this->tpl->setNotification($this->language->__('notifications.canvas_item_updates'), 'success');
 
                     $subject = $this->language->__('email_notifications.canvas_board_edited');
-                    $actualLink = BASE_URL.$basePath.'#/editCanvasItem/'.(int) $params['itemId'];
+                    $actualLink = BASE_URL.$basePath.'#/editCanvasItem/'.(int) $data['itemId'];
                     $message = sprintf(
                         $this->language->__('email_notifications.canvas_item_update_message'),
                         session('userdata.name'),
@@ -240,27 +240,27 @@ class EditCanvasItem extends Controller
                     $this->projectService->notifyProjectUsers($notification);
 
                     $closeModal = '';
-                    if (isset($_POST['submitAction']) && $_POST['submitAction'] == 'closeModal') {
+                    if (isset($data['submitAction']) && $data['submitAction'] == 'closeModal') {
                         $closeModal = '?closeModal=true';
                     }
 
-                    return Frontcontroller::redirect(BASE_URL.$basePath.'/editCanvasItem/'.$params['itemId'].$closeModal);
+                    return Frontcontroller::redirect(BASE_URL.$basePath.'/editCanvasItem/'.$data['itemId'].$closeModal);
                 } else {
                     $this->tpl->setNotification($this->language->__('notification.please_enter_title'), 'error');
                 }
             } else {
-                if (isset($_POST['description']) && ! empty($_POST['description'])) {
+                if (isset($data['description']) && ! empty($data['description'])) {
                     $currentCanvasId = (int) session($sessionKey);
 
                     $canvasItem = [
-                        'box' => $params['box'],
+                        'box' => $data['box'],
                         'author' => session('userdata.id'),
-                        'description' => $params['description'],
-                        'status' => $params['status'],
-                        'relates' => $params['relates'],
-                        'assumptions' => $params['assumptions'],
-                        'data' => $params['data'],
-                        'conclusion' => $params['conclusion'],
+                        'description' => $data['description'],
+                        'status' => $data['status'],
+                        'relates' => $data['relates'],
+                        'assumptions' => $data['assumptions'],
+                        'data' => $data['data'],
+                        'conclusion' => $data['conclusion'],
                         'canvasId' => $currentCanvasId,
                     ];
 
@@ -268,13 +268,13 @@ class EditCanvasItem extends Controller
                     $canvasTypes = $this->blueprintsService->getTranslatedBoxes($this->template);
 
                     $this->tpl->setNotification(
-                        $canvasTypes[$params['box']]['title'].' successfully created',
+                        $canvasTypes[$data['box']]['title'].' successfully created',
                         'success',
-                        ''.$params['box'].'_item_created'
+                        ''.$data['box'].'_item_created'
                     );
 
                     $subject = $this->language->__('email_notifications.canvas_board_item_created');
-                    $actualLink = BASE_URL.$basePath.'#/editCanvasItem/'.(int) ($params['itemId'] ?? $id);
+                    $actualLink = BASE_URL.$basePath.'#/editCanvasItem/'.(int) ($data['itemId'] ?? $id);
                     $message = sprintf(
                         $this->language->__('email_notifications.canvas_item_created_message'),
                         session('userdata.name'),
@@ -299,7 +299,7 @@ class EditCanvasItem extends Controller
                     $this->tpl->setNotification($this->language->__('notification.element_created'), 'success');
 
                     $closeModal = '';
-                    if (isset($_POST['submitAction']) && $_POST['submitAction'] == 'closeModal') {
+                    if (isset($data['submitAction']) && $data['submitAction'] == 'closeModal') {
                         $closeModal = '?closeModal=true';
                     }
 
@@ -310,14 +310,14 @@ class EditCanvasItem extends Controller
             }
         }
 
-        if (isset($params['comment']) && isset($params['id'])) {
-            $itemId = (int) $params['id'];
+        if (isset($data['comment']) && isset($data['id'])) {
+            $itemId = (int) $data['id'];
             $values = [
-                'text' => $params['text'],
+                'text' => $data['text'],
                 'date' => date('Y-m-d H:i:s'),
                 'userId' => (session('userdata.id')),
                 'moduleId' => $itemId,
-                'commentParent' => ($params['father']),
+                'commentParent' => ($data['father']),
             ];
 
             $commentId = $this->commentsRepo->addComment($values, $commentModule);
@@ -362,14 +362,14 @@ class EditCanvasItem extends Controller
         $this->tpl->assign('statusLabels', $statusLabels);
         $this->tpl->assign('relatesLabels', $relatesLabels);
         $this->tpl->assign('dataLabels', $this->blueprintsService->getTranslatedDataLabels($this->template));
-        if (isset($params['id'])) {
-            $canvasItemId = (int) $params['id'];
+        if (isset($data['id'])) {
+            $canvasItemId = (int) $data['id'];
             $comments = $this->commentsRepo->getComments($commentModule, $canvasItemId);
             $this->tpl->assign('canvasItem', $this->blueprintsRepo->getSingleCanvasItem($canvasItemId));
         } else {
             $value = [
                 'id' => '',
-                'box' => $params['box'],
+                'box' => $data['box'],
                 'author' => session('userdata.id'),
                 'description' => '',
                 'status' => array_key_first($statusLabels),
@@ -388,18 +388,4 @@ class EditCanvasItem extends Controller
 
         return $this->tpl->displayPartial('blueprints.canvasDialog');
     }
-
-    /**
-     * put - handle PUT requests.
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function put(array $params): void {}
-
-    /**
-     * delete - handle DELETE requests.
-     *
-     * @param  array<string, mixed>  $params  Request parameters
-     */
-    public function delete(array $params): void {}
 }

--- a/app/Domain/Blueprints/Controllers/Export.php
+++ b/app/Domain/Blueprints/Controllers/Export.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Services\BlueprintsExport;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
@@ -16,39 +18,38 @@ use Symfony\Component\HttpFoundation\Response;
  * Thin controller: resolves the board id and delegates XML generation to the
  * BlueprintsExport service. The canvas type slug comes from the route.
  */
-class Export extends Controller
+class Export
 {
-    private BlueprintsExport $exportService;
+    private string $canvasSlug;
 
-    private TemplateRegistry $templateRegistry;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * init - resolve dependencies and determine the canvas slug from the request.
+     * __construct - resolve dependencies and determine the canvas slug from the request.
      *
+     * @param  IncomingRequest  $request  Incoming request
+     * @param  Template  $tpl  Template engine
+     * @param  Language  $language  Language service
      * @param  BlueprintsExport  $exportService  Blueprints export service
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
-    public function init(
-        BlueprintsExport $exportService,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->exportService = $exportService;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private BlueprintsExport $exportService,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - generate and return the XML export file.
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Board id from the route
      */
-    public function get(array $params): Response
+    public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return new Response('Unknown canvas type', 404);
@@ -56,8 +57,8 @@ class Export extends Controller
 
         // Resolve the board id from the route/query, falling back to the session.
         $sessionKey = $this->template->getSessionKey();
-        if (isset($params['id']) && $params['id'] !== '') {
-            $canvasId = (int) $params['id'];
+        if ($id !== null && $id !== '') {
+            $canvasId = (int) $id;
         } elseif (session()->exists($sessionKey)) {
             $canvasId = (int) session($sessionKey);
         } else {

--- a/app/Domain/Blueprints/Controllers/ShowCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ShowCanvas.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
-use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
 use Leantime\Core\Mailer as MailerCore;
+use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
@@ -20,51 +22,54 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * Replaces the old per-variant Canvas\Controllers\ShowCanvas subclasses.
  * The canvas type slug comes from the route instead of a class constant.
+ *
+ * Native Laravel controller: route-bound actions, the {canvasSlug}/{id} path segments
+ * arrive via the route (canvasSlug resolved in the constructor, id as a typed action arg),
+ * and request input is read from the injected IncomingRequest instead of the legacy
+ * merged-$params argument and superglobals.
  */
-class ShowCanvas extends Controller
+class ShowCanvas
 {
-    private ProjectService $projectService;
+    private string $canvasSlug;
 
-    private BlueprintsRepository $blueprintsRepo;
-
-    private BlueprintsService $blueprintsService;
-
-    private TemplateRegistry $templateRegistry;
-
-    private string $canvasSlug = '';
-
-    private ?CanvasTemplate $template = null;
+    private ?CanvasTemplate $template;
 
     /**
-     * init - resolve dependencies and determine the canvas slug from request.
+     * __construct - resolve dependencies and determine the canvas slug from request.
      *
+     * @param  IncomingRequest  $request  Incoming request
+     * @param  Template  $tpl  Template engine
+     * @param  Language  $language  Language service
      * @param  ProjectService  $projectService  Project service
      * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
      * @param  BlueprintsService  $blueprintsService  Blueprints service
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
-    public function init(
-        ProjectService $projectService,
-        BlueprintsRepository $blueprintsRepo,
-        BlueprintsService $blueprintsService,
-        TemplateRegistry $templateRegistry
-    ): void {
-        $this->projectService = $projectService;
-        $this->blueprintsRepo = $blueprintsRepo;
-        $this->blueprintsService = $blueprintsService;
-        $this->templateRegistry = $templateRegistry;
-
-        $this->canvasSlug = strip_tags(request()->route('canvasSlug') ?? ($_GET['canvasSlug'] ?? ''));
-        $this->template = $this->templateRegistry->get($this->canvasSlug);
+    public function __construct(
+        private IncomingRequest $request,
+        private Template $tpl,
+        private Language $language,
+        private ProjectService $projectService,
+        private BlueprintsRepository $blueprintsRepo,
+        private BlueprintsService $blueprintsService,
+        TemplateRegistry $templateRegistry,
+    ) {
+        $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
+        $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
     /**
      * get - display the canvas board (and handle the board switcher).
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Active board id from the route
      */
-    public function get(array $params): Response
+    public function get(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -72,25 +77,30 @@ class ShowCanvas extends Controller
         $canvasType = $this->template->getDatabaseType();
         $sessionKey = $this->template->getSessionKey();
 
-        [$allCanvas, $currentCanvasId] = $this->resolveCurrentBoard($params, $canvasType, $sessionKey);
+        [$allCanvas, $currentCanvasId] = $this->resolveCurrentBoard($data, $canvasType, $sessionKey);
 
         // Board switcher
-        if (isset($params['searchCanvas'])) {
-            session([$sessionKey => (int) $params['searchCanvas']]);
+        if (isset($data['searchCanvas'])) {
+            session([$sessionKey => (int) $data['searchCanvas']]);
 
             return Frontcontroller::redirect(BASE_URL.'/blueprints/'.$this->canvasSlug.'/showCanvas/');
         }
 
-        return $this->renderCanvas($params, $allCanvas, $currentCanvasId);
+        return $this->renderCanvas($data, $allCanvas, $currentCanvasId);
     }
 
     /**
      * post - handle create / edit / clone / merge / import board actions.
      *
-     * @param  array<string, mixed>  $params  Request parameters
+     * @param  string|null  $id  Active board id from the route
      */
-    public function post(array $params): Response
+    public function post(?string $id = null): Response
     {
+        $data = $this->request->getRequestParams();
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
@@ -98,14 +108,14 @@ class ShowCanvas extends Controller
         $canvasType = $this->template->getDatabaseType();
         $sessionKey = $this->template->getSessionKey();
 
-        [$allCanvas, $currentCanvasId] = $this->resolveCurrentBoard($params, $canvasType, $sessionKey);
+        [$allCanvas, $currentCanvasId] = $this->resolveCurrentBoard($data, $canvasType, $sessionKey);
 
         // Add board
-        if (isset($params['newCanvas'])) {
-            if (isset($params['canvastitle']) && ! empty($params['canvastitle'])) {
-                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $params['canvastitle'], $canvasType)) {
+        if (isset($data['newCanvas'])) {
+            if (isset($data['canvastitle']) && ! empty($data['canvastitle'])) {
+                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $data['canvastitle'], $canvasType)) {
                     $values = [
-                        'title' => $params['canvastitle'],
+                        'title' => $data['canvastitle'],
                         'author' => session('userdata.id'),
                         'projectId' => session('currentProject'),
                     ];
@@ -135,10 +145,10 @@ class ShowCanvas extends Controller
         }
 
         // Edit board
-        if (isset($params['editCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
-            if (isset($params['canvastitle']) && ! empty($params['canvastitle'])) {
-                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $params['canvastitle'], $canvasType)) {
-                    $this->blueprintsRepo->updateCanvas(['title' => $params['canvastitle'], 'id' => $currentCanvasId]);
+        if (isset($data['editCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
+            if (isset($data['canvastitle']) && ! empty($data['canvastitle'])) {
+                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $data['canvastitle'], $canvasType)) {
+                    $this->blueprintsRepo->updateCanvas(['title' => $data['canvastitle'], 'id' => $currentCanvasId]);
 
                     $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
@@ -152,14 +162,14 @@ class ShowCanvas extends Controller
         }
 
         // Clone board
-        if (isset($params['cloneCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
-            if (isset($params['canvastitle']) && ! empty($params['canvastitle'])) {
-                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $params['canvastitle'], $canvasType)) {
+        if (isset($data['cloneCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
+            if (isset($data['canvastitle']) && ! empty($data['canvastitle'])) {
+                if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $data['canvastitle'], $canvasType)) {
                     $currentCanvasId = $this->blueprintsRepo->copyCanvas(
                         session('currentProject'),
                         $currentCanvasId,
                         session('userdata.id'),
-                        $params['canvastitle'],
+                        $data['canvastitle'],
                         $canvasType
                     );
 
@@ -177,9 +187,9 @@ class ShowCanvas extends Controller
         }
 
         // Merge board
-        if (isset($params['mergeCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
-            if (isset($params['canvasid']) && $params['canvasid'] > 0) {
-                if ($this->blueprintsRepo->mergeCanvas($currentCanvasId, $params['canvasid'])) {
+        if (isset($data['mergeCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
+            if (isset($data['canvasid']) && $data['canvasid'] > 0) {
+                if ($this->blueprintsRepo->mergeCanvas($currentCanvasId, $data['canvasid'])) {
                     $this->tpl->setNotification($this->language->__('notification.board_merged'), 'success');
 
                     return Frontcontroller::redirect(BASE_URL.'/blueprints/'.$this->canvasSlug.'/showCanvas/');
@@ -192,7 +202,7 @@ class ShowCanvas extends Controller
         }
 
         // Import board
-        if (isset($params['importCanvas']) && isset($_FILES['canvasfile']) && $_FILES['canvasfile']['error'] === 0) {
+        if (isset($data['importCanvas']) && isset($_FILES['canvasfile']) && $_FILES['canvasfile']['error'] === 0) {
             $uploadfile = tempnam(sys_get_temp_dir(), 'leantime.').'.xml';
 
             if (move_uploaded_file($_FILES['canvasfile']['tmp_name'], $uploadfile)) {
@@ -223,7 +233,7 @@ class ShowCanvas extends Controller
             $this->tpl->setNotification($this->language->__('notification.board_import_failed'), 'error');
         }
 
-        return $this->renderCanvas($params, $allCanvas, $currentCanvasId);
+        return $this->renderCanvas($data, $allCanvas, $currentCanvasId);
     }
 
     /**

--- a/app/Domain/Blueprints/routes.php
+++ b/app/Domain/Blueprints/routes.php
@@ -1,87 +1,50 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Leantime\Core\Http\IncomingRequest;
 use Leantime\Domain\Blueprints\Controllers;
-use Symfony\Component\HttpFoundation\Response;
 
 /*
 |--------------------------------------------------------------------------
 | Blueprints Domain Routes
 |--------------------------------------------------------------------------
 |
-| The Blueprints controllers are written for the legacy Frontcontroller
-| invocation convention: they read $_GET['id'], expect the request body merged
-| into the $params argument, dispatch by HTTP verb, and may return a string
-| fragment instead of a Response. The Frontcontroller cannot parse the
-| /blueprints/{slug}/{action}/{id} URL shape because it needs a dedicated
-| {canvasSlug} segment, so we register explicit Laravel routes here and bridge
-| each one into the controller exactly the way Frontcontroller::executeAction
-| does. Without this bridge the {id} path segment never reaches $_GET['id'],
-| POST/PATCH bodies never reach $params, and string fragments are not wrapped.
+| Native Laravel routes bound directly to plain Blueprints controllers
+| ([Controller::class, 'method']). The {canvasSlug} segment selects the
+| YAML-defined canvas variant (resolved in each controller's constructor);
+| the optional {id} segment is passed to the action as a typed argument.
+|
+| This replaces the former blueprintsDispatch() helper, which mirrored
+| Frontcontroller::executeAction (verb dispatch + merged-$params + an
+| $_GET['id'] superglobal injection). Laravel's router now does the verb
+| dispatch (one route per verb) and the controllers read their input from
+| the injected IncomingRequest.
 |
 */
 
-if (! function_exists('blueprintsDispatch')) {
-    /**
-     * Invoke a Blueprints controller the same way Frontcontroller::executeAction does.
-     *
-     * @param  string  $controllerClass  Fully-qualified controller class name
-     */
-    function blueprintsDispatch(string $controllerClass): Response
-    {
-        /** @var IncomingRequest $request */
-        $request = app(IncomingRequest::class);
-        $route = $request->route();
-
-        // The numeric {id} path segment is how the controllers and blades receive
-        // the board/item id. Mirror Frontcontroller: push it into the query bag and
-        // re-sync the PHP superglobals so $_GET['id'] and getRequestParams() see it.
-        $id = $route?->parameter('id');
-        if ($id !== null && $id !== '') {
-            $request->query->set('id', $id);
-            $request->overrideGlobals();
-        }
-
-        $controller = app()->make($controllerClass);
-
-        // Dispatch by HTTP verb (get/post/patch/delete), the same convention the
-        // rest of the app's controllers use; fall back to get() for read requests.
-        $verb = strtolower($request->getMethod());
-        if ($verb === 'head') {
-            $verb = 'get';
-        }
-        $method = method_exists($controller, $verb) ? $verb : 'get';
-
-        $params = $request->getRequestParams();
-        $response = $controller->callAction($method, $params);
-
-        // get()/post() may return a Response directly or a rendered string;
-        // wrap the latter via the controller's stored response.
-        return $response instanceof Response ? $response : $controller->getResponse();
-    }
-}
-
 Route::prefix('blueprints/{canvasSlug}')->group(function () {
-    Route::match(['get', 'post'], '/showCanvas/{id?}', fn () => blueprintsDispatch(Controllers\ShowCanvas::class))
-        ->name('blueprints.show');
-    Route::match(['get', 'post'], '/editCanvasItem/{id?}', fn () => blueprintsDispatch(Controllers\EditCanvasItem::class))
-        ->name('blueprints.editItem');
-    Route::match(['get', 'post'], '/editCanvasComment/{id?}', fn () => blueprintsDispatch(Controllers\EditCanvasComment::class))
-        ->name('blueprints.editComment');
-    Route::match(['get', 'post'], '/boardDialog/{id?}', fn () => blueprintsDispatch(Controllers\BoardDialog::class))
-        ->name('blueprints.boardDialog');
-    Route::match(['get', 'post'], '/delCanvas/{id?}', fn () => blueprintsDispatch(Controllers\DelCanvas::class))
-        ->name('blueprints.delCanvas');
-    Route::match(['get', 'post'], '/delCanvasItem/{id?}', fn () => blueprintsDispatch(Controllers\DelCanvasItem::class))
-        ->name('blueprints.delCanvasItem');
-    Route::get('/export/{id?}', fn () => blueprintsDispatch(Controllers\Export::class))
-        ->name('blueprints.export');
+    Route::get('/showCanvas/{id?}', [Controllers\ShowCanvas::class, 'get'])->name('blueprints.show');
+    Route::post('/showCanvas/{id?}', [Controllers\ShowCanvas::class, 'post'])->name('blueprints.show.post');
+
+    Route::get('/editCanvasItem/{id?}', [Controllers\EditCanvasItem::class, 'get'])->name('blueprints.editItem');
+    Route::post('/editCanvasItem/{id?}', [Controllers\EditCanvasItem::class, 'post'])->name('blueprints.editItem.post');
+
+    Route::get('/editCanvasComment/{id?}', [Controllers\EditCanvasComment::class, 'get'])->name('blueprints.editComment');
+    Route::post('/editCanvasComment/{id?}', [Controllers\EditCanvasComment::class, 'post'])->name('blueprints.editComment.post');
+
+    Route::get('/boardDialog/{id?}', [Controllers\BoardDialog::class, 'get'])->name('blueprints.boardDialog');
+    Route::post('/boardDialog/{id?}', [Controllers\BoardDialog::class, 'post'])->name('blueprints.boardDialog.post');
+
+    Route::get('/delCanvas/{id?}', [Controllers\DelCanvas::class, 'get'])->name('blueprints.delCanvas');
+    Route::post('/delCanvas/{id?}', [Controllers\DelCanvas::class, 'post'])->name('blueprints.delCanvas.post');
+
+    Route::get('/delCanvasItem/{id?}', [Controllers\DelCanvasItem::class, 'get'])->name('blueprints.delCanvasItem');
+    Route::post('/delCanvasItem/{id?}', [Controllers\DelCanvasItem::class, 'post'])->name('blueprints.delCanvasItem.post');
+
+    Route::get('/export/{id?}', [Controllers\Export::class, 'get'])->name('blueprints.export');
 });
 
 // Inline item updates (status / relates / assignee) from the board view.
-Route::patch('/api/blueprints/{canvasSlug}', fn () => blueprintsDispatch(Controllers\ApiCanvas::class))
-    ->name('blueprints.api.patch');
+Route::patch('/api/blueprints/{canvasSlug}', [Controllers\ApiCanvas::class, 'patch'])->name('blueprints.api.patch');
 
 // Legacy redirects: forward old /xxxcanvas/ URLs to /blueprints/xxx/
 $legacySlugs = ['swot', 'lean', 'cp', 'dbm', 'ea', 'em', 'insights', 'lbm', 'minempathy', 'obm', 'retros', 'risks', 'sb', 'sm', 'sq', 'value'];


### PR DESCRIPTION
## What & why

Converts the **8 Blueprints controllers** from the `blueprintsDispatch()` bridge — a route closure that re-implemented `Frontcontroller::executeAction` (verb dispatch + merged-`$params` + an `$_GET['id']` superglobal injection via `overrideGlobals()`) — to **plain native Laravel controllers** bound with native per-verb routes.

This is the request-object pilot: get these controllers off the legacy Frontcontroller machinery and onto an injected request, on a contained surface (the last user of the bridge). It's the input-side counterpart to the response/exception work in #3431.

## Changes

- Controllers no longer `extend Controller`. They use **constructor DI** with `IncomingRequest` injected, resolve `{canvasSlug}` in the constructor, and take `{id}` as a **typed action argument**.
- Request input is read from the **injected request**. The 4 simple controllers (`DelCanvas`, `DelCanvasItem`, `Export`, `BoardDialog`) read fields directly off it. The 4 data-heavy ones (`ShowCanvas`, `ApiCanvas`, `EditCanvasItem`, `EditCanvasComment`) — which pass 15-20-field collections to repos — map the request to an input array **once at the top** (`$data = $this->request->getRequestParams()`). That mapping line is exactly **where a typed input object / DTO slots in next** (the agreed direction); the array itself isn't the end state, the lack of typing is.
- `$_GET['id']`/`$_POST` superglobal reads are gone (replaced by the typed `$id` arg and the injected request). `$_FILES` (canvas XML import) is unchanged.
- `routes.php`: native `[Controller::class, 'method']` per-verb binding; `blueprintsDispatch()` and `overrideGlobals()` removed. The 16 legacy `/{slug}canvas` → `/blueprints/{slug}` redirects are unchanged.

**Behavior preserved exactly** — every notification (message/style/event-id), redirect target, repo/service call, and session read/write is byte-equivalent (reviewed via `git diff`). The 16 YAML-defined canvas variants are untouched (slug-driven).

## Testing

- Lint, **Pint**, **PHPStan (whole Blueprints domain)** clean.
- Boot harness confirms **all 14 routes bind to `Controller@method`** (no closures, no dispatch bridge).
- Full **Unit** suite green.
- `BlueprintsCest` (acceptance, runs in CI) covers `showCanvas` GET render + the legacy redirects + edit-item link wiring.

## ⚠️ Needs a manual smoke test before merge
The acceptance suite does **not** exercise the *mutation* flows. Please smoke-test on a board (any variant, e.g. `/blueprints/swot/showCanvas`):
- create / edit / clone / merge / **import** a board; delete a board
- add / edit / delete a canvas item; add a comment
- inline status / relates / assignee dropdowns (the `PATCH /api/blueprints/{slug}` path)
- the XML **export** link
- a legacy `/swotcanvas/...` URL still 301-redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)