### PR TITLE
fix(tickets): guard undefined $groupBy/$newField in list views

### DIFF
--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -12,7 +12,7 @@
     $efforts = $efforts;
     $priorities = $priorities;
     $statusLabels = $allTicketStates;
-    $newField = $newField;
+    $newField = $newField ?? [];
     $numberofColumns = count($allTicketStates) - 1;
     $size = floor(100 / $numberofColumns);
 @endphp

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -10,8 +10,8 @@
     $efforts = $efforts;
     $priorities = $priorities;
     $statusLabels = $allTicketStates;
-    $groupBy = $groupBy;
-    $newField = $newField;
+    $groupBy = $groupBy ?? [];
+    $newField = $newField ?? [];
     $numberofColumns = count($allTicketStates) - 1;
     $size = floor(100 / $numberofColumns);
 @endphp


### PR DESCRIPTION
## The bug
`/tickets/showList?currentClient=0&excludeType=milestone` (and the "all tickets" view) 500s with:

```
Undefined variable $groupBy (View: app/Domain/Tickets/Templates/showList.blade.php)
  ShowList.php:48 -> Template->display('tickets.showList')
```

## Root cause (pre-existing — not the JSON-RPC/Blueprints work)
The Blade migration (`7da61c5` "migrate all templates to Blade" + `9bb458a`) mechanically turned old `$tpl->get('x')` reads into bare **self-assignments** at the top of the view:

```php
@php
    ...
    $groupBy = $groupBy;   // <- reads an undefined var → throws
    $newField = $newField;
```

That's harmless for variables the controller assigns, but `ShowList` (via `Tickets::getTicketTemplateAssignments`) never returns a top-level `groupBy`/`newField` — `groupBy` only exists *inside* `searchCriteria`. The old `$tpl->get('groupBy')` returned `null` for a missing key; bare `$groupBy` throws. Same for `$newField` on `showAll`.

## Fix
Guard the two views' unassigned vars with `?? []`:

```php
$groupBy = $groupBy ?? [];
$newField = $newField ?? [];
```

`[]` is the right default — the only places these bare vars are consumed are array `@foreach` / `!empty()` checks in `ticketFilter` (which self-sets `$groupBy` from `$groupByOptions`) and `ticketNewBtn`/`ticketNewButton` (`@if(!empty($newField))`). Any controller-assigned value is preserved.

## Heads-up
~35 of these `$x = $x;` self-assign artifacts remain across the Tickets/Timesheets blades. The others only break if their var is similarly unassigned — **suspects to watch**: `showKanban` `$statusBreakdown`, `timesheet` `$userInfo`/`$remainingHours`, `showMy` `$dateFrom`, `editTime` `$values`. A type-aware sweep (or assigning the missing keys in the controllers) could follow as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)