### PR TITLE
feat(core): WorkStructure meta-model infrastructure

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.1';
+    public string $dbVersion = '3.5.2';
 }

--- a/app/Core/Configuration/laravelConfig.php
+++ b/app/Core/Configuration/laravelConfig.php
@@ -40,6 +40,7 @@ return [
             \Leantime\Core\Auth\AuthenticationServiceProvider::class,
             \Leantime\Core\Middleware\RateLimiter::class,
             \Leantime\Core\Database\DatabaseServiceProvider::class,
+            \Leantime\Core\WorkStructure\WorkStructureServiceProvider::class,
             \Leantime\Core\i18n\LanguageServiceProvider::class,
             // \Leantime\Core\Providers\RouteServiceProvider::class,
 

--- a/app/Core/Support/EntityRelationshipEnum.php
+++ b/app/Core/Support/EntityRelationshipEnum.php
@@ -15,6 +15,12 @@ enum EntityRelationshipEnum: string
     case Collaborator = 'collaborator';
 
     /**
-     * Add other relationship types as needed.
+     * Represents a "generated from" relationship (entity created from a canvas item).
      */
+    case GeneratedFrom = 'generated_from';
+
+    /**
+     * Represents a "maps to" relationship (cross-structure element mapping).
+     */
+    case MapsTo = 'maps_to';
 }

--- a/app/Core/WorkStructure/Events/ElementTypeRegistered.php
+++ b/app/Core/WorkStructure/Events/ElementTypeRegistered.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired when element types are added to a structure.
+ */
+class ElementTypeRegistered
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  int  $structureId  The structure ID
+     * @param  string  $typeKey  The element type key
+     * @param  string  $label  The element label
+     */
+    public function __construct(
+        public int $structureId,
+        public string $typeKey,
+        public string $label
+    ) {}
+}

--- a/app/Core/WorkStructure/Events/MappingCreated.php
+++ b/app/Core/WorkStructure/Events/MappingCreated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired when cross-structure mappings are defined.
+ */
+class MappingCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  int  $sourceStructureId  The source structure ID
+     * @param  int  $targetStructureId  The target structure ID
+     * @param  string  $mappingType  The mapping type (generates, equivalent, informs)
+     */
+    public function __construct(
+        public int $sourceStructureId,
+        public int $targetStructureId,
+        public string $mappingType
+    ) {}
+}

--- a/app/Core/WorkStructure/Events/StructureRegistered.php
+++ b/app/Core/WorkStructure/Events/StructureRegistered.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired when a new work structure is registered.
+ */
+class StructureRegistered
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  int  $structureId  The registered structure ID
+     * @param  string  $title  The structure title
+     * @param  string  $type  The structure type (system, plugin, custom)
+     */
+    public function __construct(
+        public int $structureId,
+        public string $title,
+        public string $type
+    ) {}
+}

--- a/app/Core/WorkStructure/Models/ElementDefinition.php
+++ b/app/Core/WorkStructure/Models/ElementDefinition.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Models;
+
+/**
+ * ElementDefinition model — defines an element type within a structure
+ * (e.g., "milestone", "task", "goal").
+ */
+class ElementDefinition
+{
+    public ?int $id = null;
+
+    public int $structureId = 0;
+
+    public string $typeKey = '';
+
+    public string $label = '';
+
+    public string $description = '';
+
+    public ?string $domainReference = null;
+
+    public int $sortOrder = 0;
+
+    public ?string $meta = null;
+
+    public ?string $createdAt = null;
+}

--- a/app/Core/WorkStructure/Models/RelationshipDefinition.php
+++ b/app/Core/WorkStructure/Models/RelationshipDefinition.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Models;
+
+/**
+ * RelationshipDefinition model — defines intra-structure relationships
+ * (e.g., "task belongs_to milestone").
+ */
+class RelationshipDefinition
+{
+    public ?int $id = null;
+
+    public int $structureId = 0;
+
+    public int $fromElementId = 0;
+
+    public int $toElementId = 0;
+
+    public string $relationshipType = '';
+
+    public string $description = '';
+
+    public ?string $meta = null;
+}

--- a/app/Core/WorkStructure/Models/StructureMapping.php
+++ b/app/Core/WorkStructure/Models/StructureMapping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Models;
+
+/**
+ * StructureMapping model — defines cross-structure element mappings
+ * (e.g., Logic Model "output" → Project "milestone").
+ */
+class StructureMapping
+{
+    public ?int $id = null;
+
+    public int $sourceStructureId = 0;
+
+    public int $sourceElementId = 0;
+
+    public int $targetStructureId = 0;
+
+    public int $targetElementId = 0;
+
+    public string $mappingType = 'generates';
+
+    public ?string $meta = null;
+}

--- a/app/Core/WorkStructure/Models/WorkStructure.php
+++ b/app/Core/WorkStructure/Models/WorkStructure.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Models;
+
+/**
+ * WorkStructure model — defines a structure type (e.g., "Project", "Logic Model").
+ */
+class WorkStructure
+{
+    public ?int $id = null;
+
+    public string $title = '';
+
+    public string $description = '';
+
+    public string $type = 'custom';
+
+    public ?int $createdBy = null;
+
+    public ?string $meta = null;
+
+    public ?string $createdAt = null;
+
+    public ?string $modifiedAt = null;
+
+    /** @var ElementDefinition[] */
+    public array $elements = [];
+
+    /** @var RelationshipDefinition[] */
+    public array $relationships = [];
+}

--- a/app/Core/WorkStructure/Repositories/WorkStructureRepository.php
+++ b/app/Core/WorkStructure/Repositories/WorkStructureRepository.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Repositories;
+
+use Illuminate\Database\ConnectionInterface;
+use Leantime\Core\Db\Db as DbCore;
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\WorkStructure\Models\ElementDefinition;
+use Leantime\Core\WorkStructure\Models\RelationshipDefinition;
+use Leantime\Core\WorkStructure\Models\StructureMapping;
+use Leantime\Core\WorkStructure\Models\WorkStructure;
+
+/**
+ * Repository for WorkStructure tables — CRUD via Laravel Query Builder.
+ *
+ * @api
+ */
+class WorkStructureRepository
+{
+    use DispatchesEvents;
+
+    private ConnectionInterface $db;
+
+    /**
+     * @param  DbCore  $db  Database connection wrapper
+     */
+    public function __construct(DbCore $db)
+    {
+        $this->db = $db->getConnection();
+    }
+
+    // ─── Structures ──────────────────────────────────────────────────
+
+    /**
+     * Get a structure by ID.
+     *
+     * @param  int  $id  Structure ID
+     */
+    public function getStructure(int $id): ?WorkStructure
+    {
+        $row = $this->db->table('zp_work_structures')
+            ->where('id', $id)
+            ->first();
+
+        return $row ? $this->hydrateStructure($row) : null;
+    }
+
+    /**
+     * Get a structure by title.
+     *
+     * @param  string  $title  Structure title
+     */
+    public function getStructureByTitle(string $title): ?WorkStructure
+    {
+        $row = $this->db->table('zp_work_structures')
+            ->where('title', $title)
+            ->first();
+
+        return $row ? $this->hydrateStructure($row) : null;
+    }
+
+    /**
+     * Get all structures, optionally filtered by type.
+     *
+     * @param  string|null  $type  Filter by type ('system', 'plugin', 'custom')
+     * @return WorkStructure[]
+     */
+    public function getAllStructures(?string $type = null): array
+    {
+        $query = $this->db->table('zp_work_structures');
+
+        if ($type !== null) {
+            $query->where('type', $type);
+        }
+
+        return $query->get()
+            ->map(fn ($row) => $this->hydrateStructure($row))
+            ->all();
+    }
+
+    /**
+     * Create a new structure.
+     *
+     * @param  array  $values  Structure data
+     * @return int Inserted ID
+     */
+    public function createStructure(array $values): int
+    {
+        $now = now()->toDateTimeString();
+
+        return (int) $this->db->table('zp_work_structures')->insertGetId([
+            'title' => $values['title'],
+            'description' => $values['description'] ?? '',
+            'type' => $values['type'] ?? 'custom',
+            'created_by' => $values['createdBy'] ?? null,
+            'meta' => isset($values['meta']) ? json_encode($values['meta']) : null,
+            'created_at' => $now,
+            'modified_at' => $now,
+        ]);
+    }
+
+    /**
+     * Check if a structure exists by title.
+     *
+     * @param  string  $title  Structure title
+     */
+    public function structureExists(string $title): bool
+    {
+        return $this->db->table('zp_work_structures')
+            ->where('title', $title)
+            ->exists();
+    }
+
+    // ─── Elements ────────────────────────────────────────────────────
+
+    /**
+     * Get all elements for a structure.
+     *
+     * @param  int  $structureId  Structure ID
+     * @return ElementDefinition[]
+     */
+    public function getElements(int $structureId): array
+    {
+        return $this->db->table('zp_work_structure_elements')
+            ->where('structure_id', $structureId)
+            ->orderBy('sort_order')
+            ->get()
+            ->map(fn ($row) => $this->hydrateElement($row))
+            ->all();
+    }
+
+    /**
+     * Get an element by structure ID and type key.
+     *
+     * @param  int  $structureId  Structure ID
+     * @param  string  $typeKey  Element type key
+     */
+    public function getElementByTypeKey(int $structureId, string $typeKey): ?ElementDefinition
+    {
+        $row = $this->db->table('zp_work_structure_elements')
+            ->where('structure_id', $structureId)
+            ->where('type_key', $typeKey)
+            ->first();
+
+        return $row ? $this->hydrateElement($row) : null;
+    }
+
+    /**
+     * Add an element to a structure.
+     *
+     * @param  array  $values  Element data
+     * @return int Inserted ID
+     */
+    public function addElement(array $values): int
+    {
+        return (int) $this->db->table('zp_work_structure_elements')->insertGetId([
+            'structure_id' => $values['structureId'],
+            'type_key' => $values['typeKey'],
+            'label' => $values['label'],
+            'description' => $values['description'] ?? '',
+            'domain_reference' => $values['domainReference'] ?? null,
+            'sort_order' => $values['sortOrder'] ?? 0,
+            'meta' => isset($values['meta']) ? json_encode($values['meta']) : null,
+            'created_at' => now()->toDateTimeString(),
+        ]);
+    }
+
+    // ─── Relationships ───────────────────────────────────────────────
+
+    /**
+     * Get all relationships for a structure.
+     *
+     * @param  int  $structureId  Structure ID
+     * @return RelationshipDefinition[]
+     */
+    public function getRelationships(int $structureId): array
+    {
+        return $this->db->table('zp_work_structure_relationships')
+            ->where('structure_id', $structureId)
+            ->get()
+            ->map(fn ($row) => $this->hydrateRelationship($row))
+            ->all();
+    }
+
+    /**
+     * Add an intra-structure relationship.
+     *
+     * @param  array  $values  Relationship data
+     * @return int Inserted ID
+     */
+    public function addRelationship(array $values): int
+    {
+        return (int) $this->db->table('zp_work_structure_relationships')->insertGetId([
+            'structure_id' => $values['structureId'],
+            'from_element_id' => $values['fromElementId'],
+            'to_element_id' => $values['toElementId'],
+            'relationship_type' => $values['relationshipType'],
+            'description' => $values['description'] ?? '',
+            'meta' => isset($values['meta']) ? json_encode($values['meta']) : null,
+        ]);
+    }
+
+    // ─── Mappings ────────────────────────────────────────────────────
+
+    /**
+     * Get all mappings between two structures.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  int  $targetStructureId  Target structure ID
+     * @return StructureMapping[]
+     */
+    public function getMappings(int $sourceStructureId, int $targetStructureId): array
+    {
+        return $this->db->table('zp_work_structure_mappings')
+            ->where('source_structure_id', $sourceStructureId)
+            ->where('target_structure_id', $targetStructureId)
+            ->get()
+            ->map(fn ($row) => $this->hydrateMapping($row))
+            ->all();
+    }
+
+    /**
+     * Add a cross-structure mapping.
+     *
+     * @param  array  $values  Mapping data
+     * @return int Inserted ID
+     */
+    public function addMapping(array $values): int
+    {
+        return (int) $this->db->table('zp_work_structure_mappings')->insertGetId([
+            'source_structure_id' => $values['sourceStructureId'],
+            'source_element_id' => $values['sourceElementId'],
+            'target_structure_id' => $values['targetStructureId'],
+            'target_element_id' => $values['targetElementId'],
+            'mapping_type' => $values['mappingType'] ?? 'generates',
+            'meta' => isset($values['meta']) ? json_encode($values['meta']) : null,
+        ]);
+    }
+
+    /**
+     * Get distinct target structure IDs that have mappings from a given source.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @return int[]
+     */
+    public function getTargetStructureIds(int $sourceStructureId): array
+    {
+        return $this->db->table('zp_work_structure_mappings')
+            ->where('source_structure_id', $sourceStructureId)
+            ->distinct()
+            ->pluck('target_structure_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+
+    /**
+     * Check if a mapping exists.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  int  $sourceElementId  Source element ID
+     * @param  int  $targetStructureId  Target structure ID
+     */
+    public function mappingExists(int $sourceStructureId, int $sourceElementId, int $targetStructureId): bool
+    {
+        return $this->db->table('zp_work_structure_mappings')
+            ->where('source_structure_id', $sourceStructureId)
+            ->where('source_element_id', $sourceElementId)
+            ->where('target_structure_id', $targetStructureId)
+            ->exists();
+    }
+
+    // ─── Hydrators ───────────────────────────────────────────────────
+
+    /**
+     * Hydrate a WorkStructure model from a database row.
+     */
+    private function hydrateStructure(object $row): WorkStructure
+    {
+        $model = new WorkStructure;
+        $model->id = (int) $row->id;
+        $model->title = $row->title;
+        $model->description = $row->description ?? '';
+        $model->type = $row->type;
+        $model->createdBy = $row->created_by ? (int) $row->created_by : null;
+        $model->meta = $row->meta;
+        $model->createdAt = $row->created_at;
+        $model->modifiedAt = $row->modified_at;
+
+        return $model;
+    }
+
+    /**
+     * Hydrate an ElementDefinition model from a database row.
+     */
+    private function hydrateElement(object $row): ElementDefinition
+    {
+        $model = new ElementDefinition;
+        $model->id = (int) $row->id;
+        $model->structureId = (int) $row->structure_id;
+        $model->typeKey = $row->type_key;
+        $model->label = $row->label;
+        $model->description = $row->description ?? '';
+        $model->domainReference = $row->domain_reference;
+        $model->sortOrder = (int) $row->sort_order;
+        $model->meta = $row->meta;
+        $model->createdAt = $row->created_at;
+
+        return $model;
+    }
+
+    /**
+     * Hydrate a RelationshipDefinition model from a database row.
+     */
+    private function hydrateRelationship(object $row): RelationshipDefinition
+    {
+        $model = new RelationshipDefinition;
+        $model->id = (int) $row->id;
+        $model->structureId = (int) $row->structure_id;
+        $model->fromElementId = (int) $row->from_element_id;
+        $model->toElementId = (int) $row->to_element_id;
+        $model->relationshipType = $row->relationship_type;
+        $model->description = $row->description ?? '';
+        $model->meta = $row->meta;
+
+        return $model;
+    }
+
+    /**
+     * Hydrate a StructureMapping model from a database row.
+     */
+    private function hydrateMapping(object $row): StructureMapping
+    {
+        $model = new StructureMapping;
+        $model->id = (int) $row->id;
+        $model->sourceStructureId = (int) $row->source_structure_id;
+        $model->sourceElementId = (int) $row->source_element_id;
+        $model->targetStructureId = (int) $row->target_structure_id;
+        $model->targetElementId = (int) $row->target_element_id;
+        $model->mappingType = $row->mapping_type;
+        $model->meta = $row->meta;
+
+        return $model;
+    }
+}

--- a/app/Core/WorkStructure/Services/MappingService.php
+++ b/app/Core/WorkStructure/Services/MappingService.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Services;
+
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\WorkStructure\Models\WorkStructure;
+use Leantime\Core\WorkStructure\Repositories\WorkStructureRepository;
+
+/**
+ * Cross-structure mapping query service.
+ *
+ * Resolves element type mappings between different work structures
+ * (e.g., Logic Model "output" → Project "milestone").
+ *
+ * @api
+ */
+class MappingService
+{
+    use DispatchesEvents;
+
+    /**
+     * @param  WorkStructureRepository  $repo  WorkStructure repository
+     */
+    public function __construct(
+        private WorkStructureRepository $repo
+    ) {}
+
+    /**
+     * Get all mappings between two structures.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  int  $targetStructureId  Target structure ID
+     * @return \Leantime\Core\WorkStructure\Models\StructureMapping[]
+     *
+     * @api
+     */
+    public function getMappings(int $sourceStructureId, int $targetStructureId): array
+    {
+        return $this->repo->getMappings($sourceStructureId, $targetStructureId);
+    }
+
+    /**
+     * Get the target element type key for a given source element type key.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  string  $sourceTypeKey  Source element type key
+     * @param  int  $targetStructureId  Target structure ID
+     * @return string|null Target element type key, or null if no mapping exists
+     *
+     * @api
+     */
+    public function getTargetElementKey(int $sourceStructureId, string $sourceTypeKey, int $targetStructureId): ?string
+    {
+        $sourceElement = $this->repo->getElementByTypeKey($sourceStructureId, $sourceTypeKey);
+
+        if ($sourceElement === null) {
+            return null;
+        }
+
+        $mappings = $this->repo->getMappings($sourceStructureId, $targetStructureId);
+
+        foreach ($mappings as $mapping) {
+            if ($mapping->sourceElementId === $sourceElement->id) {
+                $targetElement = $this->repo->getElements($targetStructureId);
+
+                foreach ($targetElement as $el) {
+                    if ($el->id === $mapping->targetElementId) {
+                        return $el->typeKey;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get all target structures that have mappings from a given source structure.
+     *
+     * Each returned structure includes its elements populated.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @return WorkStructure[]
+     *
+     * @api
+     */
+    public function getTargetStructures(int $sourceStructureId): array
+    {
+        $targetIds = $this->repo->getTargetStructureIds($sourceStructureId);
+        $structures = [];
+
+        foreach ($targetIds as $targetId) {
+            $structure = $this->repo->getStructure($targetId);
+
+            if ($structure !== null) {
+                $structure->elements = $this->repo->getElements($targetId);
+                $structures[] = $structure;
+            }
+        }
+
+        return $structures;
+    }
+
+    /**
+     * Get target element type keys that have mappings from the source structure.
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  int  $targetStructureId  Target structure ID
+     * @return string[] Array of target element typeKeys (e.g., ['milestone', 'task', 'goal'])
+     *
+     * @api
+     */
+    public function getMappedElementKeys(int $sourceStructureId, int $targetStructureId): array
+    {
+        $mappings = $this->repo->getMappings($sourceStructureId, $targetStructureId);
+        $targetElements = $this->repo->getElements($targetStructureId);
+
+        $elementIdToKey = [];
+        foreach ($targetElements as $el) {
+            $elementIdToKey[$el->id] = $el->typeKey;
+        }
+
+        $keys = [];
+        foreach ($mappings as $mapping) {
+            $key = $elementIdToKey[$mapping->targetElementId] ?? null;
+            if ($key !== null && ! in_array($key, $keys, true)) {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Get the source element type key for a given target element type key.
+     *
+     * @param  int  $targetStructureId  Target structure ID
+     * @param  string  $targetTypeKey  Target element type key
+     * @param  int  $sourceStructureId  Source structure ID
+     * @return string|null Source element type key, or null if no mapping exists
+     *
+     * @api
+     */
+    public function getSourceElementKey(int $targetStructureId, string $targetTypeKey, int $sourceStructureId): ?string
+    {
+        $targetElement = $this->repo->getElementByTypeKey($targetStructureId, $targetTypeKey);
+
+        if ($targetElement === null) {
+            return null;
+        }
+
+        $mappings = $this->repo->getMappings($sourceStructureId, $targetStructureId);
+
+        foreach ($mappings as $mapping) {
+            if ($mapping->targetElementId === $targetElement->id) {
+                $sourceElements = $this->repo->getElements($sourceStructureId);
+
+                foreach ($sourceElements as $el) {
+                    if ($el->id === $mapping->sourceElementId) {
+                        return $el->typeKey;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Core/WorkStructure/Services/MappingService.php
+++ b/app/Core/WorkStructure/Services/MappingService.php
@@ -59,15 +59,16 @@ class MappingService
 
         $mappings = $this->repo->getMappings($sourceStructureId, $targetStructureId);
 
+        // Resolve target element IDs → typeKeys with a single fetch instead of
+        // re-querying all target elements inside the mappings loop.
+        $targetIdToKey = [];
+        foreach ($this->repo->getElements($targetStructureId) as $el) {
+            $targetIdToKey[$el->id] = $el->typeKey;
+        }
+
         foreach ($mappings as $mapping) {
             if ($mapping->sourceElementId === $sourceElement->id) {
-                $targetElement = $this->repo->getElements($targetStructureId);
-
-                foreach ($targetElement as $el) {
-                    if ($el->id === $mapping->targetElementId) {
-                        return $el->typeKey;
-                    }
-                }
+                return $targetIdToKey[$mapping->targetElementId] ?? null;
             }
         }
 
@@ -151,15 +152,16 @@ class MappingService
 
         $mappings = $this->repo->getMappings($sourceStructureId, $targetStructureId);
 
+        // Resolve source element IDs → typeKeys with a single fetch instead of
+        // re-querying all source elements inside the mappings loop.
+        $sourceIdToKey = [];
+        foreach ($this->repo->getElements($sourceStructureId) as $el) {
+            $sourceIdToKey[$el->id] = $el->typeKey;
+        }
+
         foreach ($mappings as $mapping) {
             if ($mapping->targetElementId === $targetElement->id) {
-                $sourceElements = $this->repo->getElements($sourceStructureId);
-
-                foreach ($sourceElements as $el) {
-                    if ($el->id === $mapping->sourceElementId) {
-                        return $el->typeKey;
-                    }
-                }
+                return $sourceIdToKey[$mapping->sourceElementId] ?? null;
             }
         }
 

--- a/app/Core/WorkStructure/Services/StructureRegistry.php
+++ b/app/Core/WorkStructure/Services/StructureRegistry.php
@@ -3,6 +3,7 @@
 namespace Leantime\Core\WorkStructure\Services;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\WorkStructure\Events\ElementTypeRegistered;
 use Leantime\Core\WorkStructure\Events\MappingCreated;
@@ -44,10 +45,23 @@ class StructureRegistry
      */
     public function register(string $title, string $type, array $elements, array $relationships = []): int
     {
+        // Plugins call this from boot-time register.php. During a fresh install or
+        // a pending update the WorkStructure tables may not exist yet — skip rather
+        // than crash boot; the plugin re-registers idempotently on the next request.
+        if (! $this->schemaReady()) {
+            return 0;
+        }
+
         if ($this->has($title)) {
             $structure = $this->get($title);
 
-            return $structure->id;
+            // Cache said it exists but the row is gone (deleted/cache drift):
+            // fall through and recreate instead of dereferencing null.
+            if ($structure !== null) {
+                return $structure->id;
+            }
+
+            $this->clearCache($title);
         }
 
         $structureId = $this->repo->createStructure([
@@ -105,6 +119,10 @@ class StructureRegistry
      */
     public function registerMappings(int $sourceStructureId, int $targetStructureId, array $mappings): void
     {
+        if (! $this->schemaReady()) {
+            return;
+        }
+
         foreach ($mappings as $mapping) {
             $sourceElement = $this->repo->getElementByTypeKey($sourceStructureId, $mapping['sourceTypeKey']);
             $targetElement = $this->repo->getElementByTypeKey($targetStructureId, $mapping['targetTypeKey']);
@@ -138,6 +156,10 @@ class StructureRegistry
      */
     public function has(string $title): bool
     {
+        if (! $this->schemaReady()) {
+            return false;
+        }
+
         return Cache::rememberForever(self::CACHE_PREFIX.'exists.'.$title, function () use ($title) {
             return $this->repo->structureExists($title);
         });
@@ -152,6 +174,10 @@ class StructureRegistry
      */
     public function get(string $title): ?WorkStructure
     {
+        if (! $this->schemaReady()) {
+            return null;
+        }
+
         return Cache::rememberForever(self::CACHE_PREFIX.'structure.'.$title, function () use ($title) {
             $structure = $this->repo->getStructureByTitle($title);
 
@@ -173,5 +199,23 @@ class StructureRegistry
     {
         Cache::forget(self::CACHE_PREFIX.'exists.'.$title);
         Cache::forget(self::CACHE_PREFIX.'structure.'.$title);
+    }
+
+    /**
+     * Whether the WorkStructure schema has been created yet.
+     *
+     * Guards the boot-time plugin registration path against a fresh install or a
+     * pending update where migration 30502 hasn't run. Cached per request so the
+     * hasTable lookup doesn't repeat for every register()/has()/get() call.
+     */
+    private function schemaReady(): bool
+    {
+        static $ready = null;
+
+        if ($ready === null) {
+            $ready = Schema::hasTable('zp_work_structures');
+        }
+
+        return $ready;
     }
 }

--- a/app/Core/WorkStructure/Services/StructureRegistry.php
+++ b/app/Core/WorkStructure/Services/StructureRegistry.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\WorkStructure\Events\ElementTypeRegistered;
+use Leantime\Core\WorkStructure\Events\MappingCreated;
+use Leantime\Core\WorkStructure\Events\StructureRegistered;
+use Leantime\Core\WorkStructure\Models\WorkStructure;
+use Leantime\Core\WorkStructure\Repositories\WorkStructureRepository;
+
+/**
+ * Plugin registration service for work structures.
+ *
+ * Provides an idempotent API for plugins to register their structure
+ * definitions, elements, relationships, and cross-structure mappings.
+ *
+ * @api
+ */
+class StructureRegistry
+{
+    use DispatchesEvents;
+
+    private const CACHE_PREFIX = 'workstructure.';
+
+    /**
+     * @param  WorkStructureRepository  $repo  WorkStructure repository
+     */
+    public function __construct(
+        private WorkStructureRepository $repo
+    ) {}
+
+    /**
+     * Register a structure with elements and relationships (idempotent).
+     *
+     * @param  string  $title  Structure title (unique)
+     * @param  string  $type  'system', 'plugin', 'custom'
+     * @param  array  $elements  Array of element definitions [{typeKey, label, description?, domainReference?, sortOrder, meta?}]
+     * @param  array  $relationships  Array of relationship defs [{fromTypeKey, toTypeKey, relationshipType, description?}]
+     * @return int Structure ID
+     *
+     * @api
+     */
+    public function register(string $title, string $type, array $elements, array $relationships = []): int
+    {
+        if ($this->has($title)) {
+            $structure = $this->get($title);
+
+            return $structure->id;
+        }
+
+        $structureId = $this->repo->createStructure([
+            'title' => $title,
+            'type' => $type,
+        ]);
+
+        // Add elements
+        $elementIds = [];
+        foreach ($elements as $element) {
+            $elementId = $this->repo->addElement([
+                'structureId' => $structureId,
+                'typeKey' => $element['typeKey'],
+                'label' => $element['label'],
+                'description' => $element['description'] ?? '',
+                'domainReference' => $element['domainReference'] ?? null,
+                'sortOrder' => $element['sortOrder'] ?? 0,
+                'meta' => $element['meta'] ?? null,
+            ]);
+            $elementIds[$element['typeKey']] = $elementId;
+
+            ElementTypeRegistered::dispatch($structureId, $element['typeKey'], $element['label']);
+        }
+
+        // Add relationships (resolve typeKey → element ID)
+        foreach ($relationships as $rel) {
+            $fromId = $elementIds[$rel['fromTypeKey']] ?? null;
+            $toId = $elementIds[$rel['toTypeKey']] ?? null;
+
+            if ($fromId !== null && $toId !== null) {
+                $this->repo->addRelationship([
+                    'structureId' => $structureId,
+                    'fromElementId' => $fromId,
+                    'toElementId' => $toId,
+                    'relationshipType' => $rel['relationshipType'],
+                    'description' => $rel['description'] ?? '',
+                ]);
+            }
+        }
+
+        $this->clearCache($title);
+        StructureRegistered::dispatch($structureId, $title, $type);
+
+        return $structureId;
+    }
+
+    /**
+     * Register cross-structure mappings (idempotent per source element + target structure).
+     *
+     * @param  int  $sourceStructureId  Source structure ID
+     * @param  int  $targetStructureId  Target structure ID
+     * @param  array  $mappings  Array of [{sourceTypeKey, targetTypeKey, mappingType}]
+     *
+     * @api
+     */
+    public function registerMappings(int $sourceStructureId, int $targetStructureId, array $mappings): void
+    {
+        foreach ($mappings as $mapping) {
+            $sourceElement = $this->repo->getElementByTypeKey($sourceStructureId, $mapping['sourceTypeKey']);
+            $targetElement = $this->repo->getElementByTypeKey($targetStructureId, $mapping['targetTypeKey']);
+
+            if ($sourceElement === null || $targetElement === null) {
+                continue;
+            }
+
+            if ($this->repo->mappingExists($sourceStructureId, $sourceElement->id, $targetStructureId)) {
+                continue;
+            }
+
+            $this->repo->addMapping([
+                'sourceStructureId' => $sourceStructureId,
+                'sourceElementId' => $sourceElement->id,
+                'targetStructureId' => $targetStructureId,
+                'targetElementId' => $targetElement->id,
+                'mappingType' => $mapping['mappingType'] ?? 'generates',
+            ]);
+
+            MappingCreated::dispatch($sourceStructureId, $targetStructureId, $mapping['mappingType'] ?? 'generates');
+        }
+    }
+
+    /**
+     * Check if a structure is registered.
+     *
+     * @param  string  $title  Structure title
+     *
+     * @api
+     */
+    public function has(string $title): bool
+    {
+        return Cache::rememberForever(self::CACHE_PREFIX.'exists.'.$title, function () use ($title) {
+            return $this->repo->structureExists($title);
+        });
+    }
+
+    /**
+     * Get a registered structure by title (cached).
+     *
+     * @param  string  $title  Structure title
+     *
+     * @api
+     */
+    public function get(string $title): ?WorkStructure
+    {
+        return Cache::rememberForever(self::CACHE_PREFIX.'structure.'.$title, function () use ($title) {
+            $structure = $this->repo->getStructureByTitle($title);
+
+            if ($structure !== null && $structure->id !== null) {
+                $structure->elements = $this->repo->getElements($structure->id);
+                $structure->relationships = $this->repo->getRelationships($structure->id);
+            }
+
+            return $structure;
+        });
+    }
+
+    /**
+     * Clear cache for a structure.
+     *
+     * @param  string  $title  Structure title
+     */
+    private function clearCache(string $title): void
+    {
+        Cache::forget(self::CACHE_PREFIX.'exists.'.$title);
+        Cache::forget(self::CACHE_PREFIX.'structure.'.$title);
+    }
+}

--- a/app/Core/WorkStructure/Services/WorkStructureService.php
+++ b/app/Core/WorkStructure/Services/WorkStructureService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Leantime\Core\WorkStructure\Services;
+
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\WorkStructure\Models\ElementDefinition;
+use Leantime\Core\WorkStructure\Models\RelationshipDefinition;
+use Leantime\Core\WorkStructure\Models\WorkStructure;
+use Leantime\Core\WorkStructure\Repositories\WorkStructureRepository;
+
+/**
+ * CRUD service for work structures, elements, and relationships.
+ *
+ * @api
+ */
+class WorkStructureService
+{
+    use DispatchesEvents;
+
+    /**
+     * @param  WorkStructureRepository  $repo  WorkStructure repository
+     */
+    public function __construct(
+        private WorkStructureRepository $repo
+    ) {}
+
+    /**
+     * Get a structure by ID with its elements and relationships.
+     *
+     * @param  int  $id  Structure ID
+     *
+     * @api
+     */
+    public function getStructure(int $id): ?WorkStructure
+    {
+        $structure = $this->repo->getStructure($id);
+
+        if ($structure !== null) {
+            $structure->elements = $this->repo->getElements($id);
+            $structure->relationships = $this->repo->getRelationships($id);
+        }
+
+        return $structure;
+    }
+
+    /**
+     * Get a structure by title with its elements and relationships.
+     *
+     * @param  string  $title  Structure title
+     *
+     * @api
+     */
+    public function getStructureByTitle(string $title): ?WorkStructure
+    {
+        $structure = $this->repo->getStructureByTitle($title);
+
+        if ($structure !== null && $structure->id !== null) {
+            $structure->elements = $this->repo->getElements($structure->id);
+            $structure->relationships = $this->repo->getRelationships($structure->id);
+        }
+
+        return $structure;
+    }
+
+    /**
+     * Get all elements for a structure, ordered by sort_order.
+     *
+     * @param  int  $structureId  Structure ID
+     * @return ElementDefinition[]
+     *
+     * @api
+     */
+    public function getElements(int $structureId): array
+    {
+        return $this->repo->getElements($structureId);
+    }
+
+    /**
+     * Get all intra-structure relationships.
+     *
+     * @param  int  $structureId  Structure ID
+     * @return RelationshipDefinition[]
+     *
+     * @api
+     */
+    public function getRelationships(int $structureId): array
+    {
+        return $this->repo->getRelationships($structureId);
+    }
+
+    /**
+     * Create a new structure.
+     *
+     * @param  array  $values  Structure data (title, description, type, createdBy, meta)
+     * @return int Created structure ID
+     *
+     * @api
+     */
+    public function createStructure(array $values): int
+    {
+        return $this->repo->createStructure($values);
+    }
+
+    /**
+     * Add an element to a structure.
+     *
+     * @param  array  $values  Element data (structureId, typeKey, label, description, domainReference, sortOrder, meta)
+     * @return int Created element ID
+     *
+     * @api
+     */
+    public function addElement(array $values): int
+    {
+        return $this->repo->addElement($values);
+    }
+
+    /**
+     * Add an intra-structure relationship.
+     *
+     * @param  array  $values  Relationship data (structureId, fromElementId, toElementId, relationshipType, description, meta)
+     * @return int Created relationship ID
+     *
+     * @api
+     */
+    public function addRelationship(array $values): int
+    {
+        return $this->repo->addRelationship($values);
+    }
+}

--- a/app/Core/WorkStructure/WorkStructureServiceProvider.php
+++ b/app/Core/WorkStructure/WorkStructureServiceProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Leantime\Core\WorkStructure;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+use Leantime\Core\WorkStructure\Repositories\WorkStructureRepository;
+use Leantime\Core\WorkStructure\Services\MappingService;
+use Leantime\Core\WorkStructure\Services\StructureRegistry;
+use Leantime\Core\WorkStructure\Services\WorkStructureService;
+
+/**
+ * Registers the WorkStructure infrastructure and seeds the built-in
+ * "Project" system structure.
+ *
+ * WorkStructure is a meta-model that describes how Leantime entities are
+ * composed and how they map across structures (e.g., a Logic Model "output"
+ * generates a Project "milestone"). It lives in Core — like Plugins and Auth —
+ * because it governs domains rather than being one. Plugins register their own
+ * structures and mappings through {@see StructureRegistry}.
+ */
+class WorkStructureServiceProvider extends ServiceProvider
+{
+    /**
+     * Bind the WorkStructure services as singletons.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(WorkStructureRepository::class);
+        $this->app->singleton(StructureRegistry::class);
+        $this->app->singleton(MappingService::class);
+        $this->app->singleton(WorkStructureService::class);
+    }
+
+    /**
+     * Seed the built-in "Project" structure (idempotent).
+     *
+     * StructureRegistry::register() is cache-guarded and a no-op once the
+     * structure exists, so this costs a cache read in steady state. Wrapped in
+     * try/catch because the tables do not exist yet during a fresh install.
+     */
+    public function boot(): void
+    {
+        try {
+            /** @var StructureRegistry $registry */
+            $registry = $this->app->make(StructureRegistry::class);
+
+            $registry->register(
+                'Project',
+                'system',
+                [
+                    ['typeKey' => 'milestone', 'label' => 'Milestone', 'domainReference' => 'Leantime\\Domain\\Tickets', 'sortOrder' => 1],
+                    ['typeKey' => 'task', 'label' => 'Task', 'domainReference' => 'Leantime\\Domain\\Tickets', 'sortOrder' => 2],
+                    ['typeKey' => 'goal', 'label' => 'Goal', 'domainReference' => 'Leantime\\Domain\\Goalcanvas', 'sortOrder' => 3],
+                ],
+                [
+                    ['fromTypeKey' => 'task', 'toTypeKey' => 'milestone', 'relationshipType' => 'belongs_to'],
+                    ['fromTypeKey' => 'milestone', 'toTypeKey' => 'goal', 'relationshipType' => 'measures'],
+                ]
+            );
+        } catch (\Throwable $e) {
+            // Tables may not exist yet during install/update — degrade gracefully.
+            Log::debug('WorkStructure seed skipped: '.$e->getMessage());
+        }
+    }
+}

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -81,6 +81,7 @@ class Install
         30413,
         30500,
         30501,
+        30502,
     ];
 
     /**
@@ -2493,6 +2494,85 @@ class Install
             Log::error('Migration 30501: '.$e->getMessage());
 
             return ['Migration 30501 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30502: Create the WorkStructure tables (structures, elements,
+     * relationships, mappings) for the meta-model that orchestrates entities
+     * across domains. Mirrors SchemaBuilder::createWorkStructureTables().
+     *
+     * @return bool|array Returns true on success, array of errors on failure
+     */
+    public function update_sql_30502(): bool|array
+    {
+        try {
+            if (! Schema::hasTable('zp_work_structures')) {
+                Schema::create('zp_work_structures', function (Blueprint $table) {
+                    $table->id();
+                    $table->string('title', 255);
+                    $table->text('description')->nullable();
+                    $table->string('type', 50)->default('custom');
+                    $table->integer('created_by')->nullable();
+                    $table->json('meta')->nullable();
+                    $table->dateTime('created_at')->nullable();
+                    $table->dateTime('modified_at')->nullable();
+
+                    $table->unique(['title'], 'idx_work_structures_title');
+                    $table->index(['type'], 'idx_work_structures_type');
+                });
+            }
+
+            if (! Schema::hasTable('zp_work_structure_elements')) {
+                Schema::create('zp_work_structure_elements', function (Blueprint $table) {
+                    $table->id();
+                    $table->unsignedBigInteger('structure_id');
+                    $table->string('type_key', 50);
+                    $table->string('label', 100);
+                    $table->text('description')->nullable();
+                    $table->string('domain_reference', 255)->nullable();
+                    $table->integer('sort_order')->default(0);
+                    $table->json('meta')->nullable();
+                    $table->dateTime('created_at')->nullable();
+
+                    $table->index(['structure_id'], 'idx_wse_structure_id');
+                    $table->unique(['structure_id', 'type_key'], 'idx_wse_structure_type_key');
+                });
+            }
+
+            if (! Schema::hasTable('zp_work_structure_relationships')) {
+                Schema::create('zp_work_structure_relationships', function (Blueprint $table) {
+                    $table->id();
+                    $table->unsignedBigInteger('structure_id');
+                    $table->unsignedBigInteger('from_element_id');
+                    $table->unsignedBigInteger('to_element_id');
+                    $table->string('relationship_type', 50);
+                    $table->text('description')->nullable();
+                    $table->json('meta')->nullable();
+
+                    $table->index(['structure_id'], 'idx_wsr_structure_id');
+                });
+            }
+
+            if (! Schema::hasTable('zp_work_structure_mappings')) {
+                Schema::create('zp_work_structure_mappings', function (Blueprint $table) {
+                    $table->id();
+                    $table->unsignedBigInteger('source_structure_id');
+                    $table->unsignedBigInteger('source_element_id');
+                    $table->unsignedBigInteger('target_structure_id');
+                    $table->unsignedBigInteger('target_element_id');
+                    $table->string('mapping_type', 50)->default('generates');
+                    $table->json('meta')->nullable();
+
+                    $table->index(['source_structure_id', 'target_structure_id'], 'idx_wsm_source_target');
+                });
+            }
+        } catch (\Exception $e) {
+            Log::error('Migration 30502: '.$e->getMessage());
+
+            return ['Migration 30502 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -2567,6 +2567,10 @@ class Install
                     $table->json('meta')->nullable();
 
                     $table->index(['source_structure_id', 'target_structure_id'], 'idx_wsm_source_target');
+                    // Enforce the same idempotency key StructureRegistry::registerMappings()
+                    // checks in application code, so a race can't insert a duplicate mapping
+                    // for the same source element → target structure.
+                    $table->unique(['source_structure_id', 'source_element_id', 'target_structure_id'], 'idx_wsm_unique_mapping');
                 });
             }
         } catch (\Exception $e) {

--- a/app/Domain/Install/Services/SchemaBuilder.php
+++ b/app/Domain/Install/Services/SchemaBuilder.php
@@ -887,6 +887,10 @@ class SchemaBuilder
             $table->json('meta')->nullable();
 
             $table->index(['source_structure_id', 'target_structure_id'], 'idx_wsm_source_target');
+            // Enforce the same idempotency key StructureRegistry::registerMappings()
+            // checks in application code, so a race can't insert a duplicate mapping
+            // for the same source element → target structure.
+            $table->unique(['source_structure_id', 'source_element_id', 'target_structure_id'], 'idx_wsm_unique_mapping');
         });
     }
 }

--- a/app/Domain/Install/Services/SchemaBuilder.php
+++ b/app/Domain/Install/Services/SchemaBuilder.php
@@ -57,6 +57,7 @@ class SchemaBuilder
         $this->createAccessTokensTable();
         $this->createJobsTable();
         $this->createRecurringPatternsTable();
+        $this->createWorkStructureTables();
     }
 
     /**
@@ -826,6 +827,66 @@ class SchemaBuilder
             $table->tinyInteger('enabled')->default(1);
 
             $table->index(['entityId'], 'idx_recurring_patterns_entityId');
+        });
+    }
+
+    /**
+     * Create the WorkStructure tables: structure definitions, their element
+     * types, intra-structure relationships, and cross-structure mappings.
+     */
+    private function createWorkStructureTables(): void
+    {
+        Schema::create('zp_work_structures', function (Blueprint $table) {
+            $table->id();
+            $table->string('title', 255);
+            $table->text('description')->nullable();
+            $table->string('type', 50)->default('custom');
+            $table->integer('created_by')->nullable();
+            $table->json('meta')->nullable();
+            $table->dateTime('created_at')->nullable();
+            $table->dateTime('modified_at')->nullable();
+
+            $table->unique(['title'], 'idx_work_structures_title');
+            $table->index(['type'], 'idx_work_structures_type');
+        });
+
+        Schema::create('zp_work_structure_elements', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('structure_id');
+            $table->string('type_key', 50);
+            $table->string('label', 100);
+            $table->text('description')->nullable();
+            $table->string('domain_reference', 255)->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->json('meta')->nullable();
+            $table->dateTime('created_at')->nullable();
+
+            $table->index(['structure_id'], 'idx_wse_structure_id');
+            $table->unique(['structure_id', 'type_key'], 'idx_wse_structure_type_key');
+        });
+
+        Schema::create('zp_work_structure_relationships', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('structure_id');
+            $table->unsignedBigInteger('from_element_id');
+            $table->unsignedBigInteger('to_element_id');
+            $table->string('relationship_type', 50);
+            $table->text('description')->nullable();
+            $table->json('meta')->nullable();
+
+            $table->index(['structure_id'], 'idx_wsr_structure_id');
+        });
+
+        Schema::create('zp_work_structure_mappings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('source_structure_id');
+            $table->unsignedBigInteger('source_element_id');
+            $table->unsignedBigInteger('target_structure_id');
+            $table->unsignedBigInteger('target_element_id');
+            $table->string('mapping_type', 50)->default('generates');
+            $table->json('meta')->nullable();
+
+            $table->index(['source_structure_id', 'target_structure_id'], 'idx_wsm_source_target');
         });
     }
 }


### PR DESCRIPTION
## Summary

Adds **WorkStructure** — a Core infrastructure concern that describes how Leantime entities compose and how they map across structures. It is the orchestration "brain" that a Logic Model board (PR 2) and future orchestrators (Program, Strategy) build on.

This is **PR 1 of 2** porting [#3275](https://github.com/Leantime/leantime/pull/3275) (which targeted the abandoned `feature/phase-0-modernization` branch) onto `master`. PR 2 adds the Logic Model canvas board and builds on this.

### Why Core, not a Domain?
WorkStructure has no UI — just models, a repository, services, and events. It *governs* domains rather than being one (a Project is made of milestones/tasks/goals; a task `belongs_to` a milestone; a Logic Model output `maps_to` a Project milestone). That's the same shape as `Core/Plugins` and `Core/Auth`: infra in Core, registered via a ServiceProvider. (Its instance-level twin is the existing `Entityrelations`.)

### What's included
- `app/Core/WorkStructure/` — `Models/`, `Repositories/WorkStructureRepository` (Query Builder over 4 tables), `Services/` (`StructureRegistry`, `MappingService`, `WorkStructureService` — the `@api` surface plugins register against), and lifecycle `Events/`.
- `WorkStructureServiceProvider` — binds the services and seeds the built-in **"Project"** structure in `boot()` (idempotent, cache-guarded, degrades gracefully before tables exist). Registered in `laravelConfig.php` after `DatabaseServiceProvider`. **Replaces** the PR's `register.php` event-hook seeding, which targeted an event that no longer exists on master.
- **Schema** — `SchemaBuilder::createWorkStructureTables()` (fresh installs) + `Install::update_sql_30502()` and `dbVersion` `3.5.1 → 3.5.2` (existing installs): `zp_work_structures`, `_elements`, `_relationships`, `_mappings`.
- `EntityRelationshipEnum` gains `GeneratedFrom` and `MapsTo` for the instance-level provenance links the Logic Model wizard will write into `zp_entity_relationship`.

### Notes
- The wizard / entity-generation / health / fixtures / export remain in the private **StrategyPro** plugin, which registers its "Logic Model" structure and mappings through `StructureRegistry`. The plugin must reference the new `Leantime\Core\WorkStructure\…` namespace.

## Test plan
- [ ] Fresh install creates the 4 `zp_work_structure*` tables.
- [ ] Existing-install upgrade runs `update_sql_30502`; `db-version` advances to `30502`.
- [ ] After boot, `app(\Leantime\Core\WorkStructure\Services\StructureRegistry::class)->get('Project')` returns the seeded structure with 3 elements + 2 relationships; booting twice does not duplicate.
- [x] `php -l` clean, Laravel Pint clean, DB-free autoload/API smoke test passes.
- [ ] `make phpstan` (Docker) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)