### PR TITLE
fix(comments): stop shadowing controller $comments array in Discussion template

### DIFF
--- a/app/Domain/Comments/Templates/submodules/generalComment.blade.php
+++ b/app/Domain/Comments/Templates/submodules/generalComment.blade.php
@@ -1,5 +1,12 @@
 @php
-    $comments = app()->make(Leantime\Domain\Comments\Repositories\Comments::class);
+    // Repository is used downstream for getReplies(). Renamed from
+    // $comments because the controller already assigns $comments to
+    // the array of comments to render — overwriting it with the
+    // repository object made the @foreach below iterate the object's
+    // (empty) public properties instead of the array, so every
+    // Discussion section came up empty regardless of how the comment
+    // was added.
+    $commentsRepo = app()->make(Leantime\Domain\Comments\Repositories\Comments::class);
     $formUrl = CURRENT_URL;
     $formHash = md5($formUrl);
 
@@ -112,8 +119,8 @@
                         </div>
 
                         <div class="replies">
-                            @if ($comments->getReplies($row['id']))
-                                @foreach ($comments->getReplies($row['id']) as $comment)
+                            @if ($commentsRepo->getReplies($row['id']))
+                                @foreach ($commentsRepo->getReplies($row['id']) as $comment)
                                     <div>
                                         <div class="commentImage">
                                             <img src="{{ BASE_URL }}/api/users?profileImage={{ $comment['userId'] }}&v={{ format($comment['userModified'])->timestamp() }}"/>


### PR DESCRIPTION
> Replaces #3458 (closed) — that branch accidentally included commits from #3457. This PR contains only the one-line template fix.

## Summary

- The Discussion submodule (`generalComment.blade.php`) reassigned `$comments` to the Comments **Repository** at the top of the template so it could call `$comments->getReplies($id)`. That overwrote the array of comments the controller had already assigned to the same name (`$this->tpl->assign('comments', $comments)`), so the `@foreach ($comments as $row)` further down iterated the repository object — which yields nothing — and every Discussion section came up empty.
- Renames the local repository handle to `$commentsRepo` so the controller-provided `$comments` array is preserved for the render loop, and updates the two `getReplies()` call sites accordingly.

## How this was found

Posting a comment via the mobile RPC client (`leantime.rpc.Comments.Comments.addComment`) returned success and the row was visible in `zp_comment` (e.g. comment id 325 against ticket 1702 with `module='ticket'`, `commentParent=0`), but the web Discussion section rendered empty. Reproduced on `projects.leantime.io` with comments created via the web form too — same empty state — confirming it wasn't an RPC-only issue.

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php` → 6/6 passing
- [x] `./vendor/bin/pint --test` on the changed file → clean
- [ ] Open any ticket with existing comments → Discussion section renders the list
- [ ] Reply to a comment → reply renders nested under the parent (verifies `getReplies()` calls still work via `$commentsRepo`)
- [ ] Delete a comment → existing delete flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)