### PR TITLE
feat(permissions): roll the engine across the Users domain (company-scope)

### DIFF
--- a/app/Command/SyncPermissionsCommand.php
+++ b/app/Command/SyncPermissionsCommand.php
@@ -3,6 +3,7 @@
 namespace Leantime\Command;
 
 use Illuminate\Console\Command;
+use Leantime\Core\Auth\Permissions\PermissionRegistry;
 use Leantime\Core\Auth\Permissions\PermissionRepository;
 use Leantime\Core\Auth\Permissions\PermissionSeeder;
 use Leantime\Core\Auth\Permissions\PermissionService;
@@ -31,6 +32,7 @@ class SyncPermissionsCommand extends Command
         private readonly PermissionSeeder $seeder,
         private readonly PermissionRepository $repo,
         private readonly PermissionService $permissions,
+        private readonly PermissionRegistry $registry,
     ) {
         parent::__construct();
     }
@@ -46,6 +48,12 @@ class SyncPermissionsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        // Re-glob providers from disk first — the discovered-provider list is cached
+        // cross-request outside debug mode, so a stale cache (e.g. predating a newly-shipped
+        // domain's permission class) would otherwise hide its permissions from the sync. This
+        // also makes the command a reliable recovery step after such a cache goes stale.
+        $this->registry->flush();
 
         $keys = $this->seeder->syncDiscoveredPermissions();
         $io->success(count($keys).' permissions synced.');

--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -61,7 +61,16 @@ final class DefaultRolePermissions
             ['scope' => 'project', 'keys' => ['comments.create']],
         ],
         'editor' => [['scope' => 'project', 'verbs' => ['create', 'edit', 'delete']]],
-        'manager' => [['scope' => 'project', 'verbs' => ['*']]],
+        'manager' => [
+            ['scope' => 'project', 'verbs' => ['*']],
+            // Managers may INVITE users (the NewUser screen is manager+). The client-scoping
+            // — a manager can only invite into their own client — stays in the controller/
+            // service, not here. They CANNOT view the roster, edit, delete, or import users;
+            // those remain admin+. users.* are company-wide, so this is an explicit global
+            // key grant rather than a 'create' verb rule (a verb rule would also need a global
+            // scope and is fine, but the explicit key documents that ONLY create is intended).
+            ['scope' => 'global', 'keys' => ['users.create']],
+        ],
         'admin' => [['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']]],
         'owner' => [['scope' => 'any', 'verbs' => ['*']]],
     ];

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.5';
+    public string $dbVersion = '3.5.6';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -2747,6 +2747,13 @@ class Install
     public function update_sql_30506(): bool|array
     {
         try {
+            // The discovered-provider list is cached cross-request (installation store) outside
+            // debug mode. An install that already ran 30505 cached it WITHOUT UsersPermissions
+            // (which didn't exist then) — seeding against that stale list would never create the
+            // users.* permissions, leaving admin/owner/manager with no user-management grants
+            // (and, with enforcement on, 403'd out of user management). Flush it first.
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
             $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
             $seeder->syncDiscoveredPermissions();
             $seeder->seedBuiltInRoles();

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -86,6 +86,7 @@ class Install
         // 30504 which puts push columns on zp_access_tokens instead.
         30504,
         30505,
+        30506,
     ];
 
     /**
@@ -2731,6 +2732,28 @@ class Install
             Log::error('Migration 30505: '.$e->getMessage());
 
             return ['Migration 30505 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30506: the Users domain joined the native permission engine. Re-sync the
+     * discovered permission catalog (adds users.view/create/edit/delete/import, all
+     * company-wide) and re-seed the built-in role grants. The engine tables already exist
+     * (created in 30505), so this is table-creation-free. Both seeder calls are idempotent and
+     * additive — re-running never removes an admin's customized zp_role_permissions rows.
+     */
+    public function update_sql_30506(): bool|array
+    {
+        try {
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30506: '.$e->getMessage());
+
+            return ['Migration 30506 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Plugins/Services/Plugins.php
+++ b/app/Domain/Plugins/Services/Plugins.php
@@ -956,6 +956,13 @@ class Plugins
         Cache::store('installation')->forget('domainEvents');
         Cache::store('installation')->forget('commands');
         Cache::store('installation')->forget('plugins.enabledPlugins');
+        // Permission engine caches (provider discovery + the role->permission map/meta), all
+        // cross-request on the installation store — a documented cache clear must bust them too,
+        // or a newly-shipped domain/plugin permission class stays invisible (and acts as a
+        // recovery path if the provider cache ever goes stale).
+        Cache::store('installation')->forget('permissionProviders');
+        Cache::store('installation')->forget('leantime.permissionMap');
+        Cache::store('installation')->forget('leantime.permissionMeta');
 
         session()->forget('template_paths');
         session()->forget('composers');

--- a/app/Domain/Users/Controllers/DelUser.php
+++ b/app/Domain/Users/Controllers/DelUser.php
@@ -2,10 +2,10 @@
 
 namespace Leantime\Domain\Users\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Services\Users;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,10 +26,9 @@ class DelUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::DELETE, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }
@@ -49,10 +48,9 @@ class DelUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::DELETE, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }

--- a/app/Domain/Users/Controllers/EditUser.php
+++ b/app/Domain/Users/Controllers/EditUser.php
@@ -2,12 +2,13 @@
 
 namespace Leantime\Domain\Users\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Services\Users;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,10 +38,9 @@ class EditUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::EDIT, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }
@@ -74,10 +74,9 @@ class EditUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::EDIT, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }

--- a/app/Domain/Users/Controllers/Import.php
+++ b/app/Domain/Users/Controllers/Import.php
@@ -5,10 +5,11 @@
 namespace Leantime\Domain\Users\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Ldap\Services\Ldap as LdapService;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Services\Users as UserService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,13 +32,9 @@ class Import extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(UsersPermissions::IMPORT, global: true)]
     public function get(): Response
     {
-        // Only Admins
-        if (! Auth::userIsAtLeast(Roles::$admin)) {
-            return $this->tpl->display('errors.error403');
-        }
-
         $this->tpl->assign('allUsers', $this->userService->getAll());
         $this->tpl->assign('admin', true);
         $this->tpl->assign('roles', Roles::getRoles());
@@ -53,6 +50,7 @@ class Import extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(UsersPermissions::IMPORT, global: true)]
     public function post($params): Response
     {
         // Password Submit to connect to ldap and retrieve users. Sets tmp session var

--- a/app/Domain/Users/Controllers/NewUser.php
+++ b/app/Domain/Users/Controllers/NewUser.php
@@ -2,11 +2,13 @@
 
 namespace Leantime\Domain\Users\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Services\Users as UserService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -36,14 +38,9 @@ class NewUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::CREATE, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager], true);
-
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
-            return $this->tpl->displayPartial('errors.error403');
-        }
-
         $projectrelation = [];
         if (isset($params['preSelectProjectId'])) {
             $preSelected = explode(',', $params['preSelectProjectId']);
@@ -65,14 +62,9 @@ class NewUser extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(UsersPermissions::CREATE, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager], true);
-
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
-            return $this->tpl->displayPartial('errors.error403');
-        }
-
         $values = $this->getDefaultValues();
         $projectrelation = [];
 

--- a/app/Domain/Users/Controllers/ShowAll.php
+++ b/app/Domain/Users/Controllers/ShowAll.php
@@ -2,9 +2,10 @@
 
 namespace Leantime\Domain\Users\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Services\Users as UserService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,15 +21,9 @@ class ShowAll extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function get(): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
-        // Only Admins
-        if (! Auth::userIsAtLeast(Roles::$admin)) {
-            return $this->tpl->display('errors.error403');
-        }
-
         $this->tpl->assign('allUsers', $this->userService->getAllVisibleToUser());
         $this->tpl->assign('admin', true);
         $this->tpl->assign('roles', Roles::getRoles());

--- a/app/Domain/Users/Permissions/UsersPermissions.php
+++ b/app/Domain/Users/Permissions/UsersPermissions.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Leantime\Domain\Users\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Users (account management) permission vocabulary — the verbs only.
+ *
+ * Declares *what* can be done with user accounts; it says nothing about *which roles* may do
+ * it. Role assignment is centrally owned (defaults in
+ * {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions}, runtime in `zp_role_permissions`).
+ *
+ * Every user capability is COMPANY-WIDE, not project-scoped: managing accounts is authority a
+ * user holds across the whole installation, evaluated against their GLOBAL role (see
+ * {@see \Leantime\Core\Auth\RoleResolver}). So every Permission below is constructed with
+ * `projectScoped = false`, and call sites gate with `#[RequiresPermission(..., global: true)]`.
+ *
+ * These verbs cover MANAGING OTHER accounts only. Editing one's OWN profile/settings/avatar is
+ * self-service that every authenticated user may do and is deliberately NOT gated by any
+ * `users.*` permission (see {@see \Leantime\Domain\Users\Controllers\EditOwn} and the
+ * self-service methods on the Users service).
+ */
+final class UsersPermissions implements ProvidesPermissions
+{
+    /** View the company user roster / read another account. */
+    public const VIEW = 'users.view';
+
+    /** Invite / create new accounts. */
+    public const CREATE = 'users.create';
+
+    /** Edit another account (role, client, status, profile fields). */
+    public const EDIT = 'users.edit';
+
+    /** Delete accounts. */
+    public const DELETE = 'users.delete';
+
+    /** Bulk-import accounts from a directory (LDAP). */
+    public const IMPORT = 'users.import';
+
+    public function domain(): string
+    {
+        return 'users';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View users', false),
+            new Permission(self::CREATE, 'Invite/create users', false),
+            new Permission(self::EDIT, 'Edit users', false),
+            new Permission(self::DELETE, 'Delete users', false),
+            new Permission(self::IMPORT, 'Import users (LDAP)', false),
+        ];
+    }
+}

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -593,10 +593,16 @@ class Users extends BaseService
     }
 
     /**
-     * @api
+     * @internal Self-service only — invoked by saveOwnProfile() with the session user's id.
+     *           Intentionally NOT @api: it writes name/email/notifications to $id, so exposing
+     *           it over JSON-RPC would be an IDOR account takeover. The id is pinned to the
+     *           session user below as defense-in-depth.
      */
     public function editOwn($values, $id): void
     {
+        // Self-service: pin to the authenticated user (ignore any caller-supplied id).
+        $id = (int) session('userdata.id');
+
         $this->userRepo->editOwn($values, $id);
 
         $user = $this->getUser($id);
@@ -665,6 +671,10 @@ class Users extends BaseService
      */
     public function getOwnProfileSettings(int $userId): array
     {
+        // Self-service read: pin to the authenticated user (ignore any caller-supplied id —
+        // otherwise the RPC entry point leaks another account's profile/role/2FA status).
+        $userId = (int) session('userdata.id');
+
         $row = $this->getUser($userId);
 
         if ($row === false) {
@@ -759,6 +769,9 @@ class Users extends BaseService
      */
     public function getNotificationPreferences(int $userId): array
     {
+        // Self-service read: pin to the authenticated user (ignore any caller-supplied id — prevents RPC IDOR).
+        $userId = (int) session('userdata.id');
+
         $enabledEventTypes = $this->settingsService->getSetting('usersettings.'.$userId.'.notificationEventTypes');
         if (! $enabledEventTypes) {
             $enabledEventTypes = $this->settingsService->getSetting('companysettings.defaultNotificationEventTypes');
@@ -812,6 +825,10 @@ class Users extends BaseService
      */
     public function saveOwnProfile(int $userId, array $post): string
     {
+        // Self-service: pin to the authenticated user; ignore any caller-supplied id so the RPC
+        // entry point cannot edit another account (IDOR). EditOwn already passes the session id.
+        $userId = (int) session('userdata.id');
+
         $row = $this->getUser($userId);
 
         $values = [
@@ -862,6 +879,10 @@ class Users extends BaseService
      */
     public function changeOwnPassword(int $userId, string $currentPassword, string $newPassword, string $confirmPassword): string
     {
+        // Self-service: pin to the authenticated user (ignore any caller-supplied id — otherwise
+        // the RPC entry point is a current-password oracle / takeover vector against any account).
+        $userId = (int) session('userdata.id');
+
         $row = $this->getUser($userId);
 
         if (! password_verify($currentPassword, $row['password'])) {
@@ -902,6 +923,9 @@ class Users extends BaseService
      */
     public function saveOwnAppearanceSettings(int $userId, array $post): void
     {
+        // Self-service: pin to the authenticated user (ignore any caller-supplied id — prevents RPC IDOR).
+        $userId = (int) session('userdata.id');
+
         $postTheme = htmlentities($post['theme'] ?? 'default');
         $postColorMode = htmlentities($post['colormode'] ?? 'light');
         $postColorScheme = htmlentities($post['colorscheme'] ?? 'themeDefault');
@@ -931,6 +955,9 @@ class Users extends BaseService
      */
     public function saveOwnLocaleSettings(int $userId, array $post): void
     {
+        // Self-service: pin to the authenticated user (ignore any caller-supplied id — prevents RPC IDOR).
+        $userId = (int) session('userdata.id');
+
         $postLang = htmlentities($post['language'] ?? '');
         $dateFormat = htmlentities($post['date_format'] ?? '');
         $timeFormat = htmlentities($post['time_format'] ?? '');
@@ -967,6 +994,9 @@ class Users extends BaseService
      */
     public function saveOwnNotificationPreferences(int $userId, array $post): void
     {
+        // Self-service: pin to the authenticated user (ignore any caller-supplied id — prevents RPC IDOR).
+        $userId = (int) session('userdata.id');
+
         $row = $this->getUser($userId);
 
         $values = [

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -4,7 +4,8 @@ namespace Leantime\Domain\Users\Services;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
-use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Mailer as MailerCore;
 use Leantime\Core\Support\Avatarcreator;
@@ -19,6 +20,7 @@ use Leantime\Domain\Notifications\Models\Notification;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Services\Setting as SettingService;
+use Leantime\Domain\Users\Permissions\UsersPermissions;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 use Ramsey\Uuid\Uuid;
 use SVG\SVG;
@@ -27,10 +29,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @api
  */
-class Users
+class Users extends BaseService
 {
-    use DispatchesEvents;
-
     public function __construct(
         protected UserRepository $userRepo,
         protected LanguageCore $language,
@@ -52,6 +52,10 @@ class Users
      * @throws BindingResolutionException
      *
      * @api
+     *
+     * Intentionally NOT gated by a users.* permission: avatars are non-sensitive and rendered
+     * for every user across the app (the avatar route resolves through here). The sensitive
+     * account/roster surface is getAll()/getAllVisibleToUser(), which ARE users.view-gated.
      */
     public function getProfilePicture($id): SVG|Response|string
     {
@@ -84,6 +88,7 @@ class Users
     /**
      * @api
      */
+    #[RequiresPermission(UsersPermissions::EDIT, global: true)]
     public function editUser($values, $id): bool
     {
 
@@ -96,6 +101,7 @@ class Users
     /**
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getNumberOfUsers(bool $activeOnly = false, bool $includeApi = true): int
     {
         $filters = [];
@@ -116,6 +122,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getAll(bool $activeOnly = false): mixed
     {
         $users = $this->userRepo->getAll($activeOnly);
@@ -143,6 +150,11 @@ class Users
      * user id (the login response returns the access-token row id, not
      * the underlying user id), so they need a "who am I" endpoint that
      * doesn't require the answer they're trying to look up.
+     *
+     * Intentionally NOT gated by users.view: this is the foundational user read used by dozens
+     * of internal view composers (comment authors, assignees, avatars) and the self "who am I"
+     * lookup — gating it would break those for non-admins. The sensitive roster/management
+     * surface is getAll()/getAllVisibleToUser(), which ARE users.view-gated.
      */
     public function getUser($id = null): array|bool
     {
@@ -167,6 +179,7 @@ class Users
     /**
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getUserByEmail($email, $status = 'a'): false|array
     {
         return $this->userRepo->getUserByEmail($email, $status);
@@ -175,6 +188,7 @@ class Users
     /**
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getAllBySource($source): false|array
     {
         return $this->userRepo->getAllBySource($source);
@@ -273,8 +287,6 @@ class Users
      *
      * @param  string  $password  The string to be checked
      * @return bool returns true if password meets requirements
-     *
-     * @api
      */
     public function checkPasswordStrength(string $password): bool
     {
@@ -307,6 +319,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::CREATE, global: true)]
     public function createUserInvite(array $values): bool|int
     {
 
@@ -362,6 +375,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::CREATE, global: true)]
     public function addUser(array $values): bool|int
     {
         $values = [
@@ -396,6 +410,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function usernameExist(string $username, int|string $notUserId = ''): bool
     {
         return $this->userRepo->usernameExist($username, $notUserId);
@@ -412,6 +427,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::EDIT, entityScoped: true)]
     public function patchUser(int $id, array $params): bool
     {
         $currentUserId = (int) session('userdata.id');
@@ -429,8 +445,8 @@ class Users
             'status', 'user',
         ];
 
-        if (Auth::userIsAtLeast(Roles::$admin)) {
-            // Admins can patch any user, but only whitelisted fields
+        if ($this->can(UsersPermissions::EDIT, forceGlobal: true)) {
+            // users.edit holders (admin+) can patch any user, but only whitelisted fields
             $filteredParams = array_intersect_key($params, array_flip($adminPatchableFields));
         } elseif ($id === $currentUserId) {
             // Regular users can only patch their own profile with limited fields
@@ -600,17 +616,18 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::DELETE, entityScoped: true)]
     public function deleteUser(int $id): bool
     {
+        // Defense-in-depth: authorize on every call (RPC + the DelUser controller). The
+        // attribute defers (entityScoped), so this in-method check is the single source of
+        // truth and throws AuthorizationException (RPC -32001 / 403) when denied.
+        $this->authorize(UsersPermissions::DELETE, forceGlobal: true);
 
-        if (Auth::userIsAtLeast(Roles::$admin, true)) {
-            $this->userRepo->deleteUser($id);
-            $this->projectRepository->deleteAllProjectRelations($id);
+        $this->userRepo->deleteUser($id);
+        $this->projectRepository->deleteAllProjectRelations($id);
 
-            return true;
-        }
-
-        throw new \Exception('Not authorized');
+        return true;
     }
 
     /**
@@ -624,6 +641,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getAllVisibleToUser(): array
     {
         if (Auth::userIsAtLeast(Roles::$admin)) {
@@ -1010,8 +1028,6 @@ class Users
      * @link https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.types
      *
      * @return array<string, array<int, string>> Format groups keyed by 'dates'/'times'.
-     *
-     * @api
      */
     public function getSupportedDateTimeFormats(): array
     {
@@ -1106,8 +1122,6 @@ class Users
      * @param  int  $id  The id of the user being edited.
      * @param  array<string, mixed>  $post  Raw request input (for password comparison).
      * @return string Status code described above.
-     *
-     * @api
      */
     public function validateUserUpdate(array $values, array $row, int $id, array $post): string
     {
@@ -1140,6 +1154,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::EDIT, global: true)]
     public function updateUser(array $values, int $id, ?array $projects): void
     {
         $this->editUser($values, $id);
@@ -1174,6 +1189,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getUserProjectIds(int $userId): array
     {
         $projects = $this->projectService->getUserProjectRelation($userId);
@@ -1205,6 +1221,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::EDIT, global: true)]
     public function resendUserInvite(int $id, array $row): string
     {
         if (session()->exists('lastInvite.'.$id) && session('lastInvite.'.$id) >= time() - 240) {
@@ -1249,6 +1266,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::CREATE, global: true)]
     public function inviteNewUser(array $post, int|string|null $sessionClientId, bool $isManager): string
     {
         $values = [
@@ -1298,6 +1316,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::IMPORT, global: true)]
     public function fetchLdapMembers(string $bindUsername, string $password): array|false
     {
         $ldapService = app()->make(LdapService::class);
@@ -1318,6 +1337,7 @@ class Users
      *
      * @api
      */
+    #[RequiresPermission(UsersPermissions::IMPORT, global: true)]
     public function importSelectedLdapUsers(array $stagedUsers, array $selectedUsernames): void
     {
         $users = [];

--- a/app/Domain/Users/Templates/editUser.blade.php
+++ b/app/Domain/Users/Templates/editUser.blade.php
@@ -37,6 +37,14 @@
                     <select name="role" id="role">
 
                         @foreach ($roles as $key => $role)
+                            {{-- Privilege ceiling (parity with newUser): a manager may never
+                                 assign the admin(40)/owner(50) roles. Editing users is admin+
+                                 today, so this is defense-in-depth against any future widening
+                                 of who can reach this screen — a lower role must never be able
+                                 to escalate an account above its own authority. --}}
+                            @if ($login::userHasRole(\Leantime\Domain\Auth\Models\Roles::$manager) && $key > 30)
+                                @continue
+                            @endif
                             <option value="{{ $key }}"
                                 @if ($key == $values['role']) selected="selected" @endif>
                                 {!! __('label.roles.' . $role) !!}

--- a/app/Domain/Users/Templates/showAll.blade.php
+++ b/app/Domain/Users/Templates/showAll.blade.php
@@ -17,7 +17,9 @@
 
         <div class="row">
             <div class="col-md-6">
+                @can('users.create')
                 <a href="{{ BASE_URL }}/users/newUser" class="btn btn-primary userEditModal"><i class='fa fa-plus'></i> {!! __('buttons.add_user') !!} </a>
+                @endcan
             </div>
             <div class="col-md-6 align-right">
 
@@ -66,7 +68,7 @@
                         @else
                             {!! __('label.no') !!}
                         @endif</td>
-                        <td><a href="{{ BASE_URL }}/users/delUser/{{ $row['id'] }}" class="delete"><i class="fa fa-trash"></i> {!! __('links.delete') !!}</a></td>
+                        <td>@can('users.delete')<a href="{{ BASE_URL }}/users/delUser/{{ $row['id'] }}" class="delete"><i class="fa fa-trash"></i> {!! __('links.delete') !!}</a>@endcan</td>
                     </tr>
             @endforeach
             </tbody>

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -29,6 +29,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('comments.moderate', 'Moderate', true),
             // Company-wide (not project-scoped):
             new Permission('users.view', 'View users', false),
+            new Permission('users.create', 'Invite/create users', false),
+            new Permission('users.edit', 'Edit users', false),
+            new Permission('users.delete', 'Delete users', false),
+            new Permission('users.import', 'Import users', false),
             new Permission('company.settings.edit', 'Edit company settings', false),
         ];
     }
@@ -66,6 +70,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+
+        $this->assertNotContains('users.create', $grants);      // company-wide, manager+
         $this->assertNotContains('company.settings.edit', $grants);
     }
 
@@ -75,7 +80,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
-        $this->assertNotContains('users.view', $grants);          // company-wide, admin+
+        // Managers may INVITE users (within their own client — scoped in the controller), but
+        // cannot view the roster, edit, delete, or import accounts (those stay admin+).
+        $this->assertContains('users.create', $grants);
+        $this->assertNotContains('users.view', $grants);
+        $this->assertNotContains('users.edit', $grants);
+        $this->assertNotContains('users.delete', $grants);
+        $this->assertNotContains('users.import', $grants);
         $this->assertNotContains('company.settings.edit', $grants);
     }
 
@@ -84,6 +95,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $grants = $this->grantsFor('admin');
 
         $this->assertContains('users.view', $grants);
+        $this->assertContains('users.create', $grants);
+        $this->assertContains('users.edit', $grants);
+        $this->assertContains('users.delete', $grants);
+        $this->assertContains('users.import', $grants);   // full user management
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
         $this->assertNotContains('company.settings.edit', $grants); // owner-only

--- a/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
+++ b/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Unit\app\Domain\Users\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\Avatarcreator;
 use Leantime\Core\UI\Theme as ThemeCore;
@@ -340,5 +342,99 @@ class UsersServiceTest extends TestCase
             ->searchProjectUsers(5);
 
         $this->assertSame([], $users);
+    }
+
+    // ---------------------------------------------------------------------
+    // Authorization. The company-wide manage-others methods
+    // (editUser/updateUser/addUser/getAll/…) gate via the dispatch-time
+    // #[RequiresPermission(global: true)] attribute (covered by PermissionEnforcerTest).
+    // These two methods authorize in their own body, so they gate on direct calls too.
+    // ---------------------------------------------------------------------
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'currentUserCan' => fn () => false,
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]);
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'currentUserCan' => fn () => true,
+            'authorize' => fn () => null,
+        ]);
+    }
+
+    public function test_delete_user_throws_without_delete_permission(): void
+    {
+        $service = $this->makeService($this->make(UserRepository::class));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteUser(5);
+    }
+
+    public function test_patch_user_allows_self_with_limited_fields_without_edit_permission(): void
+    {
+        session(['userdata' => ['id' => 7]]);
+
+        $patched = [];
+        $service = $this->makeService($this->make(UserRepository::class, [
+            'patchUser' => function ($id, $fields) use (&$patched) {
+                $patched = ['id' => $id, 'fields' => $fields];
+
+                return true;
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions()); // no users.edit
+
+        // Editing OWN account (id === session user) is allowed even without users.edit...
+        $result = $service->patchUser(7, ['firstname' => 'Bob', 'role' => '50']);
+
+        $this->assertTrue($result);
+        $this->assertSame(7, $patched['id']);
+        $this->assertArrayHasKey('firstname', $patched['fields']);
+        // ...but the privileged 'role' field is stripped — no self privilege-escalation.
+        $this->assertArrayNotHasKey('role', $patched['fields']);
+    }
+
+    public function test_patch_user_denies_other_account_without_edit_permission(): void
+    {
+        session(['userdata' => ['id' => 7]]);
+
+        $service = $this->makeService($this->make(UserRepository::class, [
+            'patchUser' => fn () => true,
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        // Patching ANOTHER account without users.edit must fail (closes the RPC escalation hole).
+        $this->assertFalse($service->patchUser(99, ['role' => '50']));
+    }
+
+    public function test_patch_user_allows_other_account_with_edit_permission(): void
+    {
+        session(['userdata' => ['id' => 7]]);
+
+        $patched = [];
+        $service = $this->makeService($this->make(UserRepository::class, [
+            'patchUser' => function ($id, $fields) use (&$patched) {
+                $patched = ['id' => $id, 'fields' => $fields];
+
+                return true;
+            },
+        ]));
+        $service->setPermissionService($this->allowingPermissions()); // has users.edit
+
+        $result = $service->patchUser(99, ['role' => '20']);
+
+        $this->assertTrue($result);
+        $this->assertSame(99, $patched['id']);
+        // A users.edit holder may set privileged fields on another account.
+        $this->assertArrayHasKey('role', $patched['fields']);
     }
 }

--- a/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
+++ b/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
@@ -437,4 +437,32 @@ class UsersServiceTest extends TestCase
         // A users.edit holder may set privileged fields on another account.
         $this->assertArrayHasKey('role', $patched['fields']);
     }
+
+    public function test_self_service_methods_ignore_caller_supplied_id_and_pin_to_session(): void
+    {
+        // Self-service methods (editOwn/saveOwn*/getOwn*/changeOwnPassword) must operate on the
+        // authenticated user only — over JSON-RPC a caller controls the $userId argument, so a
+        // foreign id must NOT be honored (otherwise it is a cross-account IDOR). Representative
+        // check via changeOwnPassword: the credential lookup must hit the SESSION user (7), not
+        // the attacker-supplied id (99).
+        session(['userdata' => ['id' => 7]]);
+
+        $seenId = null;
+        $repo = $this->make(UserRepository::class, [
+            'getUser' => function ($id) use (&$seenId) {
+                $seenId = $id;
+
+                return [
+                    'id' => $id,
+                    'password' => password_hash('correct-horse', PASSWORD_DEFAULT),
+                    'firstname' => 'A', 'lastname' => 'B', 'username' => 'a@b.com',
+                    'phone' => '', 'notifications' => 1, 'twoFAEnabled' => 0,
+                ];
+            },
+        ]);
+
+        $this->makeService($repo)->changeOwnPassword(99, 'wrong', 'NewPass1!', 'NewPass1!');
+
+        $this->assertSame(7, $seenId, 'self-service must pin to the session user, not the caller-supplied id');
+    }
 }


### PR DESCRIPTION
## Summary

Extends the native permission engine to **Users** — the first **company-scoped** domain, which exercises the **`global` (company-wide) resolution mode** the project-scoped Tickets + Comments work (#3469) never touched.

> Builds on #3461 + #3469 (both merged). Enforcement is on by default (`LEAN_PERMISSIONS_ENFORCE`).

## Vocabulary

`UsersPermissions`: `view` / `create` / `edit` / `delete` / `import` — **every key `projectScoped = false`** (resolved against the global role). Managing *other* accounts only; editing one's **own** profile/settings/avatar is self-service and deliberately **not** a `users.*` capability.

## Matrix (verified on a live DB)

`admin` + `owner` auto-grant all `users.*` via their existing `scope:any` wildcard. `manager` gets an **explicit `users.create` only** (managers may invite — scoped to their own client in the controller — but cannot view the roster, edit, delete, or import). Lower roles get none.

| role | `users.*` grants |
|---|---|
| readonly / commenter / editor | — (none) |
| manager | `users.create` |
| admin / owner | view, create, edit, delete, import |

## Security fixes (not just coverage)

- **Closed real RPC role-escalation holes.** `editUser` / `updateUser` / `addUser` / `createUserInvite` / `inviteNewUser` / `resendUserInvite` had **no server-side role check** (relied on the controller) — any authenticated RPC caller could `leantime.rpc.Users.editUser` themselves to **owner**. Now `#[RequiresPermission(EDIT/CREATE, global: true)]`.
- **`Import::post()` had no role guard** (bulk LDAP import) — now `users.import`-gated, matching `get()`.
- **`editUser`'s role dropdown had no privilege ceiling** (unlike `newUser`) — a lower role reaching it could assign admin/owner. Added the manager ceiling clamp for parity + defense-in-depth.

## Service (`Users` now extends `BaseService`)

- Roster/lookup reads (`getAll`/`getAllBySource`/`getUserByEmail`/`getNumberOfUsers`/`usernameExist`/`getAllVisibleToUser`/`getUserProjectIds`) → `users.view` via the **dispatch-only attribute** — internal view-composer calls are unaffected (it fires only at the RPC boundary).
- `deleteUser` / `patchUser` migrated off `Auth::userIsAtLeast` to the engine. **`patchUser` keeps its self-vs-other branch**: a user may patch their OWN limited fields without `users.edit`; privileged fields / other accounts require it (no self-escalation — covered by tests).
- **Intentionally ungated** (documented in code): `getUser` / `getProfilePicture` — foundational reads used by dozens of composers + the mobile "who am I" self-lookup; gating breaks them, and the sensitive surface (`getAll*`) is gated. De-`@api`'d 3 pure helpers (`checkPasswordStrength` / `getSupportedDateTimeFormats` / `validateUserUpdate`).

## Controllers / Templates

- `ShowAll`(VIEW) / `NewUser`(CREATE) / `EditUser`(EDIT) / `DelUser`(DELETE) / `Import`(IMPORT) replace `Auth::authOrRedirect`/`userIsAtLeast` with `#[RequiresPermission(global: true)]`. `EditOwn` / `PatchUserSettings` / `ProfileImage` stay self-service (untouched).
- `showAll.blade` action surfaces gated with `@can('users.create')` / `@can('users.delete')`.

## Migration

`update_sql_30506` re-syncs the catalog + re-seeds grants (table-creation-free, idempotent — admin customizations survive); `dbVersion 3.5.5 → 3.5.6`. Fresh installs auto-discover `UsersPermissions` via `setupDB`.

## Verification

- ✅ Full unit suite **419 tests / 1008 assertions** — incl. new `UsersServiceTest` authz cases (deleteUser denial; patchUser self-allowed / other-denied / other-allowed-with-edit) and the `DefaultRolePermissionsTest` `users.*` matrix lock.
- ✅ Pint + PHPStan clean. Live `permissions:sync --seed` → 14 permissions; DB grant spot-check matches the matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
