### PR TITLE
fix: restore data binding in milestone & wiki dialogs

### DIFF
--- a/app/Domain/Tickets/Templates/milestoneDialog.blade.php
+++ b/app/Domain/Tickets/Templates/milestoneDialog.blade.php
@@ -1,5 +1,5 @@
 @php
-    $currentMilestone = $currentMilestone ?? null;
+    $currentMilestone = $milestone ?? null;
     $milestones = $milestones ?? [];
     $statusLabels = $statusLabels ?? [];
 @endphp

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
 @php
-    $currentArticle = $currentArticle ?? null;
+    $currentArticle = $article ?? null;
 
     $wikiHL = $wikiHeadlines ?? [];
     $wikiHeadlines = [];

--- a/app/Domain/Wiki/Templates/wikiDialog.blade.php
+++ b/app/Domain/Wiki/Templates/wikiDialog.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
 @php
-    $currentWiki = $currentWiki ?? null;
+    $currentWiki = $wiki ?? null;
 @endphp
 
 <h4 class="widgettitle title-light"><i class="fa fa-book"></i> {!! __('label.wiki') !!} {{ $tpl->escape($currentWiki->title) }}</h4>


### PR DESCRIPTION
## Problem

A customer reported `Attempt to read property "id" on null` in the milestone editor (`milestoneDialog.blade.php`). This is a regression on **`master`** and the current release — opening the milestone edit/create dialog throws every time.

## Root cause

Commit 9bb458a59 ("replace all `$tpl->get()`/`$tpl->assign()` in blade templates") mechanically converted `$tpl->get('milestone')` into a direct variable, but produced a **self-referential** fallback that points at a variable name the controller never passes:

```php
$currentMilestone = $currentMilestone ?? null;   // controller assigns 'milestone', not 'currentMilestone'
```

So `$currentMilestone` was always `null`, and `{{ $currentMilestone->id }}` (line 11 `window.onload` redirect + line 26 form action) threw at render time.

The same find-replace mistake hit two sibling dialogs from the same commit, not yet reported:

| Template | Reads | Controller assigns |
|---|---|---|
| `Tickets/.../milestoneDialog.blade.php` | `$currentMilestone` | `milestone` (`EditMilestone:76`) |
| `Wiki/.../wikiDialog.blade.php` | `$currentWiki` | `wiki` (`WikiModal:32`) |
| `Wiki/.../articleDialog.blade.php` | `$currentArticle` | `article` (`ArticleDialog:59`) |

Canvas/Blueprints `canvasDialog` and Wiki `show.blade.php` were already correct (controllers assign the matching `current*` key) and are untouched.

## Fix

One line per template — point each local at the key the controller actually assigns:

```php
$currentMilestone = $milestone ?? null;
$currentWiki      = $wiki ?? null;
$currentArticle   = $article ?? null;
```

After the fix, the create path (`getNewMilestone()` → `TicketModel` with `id = null`) is also safe: `isset($currentMilestone->id)` hides the delete link and the form posts to the create endpoint.

## Testing

- [ ] Roadmap → open an existing milestone: dialog opens, fields populated, no error
- [ ] Roadmap → new milestone: blank dialog, no delete icon, saves to create
- [ ] Open a wiki and an article dialog: no "property on null" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)