### PR TITLE
fix(comments): open the edit/reply box above the replies thread

### DIFF
--- a/app/Domain/Comments/Js/commentsController.js
+++ b/app/Domain/Comments/Js/commentsController.js
@@ -5,11 +5,13 @@ leantime.commentsController = (function () {
         // Show the "Add new comment" toggler that makeInputReadonly may have hidden
         jQuery("[class^='mainToggler']").show();
 
-        // Show reply-level comment boxes (legacy .commentBox class only).
-        // Do NOT show commentBox-{hash} containers — those are the "new comment"
-        // forms that start hidden and open on-demand via toggleCommentBoxes().
-        jQuery(".commentBox").show();
-        jQuery(".replies .commentBox").hide();
+        // Keep per-comment reply/edit boxes (legacy .commentBox class) hidden;
+        // they open on-demand via toggleCommentBoxes(). These boxes now live
+        // outside .replies (so editing a comment with replies no longer jumps it
+        // below them), so hide by the class itself rather than by .replies
+        // containment. The "new comment" form uses commentBox-{hash} and is
+        // unaffected.
+        jQuery(".commentBox").hide();
         jQuery(".deleteComment, .replyButton").show();
 
         // Enable Tiptap editors in comment areas

--- a/app/Domain/Comments/Templates/submodules/generalComment.blade.php
+++ b/app/Domain/Comments/Templates/submodules/generalComment.blade.php
@@ -97,6 +97,20 @@
                             </span>
                         </div>
 
+                        {{-- Reply/edit box for the parent comment. Kept ABOVE the replies thread so
+                             editing a comment that has replies opens the editor in place rather than
+                             jumping below its replies. (#3319) --}}
+                        <div style="display:none;" id="comment-{{ $formHash }}-{{ $row['id'] }}" class="commentBox">
+                            <div class="commentImage">
+                                <img src="{{ BASE_URL }}/api/users?profileImage={{ session('userdata.id') }}&v={{ format(session('userdata.modified'))->timestamp() }}"/>
+                            </div>
+                            <div class="commentReply">
+                                <input type="submit" value="{{ __('links.reply') }}" name="comment" id="submit-reply-button" class="btn btn-primary"/>
+                                <input type="button" onclick="cancel({{ $row['id'] }}, '{{ $formHash }}')" value="{{ __('links.cancel') }}" class="btn btn-primary"/>
+                            </div>
+                            <div class="clearall"></div>
+                        </div>
+
                         <div class="replies">
                             @if ($comments->getReplies($row['id']))
                                 @foreach ($comments->getReplies($row['id']) as $comment)
@@ -140,16 +154,6 @@
                                     </div>
                                 @endforeach
                             @endif
-                            <div style="display:none;" id="comment-{{ $formHash }}-{{ $row['id'] }}" class="commentBox">
-                                <div class="commentImage">
-                                    <img src="{{ BASE_URL }}/api/users?profileImage={{ session('userdata.id') }}&v={{ format(session('userdata.modified'))->timestamp() }}"/>
-                                </div>
-                                <div class="commentReply">
-                                    <input type="submit" value="{{ __('links.reply') }}" name="comment" id="submit-reply-button" class="btn btn-primary"/>
-                                    <input type="button" onclick="cancel({{ $row['id'] }}, '{{ $formHash }}')" value="{{ __('links.cancel') }}" class="btn btn-primary"/>
-                                </div>
-                                <div class="clearall"></div>
-                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## What
**#3319** — Editing a comment that has replies made it "jump" below its replies. The edit/reply box lived **inside** `.replies`, after the replies loop, so showing it for an edit rendered it under all the replies. Moved the box out of `.replies` to sit directly under the parent comment, so editing opens in place.

## Test
On a ticket with a comment that has at least one reply, click Edit on the parent comment → the editor opens in place, above the replies, not at the bottom.

Fixes #3319
