### PR TITLE
fix(tickets): ticket modal crashes on milestone type

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -80,7 +80,7 @@ class Tickets
 
     public array $type = ['task', 'subtask', 'story', 'bug'];
 
-    public array $typeIcons = ['story' => 'fa-book', 'task' => 'fa-check-square', 'subtask' => 'fa-diagram-successor', 'bug' => 'fa-bug'];
+    public array $typeIcons = ['story' => 'fa-book', 'task' => 'fa-check-square', 'subtask' => 'fa-diagram-successor', 'bug' => 'fa-bug', 'milestone' => 'fa-flag'];
 
     /**
      * @var bool

--- a/app/Domain/Tickets/Templates/showTicketModal.blade.php
+++ b/app/Domain/Tickets/Templates/showTicketModal.blade.php
@@ -23,7 +23,7 @@ $todoTypeIcons = $ticketTypeIcons ?? [];
         <small><a href="#/tickets/showTicket/<?= $ticket->dependingTicketId ?>"><?= $tpl->escape($ticket->parentHeadline) ?></a></small> //
     <?php } ?>
     <small class="tw-float-right tw-pr-md" style="padding:5px 30px 0px 0px">Created by <?php $tpl->e($ticket->userFirstname); ?> <?php $tpl->e($ticket->userLastname); ?> | Last Updated: <?= format($ticket->date)->date(); ?> </small>
-    <h1 class="tw-mb-0" style="margin-bottom:0px;"><i class="fa <?php echo $todoTypeIcons[strtolower($ticket->type)]; ?>"></i> #<?= $ticket->id ?> - <?php $tpl->e($ticket->headline); ?></h1>
+    <h1 class="tw-mb-0" style="margin-bottom:0px;"><i class="fa <?php echo $todoTypeIcons[strtolower($ticket->type)] ?? 'fa-circle'; ?>"></i> #<?= $ticket->id ?> - <?php $tpl->e($ticket->headline); ?></h1>
 
     <br />
 


### PR DESCRIPTION
## Summary

Pre-existing core bug surfaced while testing cross-entity navigation from a Logic Model canvas. Opening any milestone-type ticket via the modal route (\`#/tickets/showTicket/{id}\`) throws \`Undefined array key \"milestone\"\` and the modal fails to render entirely.

## Root cause

\`showTicketModal.blade.php\` line 26 renders the ticket icon as:

\`\`\`php
<i class=\"fa <?= \$todoTypeIcons[strtolower(\$ticket->type)] ?>\"></i>
\`\`\`

With no \`isset\` guard. The icon map in \`TicketsRepository\` (line 83) is:

\`\`\`php
['story' => 'fa-book', 'task' => 'fa-check-square', 'subtask' => 'fa-diagram-successor', 'bug' => 'fa-bug']
\`\`\`

Notably missing \`milestone\` — even though milestones are first-class entities (the milestone roadmap creates them, the StrategyPro wizard creates them, etc.). When a milestone ticket is opened in the modal, the array lookup fails and the whole modal crashes.

## Two-part fix

1. **Data fix** — Add \`'milestone' => 'fa-flag'\` to the typeIcons map. Milestone is a real type that needed a real icon.

2. **Defensive guard** — Null-coalescing fallback to \`fa-circle\` in the template so any future ticket type added without a map entry renders with a neutral icon rather than crashing the entire view:

\`\`\`php
<i class=\"fa <?= \$todoTypeIcons[strtolower(\$ticket->type)] ?? 'fa-circle' ?>\"></i>
\`\`\`

## Test plan

- [x] **Open a milestone ticket via the modal route** — \`#/tickets/showTicket/{id}\` where the ticket has \`type='milestone'\`. Modal renders cleanly with the flag icon. Verified locally with ticket 39.
- [x] **Other ticket types unaffected** — task/story/bug tickets still render with their existing icons (no template behaviour change for the happy path).
- [x] **Pint passes** on both touched files.

## Files changed

- \`app/Domain/Tickets/Repositories/Tickets.php\` — one map entry added
- \`app/Domain/Tickets/Templates/showTicketModal.blade.php\` — null-coalescing fallback

## How this surfaced

A separate plugin PR (\`Leantime/plugins#44\`) makes the wizard-generated entity pills on each Logic Model canvas item clickable. Pills route to \`#/tickets/showTicket/{id}\` for tasks AND milestones — which is when this latent core bug became user-visible. The fix is unrelated to the plugin work; it stands on its own as a small core hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)