### PR TITLE
feat(permissions): enforce Tickets + Comments via the engine — full @api coverage

### DIFF
--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -47,11 +47,19 @@ final class DefaultRolePermissions
      * Each rule: scope = project|global|any; verbs = list of last-segment verbs or ['*'];
      * exclude = exact keys or 'prefix.*' globs removed from the match.
      *
-     * @var array<string, array<int, array{scope: string, verbs: array<int, string>, exclude?: array<int, string>}>>
+     * A rule grants by `verbs` (the convention) OR by explicit `keys` (for permissions that
+     * don't follow the verb convention).
+     *
+     * @var array<string, array<int, array{scope: string, verbs?: array<int, string>, keys?: array<int, string>, exclude?: array<int, string>}>>
      */
     private const GRANTS = [
         'readonly' => [['scope' => 'project', 'verbs' => ['view']]],
-        'commenter' => [['scope' => 'project', 'verbs' => ['comment', 'upload']]],
+        'commenter' => [
+            ['scope' => 'project', 'verbs' => ['comment', 'upload']],
+            // Commenting via the Comments domain: the 'create' verb otherwise seeds at
+            // editor+, but a commenter is allowed to add comments — grant the key explicitly.
+            ['scope' => 'project', 'keys' => ['comments.create']],
+        ],
         'editor' => [['scope' => 'project', 'verbs' => ['create', 'edit', 'delete']]],
         'manager' => [['scope' => 'project', 'verbs' => ['*']]],
         'admin' => [['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']]],
@@ -109,7 +117,7 @@ final class DefaultRolePermissions
     }
 
     /**
-     * @param  array{scope: string, verbs: array<int, string>, exclude?: array<int, string>}  $rule
+     * @param  array{scope: string, verbs?: array<int, string>, keys?: array<int, string>, exclude?: array<int, string>}  $rule
      */
     private static function matches(Permission $permission, array $rule): bool
     {
@@ -120,8 +128,13 @@ final class DefaultRolePermissions
             return false;
         }
 
+        // Explicit key allow-list (for permissions that don't follow the verb convention).
+        if (isset($rule['keys'])) {
+            return in_array($permission->key, $rule['keys'], true);
+        }
+
         $verb = Str::afterLast($permission->key, '.');
-        if ($rule['verbs'] !== ['*'] && ! in_array($verb, $rule['verbs'], true)) {
+        if (($rule['verbs'] ?? []) !== ['*'] && ! in_array($verb, $rule['verbs'] ?? [], true)) {
             return false;
         }
 

--- a/app/Core/Auth/Permissions/PermissionEnforcer.php
+++ b/app/Core/Auth/Permissions/PermissionEnforcer.php
@@ -45,7 +45,18 @@ class PermissionEnforcer
             return;
         }
 
-        if ($this->permissions->currentUserCan($attribute->permission, $this->resolveProjectId($attribute, $params))) {
+        // Entity-scoped: the method loads the entity and authorizes its project in its own
+        // body (the enforcer can't see the entity's project here). The attribute is just the
+        // declared-coverage marker; defer to the in-method $this->authorize() call.
+        if ($attribute->entityScoped) {
+            return;
+        }
+
+        $allowed = $attribute->global
+            ? $this->permissions->currentUserCan($attribute->permission, null, true)
+            : $this->permissions->currentUserCan($attribute->permission, $this->resolveProjectId($attribute, $params));
+
+        if ($allowed) {
             return;
         }
 

--- a/app/Core/Auth/Permissions/RequiresPermission.php
+++ b/app/Core/Auth/Permissions/RequiresPermission.php
@@ -19,13 +19,17 @@ use Attribute;
  * global handler renders as 403 on the web and `JsonRpcErrorResponse::fromException`
  * maps to RPC error -32001.
  *
- * For project-scoped permissions, set {@see $projectIdParam} to the name of the
- * request/method parameter carrying the project id so the check resolves the role
- * against the entity's project rather than the session project. When omitted, the
- * enforcer falls back to the current session project (`session('currentProject')`).
- *
- * Contextual checks that depend on runtime data (ownership, cross-project ids resolved
- * from a loaded entity) belong in the method body via `$this->authorize(...)`, not here.
+ * How the project scope is resolved (mutually informative):
+ *  - `projectIdParam: 'projectId'` — the enforcer reads that request param and runs the
+ *    full project-scoped check. Use when the project id is a clean top-level argument.
+ *  - `global: true` — a company-wide capability (users/clients/settings); the enforcer
+ *    checks against the global role, not a project.
+ *  - `entityScoped: true` — the project comes from an entity the method loads itself
+ *    (e.g. `$ticket->projectId`), which the enforcer can't see beforehand. The attribute is
+ *    then a declared-coverage marker and the method body MUST call
+ *    `$this->authorize($perm, $entity->projectId)` to do the precise check.
+ *  - none of the above — falls back to the current session project (`session('currentProject')`),
+ *    appropriate for session-scoped views.
  */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class RequiresPermission
@@ -33,11 +37,15 @@ final class RequiresPermission
     /**
      * @param  string  $permission  The required `domain.action` key (use a domain
      *                              permission constant, e.g. `TicketsPermissions::CREATE`).
-     * @param  string|null  $projectIdParam  Name of the parameter holding the project id
-     *                                       for project-scoped checks; null = session project.
+     * @param  string|null  $projectIdParam  Name of the request param holding the project id.
+     * @param  bool  $global  Company-wide capability — check the global role, not a project.
+     * @param  bool  $entityScoped  Project is derived from an entity the method loads; the
+     *                              enforcer defers and the method self-authorizes in its body.
      */
     public function __construct(
         public readonly string $permission,
         public readonly ?string $projectIdParam = null,
+        public readonly bool $global = false,
+        public readonly bool $entityScoped = false,
     ) {}
 }

--- a/app/Core/Configuration/DefaultConfig.php
+++ b/app/Core/Configuration/DefaultConfig.php
@@ -82,6 +82,16 @@ class DefaultConfig
     public int|bool $debug = 0;
 
     /**
+     * @var bool When true, a denied #[RequiresPermission] attribute blocks the request
+     *           (403 web / JSON-RPC -32001). When false the central enforcer only LOGS the
+     *           would-be denial (audit mode), so permission coverage can be rolled out and
+     *           observed before being enforced. In-method $this->authorize() calls always
+     *           enforce regardless of this flag.
+     */
+    #[LaravelConfig('permissions.enforce')]
+    public bool $permissionsEnforce = true;
+
+    /**
      * @var string editor used for code editing
      */
     public string $editor = 'phpstorm';

--- a/app/Domain/Comments/Permissions/CommentsPermissions.php
+++ b/app/Domain/Comments/Permissions/CommentsPermissions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Comments\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Comments permission vocabulary — verbs only.
+ *
+ * Comments are project-scoped (a comment lives on a project-owned entity). Note the
+ * distinct `moderate` verb: editing/deleting *someone else's* comment is a manager+
+ * capability (the matrix grants `moderate` only via `manager: project *`), while the
+ * author always edits/deletes their own via the ownership check in the service. Keeping a
+ * dedicated `moderate` verb avoids over-granting (a `comments.edit` would seed at editor+).
+ */
+final class CommentsPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'comments.view';
+
+    public const CREATE = 'comments.create';
+
+    /** Edit/delete ANY comment (not your own) — manager+. Authors bypass via ownership. */
+    public const MODERATE = 'comments.moderate';
+
+    public function domain(): string
+    {
+        return 'comments';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View comments'),
+            new Permission(self::CREATE, 'Add comments'),
+            new Permission(self::MODERATE, 'Moderate (edit/delete) any comment'),
+        ];
+    }
+}

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -3,6 +3,7 @@
 namespace Leantime\Domain\Comments\Services;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Comments\Permissions\CommentsPermissions;
@@ -66,6 +67,7 @@ class Comments extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::VIEW)]
     public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
     {
         return $this->commentRepository->getComments($module, $entityId, $parent, $commentOrder);
@@ -76,6 +78,7 @@ class Comments extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function addComment($values, $module, $entityId, $entity = null): bool
     {
         // RPC callers (mobile) typically don't pre-load the entity — they
@@ -205,6 +208,7 @@ class Comments extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function editComment($values, $id): bool
     {
         if (! $this->canModifyComment((int) $id)) {
@@ -219,6 +223,7 @@ class Comments extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function deleteComment($commentId): bool
     {
         if (! $this->canModifyComment((int) $commentId)) {
@@ -232,8 +237,6 @@ class Comments extends BaseService
      * @param  ?int  $projectId  Project ID
      * @param  ?int  $moduleId  Id of the entity to pull comments from
      * @return array
-     *
-     * @api
      */
     public function pollComments(?int $projectId = null, ?int $moduleId = null): array|false
     {
@@ -268,6 +271,7 @@ class Comments extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE)]
     public function toggleCommentReaction(int $userId, int $commentId, string $reaction): bool
     {
         // Validate reaction against known types
@@ -313,6 +317,7 @@ class Comments extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::VIEW)]
     public function getCommentReactions(int $commentId, int $userId): array
     {
         // Get reactions with user names for tooltips

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -3,9 +3,9 @@
 namespace Leantime\Domain\Comments\Services;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language as LanguageCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Comments\Permissions\CommentsPermissions;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Notifications\Models\Notification;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -14,7 +14,7 @@ use Leantime\Domain\Reactions\Services\Reactions as ReactionsService;
 /**
  * @api
  */
-class Comments
+class Comments extends BaseService
 {
     private CommentRepository $commentRepository;
 
@@ -84,6 +84,14 @@ class Comments
         if ($entity === null && $module && $entityId) {
             $entity = $this->loadEntityForComment($module, (int) $entityId);
         }
+
+        // Commenting is a commenter+ capability. Resolve the host entity's project so the
+        // check is scoped to it (ticket -> projectId; project -> its own id), then authorize.
+        $projectId = is_object($entity) && isset($entity->projectId)
+            ? (int) $entity->projectId
+            : ($module === 'project' ? (int) $entityId : null);
+
+        $this->authorize(CommentsPermissions::CREATE, $projectId);
 
         // Default father (parent comment id) to 0 if not provided. The
         // original code REQUIRED it via isset(), which forced every caller
@@ -180,17 +188,14 @@ class Comments
 
         $currentUserId = session('userdata.id');
 
-        // Comment author can always modify their own comment
+        // Comment author can always modify their own comment.
         if ((int) $comment['userId'] === (int) $currentUserId) {
             return true;
         }
 
-        // Managers and above can modify any comment
-        if (Auth::userIsAtLeast(Roles::$manager)) {
-            return true;
-        }
-
-        return false;
+        // Otherwise moderation (editing/deleting someone else's comment) is a manager+
+        // capability, expressed as the comments.moderate permission.
+        return $this->can(CommentsPermissions::MODERATE);
     }
 
     /**

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -237,7 +237,10 @@ class Comments extends BaseService
      * @param  ?int  $projectId  Project ID
      * @param  ?int  $moduleId  Id of the entity to pull comments from
      * @return array
+     *
+     * @api
      */
+    #[RequiresPermission(CommentsPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollComments(?int $projectId = null, ?int $moduleId = null): array|false
     {
 

--- a/app/Domain/Comments/Templates/submodules/generalComment.blade.php
+++ b/app/Domain/Comments/Templates/submodules/generalComment.blade.php
@@ -66,12 +66,12 @@
                                             </a>
 
                                             <ul class="dropdown-menu">
-                                                @if (($row['userId'] == session('userdata.id')) || $login::userIsAtLeast($roles::$manager))
+                                                @if (($row['userId'] == session('userdata.id')) || can('comments.moderate'))
                                                     <li><a href="{{ $deleteUrlBase . $row['id'] }}" class="deleteComment formModal">
                                                         <span class="fa fa-trash"></span> {!! __('links.delete') !!}
                                                     </a></li>
                                                 @endif
-                                                @if (($row['userId'] == session('userdata.id')) || $login::userIsAtLeast($roles::$manager))
+                                                @if (($row['userId'] == session('userdata.id')) || can('comments.moderate'))
                                                     <li>
                                                         <a href="javascript:void(0);" onclick="toggleCommentBoxes({{ $row['id'] }}, null, '{{ $formHash }}', true)">
                                                             <span class="fa fa-edit"></span> {!! __('label.edit') !!}

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -257,6 +257,13 @@ class Install
             $schemaBuilder->createAllTables();
             $schemaBuilder->insertInitialData($values, $pwReset);
 
+            // Seed the permission engine for fresh installs: sync the domain-declared
+            // vocabulary into zp_permissions and grant the built-in roles their defaults.
+            // (update_sql_* seeds existing installs; this covers the fresh-install path.)
+            $permissionSeeder = app()->make(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $permissionSeeder->syncDiscoveredPermissions();
+            $permissionSeeder->seedBuiltInRoles();
+
             return true;
         } catch (\Exception $e) {
             Log::error($e);

--- a/app/Domain/Tickets/Controllers/DelMilestone.php
+++ b/app/Domain/Tickets/Controllers/DelMilestone.php
@@ -3,10 +3,10 @@
 namespace Leantime\Domain\Tickets\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -16,21 +16,15 @@ class DelMilestone extends Controller
 
     public function init(TicketService $ticketService): void
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->ticketService = $ticketService;
     }
 
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::DELETE)]
     public function get(): Response
     {
-        // Only admins
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return $this->tpl->displayPartial('errors.error403');
-        }
-
         if (! isset($_GET['id'])) {
             return $this->tpl->displayPartial('errors.error404', responseCode: 404);
         }
@@ -45,14 +39,11 @@ class DelMilestone extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::DELETE)]
     public function post($params): Response
     {
         if (! isset($_GET['id'], $params['del'])) {
             return $this->tpl->displayPartial('errors.error404', responseCode: 404);
-        }
-
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return $this->tpl->displayPartial('errors.error403', responseCode: 403);
         }
 
         if ($result = $this->ticketService->deleteMilestone($id = (int) ($_GET['id']))) {

--- a/app/Domain/Tickets/Controllers/DelTicket.php
+++ b/app/Domain/Tickets/Controllers/DelTicket.php
@@ -2,10 +2,10 @@
 
 namespace Leantime\Domain\Tickets\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,57 +15,41 @@ class DelTicket extends Controller
 
     public function init(TicketService $ticketService): void
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->ticketService = $ticketService;
     }
 
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(TicketsPermissions::DELETE)]
     public function get(): Response
     {
-
-        // Only admins
-        if (Auth::userIsAtLeast(Roles::$editor)) {
-
-            if (isset($_GET['id'])) {
-                $id = (int) ($_GET['id']);
-
-                try {
-
-                    $this->ticketService->canDelete($id);
-
-                } catch (\Exception $e) {
-
-                    $this->tpl->assign('error', $e->getMessage());
-
-                    return $this->tpl->displayPartial('tickets.delTicket');
-                }
-
-                $this->tpl->assign('error', '');
-                $this->tpl->assign('ticket', $this->ticketService->getTicket($id));
-
-                return $this->tpl->displayPartial('tickets.delTicket');
-
-            } else {
-                return $this->tpl->display('errors.error404', responseCode: 404);
-            }
-        } else {
-            return $this->tpl->display('errors.error403', responseCode: 403);
+        if (! isset($_GET['id'])) {
+            return $this->tpl->display('errors.error404', responseCode: 404);
         }
+
+        $id = (int) $_GET['id'];
+
+        try {
+            $this->ticketService->canDelete($id);
+        } catch (\Exception $e) {
+            $this->tpl->assign('error', $e->getMessage());
+
+            return $this->tpl->displayPartial('tickets.delTicket');
+        }
+
+        $this->tpl->assign('error', '');
+        $this->tpl->assign('ticket', $this->ticketService->getTicket($id));
+
+        return $this->tpl->displayPartial('tickets.delTicket');
     }
 
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(TicketsPermissions::DELETE)]
     public function post($params): Response
     {
-        // Only admins
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return $this->tpl->display('errors.error403', responseCode: 403);
-        }
-
         if (! isset($params['del'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }

--- a/app/Domain/Tickets/Controllers/MoveTicket.php
+++ b/app/Domain/Tickets/Controllers/MoveTicket.php
@@ -3,11 +3,11 @@
 namespace Leantime\Domain\Tickets\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller as FrontcontrollerCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,8 +21,6 @@ class MoveTicket extends Controller
         TicketService $ticketService,
         ProjectService $projectService
     ): void {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->ticketService = $ticketService;
         $this->projectService = $projectService;
     }
@@ -30,6 +28,7 @@ class MoveTicket extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::EDIT)]
     public function get($params): Response
     {
         $ticketId = $params['id'] ?? '';
@@ -51,6 +50,7 @@ class MoveTicket extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::EDIT)]
     public function post($params): Response
     {
         if (! empty($ticketId = (int) $_GET['id'] ?? null) && ! empty($projectId = (int) $params['projectId'] ?? null)) {

--- a/app/Domain/Tickets/Controllers/NewTicket.php
+++ b/app/Domain/Tickets/Controllers/NewTicket.php
@@ -3,16 +3,16 @@
 namespace Leantime\Domain\Tickets\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Support\FromFormat;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Files\Services\Files as FileService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
+use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users as UserService;
@@ -43,8 +43,6 @@ class NewTicket extends Controller
         TimesheetService $timesheetService,
         UserService $userService
     ): void {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->projectService = $projectService;
         $this->ticketService = $ticketService;
         $this->sprintService = $sprintService;
@@ -61,6 +59,7 @@ class NewTicket extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::CREATE)]
     public function get(): Response
     {
         $ticket = app()->make(TicketModel::class, [
@@ -105,6 +104,7 @@ class NewTicket extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(TicketsPermissions::CREATE)]
     public function post($params): Response
     {
         if (isset($params['saveTicket']) || isset($params['saveAndCloseTicket'])) {

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Exceptions\NotFoundException;
@@ -29,6 +30,7 @@ use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
+use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Repositories\TicketHistory;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
@@ -37,7 +39,7 @@ use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 /**
  * @api
  */
-class Tickets
+class Tickets extends BaseService
 {
     use DispatchesEvents;
 
@@ -2068,9 +2070,10 @@ class Tickets
             'collaborators' => $values['collaborators'] ?? [],
         ];
 
-        if (! $this->projectService->isUserAssignedToProject(session('userdata.id'), $values['projectId'])) {
-            return ['msg' => 'notifications.ticket_save_error_no_access', 'type' => 'error'];
-        }
+        // Editor+ role in the target project AND access to it (engine combines capability +
+        // project membership). Replaces the previous access-only check, which let any
+        // assigned role create via RPC.
+        $this->authorize(TicketsPermissions::CREATE, (int) $values['projectId']);
 
         if ($values['headline'] === '') {
             return ['msg' => 'notifications.ticket_save_error_no_headline', 'type' => 'error'];
@@ -2401,18 +2404,15 @@ class Tickets
      */
     public function patchTicket(int $id, array $values): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            throw new AuthorizationException('You are not allowed to edit tasks.');
-        }
-
+        // getTicket() returns false when the user can't access the ticket's project.
         $ticket = $this->getTicket($id);
         if (! $ticket) {
             throw new NotFoundException('The task you tried to edit could not be found.');
         }
 
-        if (! $this->projectService->isUserAssignedToProject(session('userdata.id'), $ticket->projectId)) {
-            throw new AuthorizationException('You are not allowed to edit this task.');
-        }
+        // Editor+ in the ticket's project (project-scoped role, not the session role) AND
+        // access to it. Replaces the prior session-scoped userIsAtLeast + assignment checks.
+        $this->authorize(TicketsPermissions::EDIT, (int) $ticket->projectId);
 
         return $this->patch($id, $values);
     }
@@ -3240,9 +3240,12 @@ class Tickets
 
         $ticket = $this->getTicket($id);
 
-        if (! $ticket || ! $this->projectService->isUserAssignedToProject(session('userdata.id'), $ticket->projectId)) {
+        if (! $ticket) {
             return ['msg' => 'notifications.ticket_delete_error', 'type' => 'error'];
         }
+
+        // Editor+ in the ticket's project AND access to it (was access-only, no role gate).
+        $this->authorize(TicketsPermissions::DELETE, (int) $ticket->projectId);
 
         // Collaborator relationship rows are cleaned up inside the repository's delticket().
         if ($this->ticketRepository->delticket($id)) {
@@ -3286,9 +3289,12 @@ class Tickets
 
         $ticket = $this->getTicket($id);
 
-        if (! $this->projectService->isUserAssignedToProject(session('userdata.id'), $ticket->projectId)) {
+        if (! $ticket) {
             return ['msg' => 'notifications.milestone_delete_error', 'type' => 'error'];
         }
+
+        // Editor+ in the milestone's project AND access to it (was access-only, no role gate).
+        $this->authorize(TicketsPermissions::DELETE, (int) $ticket->projectId);
 
         if ($this->ticketRepository->delMilestone($id)) {
             self::dispatchEvent('milestone_deleted');

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Events\DispatchesEvents;
@@ -95,6 +96,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getStatusLabels($projectId = null): array
     {
         return $this->ticketRepository->getStateLabels($projectId);
@@ -108,6 +110,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllStatusLabelsByUserId($userId): array
     {
         // Request-scoped memo: this is called repeatedly within a single dashboard
@@ -152,8 +155,8 @@ class Tickets extends BaseService
      * @params array $params label information
      *
      * @api
-     * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT)]
     public function saveStatusLabels($params): bool
     {
         if (isset($params['labelKeys']) && is_array($params['labelKeys']) && count($params['labelKeys']) > 0) {
@@ -184,6 +187,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getKanbanColumns(): array
     {
 
@@ -205,6 +209,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getTypeIcons(): array
     {
 
@@ -216,6 +221,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getEffortLabels(): array
     {
 
@@ -227,6 +233,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getTicketTypes(): array
     {
 
@@ -238,6 +245,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getPriorityLabels(): array
     {
 
@@ -355,6 +363,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function countSetFilters(array $searchCriteria): int
     {
         $count = 0;
@@ -382,6 +391,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getSetFilters(array $searchCriteria, bool $includeGroup = false): array
     {
         $setFilters = [];
@@ -417,6 +427,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAll(?array $searchCriteria = null, ?int $limit = null): array|false
     {
 
@@ -527,6 +538,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllOpenUserTickets(?int $userId = null, ?int $project = null): array
     {
 
@@ -579,6 +591,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getScheduledTasks(CarbonImmutable|string $dateFrom, CarbonImmutable|string $dateTo, ?int $userId)
     {
 
@@ -618,6 +631,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllGrouped($searchCriteria): array
     {
         $ticketGroups = [];
@@ -1014,6 +1028,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getStatusBreakdownBySwimlane(array $groupedTickets, array $statusColumns): array
     {
         $breakdown = [];
@@ -1088,6 +1103,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllPossibleParents(TicketModel $ticket, string $projectId = 'currentProject'): array
     {
 
@@ -1112,6 +1128,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getTicket($id): TicketModel|bool
     {
 
@@ -1165,6 +1182,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getLastTickets($projectId, int $limit = 5): bool|array
     {
 
@@ -1202,6 +1220,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getOpenUserTicketsThisWeekAndLater($userId, $projectId, bool $includeDoneTickets = false, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
@@ -1303,6 +1322,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getOpenUserTicketsByProject($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
@@ -1346,6 +1366,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getOpenUserTicketsByPriority($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
@@ -1404,6 +1425,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getOpenUserTicketsBySprint($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
@@ -1456,6 +1478,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllMilestones($searchCriteria, string $sortBy = 'standard'): array|false
     {
         if (is_array($searchCriteria) && $searchCriteria['currentProject'] > 0) {
@@ -1584,6 +1607,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllMilestonesOverview(bool $includeArchived = false, string $sortBy = 'duedate', bool $includeTasks = false, int $clientId = 0, array $searchCriteria = []): false|array
     {
 
@@ -1620,6 +1644,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllMilestonesByUserProjects($userId): array
     {
 
@@ -1663,6 +1688,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getMilestoneProgress(int|string $milestoneId): float
     {
 
@@ -1835,6 +1861,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllSubtasks(int $ticketId): false|array
     {
 
@@ -1862,10 +1889,13 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function quickAddTicket($params): array|bool|int
     {
 
         $projectId = $params['projectId'] ?? session('currentProject');
+
+        $this->authorize(TicketsPermissions::CREATE, $projectId !== null ? (int) $projectId : null);
 
         // Resolve the default status from the PROJECT's status config
         // rather than hardcoding `3`. The hardcoded `3` was the "New"
@@ -1966,14 +1996,18 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function quickAddMilestone(array $params): array|bool|int
     {
+        $projectId = $params['projectId'] ?? session('currentProject');
+
+        $this->authorize(TicketsPermissions::CREATE, $projectId !== null ? (int) $projectId : null);
 
         $values = [
             'headline' => $params['headline'],
             'type' => 'milestone',
             'description' => '',
-            'projectId' => $params['projectId'] ?? session('currentProject'),
+            'projectId' => $projectId,
             'editorId' => $params['editorId'] ?? session('userdata.id'),
             'userId' => session('userdata.id') ?? $params['userId'] ?? null,
             'date' => dtHelper()->userNow()->formatDateTimeForDb(),
@@ -2040,6 +2074,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function addTicket($values): array|int|bool
     {
         $values = [
@@ -2146,6 +2181,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function updateTicket($values): array|bool
     {
         // Server-side authorization. Editing is gated to editor+ in the UI, but the
@@ -2295,6 +2331,7 @@ class Tickets extends BaseService
      * (statusType === 'DONE' for the project). Used by mobile's
      * "Done" filter to show completed work.
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getAllDoneUserTickets(?int $userId = null, ?int $project = null): array
     {
         $tickets = $this->ticketRepository->simpleTicketQuery($userId, $project);
@@ -2331,12 +2368,15 @@ class Tickets extends BaseService
      * mobile's "Done" filter — tap the checked checkbox to bring a task
      * back into the active list.
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function markTicketReopen(int $id): bool
     {
         $ticket = $this->ticketRepository->getTicket($id);
         if (! $ticket || empty($ticket->projectId)) {
             return false;
         }
+
+        $this->authorize(TicketsPermissions::EDIT, (int) $ticket->projectId);
 
         $statusLabels = $this->ticketRepository->getStateLabels((int) $ticket->projectId);
         if (! is_array($statusLabels)) {
@@ -2402,6 +2442,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function patchTicket(int $id, array $values): bool
     {
         // getTicket() returns false when the user can't access the ticket's project.
@@ -2491,6 +2532,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function moveTicket(int $id, int $projectId): bool
     {
         $ticket = $this->getTicket($id);
@@ -2498,6 +2540,8 @@ class Tickets extends BaseService
         if (! $ticket) {
             return false;
         }
+
+        $this->authorize(TicketsPermissions::EDIT, (int) $ticket->projectId);
 
         if ($ticket->type == 'milestone') {
             $milestoneTickets = $this->getAll(['milestone' => $ticket->id]);
@@ -2526,6 +2570,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function quickUpdateMilestone($params): array|bool
     {
         if ($params['headline'] == '') {
@@ -2615,6 +2660,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getMilestone(int $id): TicketModel|bool
     {
         return $this->ticketRepository->getTicket($id);
@@ -2626,8 +2672,6 @@ class Tickets extends BaseService
      * one week from today.
      *
      * @return TicketModel The pre-populated milestone model.
-     *
-     * @api
      */
     public function getNewMilestone(): TicketModel
     {
@@ -2653,6 +2697,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission('comments.create', entityScoped: true)]
     public function addMilestoneComment(array $params, mixed $milestone): bool
     {
         $milestoneId = (int) $params['id'];
@@ -2706,6 +2751,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function updateMilestoneFromDialog(array $params): array|bool
     {
         $result = $this->quickUpdateMilestone($params);
@@ -2752,6 +2798,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function createMilestoneFromDialog(array $params): array|bool|int
     {
         $result = $this->quickAddMilestone($params);
@@ -2793,6 +2840,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getClientNameById(int $clientId): string
     {
         if ($clientId <= 0) {
@@ -2815,8 +2863,6 @@ class Tickets extends BaseService
      *
      * @param  array  $params  The incoming request params.
      * @return array The normalized params.
-     *
-     * @api
      */
     public function normalizeRoadmapParams(array $params): array
     {
@@ -2840,8 +2886,6 @@ class Tickets extends BaseService
      *
      * @param  array  $params  The incoming request params.
      * @return array The search criteria with the overview status default applied.
-     *
-     * @api
      */
     public function getMilestonesOverviewSearchCriteria(array $params): array
     {
@@ -2869,6 +2913,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function quickAddTicketFromKanban(array $formParams, ?string $swimlane, ?string $groupBy, bool $stayOpen = false): array
     {
         if ($swimlane !== null && $swimlane !== '' && ! empty($groupBy)) {
@@ -2938,8 +2983,10 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::CREATE, entityScoped: true)]
     public function upsertSubtask($values, $parentTicket): bool
     {
+        $this->authorize(TicketsPermissions::CREATE, (int) $parentTicket->projectId);
 
         $subtaskId = $values['subtaskId'] ?? 'new';
 
@@ -3003,6 +3050,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function sortTickets(array $params): bool
     {
         if (! Auth::userIsAtLeast(Roles::$editor)) {
@@ -3128,6 +3176,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function updateTicketStatusAndSorting($params, $handler = null): bool
     {
         if (! Auth::userIsAtLeast(Roles::$editor)) {
@@ -3235,6 +3284,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::DELETE, entityScoped: true)]
     public function delete($id): array|bool
     {
 
@@ -3284,6 +3334,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::DELETE, entityScoped: true)]
     public function deleteMilestone($id): array|bool
     {
 
@@ -3310,6 +3361,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getLastTicketViewUrl(): mixed
     {
 
@@ -3361,6 +3413,7 @@ class Tickets extends BaseService
     /**
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getGroupByFieldOptions(): array
     {
         // Alphabetically ordered (except "No Grouping" stays first as default)
@@ -3439,6 +3492,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getSortByFieldOptions(): array
     {
         return [
@@ -3502,6 +3556,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
     public function getNewFieldOptions(): array
     {
         if (! defined('BASE_URL')) {
@@ -4218,8 +4273,6 @@ class Tickets extends BaseService
      *
      * @param  array  $values  The values of the ticket fields.
      * @return array The values of the ticket fields after preparing the dates.
-     *
-     * @api
      */
     public function prepareTicketDates(&$values)
     {
@@ -4339,6 +4392,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function findMilestone(string $term, int $projectId)
     {
 
@@ -4365,6 +4419,7 @@ class Tickets extends BaseService
      *
      * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function findTicket(string $term, int $projectId, ?int $userId)
     {
 
@@ -4387,8 +4442,6 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  The ID of the project (optional)
      * @param  int|null  $userId  The ID of the user (optional)
      * @return array|false An array of milestones or false if an error occurred
-     *
-     * @api
      */
     public function pollForNewAccountMilestones(?int $projectId = null, ?int $userId = null): array|false
     {
@@ -4416,8 +4469,6 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  (optional) The ID of the project to filter milestones by.
      * @param  int|null  $userId  (optional) The ID of the user to filter milestones by.
      * @return array|false An array of milestones with prepared dates for API response, or false if an error occurs.
-     *
-     * @api
      */
     public function pollForUpdatedAccountMilestones(?int $projectId = null, ?int $userId = null): array|false
     {
@@ -4449,8 +4500,6 @@ class Tickets extends BaseService
      * @param  int|null  $userId  The ID of the user to filter the todos (optional).
      * @return array|false The retrieved todos as an array of associative arrays.
      *                     Returns false if an error occurs during retrieval.
-     *
-     * @api
      */
     public function pollForNewAccountTodos(?int $projectId = null, ?int $userId = null): array|false
     {
@@ -4476,8 +4525,6 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  The ID of the project (optional)
      * @param  int|null  $userId  The ID of the user (optional)
      * @return array|false An array of updated account todos or false if there was an error
-     *
-     * @api
      */
     public function pollForUpdatedAccountTodos(?int $projectId = null, ?int $userId = null): array|false
     {

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -4442,7 +4442,10 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  The ID of the project (optional)
      * @param  int|null  $userId  The ID of the user (optional)
      * @return array|false An array of milestones or false if an error occurred
+     *
+     * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForNewAccountMilestones(?int $projectId = null, ?int $userId = null): array|false
     {
         $todos = $this->ticketRepository->getAllBySearchCriteria(
@@ -4469,7 +4472,10 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  (optional) The ID of the project to filter milestones by.
      * @param  int|null  $userId  (optional) The ID of the user to filter milestones by.
      * @return array|false An array of milestones with prepared dates for API response, or false if an error occurs.
+     *
+     * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForUpdatedAccountMilestones(?int $projectId = null, ?int $userId = null): array|false
     {
         $milestones = $this->ticketRepository->getAllBySearchCriteria(
@@ -4500,7 +4506,10 @@ class Tickets extends BaseService
      * @param  int|null  $userId  The ID of the user to filter the todos (optional).
      * @return array|false The retrieved todos as an array of associative arrays.
      *                     Returns false if an error occurs during retrieval.
+     *
+     * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForNewAccountTodos(?int $projectId = null, ?int $userId = null): array|false
     {
         $todos = $this->ticketRepository->getAllBySearchCriteria(
@@ -4525,7 +4534,10 @@ class Tickets extends BaseService
      * @param  int|null  $projectId  The ID of the project (optional)
      * @param  int|null  $userId  The ID of the user (optional)
      * @return array|false An array of updated account todos or false if there was an error
+     *
+     * @api
      */
+    #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForUpdatedAccountTodos(?int $projectId = null, ?int $userId = null): array|false
     {
         $todos = $this->ticketRepository->getAllBySearchCriteria(

--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -351,7 +351,7 @@
 
     jQuery(document).ready(function(){
 
-    @if ($login::userIsAtLeast($roles::$editor))
+    @if (can('tickets.edit'))
         leantime.ticketsController.initUserDropdown();
         leantime.ticketsController.initMilestoneDropdown();
         leantime.ticketsController.initDueDateTimePickers();

--- a/app/Domain/Tickets/Templates/submodules/ticketNewBtn.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketNewBtn.blade.php
@@ -1,4 +1,4 @@
-@if ($login::userIsAtLeast($roles::$editor) && !empty($newField))
+@if (can('tickets.create') && !empty($newField))
     <div class="btn-group pull-left" style="margin-right:5px;">
         <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">{!! __('links.new_with_icon') !!} <span class="caret"></span></button>
         <ul class="dropdown-menu">

--- a/app/Domain/Tickets/Templates/submodules/ticketNewButton.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketNewButton.blade.php
@@ -1,4 +1,4 @@
-@if ($login::userIsAtLeast($roles::$editor) && !empty($newField))
+@if (can('tickets.create') && !empty($newField))
     <div class="btn-group">
         <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">{!! __('links.new_with_icon') !!} <span class="caret"></span></button>
         <ul class="dropdown-menu">

--- a/config/sample.env
+++ b/config/sample.env
@@ -8,6 +8,8 @@ LEAN_APP_DIR = ''                                  # Base of application without
 
 LEAN_DEBUG = 0                                     # Debug flag
 
+# LEAN_PERMISSIONS_ENFORCE = true                  # Enforce #[RequiresPermission] denials (403 / RPC -32001). Set false for audit/log-only mode.
+
 # Database
 LEAN_DB_HOST = 'localhost'                         # Database host
 LEAN_DB_USER = ''                                  # Database username

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit\app\Core\Auth\Permissions;
+
+use Leantime\Core\Auth\Permissions\DefaultRolePermissions;
+use Leantime\Core\Auth\Permissions\Permission;
+
+/**
+ * Locks the built-in role -> permission matrix against a representative catalog so a change
+ * to DefaultRolePermissions that would over- or under-grant a role fails loudly. This is the
+ * grant-equivalence guard for the pilot: it proves the seeded grants match the documented
+ * role capabilities (readonly view-only; commenter comment/upload; editor content CRUD;
+ * manager moderation + all project perms; admin everything-but-company-settings; owner all).
+ */
+class DefaultRolePermissionsTest extends \Unit\TestCase
+{
+    /** @return array<int, Permission> */
+    private function catalog(): array
+    {
+        return [
+            new Permission('tickets.view', 'View', true),
+            new Permission('tickets.comment', 'Comment', true),
+            new Permission('tickets.upload', 'Upload', true),
+            new Permission('tickets.create', 'Create', true),
+            new Permission('tickets.edit', 'Edit', true),
+            new Permission('tickets.delete', 'Delete', true),
+            new Permission('comments.view', 'View', true),
+            new Permission('comments.create', 'Create', true),
+            new Permission('comments.moderate', 'Moderate', true),
+            // Company-wide (not project-scoped):
+            new Permission('users.view', 'View users', false),
+            new Permission('company.settings.edit', 'Edit company settings', false),
+        ];
+    }
+
+    private function grantsFor(string $role): array
+    {
+        return DefaultRolePermissions::grantsFor($role, $this->catalog());
+    }
+
+    public function test_readonly_can_only_view_project_content(): void
+    {
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view'], $this->grantsFor('readonly'));
+    }
+
+    public function test_commenter_adds_comment_upload_and_can_create_comments(): void
+    {
+        $grants = $this->grantsFor('commenter');
+
+        $this->assertContains('tickets.view', $grants);     // inherited
+        $this->assertContains('tickets.comment', $grants);
+        $this->assertContains('tickets.upload', $grants);
+        $this->assertContains('comments.create', $grants);  // explicit commenter grant
+        $this->assertNotContains('tickets.create', $grants);
+        $this->assertNotContains('tickets.delete', $grants);
+        $this->assertNotContains('comments.moderate', $grants);
+    }
+
+    public function test_editor_gets_content_crud_but_not_moderation_or_company(): void
+    {
+        $grants = $this->grantsFor('editor');
+
+        $this->assertContains('tickets.create', $grants);
+        $this->assertContains('tickets.edit', $grants);
+        $this->assertContains('tickets.delete', $grants);
+        $this->assertContains('comments.create', $grants);    // inherited
+        $this->assertNotContains('comments.moderate', $grants); // manager+ only
+        $this->assertNotContains('users.view', $grants);        // company-wide, admin+
+        $this->assertNotContains('company.settings.edit', $grants);
+    }
+
+    public function test_manager_moderates_and_holds_all_project_perms_but_no_company(): void
+    {
+        $grants = $this->grantsFor('manager');
+
+        $this->assertContains('comments.moderate', $grants);
+        $this->assertContains('tickets.delete', $grants);
+        $this->assertNotContains('users.view', $grants);          // company-wide, admin+
+        $this->assertNotContains('company.settings.edit', $grants);
+    }
+
+    public function test_admin_gets_company_wide_except_company_settings(): void
+    {
+        $grants = $this->grantsFor('admin');
+
+        $this->assertContains('users.view', $grants);
+        $this->assertContains('comments.moderate', $grants);
+        $this->assertContains('tickets.delete', $grants);
+        $this->assertNotContains('company.settings.edit', $grants); // owner-only
+    }
+
+    public function test_owner_gets_everything_including_company_settings(): void
+    {
+        $grants = $this->grantsFor('owner');
+
+        $this->assertContains('company.settings.edit', $grants);
+        $this->assertContains('users.view', $grants);
+        $this->assertContains('comments.moderate', $grants);
+        $this->assertContains('tickets.delete', $grants);
+    }
+}

--- a/tests/Unit/app/Core/Auth/Permissions/PermissionEnforcerTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/PermissionEnforcerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\app\Core\Auth\Permissions;
+
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+
+/**
+ * Verifies the PermissionEnforcer resolves the project scope correctly for each
+ * RequiresPermission mode: entityScoped defers (the method self-authorizes its loaded entity),
+ * global checks the company-wide role, projectIdParam reads the named request param, and the
+ * default falls back to the session project. A method with no attribute is a complete no-op.
+ */
+class PermissionEnforcerTest extends \Unit\TestCase
+{
+    use \Codeception\Test\Feature\Stub;
+
+    /**
+     * Build an enforcer whose engine records every currentUserCan(...) call into $calls and
+     * answers $allow, so we can assert exactly what the enforcer asked the engine.
+     *
+     * @param  array<int, array{key: string, projectId: ?int, forceGlobal: bool}>  $calls
+     */
+    private function spyEnforcer(array &$calls, bool $allow = true): PermissionEnforcer
+    {
+        $permissions = $this->make(PermissionService::class, [
+            'currentUserCan' => function (string $key, ?int $projectId = null, ?bool $forceGlobal = false) use (&$calls, $allow): bool {
+                $calls[] = ['key' => $key, 'projectId' => $projectId, 'forceGlobal' => (bool) $forceGlobal];
+
+                return $allow;
+            },
+        ]);
+
+        return new PermissionEnforcer($permissions);
+    }
+
+    public function test_entity_scoped_defers_and_never_calls_the_engine(): void
+    {
+        // entityScoped methods authorize their loaded entity's project in their own body, so the
+        // enforcer must not run a check here (it can't see the entity, would use the wrong
+        // project). Even a denying engine must produce no call and no throw.
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls, allow: false);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'entityScopedAction', ['id' => 5]);
+
+        $this->assertSame([], $calls, 'entityScoped should defer to the in-method authorize()');
+    }
+
+    public function test_global_checks_company_role_not_a_project(): void
+    {
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'globalAction', []);
+
+        $this->assertSame([['key' => 'users.create', 'projectId' => null, 'forceGlobal' => true]], $calls);
+    }
+
+    public function test_project_id_param_is_read_from_the_named_argument(): void
+    {
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'paramAction', ['projectId' => 42]);
+
+        $this->assertSame([['key' => 'tickets.view', 'projectId' => 42, 'forceGlobal' => false]], $calls);
+    }
+
+    public function test_default_falls_back_to_the_session_project(): void
+    {
+        session(['currentProject' => 7]);
+
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'sessionAction', []);
+
+        $this->assertSame([['key' => 'tickets.view', 'projectId' => 7, 'forceGlobal' => false]], $calls);
+    }
+
+    public function test_unannotated_method_is_a_noop(): void
+    {
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls, allow: false);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'plainAction', []);
+
+        $this->assertSame([], $calls);
+    }
+}
+
+/**
+ * Fixture exercising each RequiresPermission resolution mode. Bodies are intentionally empty —
+ * only the attributes matter to the enforcer.
+ */
+class PermissionEnforcerFixture
+{
+    #[RequiresPermission('tickets.edit', entityScoped: true)]
+    public function entityScopedAction(int $id): void {}
+
+    #[RequiresPermission('users.create', global: true)]
+    public function globalAction(): void {}
+
+    #[RequiresPermission('tickets.view', projectIdParam: 'projectId')]
+    public function paramAction(int $projectId): void {}
+
+    #[RequiresPermission('tickets.view')]
+    public function sessionAction(): void {}
+
+    public function plainAction(): void {}
+}

--- a/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
@@ -14,6 +14,10 @@ use Leantime\Domain\Api\Controllers\Jsonrpc;
  * The controller now builds its envelopes through the JsonRpcResponse / JsonRpcErrorResponse
  * response types, so these tests assert on the actual JSON body of the returned Response
  * (behavior) rather than on the Template::displayJson() call that used to construct it.
+ *
+ * The RPC pipeline is exercised through Comments::getComments — a stable @api read that takes
+ * a module + entityId. (The previous fixture, pollComments, was de-@api'd as a cron/poll
+ * helper, so it is no longer reachable via JSON-RPC.)
  */
 class JsonrpcTest extends \Unit\TestCase
 {
@@ -53,8 +57,8 @@ class JsonrpcTest extends \Unit\TestCase
     public function test_method_string_parsing()
     {
         $params = [
-            'method' => 'leantime.rpc.Comments.pollComments',
-            'params' => ['projectId' => 1],
+            'method' => 'leantime.rpc.Comments.getComments',
+            'params' => ['module' => 'ticket', 'entityId' => 1],
             'id' => 1,
             'jsonrpc' => '2.0',
         ];
@@ -84,8 +88,8 @@ class JsonrpcTest extends \Unit\TestCase
     public function test_missing_json_rpc_version()
     {
         $params = [
-            'method' => 'leantime.rpc.Comments.pollComments',
-            'params' => ['projectId' => 1],
+            'method' => 'leantime.rpc.Comments.getComments',
+            'params' => ['module' => 'ticket', 'entityId' => 1],
             'id' => 1,
         ];
 
@@ -99,14 +103,14 @@ class JsonrpcTest extends \Unit\TestCase
     {
         $params = [
             [
-                'method' => 'leantime.rpc.Comments.pollComments',
-                'params' => ['projectId' => 1],
+                'method' => 'leantime.rpc.Comments.getComments',
+                'params' => ['module' => 'ticket', 'entityId' => 1],
                 'id' => 1,
                 'jsonrpc' => '2.0',
             ],
             [
-                'method' => 'leantime.rpc.Comments.pollComments',
-                'params' => ['projectId' => 2],
+                'method' => 'leantime.rpc.Comments.getComments',
+                'params' => ['module' => 'ticket', 'entityId' => 2],
                 'id' => 2,
                 'jsonrpc' => '2.0',
             ],
@@ -135,7 +139,7 @@ class JsonrpcTest extends \Unit\TestCase
             {
                 public function __construct(private string $secret) {}
 
-                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
+                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
                 {
                     throw new \RuntimeException($this->secret);
                 }
@@ -143,8 +147,8 @@ class JsonrpcTest extends \Unit\TestCase
         );
 
         $params = [
-            'method' => 'leantime.rpc.Comments.pollComments',
-            'params' => ['projectId' => 1],
+            'method' => 'leantime.rpc.Comments.getComments',
+            'params' => ['module' => 'ticket', 'entityId' => 1],
             'id' => 42,
             'jsonrpc' => '2.0',
         ];
@@ -168,7 +172,7 @@ class JsonrpcTest extends \Unit\TestCase
             \Leantime\Domain\Comments\Services\Comments::class,
             fn () => new class
             {
-                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
+                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
                 {
                     throw new \Leantime\Core\Exceptions\AuthorizationException;
                 }
@@ -176,8 +180,8 @@ class JsonrpcTest extends \Unit\TestCase
         );
 
         $params = [
-            'method' => 'leantime.rpc.Comments.pollComments',
-            'params' => ['projectId' => 1],
+            'method' => 'leantime.rpc.Comments.getComments',
+            'params' => ['module' => 'ticket', 'entityId' => 1],
             'id' => 7,
             'jsonrpc' => '2.0',
         ];
@@ -198,7 +202,7 @@ class JsonrpcTest extends \Unit\TestCase
             \Leantime\Domain\Comments\Services\Comments::class,
             fn () => new class
             {
-                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
+                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
                 {
                     throw new \RuntimeException('boom');
                 }
@@ -207,8 +211,8 @@ class JsonrpcTest extends \Unit\TestCase
 
         // No 'id' => JSON-RPC notification.
         $params = [
-            'method' => 'leantime.rpc.Comments.pollComments',
-            'params' => ['projectId' => 1],
+            'method' => 'leantime.rpc.Comments.getComments',
+            'params' => ['module' => 'ticket', 'entityId' => 1],
             'jsonrpc' => '2.0',
         ];
 

--- a/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/JsonrpcTest.php
@@ -14,10 +14,6 @@ use Leantime\Domain\Api\Controllers\Jsonrpc;
  * The controller now builds its envelopes through the JsonRpcResponse / JsonRpcErrorResponse
  * response types, so these tests assert on the actual JSON body of the returned Response
  * (behavior) rather than on the Template::displayJson() call that used to construct it.
- *
- * The RPC pipeline is exercised through Comments::getComments — a stable @api read that takes
- * a module + entityId. (The previous fixture, pollComments, was de-@api'd as a cron/poll
- * helper, so it is no longer reachable via JSON-RPC.)
  */
 class JsonrpcTest extends \Unit\TestCase
 {
@@ -57,8 +53,8 @@ class JsonrpcTest extends \Unit\TestCase
     public function test_method_string_parsing()
     {
         $params = [
-            'method' => 'leantime.rpc.Comments.getComments',
-            'params' => ['module' => 'ticket', 'entityId' => 1],
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
             'id' => 1,
             'jsonrpc' => '2.0',
         ];
@@ -88,8 +84,8 @@ class JsonrpcTest extends \Unit\TestCase
     public function test_missing_json_rpc_version()
     {
         $params = [
-            'method' => 'leantime.rpc.Comments.getComments',
-            'params' => ['module' => 'ticket', 'entityId' => 1],
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
             'id' => 1,
         ];
 
@@ -103,14 +99,14 @@ class JsonrpcTest extends \Unit\TestCase
     {
         $params = [
             [
-                'method' => 'leantime.rpc.Comments.getComments',
-                'params' => ['module' => 'ticket', 'entityId' => 1],
+                'method' => 'leantime.rpc.Comments.pollComments',
+                'params' => ['projectId' => 1],
                 'id' => 1,
                 'jsonrpc' => '2.0',
             ],
             [
-                'method' => 'leantime.rpc.Comments.getComments',
-                'params' => ['module' => 'ticket', 'entityId' => 2],
+                'method' => 'leantime.rpc.Comments.pollComments',
+                'params' => ['projectId' => 2],
                 'id' => 2,
                 'jsonrpc' => '2.0',
             ],
@@ -139,7 +135,7 @@ class JsonrpcTest extends \Unit\TestCase
             {
                 public function __construct(private string $secret) {}
 
-                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
+                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
                 {
                     throw new \RuntimeException($this->secret);
                 }
@@ -147,8 +143,8 @@ class JsonrpcTest extends \Unit\TestCase
         );
 
         $params = [
-            'method' => 'leantime.rpc.Comments.getComments',
-            'params' => ['module' => 'ticket', 'entityId' => 1],
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
             'id' => 42,
             'jsonrpc' => '2.0',
         ];
@@ -172,7 +168,7 @@ class JsonrpcTest extends \Unit\TestCase
             \Leantime\Domain\Comments\Services\Comments::class,
             fn () => new class
             {
-                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
+                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
                 {
                     throw new \Leantime\Core\Exceptions\AuthorizationException;
                 }
@@ -180,8 +176,8 @@ class JsonrpcTest extends \Unit\TestCase
         );
 
         $params = [
-            'method' => 'leantime.rpc.Comments.getComments',
-            'params' => ['module' => 'ticket', 'entityId' => 1],
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
             'id' => 7,
             'jsonrpc' => '2.0',
         ];
@@ -202,7 +198,7 @@ class JsonrpcTest extends \Unit\TestCase
             \Leantime\Domain\Comments\Services\Comments::class,
             fn () => new class
             {
-                public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
+                public function pollComments(?int $projectId = null, ?int $moduleId = null): array
                 {
                     throw new \RuntimeException('boom');
                 }
@@ -211,8 +207,8 @@ class JsonrpcTest extends \Unit\TestCase
 
         // No 'id' => JSON-RPC notification.
         $params = [
-            'method' => 'leantime.rpc.Comments.getComments',
-            'params' => ['module' => 'ticket', 'entityId' => 1],
+            'method' => 'leantime.rpc.Comments.pollComments',
+            'params' => ['projectId' => 1],
             'jsonrpc' => '2.0',
         ];
 

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -394,6 +394,24 @@ class TicketsServiceTest extends TestCase
         $this->assertFalse($this->ticketsService->updateTicketStatusAndSorting(['3' => 'ticket[]=5'], null));
     }
 
+    public function test_quick_add_ticket_is_denied_without_create_permission(): void
+    {
+        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
+
+        // quickAddTicket resolves the project from its params, then authorizes tickets.create
+        // through the engine before doing any work. This was one of the RPC holes: any
+        // authenticated caller could create tickets. A denying engine must make it throw.
+        $this->ticketsService->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]));
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->ticketsService->quickAddTicket(['headline' => 'New task', 'projectId' => 9]);
+    }
+
     // ---------------------------------------------------------------------
     // Collaborator enrichment for grouped ticket views (list/kanban + widget)
     // ---------------------------------------------------------------------

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -3,6 +3,7 @@
 namespace Unit\app\Domain\Tickets\Services;
 
 use Carbon\CarbonImmutable;
+use Leantime\Core\Auth\Permissions\PermissionService;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
@@ -16,6 +17,7 @@ use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
+use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
 use Leantime\Domain\Tickets\Repositories\TicketHistory;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
 use Leantime\Domain\Tickets\Services\Tickets as TicketsService;
@@ -341,9 +343,39 @@ class TicketsServiceTest extends TestCase
     {
         session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
 
+        // patchTicket loads the ticket, then authorizes tickets.edit against its project via
+        // the permission engine. Stub getTicket so it resolves, and inject a denying engine.
+        $service = $this->construct(
+            TicketsService::class,
+            [
+                $this->make(TemplateCore::class),
+                $this->make(LanguageCore::class),
+                $this->make(EnvironmentCore::class),
+                $this->make(ProjectRepository::class),
+                $this->make(TicketRepository::class),
+                $this->make(TimesheetRepository::class),
+                $this->make(SettingRepository::class),
+                $this->make(ProjectService::class),
+                $this->make(TimesheetService::class),
+                $this->make(SprintService::class),
+                $this->make(TicketHistory::class),
+                $this->make(Goalcanvas::class),
+                $this->make(DateTimeHelper::class),
+                $this->make(CommentService::class),
+                $this->make(ClientService::class),
+            ],
+            ['getTicket' => fn () => $this->make(TicketModel::class, ['id' => 5, 'projectId' => 9])],
+        );
+
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]));
+
         $this->expectException(AuthorizationException::class);
 
-        $this->ticketsService->patchTicket(5, ['status' => 3]);
+        $service->patchTicket(5, ['status' => 3]);
     }
 
     public function test_sort_tickets_is_denied_for_non_editor(): void


### PR DESCRIPTION
## Summary

**Phase 1** of the permission overhaul: wires the native engine (#3461, merged) through **Tickets** and **Comments** end-to-end, proving one `domain.action` vocabulary across **JSON-RPC, controllers, services, and the UI** — with **full `@api` coverage** on both service classes (the JSON-RPC surface).

> **Enforcement is on by default** (`LEAN_PERMISSIONS_ENFORCE`); set it `false` for audit/log-only. Only annotated methods are affected.

## Full `@api` coverage

The service layer **is** the JSON-RPC API, so every `@api` method now carries the declarative `#[RequiresPermission]` attribute, classified per-method by reading its body (mutation vs. read vs. helper — the verb is **not** inferable from the name).

- **Attribute extended**: `#[RequiresPermission]` gains `global` (company-wide capability → checks the global role, not a project) and `entityScoped` (project comes from an entity the method loads → the enforcer defers and the method self-authorizes in its body). `PermissionEnforcer` honors both.
- **9 ungated mutator RPC holes closed** with in-method `authorize()` (project from the param/loaded entity, never the session): `quickAddTicket`, `quickAddMilestone`, `quickAddTicketFromKanban`, `createMilestoneFromDialog`, `upsertSubtask`, `addMilestoneComment`, `saveStatusLabels`, `markTicketReopen`, `moveTicket`.
- **All reads** annotated `tickets.view` / `comments.view` (`projectIdParam` where the project is a clean top-level argument, session-scoped otherwise).
- **4 genuine internal helpers de-`@api`'d** — not user actions, so they leave the API surface: `getNewMilestone`, `normalizeRoadmapParams`, `getMilestonesOverviewSearchCriteria`, `prepareTicketDates`.

## What it proves (one vocabulary, four layers)

**Comments — ownership + RPC.**
- `CommentsPermissions`: `view` / `create` / `moderate`. `moderate` is a deliberate distinct verb so editing *someone else's* comment stays **manager+** (a `comments.edit` would seed at editor+ via the matrix and over-grant).
- `addComment` authorizes `comments.create` — previously access-only, so any assigned role (incl. read-only) could comment over RPC. **Closes a hole.**
- `canModifyComment` = author **OR** `comments.moderate` — engine-backed; the UI edit/delete buttons mirror it.

**Tickets — RPC + controller.**
- `@api` mutators authorize against the **entity's project** via `$this->authorize('tickets.*', $entityProjectId)`:
  - `patchTicket` — hardened from a **session-scoped** role check to the **ticket's project** role.
  - `addTicket` / `delete` / `deleteMilestone` — had **no role check**; now editor+ in the entity's project. **Closes RPC holes.**
- Controllers `DelTicket` / `DelMilestone` / `NewTicket` / `MoveTicket` replace `Auth::authOrRedirect(...)` with `#[RequiresPermission(...)]`.

**Role assignment stays central**: `DefaultRolePermissions` carries the matrix; domain code declares only verbs.

**UI**: representative templates migrated to `@can`/`can()`. Remaining `$login::userIsAtLeast(...)` checks still work — a mechanical follow-up.

## Grant-equivalence (no lockouts)

Every migrated check maps to a seeded grant set matching the prior role set. The only intentional changes are **hardening**: closing no-role RPC holes and scoping project-bound checks to the **entity's** project.

## Verification

- ✅ **Full unit suite: 415 tests, 990 assertions** — incl. a new `PermissionEnforcerTest` (locks the four resolution modes + no-attr no-op), the DB-free `DefaultRolePermissionsTest` (grant-equivalence guard), and a `quickAddTicket` denial test.
- ✅ **Acceptance green** (enforcement on) — incl. the `ApiCest` JSON-RPC suite.
- ✅ Pint + PHPStan (level 0) clean.

## Notes

- **`poll*` methods are gated reads, not de-`@api`'d.** `Comments::pollComments` and `Tickets::pollFor{New,Updated}Account{Milestones,Todos}` are legitimate public mobile-polling reads (both `ApiCest` and `JsonrpcTest` use `pollComments` as their canonical RPC fixture), so they keep `@api` and are gated `*.view` with `projectIdParam: 'projectId'`.
- Already-correctly-gated mutators (`updateTicket`, `sortTickets`, `updateTicketStatusAndSorting`, `quickUpdateMilestone`) keep their existing checks + carry an `entityScoped` coverage marker; migrating their internals to the engine is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
