### PR TITLE
security(wiki): gate Wiki domain on the native permission engine

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.9';
+    public string $dbVersion = '3.5.10';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -90,6 +90,7 @@ class Install
         30507,
         30508,
         30509,
+        30510,
     ];
 
     /**
@@ -2840,6 +2841,32 @@ class Install
             Log::error('Migration 30509: '.$e->getMessage());
 
             return ['Migration 30509 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30510: the Wiki domain joined the native permission engine. Re-sync the discovered
+     * permission catalog (adds wiki.view/create/edit/delete, all project-scoped) and re-seed the
+     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
+     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
+     * Flush the discovered-provider cache first — an install that already ran 30505-30509 cached the
+     * provider list WITHOUT WikiPermissions, so seeding against that stale list would never create
+     * the wiki.* keys (and lower roles would lose wiki access).
+     */
+    public function update_sql_30510(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30510: '.$e->getMessage());
+
+            return ['Migration 30510 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Wiki/Controllers/ArticleDialog.php
+++ b/app/Domain/Wiki/Controllers/ArticleDialog.php
@@ -3,10 +3,12 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,6 +27,7 @@ class ArticleDialog extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
 
@@ -62,8 +65,12 @@ class ArticleDialog extends Controller
     }
 
     /**
+     * Creates or updates an article. The controller gate defers (entityScoped) to the service's
+     * createArticle/updateArticle, which authorize CREATE/EDIT against the article's real project.
+     *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
 

--- a/app/Domain/Wiki/Controllers/DelArticle.php
+++ b/app/Domain/Wiki/Controllers/DelArticle.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelArticle extends Controller
 {
-    private WikiRepository $wikiRepo;
+    private WikiService $wikiService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(WikiRepository $wikiRepo): void
+    public function init(WikiService $wikiService): void
     {
-        $this->wikiRepo = $wikiRepo;
+        $this->wikiService = $wikiService;
     }
 
     /**
@@ -26,31 +26,27 @@ class DelArticle extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('wiki.delArticle');
     }
 
     /**
-     * Handles article deletion.
+     * Handles article deletion. The controller gate defers (entityScoped) to the service's
+     * deleteArticle(), which authorizes DELETE against the article's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->wikiRepo->delArticle($id);
+            $this->wikiService->deleteArticle($id);
 
             $this->tpl->setNotification($this->language->__('notification.article_deleted'), 'success', 'article_deleted');
-
-            session()->forget('lastArticle');
-            session()->forget('currentWiki');
 
             return Frontcontroller::redirect(BASE_URL.'/wiki/show');
         }

--- a/app/Domain/Wiki/Controllers/DelWiki.php
+++ b/app/Domain/Wiki/Controllers/DelWiki.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelWiki extends Controller
 {
-    private WikiRepository $wikiRepo;
+    private WikiService $wikiService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(WikiRepository $wikiRepo): void
+    public function init(WikiService $wikiService): void
     {
-        $this->wikiRepo = $wikiRepo;
+        $this->wikiService = $wikiService;
     }
 
     /**
@@ -26,31 +26,27 @@ class DelWiki extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('wiki.delWiki');
     }
 
     /**
-     * Handles wiki deletion.
+     * Handles wiki deletion. The controller gate defers (entityScoped) to the service's
+     * deleteWiki(), which authorizes DELETE against the wiki's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->wikiRepo->delWiki($id);
+            $this->wikiService->deleteWiki($id);
 
             $this->tpl->setNotification($this->language->__('notification.wiki_deleted'), 'success', 'wiki_deleted');
-
-            session()->forget('lastArticle');
-            session()->forget('currentWiki');
 
             return Frontcontroller::redirect(BASE_URL.'/wiki/show');
         }

--- a/app/Domain/Wiki/Controllers/Show.php
+++ b/app/Domain/Wiki/Controllers/Show.php
@@ -3,11 +3,12 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
-use Leantime\Domain\Wiki\Models\Wiki;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,6 +30,7 @@ class Show extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get(array $params): Response
     {
 
@@ -146,6 +148,7 @@ class Show extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function post(array $params): Response
     {
 

--- a/app/Domain/Wiki/Controllers/Templates.php
+++ b/app/Domain/Wiki/Controllers/Templates.php
@@ -2,7 +2,9 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Symfony\Component\HttpFoundation\Response;
 
 class Templates extends Controller
@@ -12,6 +14,7 @@ class Templates extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
         return $this->tpl->displayPartial('wiki.templates');

--- a/app/Domain/Wiki/Controllers/WikiModal.php
+++ b/app/Domain/Wiki/Controllers/WikiModal.php
@@ -3,9 +3,11 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Wiki\Models\Wiki;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,6 +23,7 @@ class WikiModal extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
         $wiki = app()->make(Wiki::class);
@@ -35,8 +38,12 @@ class WikiModal extends Controller
     }
 
     /**
+     * Creates or updates a wiki (notebook). The controller gate defers (entityScoped) to the
+     * service's createWiki/updateWiki, which authorize CREATE/EDIT against the wiki's real project.
+     *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
         $wiki = app()->make(Wiki::class);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Wiki\Hxcontrollers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki;
 
 /**
@@ -22,8 +24,10 @@ class ArticleActivity extends HtmxController
     }
 
     /**
-     * Get the activity feed for an article.
+     * Get the activity feed for an article. The service's getArticleActivity() is the precise
+     * per-article-project IDOR fence; this VIEW gate stops non-viewers at dispatch.
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get(): void
     {
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
@@ -27,7 +27,7 @@ class ArticleActivity extends HtmxController
      * Get the activity feed for an article. The service's getArticleActivity() is the precise
      * per-article-project IDOR fence; this VIEW gate stops non-viewers at dispatch.
      */
-    #[RequiresPermission(WikiPermissions::VIEW)]
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function get(): void
     {
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleContent.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleContent.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Wiki\Hxcontrollers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,15 +26,14 @@ class ArticleContent extends HtmxController
     }
 
     /**
-     * Save article content via HTMX (called on auto-save or blur)
+     * Save article content via HTMX (called on auto-save or blur).
+     *
+     * Gate defers (entityScoped) to the service's updateArticle(), which authorizes EDIT against
+     * the article's real project.
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function save(): Response
     {
-        // Check permissions
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return new Response('Unauthorized', 403);
-        }
-
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);
         $content = $this->incomingRequest->request->get('description');
         $title = $this->incomingRequest->request->get('title');
@@ -86,15 +85,14 @@ class ArticleContent extends HtmxController
     }
 
     /**
-     * Create a new article and redirect to it
+     * Create a new article and redirect to it.
+     *
+     * Gate defers (entityScoped) to the service's createArticle(), which authorizes CREATE against
+     * the target wiki's project.
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function create(): Response
     {
-        // Check permissions
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return new Response('Unauthorized', 403);
-        }
-
         $currentWiki = session('currentWiki');
         if (! $currentWiki) {
             return new Response('No wiki selected', 400);

--- a/app/Domain/Wiki/Permissions/WikiPermissions.php
+++ b/app/Domain/Wiki/Permissions/WikiPermissions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Leantime\Domain\Wiki\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Wiki permission vocabulary — the verbs only.
+ *
+ * Wiki articles and wikis are PROJECT-scoped (each belongs to one project), so every capability is
+ * evaluated against the user's role IN that project (projectScoped = true, the default). The
+ * standard verbs auto-grant via the central matrix (readonly = view; editor = create/edit/delete;
+ * manager+ = all), so no {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} change is
+ * required.
+ */
+final class WikiPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'wiki.view';
+
+    public const CREATE = 'wiki.create';
+
+    public const EDIT = 'wiki.edit';
+
+    public const DELETE = 'wiki.delete';
+
+    public function domain(): string
+    {
+        return 'wiki';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View wiki articles'),
+            new Permission(self::CREATE, 'Create wiki articles'),
+            new Permission(self::EDIT, 'Edit wiki articles'),
+            new Permission(self::DELETE, 'Delete wiki articles'),
+        ];
+    }
+}

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -117,6 +117,22 @@ class Wiki extends Blueprints
         return $article;
     }
 
+    /**
+     * Resolve an article's owning project by its id alone (articles inherit their wiki's project
+     * via canvasId -> zp_canvas.projectId). Used by the service to authorize edit/delete/activity
+     * against the article's REAL project without trusting a caller-supplied projectId.
+     */
+    public function getArticleProjectId(int $id): ?int
+    {
+        $projectId = $this->dbConnection->table('zp_canvas_items')
+            ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
+            ->where('zp_canvas_items.id', $id)
+            ->where('zp_canvas_items.box', 'article')
+            ->value('zp_canvas.projectId');
+
+        return $projectId !== null ? (int) $projectId : null;
+    }
+
     public function getAllProjectWikis(int $projectId): array|false
     {
         $results = $this->dbConnection->table('zp_canvas')

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -219,8 +219,11 @@ class Wiki extends Blueprints
 
     public function updateWiki(WikiModel $wiki, int $wikiId): bool
     {
+        // type guard: zp_canvas is shared across all canvas types (one id sequence), so scope the
+        // write to wiki rows — a non-wiki id can never rename another project's canvas board.
         return $this->dbConnection->table('zp_canvas')
             ->where('id', $wikiId)
+            ->where('type', 'wiki')
             ->update(['title' => $wiki->title]) >= 0;
     }
 
@@ -246,8 +249,11 @@ class Wiki extends Blueprints
 
     public function updateArticle(Article $article): bool
     {
+        // box guard: zp_canvas_items is shared across all canvas types (one id sequence), so scope
+        // the write to article rows — a non-article id can never touch a goal/SWOT/risk item.
         return $this->dbConnection->table('zp_canvas_items')
             ->where('id', $article->id)
+            ->where('box', 'article')
             ->update([
                 'title' => $article->title,
                 'description' => $article->description,
@@ -262,8 +268,10 @@ class Wiki extends Blueprints
 
     public function delArticle(int $id): void
     {
+        // box guard (shared zp_canvas_items): only ever delete an article row by this id.
         $this->dbConnection->table('zp_canvas_items')
             ->where('id', $id)
+            ->where('box', 'article')
             ->delete();
     }
 
@@ -273,8 +281,10 @@ class Wiki extends Blueprints
             ->where('canvasId', $id)
             ->delete();
 
+        // type guard (shared zp_canvas): only ever delete a wiki board by this id.
         $this->dbConnection->table('zp_canvas')
             ->where('id', $id)
+            ->where('type', 'wiki')
             ->delete();
     }
 

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -277,11 +277,22 @@ class Wiki extends Blueprints
 
     public function delWiki(int $id): void
     {
+        // zp_canvas/zp_canvas_items are shared across all canvas families. Early-return unless this
+        // id is an actual wiki board, so the items-delete (by canvasId) can never drop another
+        // canvas type's items before the type-guarded board delete runs.
+        $isWiki = $this->dbConnection->table('zp_canvas')
+            ->where('id', $id)
+            ->where('type', 'wiki')
+            ->exists();
+
+        if (! $isWiki) {
+            return;
+        }
+
         $this->dbConnection->table('zp_canvas_items')
             ->where('canvasId', $id)
             ->delete();
 
-        // type guard (shared zp_canvas): only ever delete a wiki board by this id.
         $this->dbConnection->table('zp_canvas')
             ->where('id', $id)
             ->where('type', 'wiki')

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -2,15 +2,18 @@
 
 namespace Leantime\Domain\Wiki\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language;
 use Leantime\Domain\Audit\Repositories\Audit as AuditRepository;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
 
 /**
  * @api
  */
-class Wiki
+class Wiki extends BaseService
 {
     private WikiRepository $wikiRepository;
 
@@ -31,8 +34,13 @@ class Wiki
     /**
      * Get an article by ID and project.
      *
+     * The repository already filters by project, so this read is project-scoped: when a projectId
+     * is passed it is authorized against (closing the explicit-foreign-project RPC read); when it is
+     * omitted the call resolves to the caller's session project and can only read articles there.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, projectIdParam: 'projectId')]
     public function getArticle(?int $id, ?int $projectId = null): mixed
     {
 
@@ -59,6 +67,7 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, projectIdParam: 'projectId')]
     public function getAllProjectWikis($projectId): array|false
     {
 
@@ -71,7 +80,10 @@ class Wiki
             $wiki->projectId = $projectId;
             $wiki->author = session('userdata.id');
 
-            $id = $this->createWiki($wiki);
+            // Bootstrap only: the default notebook is created as a SIDE EFFECT of viewing a
+            // wiki-less project, so it must NOT go through the create-authorized createWiki() —
+            // that would 403 a readonly viewer. Write straight to the repository (system action).
+            $this->wikiRepository->createWiki($wiki);
             $wikis = $this->wikiRepository->getAllProjectWikis($projectId);
         }
 
@@ -79,30 +91,61 @@ class Wiki
     }
 
     /**
+     * List the article headlines in a wiki.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getAllWikiHeadlines($wikiId, $userId): false|array
     {
+        // IDOR fence: a foreign wikiId would otherwise leak another project's article titles.
+        // Resolve the wiki's project and authorize VIEW there before listing.
+        $wiki = $this->wikiRepository->getWiki((int) $wikiId);
+        if (! $wiki) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::VIEW, (int) $wiki->projectId);
+
         return $this->wikiRepository->getAllWikiHeadlines($wikiId, $userId);
     }
 
     /**
+     * Get a single wiki (notebook) by id.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getWiki($id): mixed
     {
         if ($id === null) {
             return false;
         }
 
-        return $this->wikiRepository->getWiki((int) $id);
+        $wiki = $this->wikiRepository->getWiki((int) $id);
+
+        if (! $wiki) {
+            return false;
+        }
+
+        // IDOR fence: the id alone names any project's wiki. Authorize VIEW against the wiki's
+        // ACTUAL project, not the session project — closes the cross-project read (and the
+        // ?setWiki= session-switch footgun, which routes through here) on every call surface.
+        $this->authorize(WikiPermissions::VIEW, (int) $wiki->projectId);
+
+        return $wiki;
     }
 
     /**
      * @api
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function createWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki): false|string
     {
+        // Authorize CREATE against the target project before writing. An RPC caller could set any
+        // projectId on the model, so the check is against that value (denied for non-members).
+        $projectId = (int) ($wiki->projectId ?? session('currentProject'));
+        $this->authorize(WikiPermissions::CREATE, $projectId);
 
         $wikiId = $this->wikiRepository->createWiki($wiki);
 
@@ -114,8 +157,16 @@ class Wiki
     /**
      * @api
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function updateWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki, $wikiId): bool
     {
+        // IDOR fence: authorize EDIT against the EXISTING wiki's real project (the incoming model's
+        // projectId is untrusted) before writing.
+        $existing = $this->wikiRepository->getWiki((int) $wikiId);
+        if ($existing) {
+            $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
+        }
+
         return $this->wikiRepository->updateWiki($wiki, $wikiId);
     }
 
@@ -124,8 +175,15 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function createArticle(Article $article): false|string
     {
+        // An article inherits its wiki's project (canvasId -> zp_canvas.projectId). Authorize CREATE
+        // against that project before writing, so a foreign/spoofed canvasId is denied.
+        $wiki = $this->wikiRepository->getWiki((int) $article->canvasId);
+        $projectId = $wiki ? (int) $wiki->projectId : (int) session('currentProject');
+        $this->authorize(WikiPermissions::CREATE, $projectId);
+
         $id = $this->wikiRepository->createArticle($article);
 
         if ($id !== false) {
@@ -147,8 +205,17 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function updateArticle(Article $article, ?Article $existingArticle = null): bool
     {
+        // IDOR fence: resolve the EXISTING article's real project (by id) and authorize EDIT there
+        // before writing. The incoming model's project/canvas are untrusted, so an editor in
+        // project A cannot edit or relocate an article that lives in project B.
+        $projectId = $this->wikiRepository->getArticleProjectId((int) $article->id);
+        if ($projectId !== null) {
+            $this->authorize(WikiPermissions::EDIT, $projectId);
+        }
+
         $result = $this->wikiRepository->updateArticle($article);
 
         if ($result && $existingArticle !== null) {
@@ -156,6 +223,66 @@ class Wiki
         }
 
         return $result;
+    }
+
+    /**
+     * Delete an article, fencing the operation against the article's project.
+     *
+     * @api
+     */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
+    public function deleteArticle(int $id): bool
+    {
+        // IDOR fence: the id alone identified the row before (the controller called the repository
+        // directly), so any editor could delete another project's article. Authorize DELETE against
+        // the article's real project first.
+        $projectId = $this->wikiRepository->getArticleProjectId($id);
+
+        if ($projectId === null) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::DELETE, $projectId);
+
+        $this->wikiRepository->delArticle($id);
+
+        $this->auditRepo->storeEvent(
+            action: 'article.delete',
+            values: '',
+            entity: 'article',
+            entityId: $id,
+            userId: (int) session('userdata.id'),
+            projectId: $projectId
+        );
+
+        session()->forget('lastArticle');
+
+        return true;
+    }
+
+    /**
+     * Delete a wiki (notebook), fencing the operation against the wiki's project.
+     *
+     * @api
+     */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
+    public function deleteWiki(int $id): bool
+    {
+        // IDOR fence: authorize DELETE against the wiki's real project before removing it.
+        $wiki = $this->wikiRepository->getWiki($id);
+
+        if (! $wiki) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::DELETE, (int) $wiki->projectId);
+
+        $this->wikiRepository->delWiki($id);
+
+        session()->forget('currentWiki');
+        session()->forget('lastArticle');
+
+        return true;
     }
 
     public function setCurrentWiki($id)
@@ -219,8 +346,19 @@ class Wiki
      *
      * @return array<int, array<string, mixed>>
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getArticleActivity(int $articleId, int $limit = 20): array
     {
+        // IDOR fence: a foreign articleId would otherwise leak another project's edit history
+        // (audit values include old/new titles). Authorize VIEW against the article's real project.
+        $projectId = $this->wikiRepository->getArticleProjectId($articleId);
+
+        if ($projectId === null) {
+            return [];
+        }
+
+        $this->authorize(WikiPermissions::VIEW, $projectId);
+
         $activity = [];
 
         // Get audit events for this article

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -161,11 +161,16 @@ class Wiki extends BaseService
     public function updateWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki, $wikiId): bool
     {
         // IDOR fence: authorize EDIT against the EXISTING wiki's real project (the incoming model's
-        // projectId is untrusted) before writing.
+        // projectId is untrusted) before writing. FAIL CLOSED when the id is not a wiki — zp_canvas
+        // is shared across canvas types (one id sequence), and getWiki filters type='wiki', so a
+        // non-wiki id resolves to false; refuse rather than fall through to an unguarded title write
+        // that would rename another project's canvas board.
         $existing = $this->wikiRepository->getWiki((int) $wikiId);
-        if ($existing) {
-            $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
+        if (! $existing) {
+            return false;
         }
+
+        $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
 
         return $this->wikiRepository->updateWiki($wiki, $wikiId);
     }
@@ -210,11 +215,16 @@ class Wiki extends BaseService
     {
         // IDOR fence: resolve the EXISTING article's real project (by id) and authorize EDIT there
         // before writing. The incoming model's project/canvas are untrusted, so an editor in
-        // project A cannot edit or relocate an article that lives in project B.
+        // project A cannot edit or relocate an article that lives in project B. FAIL CLOSED on an
+        // unresolved project: zp_canvas_items is a shared table (one id sequence across ALL canvas
+        // types), so a null here means the id is not an article — refuse rather than write a row we
+        // could not authorize (a non-article id would otherwise overwrite a goal/SWOT/risk item).
         $projectId = $this->wikiRepository->getArticleProjectId((int) $article->id);
-        if ($projectId !== null) {
-            $this->authorize(WikiPermissions::EDIT, $projectId);
+        if ($projectId === null) {
+            return false;
         }
+
+        $this->authorize(WikiPermissions::EDIT, $projectId);
 
         $result = $this->wikiRepository->updateArticle($article);
 

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -28,6 +28,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('sprints.create', 'Create', true),
             new Permission('sprints.edit', 'Edit', true),
             new Permission('sprints.delete', 'Delete', true),
+            new Permission('wiki.view', 'View', true),
+            new Permission('wiki.create', 'Create', true),
+            new Permission('wiki.edit', 'Edit', true),
+            new Permission('wiki.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -55,7 +59,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -70,6 +74,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertNotContains('tickets.delete', $grants);
         $this->assertNotContains('sprints.create', $grants); // commenter views but cannot create
         $this->assertContains('sprints.view', $grants);       // inherited from readonly
+        $this->assertNotContains('wiki.create', $grants);     // commenter views but cannot create
+        $this->assertContains('wiki.view', $grants);          // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -84,6 +90,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('sprints.create', $grants);
         $this->assertContains('sprints.edit', $grants);
         $this->assertContains('sprints.delete', $grants);
+        // Wiki uses the same standard project verbs, so editor auto-gets create/edit/delete.
+        $this->assertContains('wiki.create', $grants);
+        $this->assertContains('wiki.edit', $grants);
+        $this->assertContains('wiki.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Unit\app\Domain\Wiki\Services;
+
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Core\Language;
+use Leantime\Domain\Audit\Repositories\Audit as AuditRepository;
+use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Models\Wiki as WikiModel;
+use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
+use Unit\TestCase;
+
+/**
+ * Unit tests for the Wiki service's project-scoped authorization. Wiki articles and notebooks are
+ * project-scoped; mutations and single-entity reads authorize against the entity's REAL project
+ * (entityScoped), closing the IDORs where the id alone identified the row.
+ */
+class WikiServiceTest extends TestCase
+{
+    use \Codeception\Test\Feature\Stub;
+
+    private function makeService(
+        ?WikiRepository $wikiRepo = null,
+        ?AuditRepository $auditRepo = null,
+    ): WikiService {
+        return new WikiService(
+            $wikiRepo ?? $this->make(WikiRepository::class),
+            $this->make(Language::class),
+            $auditRepo ?? $this->make(AuditRepository::class),
+        );
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, ['authorize' => fn () => null]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reads: single-entity-by-id reads fence against the entity's project.
+    // ---------------------------------------------------------------------
+
+    public function test_get_wiki_is_denied_when_user_cannot_view_its_project(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getWiki(3);
+    }
+
+    public function test_get_wiki_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        // A missing wiki short-circuits to false BEFORE authorize — no enumeration oracle.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => false,
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $this->assertFalse($service->getWiki(999));
+        $this->assertSame(0, $authorizeCalls, 'A non-existent wiki must short-circuit before authorize');
+    }
+
+    public function test_get_all_wiki_headlines_is_denied_for_foreign_wiki(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getAllWikiHeadlines(3, 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Mutations: authorize against the entity's real project before writing.
+    // ---------------------------------------------------------------------
+
+    public function test_create_article_is_denied_without_create_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            // createArticle resolves the project from the target wiki (canvasId) to authorize.
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+            'createArticle' => function () {
+                throw new \RuntimeException('create must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $article = new Article;
+        $article->canvasId = 3;
+        $service->createArticle($article);
+    }
+
+    public function test_update_article_is_denied_without_edit_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => 9,
+            'updateArticle' => function () {
+                throw new \RuntimeException('update must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $article = new Article;
+        $article->id = 42;
+        $service->updateArticle($article);
+    }
+
+    public function test_create_wiki_is_denied_without_create_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'createWiki' => function () {
+                throw new \RuntimeException('create must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $wiki = new WikiModel;
+        $wiki->projectId = 9;
+        $service->createWiki($wiki);
+    }
+
+    // ---------------------------------------------------------------------
+    // Delete: new service methods that fence the previously controller->repo IDOR.
+    // ---------------------------------------------------------------------
+
+    public function test_delete_article_is_denied_and_does_not_delete_without_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => 9,
+            'delArticle' => function (): void {
+                throw new \RuntimeException('delete must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteArticle(42);
+    }
+
+    public function test_delete_article_deletes_and_audits_when_authorized(): void
+    {
+        $deletedId = null;
+        $auditedAction = null;
+
+        $service = $this->makeService(
+            wikiRepo: $this->make(WikiRepository::class, [
+                'getArticleProjectId' => fn () => 9,
+                'delArticle' => function ($id) use (&$deletedId): void {
+                    $deletedId = $id;
+                },
+            ]),
+            auditRepo: $this->make(AuditRepository::class, [
+                'storeEvent' => function (string $action) use (&$auditedAction) {
+                    $auditedAction = $action;
+                },
+            ]),
+        );
+        $service->setPermissionService($this->allowingPermissions());
+
+        $this->assertTrue($service->deleteArticle(42));
+        $this->assertSame(42, $deletedId);
+        $this->assertSame('article.delete', $auditedAction);
+    }
+
+    public function test_delete_article_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => null,
+            'delArticle' => function (): void {
+                throw new \RuntimeException('delete must not run for a non-existent article');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $this->assertFalse($service->deleteArticle(999));
+        $this->assertSame(0, $authorizeCalls);
+    }
+
+    public function test_delete_wiki_is_denied_without_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+            'delWiki' => function (): void {
+                throw new \RuntimeException('delete must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteWiki(3);
+    }
+}

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -146,6 +146,54 @@ class WikiServiceTest extends TestCase
         $service->createWiki($wiki);
     }
 
+    public function test_update_article_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        // FAIL CLOSED: zp_canvas_items is a shared table (one id sequence across all canvas types),
+        // so an unresolved project (non-article / unknown id) must refuse BEFORE authorize and never
+        // reach the repo write — otherwise a non-article id would overwrite a goal/SWOT/risk row.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => null,
+            'updateArticle' => function (): bool {
+                throw new \RuntimeException('update must not run for an unresolved/non-article id');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $article = new Article;
+        $article->id = 999;
+
+        $this->assertFalse($service->updateArticle($article));
+        $this->assertSame(0, $authorizeCalls, 'A non-article id must short-circuit before authorize');
+    }
+
+    public function test_update_wiki_returns_false_for_unknown_wiki_without_authorizing(): void
+    {
+        // FAIL CLOSED: zp_canvas is shared across canvas types, so a non-wiki / unknown id must
+        // refuse BEFORE authorize and never reach the repo title write.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => false,
+            'updateWiki' => function (): bool {
+                throw new \RuntimeException('update must not run for a non-wiki id');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $wiki = new WikiModel;
+
+        $this->assertFalse($service->updateWiki($wiki, 999));
+        $this->assertSame(0, $authorizeCalls, 'A non-wiki id must short-circuit before authorize');
+    }
+
     // ---------------------------------------------------------------------
     // Delete: new service methods that fence the previously controller->repo IDOR.
     // ---------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #3474 (Sprints) for the migration-version sequence — base auto-retargets to `master` when #3474 merges. Review the **Files changed** against the Sprints branch (only the Wiki diff).

## What & why
Wiki articles/notebooks are project-scoped, but the domain had effectively **no server-side authorization**: the create/edit dialogs (`ArticleDialog`, `WikiModal`) had no auth check at all, the delete controllers called the **repository directly** (layer violation, bypassing any service check), and single-entity reads fell back to the session project (cross-project read IDOR). This brings Wiki onto the native permission engine following the Sprints anchor, with the corrected **read-side rule** (single-entity-by-id reads fence against the entity's real project, not the session).

## Highlights
- **`WikiPermissions`** view/create/edit/delete (project-scoped). Standard verbs auto-grant via the central matrix → no `DefaultRolePermissions` change.
- **Service (now `extends BaseService`)** — model-based mutations fence in-body (`entityScoped`):
  - `createArticle` resolves project from the target wiki (`canvasId → zp_canvas.projectId`); `updateArticle`/`deleteArticle` resolve the **existing** article's real project by id (new repo helper `getArticleProjectId`) — incoming model project is untrusted → closes edit/delete/relocate IDORs.
  - `createWiki` authorizes the target project; `updateWiki`/`deleteWiki` load the existing wiki first.
  - **New** `deleteArticle`/`deleteWiki` service methods (controllers used to hit the repo directly); `deleteArticle` records an `article.delete` audit event.
  - Single-entity reads `getWiki` / `getAllWikiHeadlines` / `getArticleActivity` are `entityScoped` and authorize VIEW against the entity's real project (closes cross-project metadata leaks **and** the `?setWiki=` session-switch footgun, which routes through `getWiki`). `getArticle`/`getAllProjectWikis` stay dispatch-only `view` (`projectIdParam`) — the repo already project-filters and they're foundational page-load reads.
  - **Landmine handled:** `getAllProjectWikis` lazily creates a default notebook on view; that bootstrap now writes straight to the repository instead of the create-authorized `createWiki()`, so a **readonly viewer isn't 403'd**.
- **Controllers** — `DelArticle`/`DelWiki` rerouted onto the service (no direct repo calls, no `Auth::authOrRedirect`); `Show`/`ArticleDialog`/`WikiModal`/`Templates` + `ArticleContent`/`ArticleActivity` Hx controllers gated with `#[RequiresPermission]` (mutating posts defer `entityScoped` to the service's per-verb fence; removed the inline `Auth::userIsAtLeast` checks).

## Migration & verification
- `update_sql_30510` (flush `PermissionRegistry` → sync → seed) + `dbVersion` 3.5.10.
- **DB-verified:** `wiki.view` → all roles; `wiki.create/edit/delete` → editor+.
- `WikiServiceTest` (10 denial/fence tests) + matrix lock extended. Full unit suite **436 tests / 1064 assertions** green; pint + phpstan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)