### PR TITLE
feat(tickets): add "Not assigned" milestone filter option (#3252)

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -497,7 +497,24 @@ class Tickets
 
         if (isset($searchCriteria['milestone']) && $searchCriteria['milestone'] != '') {
             $milestoneIds = explode(',', $searchCriteria['milestone']);
-            $query->whereIn('zp_tickets.milestoneid', $milestoneIds);
+
+            // A milestone id of "0" is the "Not assigned to a milestone" filter
+            // option (#3252). Unassigned tickets store milestoneid as NULL or 0,
+            // so match both, while still honoring any real milestone ids selected
+            // alongside it.
+            $includeUnassigned = in_array('0', $milestoneIds, true);
+            $realMilestoneIds = array_values(array_filter($milestoneIds, fn ($id) => $id !== '0' && $id !== ''));
+
+            $query->where(function ($q) use ($realMilestoneIds, $includeUnassigned) {
+                if (! empty($realMilestoneIds)) {
+                    $q->whereIn('zp_tickets.milestoneid', $realMilestoneIds);
+                }
+
+                if ($includeUnassigned) {
+                    $q->orWhereNull('zp_tickets.milestoneid')
+                        ->orWhere('zp_tickets.milestoneid', 0);
+                }
+            });
         }
 
         if (isset($searchCriteria['status']) && $searchCriteria['status'] == 'all') {
@@ -1173,7 +1190,24 @@ class Tickets
 
         if (isset($searchCriteria['milestone']) && $searchCriteria['milestone'] != '') {
             $milestoneIds = explode(',', $searchCriteria['milestone']);
-            $query->whereIn('zp_tickets.milestoneid', $milestoneIds);
+
+            // A milestone id of "0" is the "Not assigned to a milestone" filter
+            // option (#3252). Unassigned tickets store milestoneid as NULL or 0,
+            // so match both, while still honoring any real milestone ids selected
+            // alongside it.
+            $includeUnassigned = in_array('0', $milestoneIds, true);
+            $realMilestoneIds = array_values(array_filter($milestoneIds, fn ($id) => $id !== '0' && $id !== ''));
+
+            $query->where(function ($q) use ($realMilestoneIds, $includeUnassigned) {
+                if (! empty($realMilestoneIds)) {
+                    $q->whereIn('zp_tickets.milestoneid', $realMilestoneIds);
+                }
+
+                if ($includeUnassigned) {
+                    $q->orWhereNull('zp_tickets.milestoneid')
+                        ->orWhere('zp_tickets.milestoneid', 0);
+                }
+            });
         }
 
         if (isset($searchCriteria['status']) && $searchCriteria['status'] == 'all') {

--- a/app/Domain/Tickets/Templates/submodules/ticketFilter.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketFilter.blade.php
@@ -73,6 +73,7 @@
                     <div class="form-group">
                         <select data-placeholder="{{ __('input.placeholders.filter_by_milestone') }}" multiple="multiple" title="{{ __('input.placeholders.filter_by_milestone') }}" name="milestone" id="milestoneSelect">
                             <option value="" data-placeholder="true">{!! __('label.all_milestones') !!}</option>
+                            <option value="0" @if (isset($searchCriteria['milestone']) && in_array('0', explode(',', (string) $searchCriteria['milestone']), true)) selected='selected' @endif>{!! __('label.not_assigned_to_milestone') !!}</option>
                             @if (is_array($milestones))
                                 @foreach ($milestones as $milestoneRow)
                                     <option value="{{ $milestoneRow->id }}"


### PR DESCRIPTION
## What
**#3252** — The milestone filter in the ToDo/Kanban view could only narrow to specific milestones; there was no way to see tasks that have **no milestone**.

- Adds a **"Not assigned to a milestone"** option (value `0`) to the filter dropdown (`ticketFilter.blade.php`).
- In `getAllBySearchCriteria` (and the matching count query), a selected `0` now matches `milestoneid IS NULL OR = 0`, while still honoring any real milestone ids selected alongside it.

## Test
ToDo view → Filter → Milestone → **Not assigned** → only tasks with no milestone show. Combine it with a real milestone to see both sets.

Fixes #3252
