### PR TITLE
cleanup: remove dead $x = $x; Blade self-assign artifacts

### DIFF
--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -3,14 +3,8 @@
 @section('content')
 
 @php
-    $sprints = $sprints;
-    $searchCriteria = $searchCriteria;
-    $currentSprint = $currentSprint;
-    $allTickets = $allTickets;
     $allTicketGroups = $allTickets;
     $todoTypeIcons = $ticketTypeIcons;
-    $efforts = $efforts;
-    $priorities = $priorities;
     $statusLabels = $allTicketStates;
     $newField = $newField ?? [];
     $numberofColumns = count($allTicketStates) - 1;

--- a/app/Domain/Tickets/Templates/showAllMilestones.blade.php
+++ b/app/Domain/Tickets/Templates/showAllMilestones.blade.php
@@ -3,14 +3,8 @@
 @section('content')
 
 @php
-    $sprints = $sprints;
-    $searchCriteria = $searchCriteria;
-    $currentSprint = $currentSprint;
-    $allTickets = $allTickets;
     $allTicketGroups = $allTickets;
     $todoTypeIcons = $ticketTypeIcons;
-    $efforts = $efforts;
-    $priorities = $priorities;
     $statusLabels = $allTicketStates;
     $numberofColumns = count($allTicketStates) - 1;
     $size = floor(100 / $numberofColumns);

--- a/app/Domain/Tickets/Templates/showAllMilestonesOverview.blade.php
+++ b/app/Domain/Tickets/Templates/showAllMilestonesOverview.blade.php
@@ -3,13 +3,8 @@
 @section('content')
 
 @php
-    $sprints = $sprints;
-    $searchCriteria = $searchCriteria;
-    $currentSprint = $currentSprint;
     $todoTypeIcons = $ticketTypeIcons;
-    $efforts = $efforts;
     $statusLabels = $allTicketStates;
-    $allTickets = $allTickets;
     $numberofColumns = count($allTicketStates) - 1;
     $size = floor(100 / $numberofColumns);
 @endphp

--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -4,12 +4,7 @@
 
 @php
     $tickets = $tickets ?? [];
-    $sprints = $sprints;
-    $searchCriteria = $searchCriteria;
-    $currentSprint = $currentSprint;
     $todoTypeIcons = $ticketTypeIcons;
-    $efforts = $efforts;
-    $priorities = $priorities;
     $allTicketGroups = $allTickets;
     $reopenState = session()->get('quickadd_reopen', null);
     $currentGroupBy = $searchCriteria['groupBy'] ?? 'all';
@@ -89,7 +84,6 @@
                 @php
                 $swimlaneExpanded = ! in_array($group['id'], session('collapsedSwimlanes', []));
                 $groupBy = $searchCriteria['groupBy'] ?? 'status';
-                $statusBreakdown = $statusBreakdown;
                 $groupIdKey = (string) $group['id'];
                 $swimlaneBreakdown = $statusBreakdown[$groupIdKey] ?? $statusBreakdown[$group['id']] ?? [];
                 $statusCounts = $swimlaneBreakdown['statusCounts'] ?? [];

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -3,12 +3,7 @@
 @section('content')
 
 @php
-    $sprints = $sprints;
-    $searchCriteria = $searchCriteria;
-    $currentSprint = $currentSprint;
     $allTicketGroups = $allTickets;
-    $efforts = $efforts;
-    $priorities = $priorities;
     $statusLabels = $allTicketStates;
     $groupBy = $groupBy ?? [];
     $newField = $newField ?? [];

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -1,7 +1,5 @@
 @php
 $values = $timesheetValues;
-$userInfo = $userInfo;
-$remainingHours = $remainingHours;
 if ($remainingHours < 0) {
     $remainingHours = 0;
 }

--- a/app/Domain/Timesheets/Templates/editTime.blade.php
+++ b/app/Domain/Timesheets/Templates/editTime.blade.php
@@ -1,6 +1,5 @@
 @php
 use Leantime\Core\Support\FromFormat;
-$values = $values;
 @endphp
 
 <script type="text/javascript">

--- a/app/Domain/Timesheets/Templates/showMy.blade.php
+++ b/app/Domain/Timesheets/Templates/showMy.blade.php
@@ -3,7 +3,6 @@
 
 @php
 /** @var \Carbon\Carbon $currentDate */
-$dateFrom = $dateFrom;
 @endphp
 
 @once


### PR DESCRIPTION
## What

Removes 32 dead `$x = $x;` self-assignment lines across 8 Blade templates. These are leftovers from the `.tpl.php` → `.blade.php` migration.

## Why

In Blade, controller-assigned variables (`$tpl->assign('x', …)`) are auto-injected into the view's scope. A `$x = $x;` line is therefore either:
- a **no-op** (when the controller assigns the variable), or
- a **fatal "Undefined variable"** (when it does not) — it can never be load-bearing.

This is the same class of artifact that caused the ticket-list 500 fixed in #3433 (`$groupBy`/`$newField`).

## Verification

Each removed line was verified dead per-variable:
- The four ticket list/board views (`showAll`, `showList`, `showKanban`, `showAllMilestones`) receive these variables **unconditionally** from `Tickets::getTicketTemplateAssignments()` (Tickets.php:3444-3463).
- `showAllMilestonesOverview`, `submodules/timesheet`, and Timesheets `showMy`/`editTime` assign them on **every render path** (the only early exits return error views, never these templates).

Genuine aliases (`$allTicketGroups = $allTickets;`, `$todoTypeIcons = $ticketTypeIcons;`, `$statusLabels = $allTicketStates;`, `$values = $timesheetValues;`) and already-guarded lines (`$tickets = $tickets ?? []`, `$groupBy/$newField ?? []`) are intentionally **left untouched** — the deletion matched only lines where the left side equals the right side with nothing else.

All `@php` blocks in the touched files lint clean (`php -l` on the extracted/compiled PHP).

## Files

- `Tickets/Templates/showAll.blade.php`
- `Tickets/Templates/showAllMilestones.blade.php`
- `Tickets/Templates/showAllMilestonesOverview.blade.php`
- `Tickets/Templates/showKanban.blade.php`
- `Tickets/Templates/showList.blade.php`
- `Tickets/Templates/submodules/timesheet.blade.php`
- `Timesheets/Templates/editTime.blade.php`
- `Timesheets/Templates/showMy.blade.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)