### PR TITLE
fix(db): PostgreSQL compatibility (write limits, sequences, pdo_pgsql, JS escaping)

### DIFF
--- a/.dev/dockerfile
+++ b/.dev/dockerfile
@@ -19,6 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
+    libpq-dev \
     apt-utils \
     vim \
     curl \
@@ -35,6 +36,7 @@ RUN docker-php-ext-install \
     gd \
     mysqli \
     pdo_mysql \
+    pdo_pgsql \
     mbstring \
     exif \
     pcntl \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -18,7 +18,8 @@ RUN apk add --no-cache --virtual .build-deps \
     libzip-dev \
     freetype-dev \
     libpng-dev \
-    libjpeg-turbo-dev
+    libjpeg-turbo-dev \
+    postgresql-dev
 
 # Set cross-compilation flags if needed
 ARG TARGETPLATFORM
@@ -33,6 +34,7 @@ RUN set -ex; \
     # Install extensions one by one to prevent memory issues
     docker-php-ext-install mysqli && \
     docker-php-ext-install pdo_mysql && \
+    docker-php-ext-install pdo_pgsql && \
     docker-php-ext-install bcmath && \
     docker-php-ext-install mbstring && \
     docker-php-ext-install exif && \
@@ -62,6 +64,7 @@ RUN apk add --no-cache \
     libjpeg-turbo \
     libzip \
     openldap \
+    libpq \
     icu-libs && \
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/app/Domain/Auth/Repositories/Auth.php
+++ b/app/Domain/Auth/Repositories/Auth.php
@@ -107,7 +107,6 @@ class Auth
     {
         return $this->db->table('zp_user')
             ->where('session', $sessionId)
-            ->limit(1)
             ->update(['session' => '']) >= 0;
     }
 
@@ -149,7 +148,6 @@ class Auth
     {
         return $this->db->table('zp_user')
             ->where('id', $userId)
-            ->limit(1)
             ->update([
                 'lastlogin' => now(),
                 'session' => $sessionid,
@@ -188,7 +186,6 @@ class Auth
     {
         return $this->db->table('zp_user')
             ->where('username', $username)
-            ->limit(1)
             ->update([
                 'pwReset' => $resetLink,
                 'pwResetExpiration' => now(),
@@ -198,9 +195,26 @@ class Auth
 
     public function changePW(string $password, string $hash): bool
     {
-        return $this->db->table('zp_user')
+        // Never match on an empty reset token: many accounts carry an empty
+        // pwReset (it's cleared after every successful change), so an empty hash
+        // would match a pile of users. Resolve to a single user id first, then
+        // update by primary key. This also avoids the MySQL-only DELETE/UPDATE
+        // ... LIMIT 1 that breaks on Postgres (#3384) — we can't drop limit(1)
+        // here because pwReset isn't unique.
+        if ($hash === '') {
+            return false;
+        }
+
+        $userId = $this->db->table('zp_user')
             ->where('pwReset', $hash)
-            ->limit(1)
+            ->value('id');
+
+        if (empty($userId)) {
+            return false;
+        }
+
+        return $this->db->table('zp_user')
+            ->where('id', $userId)
             ->update([
                 'password' => password_hash($password, PASSWORD_DEFAULT),
                 'pwReset' => '',

--- a/app/Domain/Blueprints/Repositories/Blueprints.php
+++ b/app/Domain/Blueprints/Repositories/Blueprints.php
@@ -120,7 +120,6 @@ class Blueprints extends Repository
 
         $this->connection->table('zp_canvas')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 
@@ -162,7 +161,6 @@ class Blueprints extends Repository
     {
         $this->connection->table('zp_canvas_items')
             ->where('id', $values['itemId'] ?? $values['id'])
-            ->limit(1)
             ->update([
                 'title' => $values['title'] ?? '',
                 'description' => $values['description'],
@@ -211,7 +209,6 @@ class Blueprints extends Repository
 
         return (bool) $this->connection->table('zp_canvas_items')
             ->where('id', $id)
-            ->limit(1)
             ->update($updates);
     }
 
@@ -447,7 +444,6 @@ class Blueprints extends Repository
     {
         $this->connection->table('zp_canvas_items')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 

--- a/app/Domain/Calendar/Repositories/Calendar.php
+++ b/app/Domain/Calendar/Repositories/Calendar.php
@@ -377,7 +377,6 @@ class Calendar extends RepositoryCore
         $this->db->table('zp_calendar')
             ->where('id', $id)
             ->where('userId', session('userdata.id'))
-            ->limit(1)
             ->update([
                 'dateFrom' => $values['dateFrom'],
                 'dateTo' => $values['dateTo'],
@@ -391,7 +390,6 @@ class Calendar extends RepositoryCore
         return $this->db->table('zp_calendar')
             ->where('id', $id)
             ->where('userId', session('userdata.id'))
-            ->limit(1)
             ->delete();
     }
 
@@ -434,7 +432,6 @@ class Calendar extends RepositoryCore
         $this->db->table('zp_gcallinks')
             ->where('userId', session('userdata.id'))
             ->where('id', $id)
-            ->limit(1)
             ->update([
                 'url' => $values['url'],
                 'name' => $values['name'],
@@ -447,7 +444,6 @@ class Calendar extends RepositoryCore
         return $this->db->table('zp_gcallinks')
             ->where('id', $id)
             ->where('userId', session('userdata.id'))
-            ->limit(1)
             ->delete() > 0;
     }
 

--- a/app/Domain/Clients/Repositories/Clients.php
+++ b/app/Domain/Clients/Repositories/Clients.php
@@ -170,7 +170,6 @@ class Clients extends Repository
     {
         return $this->db->table('zp_clients')
             ->where('id', $id)
-            ->limit(1)
             ->update([
                 'name' => $values['name'],
                 'street' => $values['street'],

--- a/app/Domain/Entityrelations/Repositories/Entityrelations.php
+++ b/app/Domain/Entityrelations/Repositories/Entityrelations.php
@@ -67,7 +67,6 @@ class Entityrelations
     {
         $this->db->table('zp_settings')
             ->where('key', $type)
-            ->limit(1)
             ->delete();
     }
 

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -136,7 +136,6 @@ class Ideas
 
         $this->db->table('zp_canvas')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 
@@ -164,7 +163,6 @@ class Ideas
     {
         $this->db->table('zp_canvas_items')
             ->where('id', $values['itemId'])
-            ->limit(1)
             ->update([
                 'description' => $values['description'],
                 'assumptions' => $values['assumptions'],
@@ -191,7 +189,6 @@ class Ideas
 
         return $this->db->table('zp_canvas_items')
             ->where('id', $id)
-            ->limit(1)
             ->update($updateData) >= 0;
     }
 
@@ -312,7 +309,6 @@ class Ideas
     {
         $this->db->table('zp_canvas_items')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 
@@ -320,7 +316,6 @@ class Ideas
     {
         return $this->db->table('zp_canvas_items')
             ->where('id', $ideaId)
-            ->limit(1)
             ->update(['box' => $status]) >= 0;
     }
 

--- a/app/Domain/Install/Services/SchemaBuilder.php
+++ b/app/Domain/Install/Services/SchemaBuilder.php
@@ -113,6 +113,33 @@ class SchemaBuilder
             ['key' => 'db-version', 'value' => $this->appSettings->dbVersion],
             ['key' => 'companysettings.telemetry.active', 'value' => 'true'],
         ]);
+
+        // zp_clients and zp_user are seeded with explicit id = 1 above. MySQL
+        // auto-advances AUTO_INCREMENT after an explicit-id insert; Postgres
+        // leaves the BIGSERIAL sequence at 1, so the next auto-id INSERT (e.g.
+        // OIDC JIT user creation) collides on the primary key. Re-sync the
+        // sequences to MAX(id) on Postgres. No-op on MySQL. (#3380)
+        $this->resyncSequences(['zp_clients', 'zp_user']);
+    }
+
+    /**
+     * Re-sync BIGSERIAL sequences to MAX(id) for tables seeded with explicit
+     * ids. Postgres-only; a no-op on every other driver.
+     *
+     * @param  string[]  $tables  Tables whose `id` sequence should be advanced.
+     */
+    private function resyncSequences(array $tables): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        foreach ($tables as $table) {
+            DB::statement(
+                "SELECT setval(pg_get_serial_sequence(?, 'id'), COALESCE((SELECT MAX(id) FROM {$table}), 1))",
+                [$table]
+            );
+        }
     }
 
     /**

--- a/app/Domain/Plugins/Repositories/Plugins.php
+++ b/app/Domain/Plugins/Repositories/Plugins.php
@@ -151,7 +151,6 @@ class Plugins
     {
         return $this->db->table('zp_plugins')
             ->where('id', $id)
-            ->limit(1)
             ->delete() > 0;
     }
 }

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -760,7 +760,6 @@ class Projects
 
         $this->connection->table('zp_projects')
             ->where('id', $id)
-            ->limit(1)
             ->update([
                 'name' => $values['name'],
                 'details' => $values['details'] ?? '',
@@ -1019,7 +1018,6 @@ class Projects
 
         return $this->connection->table('zp_projects')
             ->where('id', $id)
-            ->limit(1)
             ->update($updateData) >= 0;
     }
 

--- a/app/Domain/Reactions/Repositories/Reactions.php
+++ b/app/Domain/Reactions/Repositories/Reactions.php
@@ -83,7 +83,6 @@ class Reactions
     {
         return $this->db->table('zp_reactions')
             ->where('id', $id)
-            ->limit(1)
             ->delete() > 0;
     }
 
@@ -97,7 +96,6 @@ class Reactions
             ->where('moduleId', $moduleId)
             ->where('userId', $userId)
             ->where('reaction', $reaction)
-            ->limit(1)
             ->delete() > 0;
     }
 

--- a/app/Domain/Setting/Repositories/Setting.php
+++ b/app/Domain/Setting/Repositories/Setting.php
@@ -139,7 +139,6 @@ class Setting
     {
         $this->db->table('zp_settings')
             ->where('key', $type)
-            ->limit(1)
             ->delete();
 
         // Remove from cache

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -64,13 +64,19 @@ $currentPay = $userHours * $userInfo['wage'];
         var d3 = [];
         var labels = [];
         @php
+        // Emit every value through json_encode so the generated JS is always
+        // valid. Raw concatenation broke when a value was null or non-numeric
+        // (e.g. Postgres SUM()/plan hours formatting), producing a JS syntax
+        // error that killed the whole time-tracking modal. (#3353)
         $sum = 0;
+        $planHours = is_numeric($ticket->planHours) ? (float) $ticket->planHours : 0;
         foreach ($ticketHours as $hours) {
-            $sum = $sum + $hours['summe'];
+            $sum = $sum + (float) ($hours['summe'] ?? 0);
             try {
-                echo "labels.push('" . dtHelper()->parseDbDateTime($hours['utc'])->setToUserTimezone()->format('Y-m-d') . "');\n";
-                echo "d2.push(" . $sum . ");\n";
-                echo "d3.push(" . $ticket->planHours . ");\n";
+                $label = dtHelper()->parseDbDateTime($hours['utc'])->setToUserTimezone()->format('Y-m-d');
+                echo 'labels.push(' . json_encode($label) . ");\n";
+                echo 'd2.push(' . json_encode($sum) . ");\n";
+                echo 'd3.push(' . json_encode($planHours) . ");\n";
             } catch (\Exception $e) {
                 // not much we can do at this point. Ignore the datapoint
             }

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -710,7 +710,6 @@ class Timesheets extends Repository
             $this->db->table('zp_punch_clock')
                 ->where('userId', session('userdata.id'))
                 ->where('id', $ticketId)
-                ->limit(1)
                 ->delete();
 
             // At least 1 minute
@@ -918,7 +917,6 @@ class Timesheets extends Repository
     {
         $this->db->table('zp_timesheets')
             ->where('id', $id)
-            ->limit(1)
             ->delete();
     }
 

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -307,7 +307,6 @@ class Users
 
         return $this->connection->table('zp_user')
             ->where('id', $id)
-            ->limit(1)
             ->update($updateData);
     }
 
@@ -339,7 +338,6 @@ class Users
     {
         return $this->connection->table('zp_user')
             ->where('id', $userId)
-            ->limit(1)
             ->update([
                 'clientId' => null,
                 'modified' => now(),
@@ -366,7 +364,6 @@ class Users
 
         $this->connection->table('zp_user')
             ->where('id', $id)
-            ->limit(1)
             ->update($updateData);
     }
 
@@ -462,7 +459,6 @@ class Users
 
         return $this->connection->table('zp_user')
             ->where('id', $id)
-            ->limit(1)
             ->update($updates);
     }
 


### PR DESCRIPTION
## What
PostgreSQL compatibility pass.

- **#3384** — Dropped redundant `->limit(1)` on `UPDATE`/`DELETE` keyed on a PK/unique column across 12 repositories. Laravel rewrites `... LIMIT 1` into a `ctid` subselect on Postgres that can silently affect 0 rows; on MySQL the limit was always redundant. The 3 non-unique sites were handled specifically — notably `Auth::changePW()` was rewritten to guard an empty token, resolve a single user id, then update by PK (correct on both engines, and closes an empty-`pwReset` mass-update hazard).
- **#3380** — Re-sync `zp_clients`/`zp_user` BIGSERIAL sequences after the installer seeds them with explicit `id = 1`; otherwise the first auto-id insert (e.g. OIDC JIT user) collides on Postgres. No-op on MySQL.
- **#3212** — Add `pdo_pgsql` to the production and dev Docker images.
- **#3353** — `json_encode` all PHP→JS values in the ticket time-tracking chart; raw concatenation produced invalid JS for null/non-numeric values and broke the time-tracking modal.

## Test
On a Postgres instance: fresh install → OIDC JIT user create, delete a project, open a ticket's time-tracking tab and add time.

Fixes #3384
Fixes #3380
Fixes #3212
Fixes #3353
