### PR TITLE
feat(core): native permission engine foundation (Phase 0) + console addCommand fix

### DIFF
--- a/app/Command/SyncPermissionsCommand.php
+++ b/app/Command/SyncPermissionsCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Leantime\Command;
+
+use Illuminate\Console\Command;
+use Leantime\Core\Auth\Permissions\PermissionRepository;
+use Leantime\Core\Auth\Permissions\PermissionSeeder;
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Discovers every domain/plugin permission declaration and syncs the `domain.action`
+ * vocabulary into the database.
+ *
+ * Usage:
+ *   php bin/leantime permissions:sync            # upsert the vocabulary
+ *   php bin/leantime permissions:sync --seed     # also (re)grant built-in role defaults
+ *   php bin/leantime permissions:sync --prune    # also remove permissions no longer declared
+ */
+#[AsCommand(
+    name: 'permissions:sync',
+    description: 'Sync the discovered permission vocabulary into the database',
+)]
+class SyncPermissionsCommand extends Command
+{
+    public function __construct(
+        private readonly PermissionSeeder $seeder,
+        private readonly PermissionRepository $repo,
+        private readonly PermissionService $permissions,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption('seed', null, InputOption::VALUE_NONE, 'Also (re)grant the built-in roles their default permissions');
+        $this->addOption('prune', null, InputOption::VALUE_NONE, 'Remove permissions that are no longer declared in code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $keys = $this->seeder->syncDiscoveredPermissions();
+        $io->success(count($keys).' permissions synced.');
+
+        if ($input->getOption('prune')) {
+            $pruned = $this->repo->pruneOrphanPermissions($keys);
+            $io->info($pruned.' orphaned permission(s) pruned.');
+        }
+
+        if ($input->getOption('seed')) {
+            $this->seeder->seedBuiltInRoles();
+            $io->info('Built-in role defaults seeded.');
+        }
+
+        $this->permissions->flushCache();
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Core/Auth/AuthenticationServiceProvider.php
+++ b/app/Core/Auth/AuthenticationServiceProvider.php
@@ -33,7 +33,6 @@ class AuthenticationServiceProvider extends ServiceProvider
         $this->registerRequirePassword();
         $this->registerRequestRebindHandler();
         $this->registerEventRebindHandler();
-
     }
 
     protected function registerAuthenticator()

--- a/app/Core/Auth/Contracts/ChecksProjectAccess.php
+++ b/app/Core/Auth/Contracts/ChecksProjectAccess.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Leantime\Core\Auth\Contracts;
+
+/**
+ * Narrow contract the permission engine depends on for project-level data access and the
+ * per-project role, implemented by the Projects domain service.
+ *
+ * The engine lives in Core and must not depend on the 2,900-line Projects god-service
+ * directly; it depends on this abstraction (bound to Projects in PermissionServiceProvider),
+ * which also keeps the surface small and sidesteps circular-reference risk.
+ */
+interface ChecksProjectAccess
+{
+    /**
+     * Whether the user can access the given project (assigned, or via the project's
+     * `psettings` — admin/owner bypass handled by the implementation/engine).
+     */
+    public function isUserAssignedToProject(int $userId, int $projectId): bool;
+
+    /**
+     * The user's explicit role within the project, or '' when none is set (inherits global).
+     * Returns the stored role key as a string.
+     */
+    public function getProjectRole(int $userId, int $projectId): string;
+}

--- a/app/Core/Auth/Permissions/CheckPermissions.php
+++ b/app/Core/Auth/Permissions/CheckPermissions.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Enforces #[RequiresPermission] for native Laravel-routed controllers (Blueprints, the
+ * relocated image/upload controllers, etc.) — the controllers that do NOT go through
+ * Frontcontroller. Applied to all domain/plugin routes by {@see \Leantime\Core\Routing\RouteLoader}.
+ *
+ * Reads the attribute off the matched route's controller@method via the shared
+ * {@see PermissionEnforcer} (injected, not resolved through the app() helper), so the
+ * attribute remains the single source of truth — no per-route `can:` duplication. A method
+ * without the attribute is a no-op.
+ */
+class CheckPermissions
+{
+    public function __construct(private PermissionEnforcer $enforcer) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $route = $request->route();
+
+        if ($route !== null) {
+            $controller = $route->getControllerClass();
+            $method = $route->getActionMethod();
+
+            // Skip closure routes (no controller) and invokable/closure actions where the
+            // "method" resolves to the class name itself.
+            if (is_string($controller) && $controller !== '' && is_string($method) && $method !== $controller) {
+                $this->enforcer->enforce($controller, $method, $request->all());
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Support\Str;
+
+/**
+ * The single, central definition of the six built-in roles and the permissions they hold
+ * by default — the permission-era equivalent of a Spatie roles-and-permissions seeder.
+ *
+ * This is the ONLY place built-in role→permission assignment lives. Domains declare verbs
+ * ({@see ProvidesPermissions}); this maps those verbs onto roles. After install the
+ * `zp_role_permissions` table is the runtime source of truth and the admin UI edits it —
+ * this class only provides the initial defaults.
+ *
+ * Defaults are expressed as incremental grant rules per role and **unioned up the
+ * hierarchy** (a role inherits every lower role's grants), so the rules read as deltas:
+ *  - readonly  : view project content
+ *  - commenter : + comment / upload
+ *  - editor    : + create / edit / delete
+ *  - manager   : + everything else on project content (e.g. project settings)
+ *  - admin     : + all company-wide capabilities, except company settings
+ *  - owner     : + everything (incl. company settings)
+ *
+ * A rule matches a {@see Permission} by scope (project- vs company-scoped), by verb (the
+ * last dotted segment, or `*` for all), minus any excluded keys/prefixes.
+ */
+final class DefaultRolePermissions
+{
+    /**
+     * Built-in roles, ordered low→high. `level` preserves the legacy hierarchy weight.
+     *
+     * @var array<int, array{name: string, displayName: string, level: int}>
+     */
+    private const ROLES = [
+        ['name' => 'readonly', 'displayName' => 'Read Only', 'level' => 5],
+        ['name' => 'commenter', 'displayName' => 'Commenter', 'level' => 10],
+        ['name' => 'editor', 'displayName' => 'Editor', 'level' => 20],
+        ['name' => 'manager', 'displayName' => 'Company Manager', 'level' => 30],
+        ['name' => 'admin', 'displayName' => 'Admin', 'level' => 40],
+        ['name' => 'owner', 'displayName' => 'Owner', 'level' => 50],
+    ];
+
+    /**
+     * Incremental default grants per role (unioned up the hierarchy by {@see grantsFor()}).
+     *
+     * Each rule: scope = project|global|any; verbs = list of last-segment verbs or ['*'];
+     * exclude = exact keys or 'prefix.*' globs removed from the match.
+     *
+     * @var array<string, array<int, array{scope: string, verbs: array<int, string>, exclude?: array<int, string>}>>
+     */
+    private const GRANTS = [
+        'readonly' => [['scope' => 'project', 'verbs' => ['view']]],
+        'commenter' => [['scope' => 'project', 'verbs' => ['comment', 'upload']]],
+        'editor' => [['scope' => 'project', 'verbs' => ['create', 'edit', 'delete']]],
+        'manager' => [['scope' => 'project', 'verbs' => ['*']]],
+        'admin' => [['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']]],
+        'owner' => [['scope' => 'any', 'verbs' => ['*']]],
+    ];
+
+    /** @return array<int, array{name: string, displayName: string, level: int}> */
+    public static function roles(): array
+    {
+        return self::ROLES;
+    }
+
+    /**
+     * The default permission keys granted to $roleName, given the full discovered catalog.
+     * Unions this role's rules with every lower role in the hierarchy.
+     *
+     * @param  array<int, Permission>  $catalog
+     * @return array<int, string>
+     */
+    public static function grantsFor(string $roleName, array $catalog): array
+    {
+        $level = self::levelOf($roleName);
+
+        $rules = [];
+        foreach (self::ROLES as $role) {
+            if ($role['level'] <= $level) {
+                foreach (self::GRANTS[$role['name']] ?? [] as $rule) {
+                    $rules[] = $rule;
+                }
+            }
+        }
+
+        $keys = [];
+        foreach ($catalog as $permission) {
+            foreach ($rules as $rule) {
+                if (self::matches($permission, $rule)) {
+                    $keys[$permission->key] = true;
+                    break;
+                }
+            }
+        }
+
+        return array_keys($keys);
+    }
+
+    private static function levelOf(string $roleName): int
+    {
+        foreach (self::ROLES as $role) {
+            if ($role['name'] === $roleName) {
+                return $role['level'];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param  array{scope: string, verbs: array<int, string>, exclude?: array<int, string>}  $rule
+     */
+    private static function matches(Permission $permission, array $rule): bool
+    {
+        if ($rule['scope'] === 'project' && ! $permission->projectScoped) {
+            return false;
+        }
+        if ($rule['scope'] === 'global' && $permission->projectScoped) {
+            return false;
+        }
+
+        $verb = Str::afterLast($permission->key, '.');
+        if ($rule['verbs'] !== ['*'] && ! in_array($verb, $rule['verbs'], true)) {
+            return false;
+        }
+
+        foreach ($rule['exclude'] ?? [] as $excluded) {
+            if ($excluded === $permission->key) {
+                return false;
+            }
+            if (str_ends_with($excluded, '.*') && str_starts_with($permission->key, substr($excluded, 0, -1))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Core/Auth/Permissions/Permission.php
+++ b/app/Core/Auth/Permissions/Permission.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Support\Str;
+
+/**
+ * Immutable description of a single capability in the permission vocabulary.
+ *
+ * A permission is just a named, dotted `domain.action` verb (e.g. `tickets.create`,
+ * `company.settings.edit`) plus presentation/scope metadata. Crucially it carries **no
+ * role information** — which roles hold a permission is a separate, centrally-managed
+ * concern (see {@see DefaultRolePermissions} for the built-in defaults and the
+ * `zp_role_permissions` table / admin UI for runtime assignments). A domain declares only
+ * *what verbs exist*; it never declares *who gets them*.
+ *
+ * `projectScoped` distinguishes capabilities evaluated against a specific project's role
+ * (most content actions) from company-wide capabilities (user/client management, company
+ * settings) that resolve against the global role.
+ */
+final class Permission
+{
+    /**
+     * @param  string  $key  Dotted `domain.action` identifier, e.g. `tickets.create`.
+     * @param  string  $displayName  Human-readable label shown in the role/permission UI.
+     * @param  bool  $projectScoped  Whether this capability is evaluated per-project (true)
+     *                               or company-wide against the global role (false).
+     */
+    public function __construct(
+        public readonly string $key,
+        public readonly string $displayName,
+        public readonly bool $projectScoped = true,
+    ) {}
+
+    /**
+     * The owning domain — the first dotted segment of the key (e.g. `company` for
+     * `company.settings.edit`).
+     */
+    public function domain(): string
+    {
+        return Str::before($this->key, '.');
+    }
+
+    /**
+     * The action — everything after the first dotted segment (e.g. `settings.edit`
+     * for `company.settings.edit`, `create` for `tickets.create`).
+     */
+    public function action(): string
+    {
+        return Str::after($this->key, '.');
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionEnforcer.php
+++ b/app/Core/Auth/Permissions/PermissionEnforcer.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Support\Facades\Log;
+use Leantime\Core\Exceptions\AuthorizationException;
+use ReflectionException;
+use ReflectionMethod;
+
+/**
+ * Reads the {@see RequiresPermission} attribute off a resolved action/method and enforces it.
+ *
+ * Shared by the entry points so the declaration means the same everywhere:
+ *  - {@see \Leantime\Core\Controller\Frontcontroller::executeAction()} — legacy convention routes,
+ *  - {@see CheckPermissions} middleware — native Laravel routes,
+ *  - {@see \Leantime\Domain\Api\Controllers\Jsonrpc::executeApiRequest()} — JSON-RPC.
+ *
+ * Safety properties:
+ *  - A method WITHOUT the attribute is a complete no-op — it never touches the session, DB,
+ *    or permission engine. So wiring the hooks in is inert until methods are annotated.
+ *  - Audit mode (the default, `config('permissions.enforce')` falsy) only LOGS would-be
+ *    denials instead of blocking, so enforcement can be rolled out and observed per domain
+ *    before flipping to blocking.
+ */
+class PermissionEnforcer
+{
+    /** @var array<string, RequiresPermission|null> Memoized attribute lookups per class::method. */
+    private array $cache = [];
+
+    public function __construct(private PermissionService $permissions) {}
+
+    /**
+     * Enforce the permission required by $class::$method, if any.
+     *
+     * @param  object|class-string  $class  The controller instance or service class name.
+     * @param  array<string, mixed>  $params  Request/method parameters (for project-id resolution).
+     *
+     * @throws AuthorizationException When denied and not in audit mode.
+     */
+    public function enforce(object|string $class, string $method, array $params = []): void
+    {
+        $attribute = $this->attributeFor($class, $method);
+
+        if ($attribute === null) {
+            return;
+        }
+
+        if ($this->permissions->currentUserCan($attribute->permission, $this->resolveProjectId($attribute, $params))) {
+            return;
+        }
+
+        $target = (is_object($class) ? $class::class : $class).'::'.$method;
+        $user = session('userdata.id') ?? 'guest';
+
+        if (! $this->shouldBlock()) {
+            Log::info(sprintf('[permissions:audit] would deny "%s" on %s for user %s', $attribute->permission, $target, $user));
+
+            return;
+        }
+
+        // Log the permission key server-side for audit; the thrown exception stays generic
+        // so the authorization vocabulary is never exposed to the client.
+        Log::info(sprintf('Authorization denied: "%s" on %s for user %s', $attribute->permission, $target, $user));
+
+        throw new AuthorizationException;
+    }
+
+    /**
+     * The RequiresPermission attribute on $class::$method, or null. Memoized; tolerant of
+     * missing methods (returns null) so it can guard any dispatch target.
+     */
+    private function attributeFor(object|string $class, string $method): ?RequiresPermission
+    {
+        $className = is_object($class) ? $class::class : $class;
+        $key = $className.'::'.$method;
+
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        $attribute = null;
+
+        try {
+            $attributes = (new ReflectionMethod($className, $method))->getAttributes(RequiresPermission::class);
+
+            if ($attributes !== []) {
+                $attribute = $attributes[0]->newInstance();
+            }
+        } catch (ReflectionException) {
+            $attribute = null;
+        }
+
+        return $this->cache[$key] = $attribute;
+    }
+
+    /**
+     * Project id for a project-scoped check: the named parameter if the attribute declares
+     * one, else the current session project. Returns null when neither resolves.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    private function resolveProjectId(RequiresPermission $attribute, array $params): ?int
+    {
+        if ($attribute->projectIdParam !== null && isset($params[$attribute->projectIdParam])) {
+            return (int) $params[$attribute->projectIdParam];
+        }
+
+        $current = session('currentProject');
+
+        return ($current === null || (int) $current === 0) ? null : (int) $current;
+    }
+
+    /** Whether denials block (true) or are only logged (false, the default — audit mode). */
+    private function shouldBlock(): bool
+    {
+        try {
+            return (bool) config('permissions.enforce', false);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionRegistry.php
+++ b/app/Core/Auth/Permissions/PermissionRegistry.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Discovers and aggregates the permission vocabulary declared by every domain (and folder
+ * plugin) implementing {@see ProvidesPermissions}.
+ *
+ * Mirrors {@see \Leantime\Core\Events\EventDispatcher::discoverListeners()}: it globs the
+ * conventional locations, caches the discovered provider class list on the shared
+ * `installation` store outside debug mode, then instantiates each provider and merges its
+ * {@see Permission} declarations into a single keyed catalog. The catalog is the in-memory
+ * source of truth that `permissions:sync` writes into the database.
+ */
+class PermissionRegistry
+{
+    private const PROVIDER_CACHE_KEY = 'permissionProviders';
+
+    /** @var array<string, Permission>|null */
+    private ?array $catalog = null;
+
+    public function __construct(private Container $container) {}
+
+    /**
+     * The full catalog keyed by permission key (e.g. 'tickets.create' => Permission).
+     *
+     * @return array<string, Permission>
+     */
+    public function all(): array
+    {
+        if ($this->catalog !== null) {
+            return $this->catalog;
+        }
+
+        $this->catalog = [];
+
+        foreach ($this->providerClasses() as $class) {
+            $provider = $this->container->make($class);
+
+            if (! $provider instanceof ProvidesPermissions) {
+                continue;
+            }
+
+            foreach ($provider->permissions() as $permission) {
+                $this->catalog[$permission->key] = $permission;
+            }
+        }
+
+        return $this->catalog;
+    }
+
+    public function get(string $key): ?Permission
+    {
+        return $this->all()[$key] ?? null;
+    }
+
+    /** Drop the in-memory and cross-request provider caches (call on plugin enable/disable). */
+    public function flush(): void
+    {
+        $this->catalog = null;
+        Cache::store('installation')->forget(self::PROVIDER_CACHE_KEY);
+    }
+
+    /**
+     * The discovered provider class names. Cached on the installation store outside debug
+     * mode, exactly like EventDispatcher's 'domainEvents'.
+     *
+     * @return array<int, string>
+     */
+    private function providerClasses(): array
+    {
+        if ((bool) config('debug') === false) {
+            return Cache::store('installation')->rememberForever(self::PROVIDER_CACHE_KEY, fn () => $this->scanProviderClasses());
+        }
+
+        return $this->scanProviderClasses();
+    }
+
+    /**
+     * Glob the conventional provider locations and resolve each to a FQCN.
+     *
+     * @return array<int, string>
+     */
+    private function scanProviderClasses(): array
+    {
+        $patterns = [
+            APP_ROOT.'/app/Domain/*/Permissions/*Permissions.php',
+            APP_ROOT.'/app/Plugins/*/Permissions/*Permissions.php',
+        ];
+
+        $classes = [];
+
+        foreach ($patterns as $pattern) {
+            foreach ((array) glob($pattern) as $file) {
+                $class = $this->classFromPath((string) $file);
+
+                if ($class !== null) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Map an app file path to its FQCN under the Leantime namespace
+     * (app/Domain/Tickets/Permissions/TicketsPermissions.php ->
+     * Leantime\Domain\Tickets\Permissions\TicketsPermissions).
+     */
+    private function classFromPath(string $file): ?string
+    {
+        $relative = str_replace(APP_ROOT.'/app/', '', $file);
+        $relative = substr($relative, 0, -strlen('.php'));
+        $class = 'Leantime\\'.str_replace('/', '\\', $relative);
+
+        return class_exists($class) ? $class : null;
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionRepository.php
+++ b/app/Core/Auth/Permissions/PermissionRepository.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Database\ConnectionInterface;
+use Leantime\Core\Db\Db as DbCore;
+
+/**
+ * Data access for the native permission engine (no ORM — Laravel query builder over the
+ * `zp_roles`, `zp_permissions`, `zp_role_permissions` tables).
+ *
+ * Roles are the DB-backed definitions (built-ins + custom); permissions are the synced
+ * `domain.action` vocabulary; the grant map links them. This repository is consumed by
+ * {@see PermissionService} (read path, cached), {@see PermissionSeeder} (built-in seeding +
+ * vocabulary sync), `permissions:sync`, and the future role-management UI (write path).
+ */
+class PermissionRepository
+{
+    private ConnectionInterface $db;
+
+    public function __construct(DbCore $db)
+    {
+        $this->db = $db->getConnection();
+    }
+
+    // ------------------------------------------------------------------
+    // Roles
+    // ------------------------------------------------------------------
+
+    /** @return array<string, mixed>|null */
+    public function getRoleByName(string $name): ?array
+    {
+        $row = $this->db->table('zp_roles')->where('name', $name)->first();
+
+        return $row ? (array) $row : null;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getRoleById(int $id): ?array
+    {
+        $row = $this->db->table('zp_roles')->where('id', $id)->first();
+
+        return $row ? (array) $row : null;
+    }
+
+    /**
+     * All roles ordered by hierarchy level (ascending).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAllRoles(): array
+    {
+        return $this->db->table('zp_roles')
+            ->orderBy('level')
+            ->get()
+            ->map(fn ($row) => (array) $row)
+            ->all();
+    }
+
+    /**
+     * Insert or update a role keyed by its (unique) name. Returns the role id.
+     * Built-in roles pass isSystem=true so the admin UI can protect them.
+     */
+    public function upsertRole(string $name, string $displayName, int $level, bool $isSystem = false, ?string $description = null): int
+    {
+        $now = dtHelper()->userNow()->formatDateTimeForDb();
+        $existing = $this->getRoleByName($name);
+
+        if ($existing !== null) {
+            $this->db->table('zp_roles')->where('id', $existing['id'])->update([
+                'displayName' => $displayName,
+                'level' => $level,
+                'isSystem' => $isSystem ? 1 : 0,
+                'description' => $description,
+                'modified' => $now,
+            ]);
+
+            return (int) $existing['id'];
+        }
+
+        return (int) $this->db->table('zp_roles')->insertGetId([
+            'name' => $name,
+            'displayName' => $displayName,
+            'level' => $level,
+            'isSystem' => $isSystem ? 1 : 0,
+            'description' => $description,
+            'createdOn' => $now,
+            'modified' => $now,
+        ]);
+    }
+
+    /** @param  array<string, mixed>  $data */
+    public function createRole(array $data): int
+    {
+        return $this->upsertRole(
+            (string) $data['name'],
+            (string) ($data['displayName'] ?? $data['name']),
+            (int) ($data['level'] ?? 20),
+            (bool) ($data['isSystem'] ?? false),
+            $data['description'] ?? null,
+        );
+    }
+
+    /** @param  array<string, mixed>  $data */
+    public function updateRole(int $id, array $data): bool
+    {
+        $data['modified'] = dtHelper()->userNow()->formatDateTimeForDb();
+
+        return (bool) $this->db->table('zp_roles')->where('id', $id)->update($data);
+    }
+
+    /** Deletes a role and its grants. Callers must block deletion of isSystem roles. */
+    public function deleteRole(int $id): bool
+    {
+        $this->db->table('zp_role_permissions')->where('roleId', $id)->delete();
+
+        return (bool) $this->db->table('zp_roles')->where('id', $id)->delete();
+    }
+
+    // ------------------------------------------------------------------
+    // Permissions (the vocabulary)
+    // ------------------------------------------------------------------
+
+    /** @return array<int, array<string, mixed>> */
+    public function getAllPermissions(): array
+    {
+        return $this->db->table('zp_permissions')
+            ->orderBy('permissionKey')
+            ->get()
+            ->map(fn ($row) => (array) $row)
+            ->all();
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getPermissionByKey(string $key): ?array
+    {
+        $row = $this->db->table('zp_permissions')->where('permissionKey', $key)->first();
+
+        return $row ? (array) $row : null;
+    }
+
+    /**
+     * Idempotently upsert the discovered vocabulary into zp_permissions, keyed by
+     * permissionKey. Returns the full list of synced keys (for optional pruning).
+     *
+     * @param  array<int, array{key:string, domain:string, action:string, label:string, projectScoped:bool}>  $definitions
+     * @return array<int, string> The synced permission keys.
+     */
+    public function syncPermissions(array $definitions): array
+    {
+        $now = dtHelper()->userNow()->formatDateTimeForDb();
+        $keys = [];
+
+        foreach ($definitions as $def) {
+            $keys[] = $def['key'];
+            $row = [
+                'domain' => $def['domain'],
+                'action' => $def['action'],
+                'label' => $def['label'],
+                'isProjectScoped' => $def['projectScoped'] ? 1 : 0,
+                'modified' => $now,
+            ];
+
+            if ($this->getPermissionByKey($def['key']) !== null) {
+                $this->db->table('zp_permissions')->where('permissionKey', $def['key'])->update($row);
+
+                continue;
+            }
+
+            $this->db->table('zp_permissions')->insert($row + [
+                'permissionKey' => $def['key'],
+                'createdOn' => $now,
+            ]);
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Remove permissions (and their grants) whose key is not in $keepKeys. Returns the
+     * number of pruned permissions. Used by `permissions:sync --prune`.
+     *
+     * @param  array<int, string>  $keepKeys
+     */
+    public function pruneOrphanPermissions(array $keepKeys): int
+    {
+        $orphans = $this->db->table('zp_permissions')
+            ->when($keepKeys !== [], fn ($q) => $q->whereNotIn('permissionKey', $keepKeys))
+            ->pluck('id')
+            ->all();
+
+        if ($orphans === []) {
+            return 0;
+        }
+
+        $this->db->table('zp_role_permissions')->whereIn('permissionId', $orphans)->delete();
+
+        return $this->db->table('zp_permissions')->whereIn('id', $orphans)->delete();
+    }
+
+    // ------------------------------------------------------------------
+    // Grants (role <-> permission map)
+    // ------------------------------------------------------------------
+
+    /**
+     * The full role -> [permissionKey, ...] map driving runtime checks. One JOIN; the
+     * caller ({@see PermissionService}) caches the result.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function getRolePermissionMap(): array
+    {
+        $rows = $this->db->table('zp_role_permissions as rp')
+            ->join('zp_roles as r', 'r.id', '=', 'rp.roleId')
+            ->join('zp_permissions as p', 'p.id', '=', 'rp.permissionId')
+            ->select('r.name as roleName', 'p.permissionKey as permissionKey')
+            ->get();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row->roleName][] = $row->permissionKey;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Replace a role's grants with exactly the given permission keys (transactional).
+     *
+     * @param  array<int, string>  $permissionKeys
+     */
+    public function replaceRolePermissions(int $roleId, array $permissionKeys): void
+    {
+        $this->db->transaction(function () use ($roleId, $permissionKeys) {
+            $this->db->table('zp_role_permissions')->where('roleId', $roleId)->delete();
+
+            if ($permissionKeys === []) {
+                return;
+            }
+
+            $ids = $this->db->table('zp_permissions')
+                ->whereIn('permissionKey', $permissionKeys)
+                ->pluck('id')
+                ->all();
+
+            $rows = array_map(fn ($id) => ['roleId' => $roleId, 'permissionId' => $id], $ids);
+
+            if ($rows !== []) {
+                $this->db->table('zp_role_permissions')->insert($rows);
+            }
+        });
+    }
+
+    /** Grant a single permission to a role (no-op if already granted). */
+    public function grant(int $roleId, string $permissionKey): void
+    {
+        $permission = $this->getPermissionByKey($permissionKey);
+        if ($permission === null) {
+            return;
+        }
+
+        $exists = $this->db->table('zp_role_permissions')
+            ->where('roleId', $roleId)
+            ->where('permissionId', $permission['id'])
+            ->exists();
+
+        if (! $exists) {
+            $this->db->table('zp_role_permissions')->insert([
+                'roleId' => $roleId,
+                'permissionId' => $permission['id'],
+            ]);
+        }
+    }
+
+    /** Revoke a single permission from a role. */
+    public function revoke(int $roleId, string $permissionKey): void
+    {
+        $permission = $this->getPermissionByKey($permissionKey);
+        if ($permission === null) {
+            return;
+        }
+
+        $this->db->table('zp_role_permissions')
+            ->where('roleId', $roleId)
+            ->where('permissionId', $permission['id'])
+            ->delete();
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionSeeder.php
+++ b/app/Core/Auth/Permissions/PermissionSeeder.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+/**
+ * Seeds the database-backed permission system from code declarations.
+ *
+ * Two idempotent operations:
+ *  - {@see syncDiscoveredPermissions()} writes the discovered `domain.action` vocabulary
+ *    into zp_permissions. Safe to run anytime; never touches role grants, so administrator
+ *    customizations survive a re-sync.
+ *  - {@see seedBuiltInRoles()} upserts the six built-in roles and ADDITIVELY grants each its
+ *    default permissions, resolved from the central {@see DefaultRolePermissions} matrix
+ *    against the discovered catalog. Additive grants never remove an administrator's edits.
+ *
+ * Vocabulary must be synced before grants can reference it, so the install migration calls
+ * sync first, then seed.
+ */
+class PermissionSeeder
+{
+    public function __construct(
+        private PermissionRepository $repo,
+        private PermissionRegistry $registry,
+        private PermissionService $permissions,
+    ) {}
+
+    /**
+     * Upsert the discovered vocabulary into zp_permissions and bust the engine cache.
+     *
+     * @return array<int, string> The synced permission keys.
+     */
+    public function syncDiscoveredPermissions(): array
+    {
+        $definitions = array_map(
+            fn (Permission $p): array => [
+                'key' => $p->key,
+                'domain' => $p->domain(),
+                'action' => $p->action(),
+                'label' => $p->displayName,
+                'projectScoped' => $p->projectScoped,
+            ],
+            array_values($this->registry->all()),
+        );
+
+        $keys = $this->repo->syncPermissions($definitions);
+        $this->permissions->flushCache();
+
+        return $keys;
+    }
+
+    /**
+     * Upsert the six built-in roles and additively grant their default permissions from the
+     * central {@see DefaultRolePermissions} matrix.
+     */
+    public function seedBuiltInRoles(): void
+    {
+        $catalog = array_values($this->registry->all());
+        $roleIds = [];
+
+        foreach (DefaultRolePermissions::roles() as $role) {
+            $roleIds[$role['name']] = $this->repo->upsertRole(
+                $role['name'],
+                $role['displayName'],
+                $role['level'],
+                isSystem: true,
+            );
+        }
+
+        foreach (DefaultRolePermissions::roles() as $role) {
+            foreach (DefaultRolePermissions::grantsFor($role['name'], $catalog) as $permissionKey) {
+                $this->repo->grant($roleIds[$role['name']], $permissionKey);
+            }
+        }
+
+        $this->permissions->flushCache();
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionService.php
+++ b/app/Core/Auth/Permissions/PermissionService.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Leantime\Core\Auth\Contracts\ChecksProjectAccess;
+use Leantime\Core\Auth\RoleResolver;
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Domain\Auth\Models\Roles;
+
+/**
+ * The capability engine: the single runtime answer to "may the current user do X?".
+ *
+ * Consumed everywhere through one method, {@see currentUserCan()}: the JSON-RPC
+ * dispatcher and controller bases (via {@see RequiresPermission}), Blade `@can` (via the
+ * Gate::before bridge), the menu builder, and in-method `$this->authorize()` helpers.
+ *
+ * Two concerns are kept strictly separate:
+ *  - CAPABILITY — does the user's effective role hold the permission? Resolved against the
+ *    cached role->permission grant map. Effective role is project-aware (see {@see RoleResolver}).
+ *  - DATA ACCESS — for project-scoped permissions targeting a concrete project, is the user
+ *    actually a member of (or otherwise able to access) that project? Admin/owner bypass.
+ *
+ * Ownership and other entity-specific checks deliberately live in callers, not here.
+ */
+class PermissionService
+{
+    private const MAP_CACHE_KEY = 'leantime.permissionMap';
+
+    private const META_CACHE_KEY = 'leantime.permissionMeta';
+
+    public function __construct(
+        private PermissionRepository $repo,
+        private RoleResolver $roles,
+        private ChecksProjectAccess $projectAccess,
+    ) {}
+
+    /**
+     * Whether $roleName holds $permissionKey, by flat lookup on the cached grant map.
+     */
+    public function roleHasPermission(string $roleName, string $permissionKey): bool
+    {
+        return in_array($permissionKey, $this->map()[$roleName] ?? [], true);
+    }
+
+    /**
+     * The authorization decision. Resolves the effective role (project-aware for
+     * project-scoped permissions), checks the grant map, then — only for project-scoped
+     * permissions against a concrete project — ANDs in project data access.
+     *
+     * @param  string  $permissionKey  A `domain.action` key.
+     * @param  int|null  $projectId  The project the acted-on entity belongs to (for project-scoped checks).
+     * @param  bool|null  $forceGlobal  Force the global-role scope (company-wide screens). Null = inferred from the permission.
+     */
+    public function currentUserCan(string $permissionKey, ?int $projectId = null, ?bool $forceGlobal = null): bool
+    {
+        $projectScoped = $this->isProjectScoped($permissionKey);
+        $useGlobal = $forceGlobal === true || ! $projectScoped;
+
+        if ($useGlobal) {
+            $role = $this->roles->effectiveRole(true);
+        } elseif ($projectId !== null) {
+            $role = $this->roles->effectiveRoleForProject($projectId);
+        } else {
+            $role = $this->roles->effectiveRole(false);
+        }
+
+        if ($role === false || ! $this->roleHasPermission($role, $permissionKey)) {
+            return false;
+        }
+
+        // Capability granted. Enforce project data access for project-scoped checks.
+        if ($projectScoped && $projectId !== null && ! $this->canAccessAllProjects()) {
+            return $this->projectAccess->isUserAssignedToProject((int) session('userdata.id'), $projectId);
+        }
+
+        return true;
+    }
+
+    /**
+     * Authorize or throw. Services should call this instead of returning false on denial,
+     * so the failure maps cleanly to 403 (web) / RPC -32001.
+     *
+     * @throws AuthorizationException
+     */
+    public function authorize(string $permissionKey, ?int $projectId = null, ?bool $forceGlobal = null): void
+    {
+        if (! $this->currentUserCan($permissionKey, $projectId, $forceGlobal)) {
+            // Keep the permission key server-side only (audit/debug); the exception's
+            // client-facing message stays generic so we don't expose authz vocabulary.
+            Log::info('Authorization denied for permission "'.$permissionKey.'" (user '.(session('userdata.id') ?? 'guest').')');
+
+            throw new AuthorizationException;
+        }
+    }
+
+    /**
+     * Whether $permissionKey is part of the synced vocabulary. Used by the Gate::before
+     * bridge to defer (return null) on dotted abilities it does not own.
+     */
+    public function isManagedPermission(string $permissionKey): bool
+    {
+        return isset($this->meta()[$permissionKey]);
+    }
+
+    /** Whether a permission is evaluated per-project (true) or company-wide (false). */
+    public function isProjectScoped(string $permissionKey): bool
+    {
+        return (bool) ($this->meta()[$permissionKey]['projectScoped'] ?? false);
+    }
+
+    /** Forget the cached grant map + vocabulary meta. Call after any role/permission write. */
+    public function flushCache(): void
+    {
+        Cache::store('installation')->forget(self::MAP_CACHE_KEY);
+        Cache::store('installation')->forget(self::META_CACHE_KEY);
+    }
+
+    /**
+     * Admin/owner access every project (mirrors getProjectsUserHasAccessTo's bypass), so
+     * they skip the per-project membership check.
+     */
+    private function canAccessAllProjects(): bool
+    {
+        $globalRole = $this->roles->globalRole();
+
+        return $globalRole === Roles::$owner || $globalRole === Roles::$admin;
+    }
+
+    /**
+     * The role -> [permissionKey, ...] grant map, cached on the shared installation store
+     * (file/Redis) so all workers share it; busted via {@see flushCache()}.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function map(): array
+    {
+        return Cache::store('installation')->rememberForever(self::MAP_CACHE_KEY, fn () => $this->repo->getRolePermissionMap());
+    }
+
+    /**
+     * Vocabulary meta (key => ['projectScoped' => bool]), cached alongside the grant map.
+     *
+     * @return array<string, array{projectScoped: bool}>
+     */
+    private function meta(): array
+    {
+        return Cache::store('installation')->rememberForever(self::META_CACHE_KEY, function () {
+            $meta = [];
+            foreach ($this->repo->getAllPermissions() as $permission) {
+                $meta[$permission['permissionKey']] = ['projectScoped' => (bool) $permission['isProjectScoped']];
+            }
+
+            return $meta;
+        });
+    }
+}

--- a/app/Core/Auth/Permissions/PermissionServiceProvider.php
+++ b/app/Core/Auth/Permissions/PermissionServiceProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Support\ServiceProvider;
+use Leantime\Core\Auth\Contracts\ChecksProjectAccess;
+use Leantime\Core\Domains\BaseService;
+use Leantime\Domain\Projects\Services\Projects;
+
+/**
+ * Wires the native permission engine: singletons, the project-access abstraction binding,
+ * the Gate bridge, and dependency injection for {@see BaseService} subclasses.
+ *
+ * Registered in laravelConfig's provider list. Keeping this separate from
+ * AuthenticationServiceProvider keeps authn (guards/tokens) and authz (permissions) cleanly
+ * apart.
+ */
+class PermissionServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(PermissionService::class);
+        $this->app->singleton(PermissionEnforcer::class);
+        $this->app->singleton(PermissionRegistry::class);
+
+        // The engine depends on a narrow project-access abstraction, not the Projects
+        // god-service. A shared singleton so RoleResolver and PermissionService reuse one
+        // instance and we don't construct Projects more than once.
+        $this->app->singleton(ChecksProjectAccess::class, fn ($app) => $app->make(Projects::class));
+    }
+
+    public function boot(): void
+    {
+        $this->registerPermissionGate();
+        $this->injectBaseServiceDependencies();
+    }
+
+    /**
+     * Bridge Laravel's authorization Gate to the engine. Leantime's authenticated user is a
+     * stdClass (no `->can()`), so a single Gate::before hook resolves every `domain.action`
+     * ability through {@see PermissionService::currentUserCan()} — making `@can('tickets.create')`,
+     * `Gate::allows()`, and the `can` middleware all speak the one vocabulary. Non-permission
+     * abilities (no dot, or not in the synced catalog) return null so other gates still work;
+     * resolution is deferred into the closure so Projects isn't constructed at boot.
+     */
+    protected function registerPermissionGate(): void
+    {
+        $container = $this->app;
+
+        $this->app->make(GateContract::class)->before(function ($user, string $ability, array $arguments = []) use ($container) {
+            if (! str_contains($ability, '.')) {
+                return null;
+            }
+
+            try {
+                $permissions = $container->make(PermissionService::class);
+
+                if (! $permissions->isManagedPermission($ability)) {
+                    return null;
+                }
+
+                // Only treat the first gate argument as a project id when it is numeric;
+                // @can / Gate::allows may pass models or other objects. Otherwise fall back
+                // to session scope (null).
+                $projectId = isset($arguments[0]) && is_numeric($arguments[0]) ? (int) $arguments[0] : null;
+
+                return $permissions->currentUserCan($ability, $projectId);
+            } catch (\Throwable) {
+                // Permission tables not ready yet (e.g. pre-migration install) — defer.
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Inject PermissionService into every service that extends {@see BaseService}, without
+     * forcing subclass constructors to wire it. The afterResolving callback registered for
+     * the base type fires for any resolved instance that is `instanceof BaseService`.
+     */
+    protected function injectBaseServiceDependencies(): void
+    {
+        $this->app->afterResolving(BaseService::class, function (BaseService $service, $app) {
+            $service->setPermissionService($app->make(PermissionService::class));
+        });
+    }
+}

--- a/app/Core/Auth/Permissions/ProvidesPermissions.php
+++ b/app/Core/Auth/Permissions/ProvidesPermissions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+/**
+ * Contract implemented by each domain's (and plugin's) permission catalog.
+ *
+ * Implementations live at `app/Domain/{Domain}/Permissions/{Domain}Permissions.php`
+ * (and the plugin equivalent) and are auto-discovered at boot by
+ * {@see PermissionRegistry}, mirroring how `register.php` event listeners are
+ * discovered. The declared {@see Permission} objects are the single source of truth
+ * for the `domain.action` vocabulary — `permissions:sync` writes them into the
+ * `zp_permissions` table so an administrator can assign them to roles.
+ *
+ * Concrete implementations should also expose typed string constants
+ * (e.g. `const CREATE = 'tickets.create';`) so call sites reference constants
+ * rather than magic strings.
+ */
+interface ProvidesPermissions
+{
+    /**
+     * The capabilities this provider contributes to the vocabulary.
+     *
+     * @return array<int, Permission>
+     */
+    public function permissions(): array;
+
+    /**
+     * The domain key these permissions belong to (e.g. `tickets`). Used for grouping
+     * in the admin UI and as the `zp_permissions.domain` column value.
+     */
+    public function domain(): string;
+}

--- a/app/Core/Auth/Permissions/RequiresPermission.php
+++ b/app/Core/Auth/Permissions/RequiresPermission.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Leantime\Core\Auth\Permissions;
+
+use Attribute;
+
+/**
+ * Declares the permission required to invoke a controller action or an `@api`
+ * service method.
+ *
+ * The same declaration is enforced at every entry point to the service layer, all reading
+ * it through {@see PermissionEnforcer}:
+ *  - Legacy convention routes: {@see \Leantime\Core\Controller\Frontcontroller::executeAction()}.
+ *  - Native Laravel routes: the {@see CheckPermissions} middleware.
+ *  - JSON-RPC: {@see \Leantime\Domain\Api\Controllers\Jsonrpc::executeApiRequest()} on the
+ *    resolved service method (RPC bypasses the controller gate, so this is what secures it).
+ *
+ * On denial an {@see \Leantime\Core\Exceptions\AuthorizationException} is thrown, which the
+ * global handler renders as 403 on the web and `JsonRpcErrorResponse::fromException`
+ * maps to RPC error -32001.
+ *
+ * For project-scoped permissions, set {@see $projectIdParam} to the name of the
+ * request/method parameter carrying the project id so the check resolves the role
+ * against the entity's project rather than the session project. When omitted, the
+ * enforcer falls back to the current session project (`session('currentProject')`).
+ *
+ * Contextual checks that depend on runtime data (ownership, cross-project ids resolved
+ * from a loaded entity) belong in the method body via `$this->authorize(...)`, not here.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class RequiresPermission
+{
+    /**
+     * @param  string  $permission  The required `domain.action` key (use a domain
+     *                              permission constant, e.g. `TicketsPermissions::CREATE`).
+     * @param  string|null  $projectIdParam  Name of the parameter holding the project id
+     *                                       for project-scoped checks; null = session project.
+     */
+    public function __construct(
+        public readonly string $permission,
+        public readonly ?string $projectIdParam = null,
+    ) {}
+}

--- a/app/Core/Auth/RoleResolver.php
+++ b/app/Core/Auth/RoleResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Leantime\Core\Auth;
+
+use Leantime\Core\Auth\Contracts\ChecksProjectAccess;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth as AuthService;
+
+/**
+ * Single home for resolving a user's EFFECTIVE role, in both scopes Leantime cares about.
+ *
+ * Leantime roles are project-scoped: a user can hold one role globally
+ * (`session('userdata.role')`) and a different role inside a given project
+ * (`zp_relationuserproject.projectRole`). Authorization correctness depends on picking
+ * the right one:
+ *  - {@see effectiveRole()} resolves the role for the CURRENT SESSION project — the
+ *    historical behavior of `Auth::getRoleToCheck()`, which this delegates to (no
+ *    duplication). Use it for "is the current screen allowed" checks.
+ *  - {@see effectiveRoleForProject()} resolves the role for a SPECIFIC project — the
+ *    only correct basis for authorizing a mutation on an entity that may live outside
+ *    the session project. It centralizes the logic previously private to
+ *    `Tickets::userIsAtLeastForProject()`.
+ *
+ * This is infrastructure shared across every domain, hence it lives in Core/Auth. It
+ * still references the Domain-layer `Roles` definitions and `Projects` service for now;
+ * those are stable value/lookup surfaces and the coupling is intentional pragmatism
+ * (the broader Roles->Core move is deferred).
+ */
+class RoleResolver
+{
+    public function __construct(private ChecksProjectAccess $projectAccess) {}
+
+    /** The current user's global role string, or null when not authenticated. */
+    public function globalRole(): ?string
+    {
+        $role = session('userdata.role');
+
+        return ($role === null || $role === '') ? null : $role;
+    }
+
+    /**
+     * Effective role for the current session project (delegates to the existing
+     * dual-scope resolution). `$forceGlobal` short-circuits to the global role for
+     * company-wide screens (users/clients/settings).
+     */
+    public function effectiveRole(bool $forceGlobal = false): string|false
+    {
+        return AuthService::getRoleToCheck($forceGlobal);
+    }
+
+    /**
+     * Effective role for a specific project. Manager/admin/owner keep their global role
+     * everywhere; otherwise the explicit project role applies, falling back to the
+     * global role when none is set. Returns false when not authenticated.
+     */
+    public function effectiveRoleForProject(int $projectId): string|false
+    {
+        $globalRole = $this->globalRole();
+
+        if ($globalRole === null) {
+            return false;
+        }
+
+        $roles = Roles::getRoles();
+        $globalKey = array_search($globalRole, $roles, true);
+        $managerKey = array_search(Roles::$manager, $roles, true);
+
+        // Manager and above keep their global role across every project.
+        if ($globalKey !== false && $managerKey !== false && $globalKey >= $managerKey) {
+            return $globalRole;
+        }
+
+        $projectRole = $this->projectAccess->getProjectRole((int) session('userdata.id'), $projectId);
+
+        // No explicit project role -> inherit the global role.
+        return $projectRole === '' ? $globalRole : Roles::getRoleString((int) $projectRole);
+    }
+
+    /**
+     * True when $effectiveRole ranks at or above $requiredRole in the role hierarchy,
+     * using the same ordering as {@see Roles::getRoles()}.
+     */
+    public function atLeast(string $requiredRole, string|false $effectiveRole): bool
+    {
+        if ($effectiveRole === false) {
+            return false;
+        }
+
+        $roles = Roles::getRoles();
+        $requiredKey = array_search($requiredRole, $roles, true);
+        $effectiveKey = array_search($effectiveRole, $roles, true);
+
+        return $requiredKey !== false && $effectiveKey !== false && $effectiveKey >= $requiredKey;
+    }
+}

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.4';
+    public string $dbVersion = '3.5.5';
 }

--- a/app/Core/Configuration/laravelConfig.php
+++ b/app/Core/Configuration/laravelConfig.php
@@ -38,6 +38,7 @@ return [
             \Illuminate\Validation\ValidationServiceProvider::class,
 
             \Leantime\Core\Auth\AuthenticationServiceProvider::class,
+            \Leantime\Core\Auth\Permissions\PermissionServiceProvider::class,
             \Leantime\Core\Middleware\RateLimiter::class,
             \Leantime\Core\Database\DatabaseServiceProvider::class,
             \Leantime\Core\WorkStructure\WorkStructureServiceProvider::class,

--- a/app/Core/Console/Application.php
+++ b/app/Core/Console/Application.php
@@ -2,11 +2,13 @@
 
 namespace Leantime\Core\Console;
 
+use Illuminate\Console\Command as IlluminateCommand;
 use Illuminate\Console\Events\ArtisanStarting;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ProcessUtils;
 use Leantime\Core\Events\DispatchesEvents;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,6 +34,25 @@ class Application extends \Illuminate\Console\Application
         $this->events->dispatch(new ArtisanStarting($this));
 
         $this->bootstrap();
+    }
+
+    /**
+     * Inject the Laravel container into commands as they are registered.
+     *
+     * symfony/console 7.4 renamed add() to addCommand() and routes the lazy command-loader
+     * path (Application::has() -> commandLoader->get()) through addCommand(), but
+     * Illuminate\Console\Application only overrides the deprecated add() — the single place
+     * setLaravel() is called. The result is that lazily-resolved #[AsCommand] commands run
+     * with a null $laravel and fatal in Command::run(). Mirroring Illuminate's add() here on
+     * addCommand() closes that gap for every registration path (add() delegates here too).
+     */
+    public function addCommand(callable|SymfonyCommand $command): ?SymfonyCommand
+    {
+        if ($command instanceof IlluminateCommand) {
+            $command->setLaravel($this->laravel);
+        }
+
+        return parent::addCommand($command);
     }
 
     /**

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Http\HtmxRequest;
@@ -49,7 +50,7 @@ class Frontcontroller
      * @param  IncomingRequest  $incomingRequest
      * @return void
      */
-    public function __construct(IncomingRequest $request)
+    public function __construct(IncomingRequest $request, private PermissionEnforcer $permissionEnforcer)
     {
         $this->incomingRequest = $request;
         $this->config = config();
@@ -87,7 +88,9 @@ class Frontcontroller
 
     public static function dispatch_request(IncomingRequest $request): Response
     {
-        $frontcontroller = new self($request);
+        // Resolve through the container so constructor dependencies (e.g. PermissionEnforcer)
+        // are injected; dispatch() sets the active request explicitly.
+        $frontcontroller = app()->make(self::class);
 
         return $frontcontroller->dispatch($request);
     }
@@ -179,6 +182,11 @@ class Frontcontroller
     {
 
         $parameters = $this->incomingRequest->getRequestParams();
+
+        // Enforce #[RequiresPermission] on the resolved action before instantiating the
+        // controller. This is the single chokepoint for every convention-routed controller,
+        // regardless of which base class (if any) it extends.
+        $this->permissionEnforcer->enforce($controller, $method, is_array($parameters) ? $parameters : []);
 
         $controllerClass = app()->make($controller);
 

--- a/app/Core/Domains/BaseService.php
+++ b/app/Core/Domains/BaseService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Leantime\Core\Domains;
+
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Exceptions\ValidationException;
+
+/**
+ * Base class for domain services, providing the cross-cutting authorization and validation
+ * helpers a service needs. All services should extend this (it also carries the
+ * {@see DomainService} marker and the {@see DispatchesEvents} trait, so event behavior is
+ * unchanged).
+ *
+ * Dependency wiring is handled by {@see \Leantime\Core\Auth\Permissions\PermissionServiceProvider}:
+ * an `afterResolving(BaseService::class, ...)` hook calls {@see setPermissionService()} on
+ * every container-resolved subclass. That keeps the engine injected with zero constructor
+ * boilerplate in subclasses (which all have their own repo-injecting constructors) and
+ * without reaching for the `app()` helper inside service methods.
+ */
+abstract class BaseService implements DomainService
+{
+    use DispatchesEvents;
+
+    protected PermissionService $permissions;
+
+    /** Wired by PermissionServiceProvider when the service is resolved from the container. */
+    public function setPermissionService(PermissionService $permissions): void
+    {
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * Authorize the current user for a `domain.action` permission or throw. Replaces the
+     * silent `return false` pattern — a denial becomes an
+     * {@see \Leantime\Core\Exceptions\AuthorizationException} (403 web / RPC -32001).
+     *
+     * @throws \Leantime\Core\Exceptions\AuthorizationException
+     */
+    protected function authorize(string $permission, ?int $projectId = null, ?bool $forceGlobal = null): void
+    {
+        $this->permissions->authorize($permission, $projectId, $forceGlobal);
+    }
+
+    /** Non-throwing capability check, for branching. */
+    protected function can(string $permission, ?int $projectId = null, ?bool $forceGlobal = null): bool
+    {
+        return $this->permissions->currentUserCan($permission, $projectId, $forceGlobal);
+    }
+
+    /** The authenticated user's id, or null when there is no session user. */
+    protected function currentUserId(): ?int
+    {
+        $id = session('userdata.id');
+
+        return ($id === null || $id === '') ? null : (int) $id;
+    }
+
+    /**
+     * Validate input against Laravel rules, returning the validated (whitelisted) subset or
+     * throwing a {@see ValidationException} (422 web / RPC -32602 with field errors). Works
+     * identically whether input arrived via a controller or JSON-RPC.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $rules
+     * @param  array<string, string>  $messages
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    protected function validate(array $data, array $rules, array $messages = []): array
+    {
+        return ValidationException::validate($data, $rules, $messages);
+    }
+}

--- a/app/Core/Domains/DomainService.php
+++ b/app/Core/Domains/DomainService.php
@@ -3,56 +3,16 @@
 namespace Leantime\Core\Domains;
 
 /**
- * Service Interface - Base interface for all services
+ * Marker interface for all domain (and plugin) service classes.
+ *
+ * It carries no required methods on purpose. Real services have wildly different shapes
+ * (the Tickets service alone has ~75 heterogeneous methods), so a fixed CRUD contract
+ * never fit — which is exactly why the previous patch/update/create/delete/get/query
+ * interface had zero implementers. This marker instead gives the service layer a single
+ * type to scan for and a shared home (via {@see BaseService}) for the cross-cutting
+ * authorize()/validate() helpers, without forcing a fictional method surface.
+ *
+ * Granular capability interfaces (e.g. a real Crudable) may be introduced alongside this
+ * marker where they genuinely apply, opt-in per service.
  */
-interface DomainService
-{
-    /**
-     * patches the object by key.
-     *
-     * @param  int  $id  Id of the object to be patched
-     * @param  array  $params  Key=>value array where key represents the object field name and value the value.
-     * @return bool returns true on success, false on failure
-     */
-    public function patch(int $id, array $params): bool;
-
-    /**
-     * updates the object by key.
-     *
-     * @param  DomainModel  $object  expects the entire object to be updated as object or array
-     * @return array|bool Returns true on success, false on failure
-     */
-    public function update($object): bool;
-
-    /**
-     * Creates a new object
-     *
-     * @param  DomainModel  $object  Object or array to be created
-     * @return int|false Returns id of new element or false
-     */
-    public function create($object): int|false;
-
-    /**
-     * Deletes object
-     *
-     * @param  int  $id  Id of the object to be deleted
-     * @return bool Returns id of new element or false
-     */
-    public function delete(int $id);
-
-    /**
-     * Gets 1 specific item
-     *
-     * @param  int  $id  Id of the object to be retrieved
-     * @return T|array|false Returns object or array. False on failure or if item cannot be found
-     */
-    public function get(int $id);
-
-    /**
-     * Get all items
-     *
-     * @param  array|null  $searchparams  Search parameters
-     * @return array<DomainModel>|false Returns array on success, false on failure. No results should return empty array
-     */
-    public function query(?array $searchparams = null);
-}
+interface DomainService {}

--- a/app/Core/Routing/RouteLoader.php
+++ b/app/Core/Routing/RouteLoader.php
@@ -3,6 +3,8 @@
 namespace Leantime\Core\Routing;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Leantime\Core\Auth\Permissions\CheckPermissions;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Events\EventDispatcher;
 
@@ -47,11 +49,15 @@ class RouteLoader
             $domainPaths = self::getDomainPaths();
         }
 
-        foreach ($domainPaths as $domainPath) {
-            if (file_exists($routesPath = "$domainPath/routes.php")) {
-                require_once $routesPath;
+        // Routes inherit the permission-enforcement middleware so #[RequiresPermission] on a
+        // native controller action is honored without per-route `can:` declarations.
+        Route::middleware([CheckPermissions::class])->group(function () use ($domainPaths) {
+            foreach ($domainPaths as $domainPath) {
+                if (file_exists($routesPath = "$domainPath/routes.php")) {
+                    require_once $routesPath;
+                }
             }
-        }
+        });
     }
 
     /**
@@ -63,11 +69,13 @@ class RouteLoader
             isset(app(Environment::class)->plugins)
             && $configPlugins = explode(',', app(Environment::class)->plugins)
         ) {
-            foreach ($configPlugins as $plugin) {
-                if (file_exists($pluginRoutesPath = APP_ROOT.'/app/Plugins/'.$plugin.'/routes.php')) {
-                    require_once $pluginRoutesPath;
+            Route::middleware([CheckPermissions::class])->group(function () use ($configPlugins) {
+                foreach ($configPlugins as $plugin) {
+                    if (file_exists($pluginRoutesPath = APP_ROOT.'/app/Plugins/'.$plugin.'/routes.php')) {
+                        require_once $pluginRoutesPath;
+                    }
                 }
-            }
+            });
         }
     }
 
@@ -84,13 +92,15 @@ class RouteLoader
             $pluginService = app()->make(\Leantime\Core\Plugins\Plugins::class);
             $enabledPluginPaths = $pluginService->getEnabledPluginPaths();
 
-            foreach ($enabledPluginPaths as $pluginInfo) {
-                $routesPath = $pluginInfo['path'].'/routes.php';
+            Route::middleware([CheckPermissions::class])->group(function () use ($enabledPluginPaths) {
+                foreach ($enabledPluginPaths as $pluginInfo) {
+                    $routesPath = $pluginInfo['path'].'/routes.php';
 
-                if (file_exists($routesPath)) {
-                    require_once $routesPath;
+                    if (file_exists($routesPath)) {
+                        require_once $routesPath;
+                    }
                 }
-            }
+            });
         } catch (\Exception $e) {
             // Silently continue if plugin service is unavailable
         }

--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Exceptions\Contracts\LeantimeExceptionInterface;
 use Leantime\Core\Exceptions\MissingParameterException;
@@ -27,10 +28,15 @@ class Jsonrpc extends Controller
      */
     private array $json_data = [];
 
+    private PermissionEnforcer $permissionEnforcer;
+
     /**
      * init - initialize private variables or events to happen before route execution
      */
-    public function init(): void {}
+    public function init(PermissionEnforcer $permissionEnforcer): void
+    {
+        $this->permissionEnforcer = $permissionEnforcer;
+    }
 
     /**
      * Handles post requests
@@ -238,6 +244,11 @@ class Jsonrpc extends Controller
 
         // can be null
         try {
+            // RPC bypasses the controller gate, so per-method authorization is enforced here:
+            // a #[RequiresPermission] on the resolved service method is checked before the call.
+            // A denial throws AuthorizationException, mapped below to JSON-RPC -32001.
+            $this->permissionEnforcer->enforce($serviceName, $methodName, is_array($paramsFromRequest) ? $paramsFromRequest : []);
+
             $method_response = app()->make($serviceName)->$methodName(...$preparedParams);
         } catch (\Throwable $e) {
             // Leantime exceptions carry a client-safe code/message/data and map to a precise

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -85,6 +85,7 @@ class Install
         // 30503 (zp_device_tokens) intentionally skipped — superseded by
         // 30504 which puts push columns on zp_access_tokens instead.
         30504,
+        30505,
     ];
 
     /**
@@ -2649,6 +2650,80 @@ class Install
             Log::error('Migration 30504: '.$e->getMessage());
 
             return ['Migration 30504 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30505: Create the native permission engine tables (zp_roles,
+     * zp_permissions, zp_role_permissions — mirrors SchemaBuilder), then sync the
+     * discovered `domain.action` vocabulary and seed the six built-in roles with their
+     * default grants. Idempotent.
+     *
+     * @return bool|array Returns true on success, array of errors on failure
+     */
+    public function update_sql_30505(): bool|array
+    {
+        try {
+            // The legacy zp_roles rights table was dropped at update_sql_30002. If a stale
+            // copy survives on a very old install it lacks the 'level' column — replace it.
+            if (Schema::hasTable('zp_roles') && ! Schema::hasColumn('zp_roles', 'level')) {
+                Schema::drop('zp_roles');
+            }
+
+            if (! Schema::hasTable('zp_roles')) {
+                Schema::create('zp_roles', function (Blueprint $table) {
+                    $table->id();
+                    $table->string('name', 50);
+                    $table->string('displayName', 100)->nullable();
+                    $table->integer('level');
+                    $table->tinyInteger('isSystem')->default(0);
+                    $table->text('description')->nullable();
+                    $table->dateTime('createdOn')->nullable();
+                    $table->dateTime('modified')->nullable();
+
+                    $table->unique(['name'], 'idx_roles_name');
+                    $table->index(['level'], 'idx_roles_level');
+                });
+            }
+
+            if (! Schema::hasTable('zp_permissions')) {
+                Schema::create('zp_permissions', function (Blueprint $table) {
+                    $table->id();
+                    $table->string('permissionKey', 150);
+                    $table->string('domain', 60);
+                    $table->string('action', 100);
+                    $table->string('label', 191)->nullable();
+                    $table->tinyInteger('isProjectScoped')->default(1);
+                    $table->dateTime('createdOn')->nullable();
+                    $table->dateTime('modified')->nullable();
+
+                    $table->unique(['permissionKey'], 'idx_permissions_key');
+                    $table->index(['domain'], 'idx_permissions_domain');
+                });
+            }
+
+            if (! Schema::hasTable('zp_role_permissions')) {
+                Schema::create('zp_role_permissions', function (Blueprint $table) {
+                    $table->id();
+                    $table->unsignedBigInteger('roleId');
+                    $table->unsignedBigInteger('permissionId');
+
+                    $table->unique(['roleId', 'permissionId'], 'idx_role_permissions_unique');
+                    $table->index(['roleId'], 'idx_role_permissions_roleId');
+                    $table->index(['permissionId'], 'idx_role_permissions_permissionId');
+                });
+            }
+
+            // Populate the vocabulary, then grant the built-in roles their defaults.
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30505: '.$e->getMessage());
+
+            return ['Migration 30505 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Install/Services/SchemaBuilder.php
+++ b/app/Domain/Install/Services/SchemaBuilder.php
@@ -58,6 +58,9 @@ class SchemaBuilder
         $this->createJobsTable();
         $this->createRecurringPatternsTable();
         $this->createWorkStructureTables();
+        $this->createRolesTable();
+        $this->createPermissionsTable();
+        $this->createRolePermissionsTable();
     }
 
     /**
@@ -647,6 +650,68 @@ class SchemaBuilder
         Schema::create('zp_settings', function (Blueprint $table) {
             $table->string('key', 175)->primary();
             $table->text('value')->nullable();
+        });
+    }
+
+    /**
+     * Create zp_roles table — the DB-backed role definitions for the native
+     * permission engine. Ships the six built-in roles (seeded separately) and is
+     * extensible with custom roles. `level` preserves the legacy "at least"
+     * hierarchy (5..50); `isSystem` flags the built-ins as protected.
+     */
+    private function createRolesTable(): void
+    {
+        Schema::create('zp_roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50);
+            $table->string('displayName', 100)->nullable();
+            $table->integer('level');
+            $table->tinyInteger('isSystem')->default(0);
+            $table->text('description')->nullable();
+            $table->dateTime('createdOn')->nullable();
+            $table->dateTime('modified')->nullable();
+
+            $table->unique(['name'], 'idx_roles_name');
+            $table->index(['level'], 'idx_roles_level');
+        });
+    }
+
+    /**
+     * Create zp_permissions table — the `domain.action` vocabulary, synced from each
+     * domain's ProvidesPermissions declarations by `permissions:sync`. `isProjectScoped`
+     * marks capabilities evaluated against a project's role vs company-wide.
+     */
+    private function createPermissionsTable(): void
+    {
+        Schema::create('zp_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('permissionKey', 150);
+            $table->string('domain', 60);
+            $table->string('action', 100);
+            $table->string('label', 191)->nullable();
+            $table->tinyInteger('isProjectScoped')->default(1);
+            $table->dateTime('createdOn')->nullable();
+            $table->dateTime('modified')->nullable();
+
+            $table->unique(['permissionKey'], 'idx_permissions_key');
+            $table->index(['domain'], 'idx_permissions_domain');
+        });
+    }
+
+    /**
+     * Create zp_role_permissions table — the many-to-many grant map linking roles to
+     * the permissions they hold. Edited by an administrator (future role-management UI).
+     */
+    private function createRolePermissionsTable(): void
+    {
+        Schema::create('zp_role_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('roleId');
+            $table->unsignedBigInteger('permissionId');
+
+            $table->unique(['roleId', 'permissionId'], 'idx_role_permissions_unique');
+            $table->index(['roleId'], 'idx_role_permissions_roleId');
+            $table->index(['permissionId'], 'idx_role_permissions_permissionId');
         });
     }
 

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -7,6 +7,7 @@ use DateTime;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Contracts\ChecksProjectAccess;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Events\EventDispatcher as EventCore;
 use Leantime\Core\Exceptions\AuthorizationException;
@@ -35,7 +36,7 @@ use Leantime\Domain\Wiki\Repositories\Wiki;
 use SVG\SVG;
 use Symfony\Component\HttpFoundation\Response;
 
-class Projects
+class Projects implements ChecksProjectAccess
 {
     use DispatchesEvents;
 
@@ -987,20 +988,21 @@ class Projects
     /**
      * Gets the role of a user in a specific project.
      *
-     * @param  mixed  $userId  The user ID.
-     * @param  mixed  $projectId  The project ID.
-     * @return mixed The role of the user in the project (string) or an empty string if the user is not assigned to the project or if the project role is not defined.
+     * @param  int  $userId  The user ID.
+     * @param  int  $projectId  The project ID.
+     * @return string The stored project-role key, or an empty string when the user has no
+     *                explicit role in the project (or is not assigned to it).
      *
      * @api
      */
-    public function getProjectRole($userId, $projectId): mixed
+    public function getProjectRole($userId, $projectId): string
     {
 
         $project = $this->projectRepository->getUserProjectRelation($userId, $projectId);
 
         if (is_array($project)) {
             if (isset($project[0]['projectRole']) && $project[0]['projectRole'] != '') {
-                return $project[0]['projectRole'];
+                return (string) $project[0]['projectRole'];
             } else {
                 return '';
             }

--- a/app/Domain/Tickets/Permissions/TicketsPermissions.php
+++ b/app/Domain/Tickets/Permissions/TicketsPermissions.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Tickets (to-do) permission vocabulary — the verbs only.
+ *
+ * Declares *what* can be done with tickets; it says nothing about *which roles* may do it.
+ * Role assignment is centrally owned (defaults in {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions},
+ * runtime assignments in `zp_role_permissions` / the admin UI). The typed constants are
+ * used at call sites (controllers, `@api` methods, `@can`, menu) so nobody types a raw string.
+ *
+ * All ticket capabilities are project-scoped — a ticket belongs to a project, so authority
+ * is the user's role *in that project* (see {@see \Leantime\Core\Auth\RoleResolver}).
+ */
+final class TicketsPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'tickets.view';
+
+    public const COMMENT = 'tickets.comment';
+
+    public const UPLOAD = 'tickets.upload';
+
+    public const CREATE = 'tickets.create';
+
+    public const EDIT = 'tickets.edit';
+
+    public const DELETE = 'tickets.delete';
+
+    public function domain(): string
+    {
+        return 'tickets';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View to-dos'),
+            new Permission(self::COMMENT, 'Comment on to-dos'),
+            new Permission(self::UPLOAD, 'Upload files to to-dos'),
+            new Permission(self::CREATE, 'Create to-dos'),
+            new Permission(self::EDIT, 'Edit to-dos'),
+            new Permission(self::DELETE, 'Delete to-dos'),
+        ];
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -340,3 +340,21 @@ if (! function_exists('get_release_version')) {
     }
 
 }
+
+if (! function_exists('can')) {
+
+    /**
+     * Whether the current user holds a `domain.action` permission, optionally scoped to a
+     * project. The permission-era replacement for `$login::userIsAtLeast(...)` in templates.
+     *
+     * In Blade prefer the @can directive (it routes through the same Gate bridge); use this
+     * helper in legacy .tpl.php templates and anywhere a plain boolean is handy:
+     *   <?php if (can('tickets.edit', $projectId)): ?> ... <?php endif; ?>
+     */
+    function can(string $permission, ?int $projectId = null): bool
+    {
+        return app()->make(\Leantime\Core\Auth\Permissions\PermissionService::class)
+            ->currentUserCan($permission, $projectId);
+    }
+
+}

--- a/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\app\Domain\Api\Controllers;
 
 use Leantime\Core\Application;
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
 use Leantime\Core\Bootstrap\LoadConfig;
 use Leantime\Core\Bootstrap\SetRequestForConsole;
 use Leantime\Core\Language;
@@ -31,6 +32,12 @@ class JsonrpcTest extends \Unit\TestCase
         $this->app['view'] = $this->createMock(\Illuminate\View\Factory::class);
         $this->app['session'] = $this->createMock(\Illuminate\Session\SessionManager::class);
         $this->app->bootstrapWith([LoadConfig::class, SetRequestForConsole::class]);
+
+        // Jsonrpc::init() now type-hints PermissionEnforcer (resolved via app()->call in the
+        // base Controller constructor). Bind a no-op mock so the controller builds without
+        // pulling in the full permission engine (PermissionService -> Repository -> Db), which
+        // this minimal test container can't resolve. These tests don't exercise authorization.
+        $this->app->instance(PermissionEnforcer::class, $this->createMock(PermissionEnforcer::class));
 
         $this->template = $this->createMock(Template::class);
         $language = $this->createMock(Language::class);


### PR DESCRIPTION
## Summary

**Phase 0 (foundation)** of the service-layer / permission overhaul: a **native, DB-backed permission engine** (no Spatie, no Eloquent) establishing one `domain.action` vocabulary spoken by **JSON-RPC, controllers, and the service layer**, plus a thin service contract.

> **Additive and inert by default.** Enforcement is attribute-driven and **audit / log-only** until a method carries `#[RequiresPermission]` (none do yet). It changes no runtime authorization behavior on its own — it's the scaffolding the per-domain rollout (Phase 1+) builds on. Also includes a **separable console bugfix** (below).

## Design

**Permission vocabulary vs. assignment are separated (Spatie-style).**
- A domain's permission class declares only its **verbs** — `TicketsPermissions`: `view/comment/upload/create/edit/delete`. No role information.
- `Core/Auth/Permissions/DefaultRolePermissions` is the **single central** place the six built-in roles' default grants live (matched against the catalog by scope + verb, unioned up the hierarchy). After install, `zp_role_permissions` / the future admin UI own assignments — domains are never touched to re-assign.

**Engine — `app/Core/Auth/`, wired by a dedicated `PermissionServiceProvider`.**
- `RoleResolver` — effective-role resolution incl. **project-scoped** (mirrors `Tickets::userIsAtLeastForProject`), so authz resolves against the **entity's** project, not the session project.
- `PermissionService` — `currentUserCan()`/`authorize()`; cached role→permission map; capability kept distinct from project data-access.
- **All dependencies are constructor-injected — no `app()` in engine classes.** The engine depends on a narrow `ChecksProjectAccess` contract (Core), implemented by `Projects` and bound in the provider.

**Enforcement covers both routing paths, with no base-class coupling.**
- `#[RequiresPermission]` is read by a shared `PermissionEnforcer`, injected into `Frontcontroller::executeAction` (legacy convention path) and applied to **all native Laravel routes** via a `CheckPermissions` middleware wired in `RouteLoader`. JSON-RPC enforces it in `Jsonrpc` (enforcer injected via `init()`). Denial throws the existing `AuthorizationException` → 403 web / RPC `-32001`.

**Service contract.** `DomainService` → thin marker; new `BaseService` (`authorize/can/validate`). `BaseService` receives `PermissionService` via the provider's `afterResolving` hook — zero subclass constructor boilerplate, no `app()`.

**Templates.** `@can('tickets.edit', $projectId)` works via a `Gate::before` bridge; a `can()` helper covers legacy `.tpl.php`.

**Schema.** `zp_roles` / `zp_permissions` / `zp_role_permissions` via `SchemaBuilder` + idempotent `Install::update_sql_30505` + `dbVersion 3.5.5`. User→role stays on `zp_user.role` (no data migration); `zp_roles.level` preserves the legacy hierarchy.

## Console bugfix (separable — affects ALL `#[AsCommand]` commands)

`symfony/console` **7.4** renamed `add()` → `addCommand()` and routes lazy `#[AsCommand]` loading through `addCommand()`; `laravel/framework` **11.45** only overrides the deprecated `add()` (where the sole `setLaravel()` lives). Every lazily-loaded command (`cache:clearAll`, `db:migrate`, `permissions:sync`) crashed with `make() on null`. Fixed by overriding `addCommand()` in `Core/Console/Application`.

## Verification

- ✅ Pint + PHPStan (level 0) green across all 28 changed files.
- ✅ App boots; `db:migrate` runs `update_sql_30505`; `permissions:sync --seed` works.
- ✅ Clean reseed (truncate → seed) via `DefaultRolePermissions` produces the documented matrix from scratch: 6 roles (levels 5→50), 6 permissions, 28 grants; `tickets.view` → all roles, `tickets.create`/`delete` → editor+.

## Notes for reviewers

- Migration is **`30505`** (after `origin/master`'s `30504`; `30503` was intentionally burned by the device-tokens work).
- `BaseService` adoption across existing services is a mechanical follow-up sweep (single-inheritance conflicts, e.g. Canvas variants, handled there); this PR establishes the base + DI.
- The console fix is logically independent — happy to split into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
