### PR TITLE
fix: repair #3441 regressions blocking acceptance (app.js bundle syntax + stale install step)

### DIFF
--- a/app/Domain/Notifications/Services/News.php
+++ b/app/Domain/Notifications/Services/News.php
@@ -114,6 +114,9 @@ class News
         $client = new \GuzzleHttp\Client;
         $response = $client->request('GET', 'https://leantime.io/category/leantime-updates/feature-updates/feed/', [
             'headers' => ['Accept' => 'application/xml'],
+            // Fail fast when the server (or CI runner) has no egress so the news
+            // badge/widget degrades quickly instead of stalling. (#3372/#3373)
+            'connect_timeout' => 2,
             'timeout' => 5,
         ])->getBody()->getContents();
 

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -353,7 +353,13 @@ class Reports
                         'form_params' => [
                             'telemetry' => $data_string,
                         ],
-                        'timeout' => 480,
+                        // Short connect timeout so an offline/air-gapped server (or a
+                        // CI runner with no egress) fails fast instead of blocking the
+                        // dashboard's Welcome widget — and saturating PHP-FPM workers —
+                        // for minutes. The previous 480s total timeout hung the page
+                        // when telemetry was unreachable. (#3372/#3373)
+                        'connect_timeout' => 2,
+                        'timeout' => 5,
                     ])->then(function ($response) use ($today) {
                         $this->settings->saveSetting('companysettings.telemetry.lastUpdate', $today);
                     });

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -171,7 +171,7 @@ leantime.htmxProgress = (function () {
 document.addEventListener('htmx:beforeRequest', function () { leantime.htmxProgress.start(); });
 document.addEventListener('htmx:afterRequest', function () { leantime.htmxProgress.done(); });
 
-window.addEventListener("HTMX.ShowNotification", function(evt) {
+leantime.showNotification = function (evt) {
     jQuery.get(leantime.appUrl+"/notifications/getLatestGrowl", function(data){
         let notification = JSON.parse(data);
 

--- a/tests/Support/Page/Acceptance/Install.php
+++ b/tests/Support/Page/Acceptance/Install.php
@@ -34,9 +34,11 @@ class Install
         $this->I->fillField(['name' => 'company'], $company);
         $this->I->click('Install');
 
-        $this->I->waitForElementVisible('.alert');
-
-        $this->I->waitForText('The installation was successful', 90);
+        // A successful install redirects straight into the onboarding wizard
+        // (auth/userInvite), starting on the "Setting Account Details" step —
+        // there is no longer a standalone success .alert page. Wait for that
+        // step's first field to render before filling it in.
+        $this->I->waitForElementVisible(['name' => 'jobTitle'], 90);
 
         $this->I->fillField(['name' => 'jobTitle'], 'CEO');
 

--- a/tests/Support/Page/Acceptance/Install.php
+++ b/tests/Support/Page/Acceptance/Install.php
@@ -36,8 +36,9 @@ class Install
 
         // A successful install redirects straight into the onboarding wizard
         // (auth/userInvite), starting on the "Setting Account Details" step —
-        // there is no longer a standalone success .alert page. Wait for that
-        // step's first field to render before filling it in.
+        // there is no longer a standalone success .alert page. Wait for the
+        // jobTitle field (the first field this method fills) to confirm the
+        // step has rendered before continuing.
         $this->I->waitForElementVisible(['name' => 'jobTitle'], 90);
 
         $this->I->fillField(['name' => 'jobTitle'], 'CEO');


### PR DESCRIPTION
## Problem
The **Acceptance Tests (Selenium)** workflow went red on `master` on 2026-05-31 (green through 2026-05-30), blocking every open PR. Bisecting the green→red transition points at **#3441** ("Blade component tiers + central HTMX event convention") and #3444.

## Root causes (two, layered)

1. **`app.js` syntax error (the big one).** #3441 extracted `leantime.showNotification` but left the old `window.addEventListener("HTMX.ShowNotification", function(evt) {` opener while changing its closing `});` to `};` → `SyntaxError: missing ) after argument list` (`node --check` confirms). A syntax error anywhere in `app.js` stops the **entire bundle** from executing, so on every app page GridStack never initialized (**blank dashboard**), the **`.login-alert` never faded in**, and growl notifications broke. This is what took down the login/dashboard acceptance tests (and is a live, user-facing regression on master). Fix: define `leantime.showNotification` as the function so the trailing `};` is correct.

2. **Stale install step.** The install→onboarding flow changed; `InstallCest::createDBSuccessfully` waited for a removed `.alert` "installation was successful" banner. A successful install now redirects straight into the onboarding wizard (`auth/userInvite`, "Setting Account Details"). Fix: wait for the account step's `jobTitle` field. *(This was masking #1 — the other 32 tests `@Depends` on install.)*

Also folded in: short `connect_timeout` on the telemetry + news external calls so the Welcome widget can't hang the dashboard offline/in-CI (same hardening as #3448).

## Changes
- `public/assets/js/app/app.js` — fix the bundle-breaking syntax error.
- `tests/Support/Page/Acceptance/Install.php` — wait for the onboarding step, not the removed `.alert`.
- `app/Domain/Reports/Services/Reports.php`, `app/Domain/Notifications/Services/News.php` — external-call timeouts.

The committed `public/dist` bundle is stale from #3441 and should be regenerated at the next release build (`npx mix --production`); CI rebuilds from source, so this PR's source fix is what the suite exercises.

Fixes #3372
Fixes #3373
