### PR TITLE
feat(permissions): roll the engine across the Setting domain (company + project scopes)

### DIFF
--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -71,7 +71,13 @@ final class DefaultRolePermissions
             // scope and is fine, but the explicit key documents that ONLY create is intended).
             ['scope' => 'global', 'keys' => ['users.create']],
         ],
-        'admin' => [['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']]],
+        'admin' => [
+            ['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']],
+            // Admins may view AND edit the company-settings screen (incl. logo) per policy. The
+            // exclude above keeps any OTHER future company.settings.* owner-only by default;
+            // these two keys are granted to admins explicitly.
+            ['scope' => 'global', 'keys' => ['company.settings.view', 'company.settings.edit']],
+        ],
         'owner' => [['scope' => 'any', 'verbs' => ['*']]],
     ];
 

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.7';
+    public string $dbVersion = '3.5.8';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -88,6 +88,7 @@ class Install
         30505,
         30506,
         30507,
+        30508,
     ];
 
     /**
@@ -2787,6 +2788,31 @@ class Install
             Log::error('Migration 30507: '.$e->getMessage());
 
             return ['Migration 30507 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30508: the Setting domain joined the native permission engine. Re-sync the
+     * discovered permission catalog (adds company.settings.view/edit + projectsettings.labels.manage)
+     * and re-seed the built-in role grants. Table-creation-free; idempotent + additive. Flush the
+     * discovered-provider cache first — an install that already ran 30505-30507 cached the provider
+     * list WITHOUT SettingPermissions, so seeding against that stale list would never create the
+     * new keys (admins would lose the company-settings screen, managers the label dialog).
+     */
+    public function update_sql_30508(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30508: '.$e->getMessage());
+
+            return ['Migration 30508 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Setting/Controllers/EditBoxLabel.php
+++ b/app/Domain/Setting/Controllers/EditBoxLabel.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Setting\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Setting\Permissions\SettingPermissions;
 use Leantime\Domain\Setting\Services\Setting as SettingService;
 
 class EditBoxLabel extends Controller
@@ -16,20 +16,15 @@ class EditBoxLabel extends Controller
      */
     public function init(SettingService $settingsSvc): void
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager]);
-
         $this->settingsSvc = $settingsSvc;
     }
 
     /**
      * get - handle get requests
      */
+    #[RequiresPermission(SettingPermissions::PROJECT_LABELS)]
     public function get($params)
     {
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
-            return $this->tpl->display('errors.error403');
-        }
-
         $currentLabel = '';
 
         if (isset($params['module']) && isset($params['label'])) {
@@ -47,6 +42,7 @@ class EditBoxLabel extends Controller
     /**
      * post - handle post requests
      */
+    #[RequiresPermission(SettingPermissions::PROJECT_LABELS)]
     public function post($params)
     {
         // If module and label are set its an update

--- a/app/Domain/Setting/Controllers/EditCompanySettings.php
+++ b/app/Domain/Setting/Controllers/EditCompanySettings.php
@@ -2,13 +2,13 @@
 
 namespace Leantime\Domain\Setting\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\UI\Theme;
 use Leantime\Domain\Api\Services\Api as ApiService;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Notifications\Models\Notification;
+use Leantime\Domain\Setting\Permissions\SettingPermissions;
 use Leantime\Domain\Setting\Services\Setting as SettingService;
 
 class EditCompanySettings extends Controller
@@ -27,8 +27,6 @@ class EditCompanySettings extends Controller
         SettingService $settingsSvc,
         Theme $theme,
     ): void {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin], true);
-
         $this->APIService = $APIService;
         $this->settingsSvc = $settingsSvc;
         $this->theme = $theme;
@@ -37,12 +35,9 @@ class EditCompanySettings extends Controller
     /**
      * get - handle get requests
      */
+    #[RequiresPermission(SettingPermissions::COMPANY_VIEW, global: true)]
     public function get($params)
     {
-        if (! Auth::userIsAtLeast(Roles::$owner)) {
-            return $this->tpl->display('errors.error403', responseCode: 403);
-        }
-
         if (isset($_GET['resetLogo'])) {
             $this->settingsSvc->resetLogo();
 
@@ -70,6 +65,7 @@ class EditCompanySettings extends Controller
     /**
      * post - handle post requests
      */
+    #[RequiresPermission(SettingPermissions::COMPANY_EDIT, global: true)]
     public function post($params)
     {
         // The telemetry opt-out path keys off the raw POST flag; mirror it into params.

--- a/app/Domain/Setting/Controllers/EditCompanySettings.php
+++ b/app/Domain/Setting/Controllers/EditCompanySettings.php
@@ -39,6 +39,13 @@ class EditCompanySettings extends Controller
     public function get($params)
     {
         if (isset($_GET['resetLogo'])) {
+            // Resetting the logo is a WRITE, so it must require edit — not the view that gates
+            // this GET handler. Matters once view/edit are split to different roles in the admin
+            // UI (the seeded matrix grants both to admin+owner, so this is defense-in-depth).
+            if (! can('company.settings.edit')) {
+                return $this->tpl->display('errors.error403', responseCode: 403);
+            }
+
             $this->settingsSvc->resetLogo();
 
             return Frontcontroller::redirect(BASE_URL.'/setting/editCompanySettings#look');

--- a/app/Domain/Setting/Controllers/Logo.php
+++ b/app/Domain/Setting/Controllers/Logo.php
@@ -2,8 +2,6 @@
 
 namespace Leantime\Domain\Setting\Controllers;
 
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Setting\Services\Setting as SettingService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,8 +13,8 @@ use Symfony\Component\HttpFoundation\Response;
  * /setting/logo plus the backward-compatible /api/setting alias used by the company-settings
  * logo cropper. The 501 GET/PATCH/DELETE stubs from the old controller are not carried over.
  *
- * The company logo is a global setting, so the upload now requires admin+ — the legacy
- * endpoint had no role check, letting any authenticated user overwrite it.
+ * The company logo is a global setting, so the upload requires company.settings.edit (admin+)
+ * — the legacy endpoint had no role check, letting any authenticated user overwrite it.
  */
 class Logo
 {
@@ -27,7 +25,7 @@ class Logo
      */
     public function post(): Response
     {
-        if (! Auth::userIsAtLeast(Roles::$admin)) {
+        if (! can('company.settings.edit')) {
             return response()->json(['status' => 'unauthorized'], 403);
         }
 

--- a/app/Domain/Setting/Permissions/SettingPermissions.php
+++ b/app/Domain/Setting/Permissions/SettingPermissions.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Leantime\Domain\Setting\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Setting permission vocabulary — spans two scopes.
+ *
+ *  - COMPANY settings (`company.settings.*`) — company-wide (projectScoped = false), resolved
+ *    against the GLOBAL role. Covers the editCompanySettings screen + the company logo.
+ *  - PROJECT labels (`projectsettings.labels.manage`) — project-scoped (projectScoped = true),
+ *    resolved against the user's role IN the project. Renaming a project's ticket/idea state
+ *    labels (the EditBoxLabel dialog). The verb is `manage` (not `edit`) on purpose: it keeps
+ *    the capability at manager+ and stops it leaking to editor via the project
+ *    create/edit/delete grant.
+ *
+ * The generic getSetting/saveSetting/deleteSetting key/value primitives are deliberately NOT in
+ * this vocabulary — they read/write ANY setting and are internal infrastructure, excluded from
+ * the JSON-RPC surface entirely (see the Setting service).
+ */
+final class SettingPermissions implements ProvidesPermissions
+{
+    /** View company-wide settings (branding, language, notification defaults). */
+    public const COMPANY_VIEW = 'company.settings.view';
+
+    /** Edit company-wide settings (incl. the company logo). */
+    public const COMPANY_EDIT = 'company.settings.edit';
+
+    /** Rename a project's ticket/idea state labels — manager+ in the project. */
+    public const PROJECT_LABELS = 'projectsettings.labels.manage';
+
+    public function domain(): string
+    {
+        return 'setting';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::COMPANY_VIEW, 'View company settings', false),
+            new Permission(self::COMPANY_EDIT, 'Edit company settings', false),
+            new Permission(self::PROJECT_LABELS, 'Rename project labels', true),
+        ];
+    }
+}

--- a/app/Domain/Setting/Services/Setting.php
+++ b/app/Domain/Setting/Services/Setting.php
@@ -5,11 +5,13 @@ namespace Leantime\Domain\Setting\Services;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Files\Contracts\FileManagerInterface;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
 use Leantime\Domain\Notifications\Models\Notification;
 use Leantime\Domain\Reports\Services\Reports as ReportService;
+use Leantime\Domain\Setting\Permissions\SettingPermissions;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
 use Ramsey\Uuid\Uuid;
@@ -83,7 +85,8 @@ class Setting
     }
 
     /**
-     * @api
+     * @internal Internal-only; resets the company logo. Reached only via the company-settings
+     *           page (gated company.settings.view/edit) — not on the JSON-RPC surface.
      */
     public function resetLogo(): void
     {
@@ -94,7 +97,10 @@ class Setting
     }
 
     /**
-     * @api
+     * @internal Foundational key/value primitive — writes ANY setting (company.*, usersettings.*,
+     *           projectsettings.*, licenses, …). Internal-only; deliberately excluded from the
+     *           JSON-RPC surface (RPC write-any-setting would be a privilege-escalation hole).
+     *           Callers that touch sensitive keys gate at their own boundary.
      */
     public function saveSetting($key, $value): bool
     {
@@ -104,7 +110,9 @@ class Setting
     /**
      * @return false|mixed
      *
-     * @api
+     * @internal Foundational key/value primitive — reads ANY setting. Internal-only;
+     *           deliberately excluded from the JSON-RPC surface (RPC read-any-setting could
+     *           leak license keys / OIDC/LDAP config secrets stored as settings).
      */
     public function getSetting($key, $default = false): mixed
     {
@@ -112,7 +120,8 @@ class Setting
     }
 
     /**
-     * @api
+     * @internal Foundational key/value primitive — deletes ANY setting. Internal-only;
+     *           deliberately excluded from the JSON-RPC surface.
      */
     public function deleteSetting($key): void
     {
@@ -120,7 +129,7 @@ class Setting
     }
 
     /**
-     * @api
+     * @internal Infrastructure accessor (returns the repository instance) — not an API surface.
      */
     public function getSettingsRepo(): SettingRepository
     {
@@ -128,7 +137,7 @@ class Setting
     }
 
     /**
-     * @api
+     * @internal Infrastructure mutator (swaps the repository dependency) — not an API surface.
      */
     public function setSettingsRepo(SettingRepository $settingsRepo): void
     {
@@ -179,6 +188,7 @@ class Setting
      *
      * @api
      */
+    #[RequiresPermission(SettingPermissions::PROJECT_LABELS, projectIdParam: 'projectId')]
     public function getProjectLabel(string $module, int $labelKey, int $projectId): string
     {
         if ($module === 'ticketlabels') {
@@ -217,6 +227,7 @@ class Setting
      *
      * @api
      */
+    #[RequiresPermission(SettingPermissions::PROJECT_LABELS, projectIdParam: 'projectId')]
     public function saveProjectLabel(string $module, int $labelKey, string $newLabel, int $projectId): void
     {
         if ($module === 'ticketlabels') {
@@ -269,6 +280,7 @@ class Setting
      *
      * @api
      */
+    #[RequiresPermission(SettingPermissions::COMPANY_VIEW, global: true)]
     public function getCompanySettings(string $logoUrl): array
     {
         $companySettings = [
@@ -350,6 +362,7 @@ class Setting
      *
      * @api
      */
+    #[RequiresPermission(SettingPermissions::COMPANY_EDIT, global: true)]
     public function saveCompanySettings(array $params): bool
     {
         $saved = false;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -37,7 +37,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('clients.create', 'Create clients', false),
             new Permission('clients.edit', 'Edit clients', false),
             new Permission('clients.delete', 'Delete clients', false),
+            new Permission('company.settings.view', 'View company settings', false),
             new Permission('company.settings.edit', 'Edit company settings', false),
+            // Project-scoped (rename a project's ticket/idea state labels — manager+ in project):
+            new Permission('projectsettings.labels.manage', 'Rename project labels', true),
         ];
     }
 
@@ -76,6 +79,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+
         $this->assertNotContains('users.create', $grants);      // company-wide, manager+
         $this->assertNotContains('clients.view', $grants);      // company-wide, admin+
+        $this->assertNotContains('company.settings.view', $grants);
+        // Label renaming uses the 'manage' verb (not 'edit'), so it stays manager+ and does NOT
+        // leak to editor via the project create/edit/delete grant.
+        $this->assertNotContains('projectsettings.labels.manage', $grants);
         $this->assertNotContains('company.settings.edit', $grants);
     }
 
@@ -99,10 +106,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertNotContains('clients.create', $grants);
         $this->assertNotContains('clients.edit', $grants);
         $this->assertNotContains('clients.delete', $grants);
+        // Renaming a project's labels is a manager-in-project capability (project '*' grant).
+        $this->assertContains('projectsettings.labels.manage', $grants);
+        $this->assertNotContains('company.settings.view', $grants);
         $this->assertNotContains('company.settings.edit', $grants);
     }
 
-    public function test_admin_gets_company_wide_except_company_settings(): void
+    public function test_admin_gets_company_wide_including_company_settings(): void
     {
         $grants = $this->grantsFor('admin');
 
@@ -115,16 +125,22 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('clients.create', $grants);
         $this->assertContains('clients.edit', $grants);
         $this->assertContains('clients.delete', $grants);   // full client management
+        $this->assertContains('projectsettings.labels.manage', $grants);
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
-        $this->assertNotContains('company.settings.edit', $grants); // owner-only
+        // Per policy (admin views + edits company settings), admins hold both company.settings
+        // keys via an explicit grant alongside the wildcard-with-exclude rule.
+        $this->assertContains('company.settings.view', $grants);
+        $this->assertContains('company.settings.edit', $grants);
     }
 
     public function test_owner_gets_everything_including_company_settings(): void
     {
         $grants = $this->grantsFor('owner');
 
+        $this->assertContains('company.settings.view', $grants);
         $this->assertContains('company.settings.edit', $grants);
+        $this->assertContains('projectsettings.labels.manage', $grants);
         $this->assertContains('clients.delete', $grants);
         $this->assertContains('users.view', $grants);
         $this->assertContains('comments.moderate', $grants);


### PR DESCRIPTION
## Summary

The last company-scope domain — and the most mixed-scope one. Setting's 14 service methods split into four buckets, and this is the first domain to exercise the **top tier** (`company.settings.*`) plus a **project-scoped** capability.

> Builds on #3461/#3469/#3471/#3472 (all merged). Enforcement on by default.

## Vocabulary (`SettingPermissions`)

- `company.settings.view` + `company.settings.edit` — company-wide (`projectScoped=false`).
- `projectsettings.labels.manage` — **project-scoped** (`projectScoped=true`). Verb is `manage` (not `edit`) **on purpose** so it stays manager+ and doesn't leak to editor via the project create/edit/delete grant.

## Matrix (verified on a live DB)

`company.settings.view`/`edit` → **admin, owner**; `projectsettings.labels.manage` → **manager, admin, owner**; lower roles none. Admins get the two `company.settings.*` keys via an **explicit grant** added alongside the existing `any/* exclude company.settings.*` admin rule — so any *future* `company.settings.*` stays owner-only by default.

## Policy decision (company settings)

The current code is inconsistent: viewing company settings is owner-only, but **saving** is reachable by admins. Per your call, this resolves in the **permissive** direction — **admins may view AND edit** company settings (incl. logo). `EditCompanySettings` get→`company.settings.view`, post→`company.settings.edit`; `Logo` upload→`company.settings.edit`.

## Security fixes (severe RPC holes closed)

The foundational key/value primitives were `@api` — over JSON-RPC that's **write/read/delete *any* setting** (company config, licenses, OIDC/LDAP secrets stored as settings):
- `saveSetting` / `getSetting` / `deleteSetting` → **de-`@api`'d** (~86 internal callers, **zero** external/RPC/JS callers — confirmed by grep, so no functional loss).
- `resetLogo` was `@api` (any user could reset the company logo via RPC) → de-`@api`'d.
- `getSettingsRepo` / `setSettingsRepo` (infra accessors) → de-`@api`'d.
- `getProjectLabel` / `saveProjectLabel` were `@api` + ungated (rename any project's labels via RPC) → now `projectsettings.labels.manage` with `projectIdParam`.

## Migration

`update_sql_30508` (flush `PermissionRegistry` first, re-sync, re-seed); `dbVersion 3.5.7 → 3.5.8`.

## Verification

- ✅ Full unit suite **421 tests / 1034 assertions** — `DefaultRolePermissionsTest` extended with `company.settings.view` + the project-label key; the admin company-settings assertion **flipped** to reflect the policy.
- ✅ Pint + PHPStan clean. Live `permissions:sync --seed` → 21 permissions; grants match the matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
