### PR TITLE
fix(mobile): responsive stabilization sweep for phones & tablets

### DIFF
--- a/app/Domain/Menu/Js/menuController.js
+++ b/app/Domain/Menu/Js/menuController.js
@@ -65,16 +65,26 @@ leantime.menuController = (function () {
 
     };
 
+    // Below this width the sidebar is an off-canvas drawer (matches the
+    // mobile-like CSS breakpoint in mobile.css). See #3185, #2878.
+    var isMobileMenu = function () {
+        return window.innerWidth < 1200;
+    };
+
     var initLeftMenuHamburgerButton = function () {
 
-
-        var newWidth = 68;
-        if (window.innerWidth < 576) {
+        // On mobile/tablet always start with the drawer closed, regardless of
+        // the saved desktop preference. Don't persist this — it's view-only.
+        if (isMobileMenu()) {
             jQuery(".mainwrapper").removeClass("menuopen");
             jQuery(".mainwrapper").addClass("menuclosed");
         }
 
-        jQuery('.barmenu').click(function () {
+        jQuery('.barmenu').click(function (e) {
+
+            // Don't let this click bubble to the close-on-outside handler below,
+            // otherwise opening the drawer immediately closes it again.
+            e.stopPropagation();
 
             if (jQuery(".mainwrapper").hasClass('menuopen')) {
                 jQuery(".mainwrapper").removeClass("menuopen");
@@ -90,6 +100,24 @@ leantime.menuController = (function () {
                 leantime.menuRepository.updateUserMenuSettings("open");
             }
 
+        });
+
+        // Mobile drawer: tapping the dimmed backdrop closes it. The backdrop is
+        // a real element covering the content, so this is reliable even when
+        // content widgets stopPropagation on their own clicks. View-only.
+        jQuery(".menu-backdrop").on('click', function () {
+            jQuery(".mainwrapper").removeClass("menuopen").addClass("menuclosed");
+        });
+
+        // When the viewport crosses from desktop into mobile width, collapse
+        // the drawer so it doesn't sit open over the content.
+        var wasMobile = isMobileMenu();
+        jQuery(window).on('resize', function () {
+            var nowMobile = isMobileMenu();
+            if (nowMobile && !wasMobile) {
+                jQuery(".mainwrapper").removeClass("menuopen").addClass("menuclosed");
+            }
+            wasMobile = nowMobile;
         });
 
     };

--- a/app/Domain/Menu/Js/menuController.js
+++ b/app/Domain/Menu/Js/menuController.js
@@ -86,18 +86,27 @@ leantime.menuController = (function () {
             // otherwise opening the drawer immediately closes it again.
             e.stopPropagation();
 
+            // On mobile/tablet the drawer is view-only: toggle it but do NOT
+            // persist, otherwise opening the drawer on a phone would overwrite
+            // the user's saved desktop sidebar preference.
+            var persistState = !isMobileMenu();
+
             if (jQuery(".mainwrapper").hasClass('menuopen')) {
                 jQuery(".mainwrapper").removeClass("menuopen");
                 jQuery(".mainwrapper").addClass("menuclosed");
 
                 //If it doesn't have the class open, the user wants it to be open.
-                leantime.menuRepository.updateUserMenuSettings("closed");
+                if (persistState) {
+                    leantime.menuRepository.updateUserMenuSettings("closed");
+                }
             } else {
                 jQuery(".mainwrapper").removeClass("menuclosed");
                 jQuery(".mainwrapper").addClass("menuopen");
 
                 //If it doesn't have the class open, the user wants it to be open.
-                leantime.menuRepository.updateUserMenuSettings("open");
+                if (persistState) {
+                    leantime.menuRepository.updateUserMenuSettings("open");
+                }
             }
 
         });

--- a/app/Domain/Projects/Templates/partials/projectCardProgressBar.blade.php
+++ b/app/Domain/Projects/Templates/partials/projectCardProgressBar.blade.php
@@ -46,5 +46,7 @@
     </div>
 
 <script>
-    tippy('[data-tippy-content]');
+    // Idempotent init (see milestoneCard) — avoids re-instancing all tooltips
+    // every time a project progress bar renders.
+    window.leantime?.initTooltips?.();
 </script>

--- a/app/Domain/Tickets/Templates/partials/milestoneCard.blade.php
+++ b/app/Domain/Tickets/Templates/partials/milestoneCard.blade.php
@@ -42,7 +42,10 @@
         </div>
 
         <script>
-            tippy('[data-tippy-content]');
+            // Idempotent init — a bare tippy('[data-tippy-content]') here re-instanced
+            // every tooltip on the page each time a milestone card rendered (flashing
+            // + duplicate header tooltips). initTooltips skips already-instanced els.
+            window.leantime?.initTooltips?.();
         </script>
     @endfragment
 </div>

--- a/app/Domain/Widgets/Js/Widgetcontroller.js
+++ b/app/Domain/Widgets/Js/Widgetcontroller.js
@@ -55,7 +55,7 @@ leantime.widgetController = (function () {
             lazyLoad: false,
             columnOpts: {
                 breakpointForWindow: true,  // test window vs grid size
-                breakpoints: [{w:700, c:1},{w:950, c:6}]
+                breakpoints: [{w:1199, c:1}]
             },
         });
 
@@ -65,6 +65,39 @@ leantime.widgetController = (function () {
 
         grid.on('resizestop', function(Event, item) {
             saveGrid();
+        });
+
+        // Mobile/tablet (<1200px): force a static single-column grid so that
+        // scrolling or tapping a widget doesn't drag/reshuffle it (#3350). The
+        // 1-column layout comes from columnOpts.breakpoints above; setStatic
+        // disables drag/resize (so saveGrid never fires here and the desktop
+        // layout is never overwritten). Restore the draggable grid on resize up.
+        var welcomeRemoved = false;
+        var applyResponsiveGridMode = function () {
+            if (!grid) return;
+            var isMobile = window.innerWidth < 1200;
+            grid.setStatic(isMobile);
+            grid.margin(isMobile ? '0px 5px 5px 0px' : '0px 15px 15px 0px');
+
+            // Hide the low-value welcome/stats widget on mobile. Removing it from
+            // the grid engine (keeping the DOM, which CSS hides) and compacting
+            // closes the gap its grid rows would otherwise leave behind.
+            if (isMobile && !welcomeRemoved) {
+                var welcome = document.getElementById('widget_wrapper_welcome');
+                if (welcome) {
+                    try {
+                        grid.removeWidget(welcome, false);
+                        grid.compact();
+                    } catch (e) { /* grid not ready; CSS still hides it */ }
+                    welcomeRemoved = true;
+                }
+            }
+        };
+        applyResponsiveGridMode();
+        var gridResizeTimer;
+        window.addEventListener('resize', function () {
+            clearTimeout(gridResizeTimer);
+            gridResizeTimer = setTimeout(applyResponsiveGridMode, 200);
         });
 
         jQuery(".grid-stack-item").each(function(){

--- a/app/Views/Templates/layouts/app.blade.php
+++ b/app/Views/Templates/layouts/app.blade.php
@@ -55,6 +55,8 @@
 
         </div><!-- rightpanel -->
 
+        <div class="menu-backdrop" aria-hidden="true"></div>
+
     </div><!-- mainwrapper -->
 
     @include('global::sections.pageBottom')

--- a/public/assets/css/components/mobile.css
+++ b/public/assets/css/components/mobile.css
@@ -2508,4 +2508,371 @@ min-width: 1200px
 }
 
 
+/* ============================================================================
+   MOBILE-LIKE SHELL  —  phones + tablets  (< 1200px)
+   ----------------------------------------------------------------------------
+   The desktop sidebar layout is reserved for >= 1200px. Below that we use a
+   single mobile-like behaviour: fixed header, content full-width, and the left
+   menu becomes an off-canvas drawer toggled by the hamburger.
+
+   This block is appended LAST in mobile.css (which itself loads after nav.css /
+   structure.css), so for selectors it redefines it wins on source order at
+   equal specificity — no !important needed except where it must beat an
+   earlier same-file rule (e.g. the 576-1200 bucket hiding .barmenu).
+   Stabilization sweep — see GitHub #3185, #2878.
+   ============================================================================ */
+@media (max-width: 1199px) {
+
+    /* --- Hamburger must be visible (the 576-1200 bucket hid it) --- */
+    .barmenu {
+        display: inline-block !important;
+        line-height: 50px;
+    }
+
+    /* --- Header above content so its dropdowns aren't out-painted --- */
+    /* The fixed header + backdrop-filter trap dropdowns in a z-index:15 stacking
+       context, and content uses zlayer tokens up to 20+. Lift the header above
+       all content (zlayer max 40) but keep it below the nyroModal (z 100). #1938 */
+    .header {
+        z-index: 90;
+    }
+    .header,
+    .headerinner,
+    .headmenu {
+        overflow: visible;
+    }
+
+    /* Header dropdowns (notifications #1938, news, profile, project selector):
+       contain within the viewport as a panel below the header instead of
+       overflowing off the right-anchored icon. */
+    .header .dropdown-menu,
+    .headerinner .dropdown-menu {
+        position: fixed;
+        top: 50px;
+        left: 5px;
+        right: 5px;
+        width: auto;
+        min-width: 0;
+        max-width: calc(100vw - 10px);
+        max-height: calc(100vh - 60px);
+        overflow-y: auto;
+    }
+
+    /* --- Kanban: unify the horizontal scroll (#1364) ---
+       The sticky column-header bar and the ticket columns were in SEPARATE
+       horizontal scrollers, so they desynced when swiping. Make the board
+       wrapper the single horizontal scroller, drop the per-row overflow and
+       the header's sticky positioning, and match header/ticket column widths
+       so titles stay above their columns. */
+    .kanban-board-wrapper {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .kanban-board-wrapper .sortableTicketList .row-fluid {
+        overflow-x: visible;
+    }
+    .kanban-column-headers {
+        position: static !important;
+        top: auto !important;
+    }
+    .kanban-column-headers .column,
+    .sortableTicketList .row-fluid > .column {
+        flex: 0 0 280px;
+        width: 280px;
+        min-width: 280px;
+    }
+
+    /* --- Task / idea / article detail modal (#3088, #1357) ---
+       Cap the modal to the viewport (the JS no longer forces 1800px on mobile),
+       collapse the two-column main+sidebar layout to one column, make the tab
+       nav usable, and stop fixed-pixel fields from overflowing. */
+    .nyroModalCont {
+        width: 95vw !important;
+        left: 2.5vw !important;
+        max-width: 95vw !important;
+        max-height: calc(100vh - 24px) !important;
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+        box-sizing: border-box;
+        padding: 20px 12px !important;
+    }
+    .nyroModalCont .col-md-9,
+    .nyroModalCont .col-md-3 {
+        width: 100% !important;
+        display: block !important;
+        float: none !important;
+    }
+    /* The modal's jQuery-UI tab nav collapses on mobile — force it to show/wrap */
+    .nyroModalCont .tab-primary.ui-tabs .ui-tabs-nav,
+    .nyroModalCont .tabbable .ui-tabs-nav,
+    .tab-primary.ui-tabs .ui-tabs-nav {
+        display: flex !important;
+        flex-wrap: wrap;
+        height: auto;
+    }
+    /* Fields fill the column instead of fixed pixel/min widths overflowing */
+    .nyroModalCont input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]),
+    .nyroModalCont select,
+    .nyroModalCont textarea,
+    .nyroModalCont .chosen-container {
+        max-width: 100% !important;
+        min-width: 0 !important;
+        box-sizing: border-box;
+    }
+
+    /* Stack form rows: label on its own full-width line, field below it (the
+       side-by-side label/field layout wraps awkwardly — "Assigned\nto" etc). */
+    .nyroModalCont .form-group {
+        display: block !important;
+        width: 100% !important;
+    }
+    .nyroModalCont .form-group .control-label {
+        display: block !important;
+        width: 100% !important;
+        text-align: left !important;
+        margin: 0 0 4px 0 !important;
+        padding: 0 !important;
+    }
+    .nyroModalCont .form-group select,
+    .nyroModalCont .form-group .chosen-container,
+    .nyroModalCont .form-group .date-picker-form-control,
+    .nyroModalCont .form-group input[type="text"] {
+        width: 100% !important;
+    }
+    /* Save/footer bar must not float over content on small screens */
+    .nyroModalCont .sticky-modal-footer {
+        position: relative !important;
+        bottom: auto !important;
+    }
+
+    /* --- Dashboard widget cards (#3350) ---
+       Tighten widget padding, keep task-card content inside the card (the
+       "New"/status badges were overflowing), and let card rows wrap. */
+    .widgetContent {
+        padding-left: 8px !important;
+        padding-right: 8px !important;
+    }
+    .grid-stack-item-content {
+        overflow-x: hidden;
+    }
+    /* Hide the welcome/stats widget on mobile — low value and the stat strip
+       scrolls awkwardly. height:0 + min-height:0 so GridStack doesn't leave a
+       gap where it was. */
+    #widget_wrapper_welcome {
+        display: none !important;
+        height: 0 !important;
+        min-height: 0 !important;
+    }
+    .ticketBox {
+        overflow: hidden;
+    }
+    /* Show essentials only on mobile (title + status + actions menu). The
+       timer, due date, recurring and scheduler icons cram the ~240px card, and
+       the floated status pill ends up overlapping the title/date. All of this
+       is available in the task detail. Per product guidance for mobile cards. */
+    /* NB: ':not(.col-md-12)' — on the project-dashboard card variant the title
+       link lives inside a .col-md-12.timerContainer; only hide the small
+       play/timer button (the .tw-relative timerContainer), never the title. */
+    .ticketBox .timerContainer:not(.col-md-12),
+    .ticketBox .due-date-container,
+    .ticketBox .placeholder-container,
+    .ticketBox .date-picker-form-control,
+    .ticketBox .scheduler {
+        display: none !important;
+    }
+    /* Let the remaining row wrap and stop the status pill floating over text. */
+    .ticketBox .tw-flex.tw-flex-row {
+        flex-wrap: wrap;
+        align-items: center;
+        row-gap: 6px;
+    }
+    .ticketBox .ticket-title,
+    .ticketBox .title-text,
+    .ticketBox .tw-flex-1 {
+        min-width: 0;
+    }
+    .ticketBox .ticket-title {
+        flex: 1 1 100%;
+    }
+    .ticketBox .title-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .ticketBox .dropdown-toggle.status {
+        float: none !important;
+        max-width: 100%;
+    }
+
+    /* Project-dashboard "Latest To-Dos" card variant uses a .col-md-4 / .col-md-8
+       grid with floated effort/milestone/status dropdowns that squeeze the title
+       to zero width. Stack the columns, hide effort/milestone/due-date (in the
+       detail), un-float the dropdowns, and give the title room. */
+    .ticketBox .col-md-4,
+    .ticketBox .col-md-8 {
+        width: 100% !important;
+        display: block !important;
+        float: none !important;
+    }
+    .ticketBox .effortDropdown,
+    .ticketBox .milestoneDropdown,
+    .ticketBox .due-date-container,
+    .ticketBox .business-time,
+    .ticketBox .infoIcon,
+    .ticketBox .duedates {
+        display: none !important;
+    }
+    .ticketBox .dropdown.ticketDropdown,
+    .ticketBox .dropdown-toggle.status,
+    .ticketBox .statusDropdown {
+        float: none !important;
+    }
+    .ticketBox .right {
+        text-align: left;
+    }
+    /* Title link must stay visible (was collapsed to 0 width) */
+    .ticketBox a[class*="ticket-headline"],
+    .ticketBox .ticket-title a {
+        display: inline-block;
+        min-width: 0;
+    }
+
+    /* --- Content takes the full width; the drawer leaves the flow --- */
+    .rightpanel {
+        width: 100%;
+        margin-left: 0;
+        padding-top: 50px;
+    }
+
+    .mainwrapper .primaryContent,
+    .mainwrapper.menuclosed .primaryContent,
+    .mainwrapper.menuopen .primaryContent {
+        padding-left: 0;
+    }
+
+    .maincontent {
+        margin-top: 0;
+        padding: 10px;
+        width: 100%;
+    }
+
+    /* Header menu must not reserve collapsed-rail space */
+    .mainwrapper .headmenu,
+    .mainwrapper.menuclosed .headmenu,
+    .mainwrapper.menuopen .headmenu {
+        margin-left: 10px;
+    }
+
+    /* --- Left menu as an off-canvas drawer --- */
+    .mainwrapper .leftpanel,
+    .mainwrapper.menuclosed .leftpanel,
+    .mainwrapper.menuopen .leftpanel {
+        position: fixed;
+        top: 50px;
+        left: 0;
+        margin: 0;
+        width: min(85vw, 300px);
+        max-width: 300px;
+        height: calc(100vh - 50px);
+        border-radius: 0;
+        z-index: 1001;
+        display: flex;
+        transform: translateX(-100%);
+        transition: transform 0.25s ease;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    .mainwrapper.menuopen .leftpanel {
+        transform: translateX(0);
+        box-shadow: var(--large-shadow);
+    }
+
+    /* Drawer always shows full labels (undo the desktop collapsed-rail tweaks).
+       NOTE: scoped strictly to .leftpanel — must NOT touch .headmenu, whose
+       work-mode labels stay icon-only in the header (see rule below). */
+    .mainwrapper.menuclosed .leftpanel .leftmenu .nav-tabs.nav-stacked > li.dropdown a {
+        font-size: var(--base-font-size);
+        width: auto;
+        text-align: left;
+        padding: 12px 15px 8px;
+    }
+    .mainwrapper.menuclosed .leftpanel .leftmenu .nav-tabs.nav-stacked > li.dropdown a span,
+    .mainwrapper.menuclosed .leftpanel .leftmenu .nav-tabs.nav-stacked > li.dropdown a span.feature-label {
+        font-size: var(--base-font-size);
+        display: inline;
+    }
+
+    /* Header work-mode switcher (Projects / My Work / Company) is icons-only on
+       mobile — its text labels overflow the cramped header and overlap the
+       project avatar. Keep labels hidden in BOTH menu states. */
+    .headmenu .headmenu-label {
+        display: none !important;
+    }
+
+    /* Project avatar in the header: render it as a 30px square avatar, centred
+       in the 50px bar and in line with the other icons. The active-project
+       highlight (rgba white 0.2) must NOT become a full-height grey box, and the
+       avatar image must not be pushed down inside its span. */
+    .headmenu.work-modes > li > a {
+        display: inline-flex;
+        align-items: center;
+        height: 50px;
+        padding: 0 4px;
+    }
+    .headmenu.work-modes > li > a.bigProjectSelector,
+    .headmenu.work-modes > li > a.bigProjectSelector.active,
+    .headmenu.work-modes > li > a.bigProjectSelector:hover {
+        background: none !important;
+        box-shadow: none !important;
+    }
+    /* Header shows ONLY the avatar on mobile — hide the project name text and
+       caret in BOTH menu states. (menuclosed sets font-size:0, but opening the
+       drawer switches to menuopen which un-hides the name — so scope it here.) */
+    .headmenu.work-modes .bigProjectSelector {
+        font-size: 0 !important;
+    }
+    .headmenu.work-modes .bigProjectSelector .fa-caret-down {
+        display: none !important;
+    }
+    .mainwrapper.menuclosed .bigProjectSelector > .projectAvatar,
+    .headmenu.work-modes .bigProjectSelector .projectAvatar {
+        width: 30px !important;
+        height: 30px !important;
+        margin: 0 !important;
+        border-radius: var(--box-radius-small, 5px);
+        overflow: hidden;
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .headmenu.work-modes .bigProjectSelector .projectAvatar img {
+        width: 30px !important;
+        height: 30px !important;
+        margin: 0 !important;
+        object-fit: cover;
+        display: block;
+        vertical-align: middle;
+    }
+
+    /* --- Dimmed backdrop behind the open drawer (real element, tap to close) --- */
+    .mainwrapper.menuopen .menu-backdrop {
+        display: block;
+        position: fixed;
+        top: 50px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.45);
+        z-index: 1000;
+    }
+}
+
+/* Backdrop element is hidden everywhere except the open mobile drawer (above) */
+.menu-backdrop {
+    display: none;
+}
+
+
 

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -44,7 +44,58 @@ leantime.handleAsyncResponse = function (response) {
 
 jQuery.noConflict();
 
+// On touch devices, require a brief long-press + a few px of movement before a
+// jQuery-UI sortable/draggable starts dragging. Without this the whole card is a
+// drag target, so a tap "grabs" it instead of opening it and a swipe drags it
+// instead of scrolling. Set on the widget prototypes so it applies to every
+// sortable/draggable (dashboard to-dos, kanban cards, ideas cards) without
+// touching each init. Touch-only, so mouse drag on desktop is unaffected.
+// Fixes #1357 (can't tap cards), #3350 (scrolling moves tasks), #1465 (tablet drag).
+leantime.applyTouchDragGuards = function () {
+    if (!(('ontouchstart' in window || navigator.maxTouchPoints > 0) && jQuery.ui)) {
+        return;
+    }
+    if (jQuery.ui.sortable) {
+        jQuery.extend(jQuery.ui.sortable.prototype.options, { delay: 200, distance: 8 });
+    }
+    if (jQuery.ui.draggable) {
+        jQuery.extend(jQuery.ui.draggable.prototype.options, { delay: 200, distance: 8 });
+    }
+};
+
+// Initialise Tippy tooltips idempotently. Calling tippy('[data-tippy-content]')
+// on every document.ready AND every htmx.onLoad re-instanced ALL tooltips on
+// each HTMX swap, piling up dozens of duplicate "Notifications" tooltips (one of
+// which stayed visible). Skip elements that already have an instance, and scope
+// to the swapped subtree when given one.
+leantime.initTooltips = function (root) {
+    // Hover tooltips are a desktop affordance — useless on touch, and on narrow
+    // screens the header-icon tooltips flashed/stuck during HTMX page loads
+    // (a transient pointerover shows them, then the element re-renders so no
+    // mouseleave ever fires to hide them). So on mobile/touch we don't run them
+    // at all, and tear down any that already exist.
+    var isMobile = window.innerWidth < 1200 || ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
+    if (isMobile) {
+        document.querySelectorAll('[data-tippy-content]').forEach(function (el) {
+            if (el._tippy) { el._tippy.destroy(); }
+        });
+        return;
+    }
+    // Desktop: a short show-delay debounces transient hovers from layout reflow.
+    if (window.tippy && tippy.setDefaultProps) {
+        tippy.setDefaultProps({ delay: [300, 0] });
+    }
+    var scope = (root && root.querySelectorAll) ? root : document;
+    scope.querySelectorAll('[data-tippy-content]').forEach(function (el) {
+        if (!el._tippy) {
+            tippy(el, { delay: [300, 0] });
+        }
+    });
+};
+
 jQuery(document).ready(function () {
+
+    leantime.applyTouchDragGuards();
 
     leantime.replaceSVGColors();
 
@@ -52,7 +103,7 @@ jQuery(document).ready(function () {
         confetti.start();
     });
 
-    tippy('[data-tippy-content]');
+    leantime.initTooltips();
 
     if (jQuery('.login-alert .alert').text() !== '') {
         jQuery('.login-alert').fadeIn();
@@ -65,7 +116,12 @@ jQuery(document).ready(function () {
 });
 
 htmx.onLoad(function(element){
-    tippy('[data-tippy-content]');
+    leantime.initTooltips(element);
+    // Re-assert touch drag guards before HTMX-loaded sortables (e.g. the
+    // dashboard to-do list) initialise.
+    if (leantime.applyTouchDragGuards) {
+        leantime.applyTouchDragGuards();
+    }
 });
 
 window.addEventListener("HTMX.ShowNotification", function(evt) {

--- a/public/assets/js/app/core/modals.js
+++ b/public/assets/js/app/core/modals.js
@@ -40,7 +40,9 @@ leantime.modals = (function () {
                 afterShowCont: function () {
                     window.htmx.process('.nyroModalCont');
                     jQuery(".formModal, .modal").nyroModal(modalOptions);
-                    tippy('[data-tippy-content]');
+                    // Idempotent + scoped to the modal so it doesn't re-instance
+                    // page tooltips (see app.js initTooltips).
+                    window.leantime?.initTooltips?.(document.querySelector('.nyroModalCont'));
 
                     // Initialize Tiptap editors in modal (after small delay for DOM settlement)
                     setTimeout(function() {
@@ -75,8 +77,19 @@ leantime.modals = (function () {
         if(url.includes("showTicket")
             || url.includes("ideaDialog")
             || url.includes("articleDialog")) {
-            modalOptions.sizes.minW = 1800;
-            modalOptions.sizes.minH = 1800;
+            // These detail modals are intentionally large on desktop. On
+            // mobile/tablet (<1200px) the 1800px minimum makes them unusable,
+            // so only apply it on desktop. CSS caps the container to ~95vw. #3088
+            if (window.innerWidth >= 1200) {
+                modalOptions.sizes.minW = 1800;
+                modalOptions.sizes.minH = 1800;
+            }
+        }
+
+        // Never let any modal's minimum width exceed the viewport on small
+        // screens, otherwise it forces horizontal overflow. #3088
+        if (window.innerWidth < 1200) {
+            modalOptions.sizes.minW = Math.min(modalOptions.sizes.minW, window.innerWidth - 20);
         }
 
         //Ensure we have no trailing slash at the end.


### PR DESCRIPTION
## Context
Leantime was effectively unusable below ~1200px (#3185). This is a **stabilization sweep** to make phones and tablets usable now — not the eventual frontend rewrite. Everything below 1200px now behaves "mobile-like" (hamburger + off-canvas drawer, single column, full-width modals); the desktop sidebar layout is reserved for ≥1200px. It's implemented as a single appended `@media (max-width:1199px)` block in `mobile.css` (loads last → wins on source order) plus surgical JS/template edits, so the desktop layout is untouched.

## What changed
**CSS — `public/assets/css/components/mobile.css`**
- Off-canvas drawer menu with a tap-to-close backdrop; hamburger visible on tablets
- Header dropdowns (project selector, notifications) lifted above content and contained within the viewport
- Header project avatar rendered icon-sized + aligned with the other icons; name/caret hidden in both menu states
- Kanban: unified horizontal scroll so the column header and columns move together (no desync)
- Task/idea modal: ~95vw, single column, **form labels stacked above full-width fields**, tab nav usable
- Dashboard task cards simplified to **title + status**; secondary metadata hidden; welcome/stats widget hidden on mobile
- Project-dashboard "Latest To-Dos" card variant: stack columns, restore the (previously collapsed) title

**JS**
- `modals.js` — only force the 1800px detail-modal min-width on desktop; cap modal width to the viewport on mobile
- `menuController.js` — drawer threshold 576→1200, backdrop tap-to-close, resize handler (saved desktop state preserved)
- `Widgetcontroller.js` — single-column **static** GridStack on mobile so scrolling/tapping doesn't drag widgets; hide welcome widget + compact
- `app.js` — touch drag-vs-tap guard (long-press) on jQuery-UI sortables/draggables so a tap opens a card and a swipe scrolls; **idempotent + scoped tooltip init** (fixes duplicate/stuck "Notifications" tooltips that were re-instanced on every HTMX swap); hover tooltips disabled on touch/narrow
- `milestoneCard` / `projectCardProgressBar` partials — idempotent tooltip init

## GitHub issues addressed
- #3185 (unusable <1200px), #2878 (iOS menu/layout), #3088 (task modal unusable), #1938 (notifications hidden by sidebar), #3350 (dashboard drag-on-scroll), #1357 / #1465 (tap-vs-drag on cards), #1364 (kanban scroll) — mobile portions.

## Testing
Verified with Playwright across **dashboard, project dashboard, kanban, task modal, projects, ideas, calendar, table, settings, reports** at 375 / 768 / 1280px. Desktop layout confirmed unchanged. Pint passes (no PHP source changed — CSS/JS/Blade only).

## Notes / out of scope
- Build assets (`public/dist/*`) are gitignored; CI rebuilds.
- **Dashboard load performance** (5 widgets load independently → ~22 `htmx:load` / ~200 DOM mutations per load, causing hover flicker during load) is a separate, core/shared concern — not addressed here. The most visible symptom (duplicate/flashing tooltips) is fixed.
- Lower-priority polish noted but deferred: timesheet filter bar wraps on mobile (Search reachability), kanban toolbar wrap when the quick-add box is open (a scrollbar-width artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)