### PR TITLE
feat(tickets): finish collaborators feature — notifications, persistence & hardening (#1099)

### DIFF
--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -286,6 +286,14 @@ class Projects
             }
         }
 
+        // Extract collaborator IDs and re-add them (collaborators bypass filters)
+        $collaboratorIds = $this->extractCollaboratorIds($notification);
+        foreach ($collaboratorIds as $collaboratorId) {
+            if ($collaboratorId != $notification->authorId && ! in_array($collaboratorId, $users)) {
+                $users[] = $collaboratorId;
+            }
+        }
+
         $emailMessage = $notification->message;
         if ($notification->url !== false) {
             $emailMessage .= " <a href='".$notification->url['url']."'>".$notification->url['text'].'</a>';
@@ -359,6 +367,13 @@ class Projects
         foreach ($mentionedUserIds as $mentionedId) {
             if ($mentionedId != $notification->authorId && ! in_array($mentionedId, $filteredIds)) {
                 $filteredIds[] = $mentionedId;
+            }
+        }
+
+        // Re-add collaborators for in-app notifications too
+        foreach ($collaboratorIds as $collaboratorId) {
+            if ($collaboratorId != $notification->authorId && ! in_array($collaboratorId, $filteredIds)) {
+                $filteredIds[] = $collaboratorId;
             }
         }
 
@@ -624,6 +639,36 @@ class Projects
         }
 
         return array_unique($userIds);
+    }
+
+    /**
+     * Extracts collaborator user IDs from a ticket notification entity.
+     *
+     * Collaborators bypass notification filters so they always receive
+     * updates for tickets they are collaborating on.
+     *
+     * @param  Notification  $notification  The notification to extract collaborators from.
+     * @return array<int> An array of unique user IDs who are collaborators.
+     */
+    private function extractCollaboratorIds(Notification $notification): array
+    {
+        if ($notification->module !== 'tickets') {
+            return [];
+        }
+
+        $collaborators = [];
+
+        if (isset($notification->entity) && is_array($notification->entity)) {
+            $collaborators = $notification->entity['collaborators'] ?? [];
+        } elseif (isset($notification->entity) && is_object($notification->entity)) {
+            $collaborators = $notification->entity->collaborators ?? [];
+        }
+
+        if (empty($collaborators) || ! is_array($collaborators)) {
+            return [];
+        }
+
+        return array_unique(array_map('intval', array_filter($collaborators)));
     }
 
     /**

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -278,21 +278,11 @@ class Projects
         // Layer 2: Remove users who disabled this event type category
         $users = $this->filterUsersByEventType($users, $notification->module, $preloadedSettings);
 
-        // Extract mentioned user IDs and re-add them (mentions bypass filters)
+        // Mentions and collaborators both bypass the two filter layers above.
         $mentionedUserIds = $this->extractMentionedUserIds($notification);
-        foreach ($mentionedUserIds as $mentionedId) {
-            if ($mentionedId != $notification->authorId && ! in_array($mentionedId, $users)) {
-                $users[] = $mentionedId;
-            }
-        }
-
-        // Extract collaborator IDs and re-add them (collaborators bypass filters)
         $collaboratorIds = $this->extractCollaboratorIds($notification);
-        foreach ($collaboratorIds as $collaboratorId) {
-            if ($collaboratorId != $notification->authorId && ! in_array($collaboratorId, $users)) {
-                $users[] = $collaboratorId;
-            }
-        }
+        $users = $this->addBypassRecipients($users, $mentionedUserIds, $notification->authorId);
+        $users = $this->addBypassRecipients($users, $collaboratorIds, $notification->authorId);
 
         $emailMessage = $notification->message;
         if ($notification->url !== false) {
@@ -363,19 +353,9 @@ class Projects
         $filteredIds = $this->filterUsersByProjectRelevance($allUserIds, $notification, $preloadedSettings);
         $filteredIds = $this->filterUsersByEventType($filteredIds, $notification->module, $preloadedSettings);
 
-        // Re-add mentioned users for in-app notifications too
-        foreach ($mentionedUserIds as $mentionedId) {
-            if ($mentionedId != $notification->authorId && ! in_array($mentionedId, $filteredIds)) {
-                $filteredIds[] = $mentionedId;
-            }
-        }
-
-        // Re-add collaborators for in-app notifications too
-        foreach ($collaboratorIds as $collaboratorId) {
-            if ($collaboratorId != $notification->authorId && ! in_array($collaboratorId, $filteredIds)) {
-                $filteredIds[] = $collaboratorId;
-            }
-        }
+        // Re-add mentions and collaborators for in-app notifications too
+        $filteredIds = $this->addBypassRecipients($filteredIds, $mentionedUserIds, $notification->authorId);
+        $filteredIds = $this->addBypassRecipients($filteredIds, $collaboratorIds, $notification->authorId);
 
         $filteredUsersToNotify = array_filter($allUsersToNotify, fn ($u) => in_array($u['id'], $filteredIds));
 
@@ -668,7 +648,34 @@ class Projects
             return [];
         }
 
-        return array_unique(array_map('intval', array_filter($collaborators)));
+        // Only keep scalar, numeric values so non-scalars can't become bogus IDs (e.g. intval([]) === 0).
+        $scalarNumeric = array_filter($collaborators, fn ($c) => is_scalar($c) && is_numeric($c));
+        $ids = array_filter(array_map('intval', $scalarNumeric), fn ($id) => $id > 0);
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Adds bypass recipients (e.g. mentions, collaborators) to a recipient list.
+     *
+     * Bypass recipients skip the two notification filter layers, so they are
+     * appended after filtering. The notification author is never added, and
+     * existing recipients are not duplicated.
+     *
+     * @param  array<int, mixed>  $recipients  The current recipient user IDs.
+     * @param  array<int, int>  $bypassUserIds  User IDs that should always receive the notification.
+     * @param  mixed  $authorId  The notification author, excluded from the result.
+     * @return array<int, mixed> The recipient list with bypass users merged in.
+     */
+    private function addBypassRecipients(array $recipients, array $bypassUserIds, mixed $authorId): array
+    {
+        foreach ($bypassUserIds as $bypassId) {
+            if ($bypassId != $authorId && ! in_array($bypassId, $recipients)) {
+                $recipients[] = $bypassId;
+            }
+        }
+
+        return $recipients;
     }
 
     /**

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3482,7 +3482,9 @@ class Tickets
         $ticketIds = [];
 
         foreach ($groupedTickets as $group) {
-            foreach (($group['items'] ?? []) as $ticket) {
+            // Support both 'items' (list/kanban views) and 'tickets' (ToDoWidget views)
+            $items = $group['items'] ?? $group['tickets'] ?? [];
+            foreach ($items as $ticket) {
                 if (isset($ticket['id'])) {
                     $ticketIds[] = (int) $ticket['id'];
                 }
@@ -3496,11 +3498,16 @@ class Tickets
         $collaboratorsByTicket = $this->ticketRepository->getCollaboratorsByTicketIds($ticketIds);
 
         foreach ($groupedTickets as &$group) {
-            if (! isset($group['items']) || ! is_array($group['items'])) {
+            // Determine which key holds the ticket array
+            if (isset($group['items']) && is_array($group['items'])) {
+                $key = 'items';
+            } elseif (isset($group['tickets']) && is_array($group['tickets'])) {
+                $key = 'tickets';
+            } else {
                 continue;
             }
 
-            foreach ($group['items'] as &$ticket) {
+            foreach ($group[$key] as &$ticket) {
                 $ticketId = (int) ($ticket['id'] ?? 0);
                 $editorId = (int) ($ticket['editorId'] ?? 0);
                 $collaboratorIds = $collaboratorsByTicket[$ticketId] ?? [];
@@ -3597,6 +3604,7 @@ class Tickets
             }
         }
 
+        $tickets = $this->enrichGroupedTicketsWithCollaborators($tickets);
         $tickets = self::dispatch_filter('myTodoWidgetTasks', $tickets);
 
         return [
@@ -3755,6 +3763,7 @@ class Tickets
             }
         }
 
+        $tickets = $this->enrichGroupedTicketsWithCollaborators($tickets);
         $tickets = self::dispatch_filter('myTodoWidgetTasks', $tickets);
 
         return [

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3139,9 +3139,7 @@ class Tickets
             return ['msg' => 'notifications.ticket_delete_error', 'type' => 'error'];
         }
 
-        // Remove collaborator relationships before deleting the ticket
-        $this->ticketRepository->removeCollaborators($id);
-
+        // Collaborator relationship rows are cleaned up inside the repository's delticket().
         if ($this->ticketRepository->delticket($id)) {
 
             self::dispatchEvent('ticket_deleted');

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -1856,6 +1856,7 @@ class Tickets
             'milestoneid' => isset($params['milestone']) ? (int) $params['milestone'] : '',
             'dependingTicketId' => isset($params['dependingTicketId']) ? (int) $params['dependingTicketId'] : '',
             'sortIndex' => $params['sortIndex'] ?? '',
+            'collaborators' => $params['collaborators'] ?? [],
         ];
 
         if ($values['headline'] == '') {
@@ -2371,11 +2372,21 @@ class Tickets
             return false;
         }
 
+        // Handle collaborators separately since they live in the relationship table, not on zp_tickets
+        $collaboratorsUpdated = false;
+        if (array_key_exists('collaborators', $params)) {
+            $collaborators = is_array($params['collaborators']) ? $params['collaborators'] : [];
+            $this->ticketRepository->removeCollaborators($id);
+            $this->ticketRepository->addCollaborators($id, $collaborators, session('userdata.id'));
+            $collaboratorsUpdated = true;
+            unset($params['collaborators']);
+        }
+
         $params = $this->prepareTicketDates($params);
 
         $return = $this->ticketRepository->patchTicket($id, $params);
 
-        if (! $return) {
+        if (! $return && ! $collaboratorsUpdated) {
             return false;
         }
 
@@ -2404,7 +2415,7 @@ class Tickets
             $this->projectService->notifyProjectUsers($notification);
         }
 
-        return (bool) $return;
+        return true;
     }
 
     /**
@@ -3127,6 +3138,9 @@ class Tickets
         if (! $ticket || ! $this->projectService->isUserAssignedToProject(session('userdata.id'), $ticket->projectId)) {
             return ['msg' => 'notifications.ticket_delete_error', 'type' => 'error'];
         }
+
+        // Remove collaborator relationships before deleting the ticket
+        $this->ticketRepository->removeCollaborators($id);
 
         if ($this->ticketRepository->delticket($id)) {
 

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3751,12 +3751,17 @@ class Tickets
         //                }
         //            }
 
+        // Enrich while tickets are still flat — buildTicketHierarchy() nests subtasks into
+        // 'children', so enriching afterwards would only reach the root rows.
+        $tickets = $this->enrichGroupedTicketsWithCollaborators($tickets);
+
         // Process tickets to build hierarchical structure
         foreach ($tickets as $groupKey => &$ticketGroup) {
             if (isset($ticketGroup['tickets']) && is_array($ticketGroup['tickets'])) {
                 $ticketGroup['tickets'] = $this->buildTicketHierarchy($ticketGroup['tickets'], $sortingArray);
             }
         }
+        unset($ticketGroup);
 
         $onTheClock = $this->timesheetService->isClocked(session('userdata.id'));
         $effortLabels = $this->getEffortLabels();
@@ -3774,8 +3779,9 @@ class Tickets
                 }
             }
         }
+        unset($ticketGroup);
 
-        $tickets = $this->enrichGroupedTicketsWithCollaborators($tickets);
+        // Collaborators were enriched above, before the hierarchy was built.
         $tickets = self::dispatch_filter('myTodoWidgetTasks', $tickets);
 
         return [

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -307,6 +307,31 @@ class TicketsServiceTest extends TestCase
         );
     }
 
+    /**
+     * Builds a TicketsService using the default mocks but with a specific
+     * TicketRepository instance, so collaborator enrichment can be asserted.
+     */
+    private function buildServiceWithTicketRepository(TicketRepository $ticketRepository): TicketsService
+    {
+        return new TicketsService(
+            tpl: $this->make(TemplateCore::class),
+            language: $this->make(LanguageCore::class),
+            config: $this->make(EnvironmentCore::class),
+            projectRepository: $this->make(ProjectRepository::class),
+            ticketRepository: $ticketRepository,
+            timesheetsRepo: $this->make(TimesheetRepository::class),
+            settingsRepo: $this->make(SettingRepository::class),
+            projectService: $this->make(ProjectService::class),
+            timesheetService: $this->make(TimesheetService::class),
+            sprintService: $this->make(SprintService::class),
+            ticketHistoryRepo: $this->make(TicketHistory::class),
+            goalcanvasService: $this->make(Goalcanvas::class),
+            dateTimeHelper: $this->make(DateTimeHelper::class),
+            commentService: $this->make(CommentService::class),
+            clientService: $this->make(ClientService::class)
+        );
+    }
+
     // ---------------------------------------------------------------------
     // JSON-RPC authorization gates (RPC has no controller-level role gate, so
     // the @api entry methods must self-authorize).
@@ -335,5 +360,105 @@ class TicketsServiceTest extends TestCase
         session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
 
         $this->assertFalse($this->ticketsService->updateTicketStatusAndSorting(['3' => 'ticket[]=5'], null));
+    }
+
+    // ---------------------------------------------------------------------
+    // Collaborator enrichment for grouped ticket views (list/kanban + widget)
+    // ---------------------------------------------------------------------
+
+    /**
+     * enrichGroupedTicketsWithCollaborators adds metadata to 'items' groups (list/kanban views).
+     */
+    public function test_enrich_grouped_tickets_with_collaborators_items_key()
+    {
+        $service = $this->buildServiceWithTicketRepository($this->make(TicketRepository::class, [
+            'getCollaboratorsByTicketIds' => fn ($ids) => [
+                10 => [100, 200],
+                11 => [300],
+            ],
+        ]));
+
+        $groupedTickets = [
+            'group1' => [
+                'items' => [
+                    ['id' => 10, 'editorId' => 100, 'headline' => 'Task A'],
+                    ['id' => 11, 'editorId' => 0, 'headline' => 'Task B'],
+                ],
+            ],
+        ];
+
+        $method = new \ReflectionMethod($service, 'enrichGroupedTicketsWithCollaborators');
+        $method->setAccessible(true);
+        $result = $method->invoke($service, $groupedTickets);
+
+        // Ticket 10: editorId=100 is excluded from collaborator list, leaving only [200]
+        $this->assertEquals([200], $result['group1']['items'][0]['collaborators']);
+        $this->assertEquals([200], $result['group1']['items'][0]['collaboratorPreview']);
+        $this->assertEquals(1, $result['group1']['items'][0]['collaboratorCount']);
+        $this->assertEquals(0, $result['group1']['items'][0]['collaboratorOverflow']);
+
+        // Ticket 11: no editorId filter, so [300] stays
+        $this->assertEquals([300], $result['group1']['items'][1]['collaborators']);
+        $this->assertEquals(1, $result['group1']['items'][1]['collaboratorCount']);
+    }
+
+    /**
+     * enrichGroupedTicketsWithCollaborators supports the 'tickets' key (ToDoWidget views).
+     */
+    public function test_enrich_grouped_tickets_with_collaborators_tickets_key()
+    {
+        $service = $this->buildServiceWithTicketRepository($this->make(TicketRepository::class, [
+            'getCollaboratorsByTicketIds' => fn ($ids) => [
+                20 => [400, 500, 600],
+            ],
+        ]));
+
+        $groupedTickets = [
+            'thisWeek' => [
+                'labelName' => 'subtitles.due_this_week',
+                'tickets' => [
+                    ['id' => 20, 'editorId' => 400, 'headline' => 'Widget Task'],
+                ],
+            ],
+        ];
+
+        $method = new \ReflectionMethod($service, 'enrichGroupedTicketsWithCollaborators');
+        $method->setAccessible(true);
+        $result = $method->invoke($service, $groupedTickets);
+
+        // editorId=400 excluded, leaving [500, 600]
+        $this->assertEquals([500, 600], $result['thisWeek']['tickets'][0]['collaborators']);
+        $this->assertEquals([500, 600], $result['thisWeek']['tickets'][0]['collaboratorPreview']);
+        $this->assertEquals(2, $result['thisWeek']['tickets'][0]['collaboratorCount']);
+        $this->assertEquals(0, $result['thisWeek']['tickets'][0]['collaboratorOverflow']);
+    }
+
+    /**
+     * enrichGroupedTicketsWithCollaborators reports overflow when more than 2 collaborators exist.
+     */
+    public function test_enrich_grouped_tickets_collaborator_overflow()
+    {
+        $service = $this->buildServiceWithTicketRepository($this->make(TicketRepository::class, [
+            'getCollaboratorsByTicketIds' => fn ($ids) => [
+                30 => [101, 102, 103, 104, 105],
+            ],
+        ]));
+
+        $groupedTickets = [
+            'group1' => [
+                'items' => [
+                    ['id' => 30, 'editorId' => 0, 'headline' => 'Many collaborators'],
+                ],
+            ],
+        ];
+
+        $method = new \ReflectionMethod($service, 'enrichGroupedTicketsWithCollaborators');
+        $method->setAccessible(true);
+        $result = $method->invoke($service, $groupedTickets);
+
+        $this->assertEquals([101, 102, 103, 104, 105], $result['group1']['items'][0]['collaborators']);
+        $this->assertEquals([101, 102], $result['group1']['items'][0]['collaboratorPreview']);
+        $this->assertEquals(5, $result['group1']['items'][0]['collaboratorCount']);
+        $this->assertEquals(3, $result['group1']['items'][0]['collaboratorOverflow']);
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the remaining collaborator work for #1099 on top of the existing feature (originally built in 8e41134ec by @akashsah2003) and the repository hardening just merged in #3405.

This PR carries over the genuinely useful parts of #3403 and #3404 — both auto-generated bounty attempts at the same issue by @duongynhi000005-oss — resolves their overlaps, and fixes the issues flagged in the Copilot reviews. Their commits are preserved here with original authorship.

## What this adds

- **Collaborators receive notifications** — collaborators now bypass the two notification filter layers (per-project mute + event-type preference), exactly like @mentions already do, so an added collaborator is notified on ticket activity even if they muted the project. (`Projects::notifyProjectUsers`)
- **Collaborator persistence on patch & quickAdd** — inline/patch edits and quick-add now persist collaborators. Patch handling lives in the **service layer**, calling the repo's `add`/`removeCollaborators`.
- **ToDoWidget enrichment** — `enrichGroupedTicketsWithCollaborators` now also supports the `tickets`-keyed widget views (not just `items`), and the widget assignment methods enrich collaborator metadata.
- **Unit tests** for collaborator enrichment (items, widget, overflow).

## Overlap resolution (the three PRs collided)

- **Notifications:** chose the filter-bypass approach (#3404) over #3403's separate "you were added" email path. One notification path, consistent with mentions. → #3403's dedicated-email code (and its `array_diff`/`array|int|bool`→`int` bugs) is **not** carried over.
- **Delete cleanup:** lives only in the repository's `delticket()` (merged in #3405) — a data-integrity safety net for every delete path. Dropped #3404's redundant service-level `delete()` cleanup.
- **patch():** collaborator writes handled in the service layer (business logic belongs there), not the repository's `patchTicket()`.

## Copilot review fixes

- Extracted a single `addBypassRecipients()` helper in the Projects service, now used by both mentions and collaborators across email + in-app recipient lists — removes four duplicated re-add loops (addresses the drift concern).
- `extractCollaboratorIds()` keeps only scalar numeric values before `intval()` (no more `intval([]) === 0` bogus IDs) and drops non-positive ids.
- Collaborator enrichment tests rebuilt on a shared `buildServiceWithTicketRepository()` builder so they track the current `TicketsService` constructor signature.

## Testing

- PHPStan level 0: no errors
- Pint: clean
- `codecept run Unit` (TicketsServiceTest): 19 tests, 40 assertions, green

## Credit

- Base feature: @akashsah2003 (8e41134ec)
- This finishing work: @duongynhi000005-oss (commits preserved from #3403/#3404; #3405 merged separately)

Closes #1099. Supersedes #3403 and #3404.