### PR TITLE
security(comments): scope comment authz to the host entity's real project

### DIFF
--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -143,16 +143,21 @@ final class DefaultRolePermissions
             return false;
         }
 
-        // Explicit key allow-list (for permissions that don't follow the verb convention).
+        // A rule matches by EITHER an explicit key allow-list (for permissions that don't follow
+        // the verb convention) OR by verb. Compute the base match first...
         if (isset($rule['keys'])) {
-            return in_array($permission->key, $rule['keys'], true);
+            $matched = in_array($permission->key, $rule['keys'], true);
+        } else {
+            $verb = Str::afterLast($permission->key, '.');
+            $matched = ($rule['verbs'] ?? []) === ['*'] || in_array($verb, $rule['verbs'] ?? [], true);
         }
 
-        $verb = Str::afterLast($permission->key, '.');
-        if (($rule['verbs'] ?? []) !== ['*'] && ! in_array($verb, $rule['verbs'] ?? [], true)) {
+        if (! $matched) {
             return false;
         }
 
+        // ...then ALWAYS apply the exclude list, so an `exclude` alongside `keys` is honored (a
+        // `keys` rule previously returned early and bypassed the exclude, risking an over-grant).
         foreach ($rule['exclude'] ?? [] as $excluded) {
             if ($excluded === $permission->key) {
                 return false;

--- a/app/Domain/Comments/Repositories/Comments.php
+++ b/app/Domain/Comments/Repositories/Comments.php
@@ -114,10 +114,13 @@ class Comments
      * Comments are cross-module; each module maps to a project differently:
      *  - project        -> the moduleId IS the project id
      *  - ticket         -> zp_tickets.projectId
-     *  - canvas family  -> the moduleId is a zp_canvas_items row; project via its canvas
-     *    (article, goalcanvasitem, idea, and every "<type>canvasitem")
-     *  - client / other -> null (company-scoped or unknown; the caller falls back to a
-     *    session-scoped capability check so behavior is unchanged for those targets)
+     *  - canvas family  -> the moduleId is a zp_canvas_items row; project via its canvas. Only the
+     *    KNOWN canvas comment modules are resolved this way: 'article', 'idea', and every
+     *    "<type>canvasitem" (goalcanvasitem, leancanvasitem, wikicanvasitem, ...).
+     *  - client / anything else -> null (company-scoped or unknown; the caller falls back to a
+     *    session-scoped capability check so behavior is unchanged for those targets). An unknown
+     *    module is NOT run through the canvas lookup, so it can never accidentally resolve a project
+     *    from a colliding zp_canvas_items id.
      *
      * Direct table reads are used deliberately (no cross-domain service calls) to keep this a
      * decoupled, side-effect-free authorization lookup that cannot recurse into other gates.
@@ -132,23 +135,24 @@ class Comments
             return $moduleId;
         }
 
-        if ($module === 'client') {
-            return null;
-        }
-
         if ($module === 'ticket') {
             $projectId = $this->db->table('zp_tickets')->where('id', $moduleId)->value('projectId');
 
             return $projectId !== null ? (int) $projectId : null;
         }
 
-        // Canvas-family comment targets store the canvas-item id as the moduleId.
-        $projectId = $this->db->table('zp_canvas_items')
-            ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
-            ->where('zp_canvas_items.id', $moduleId)
-            ->value('zp_canvas.projectId');
+        // Canvas-backed comment targets store the canvas-item id as the moduleId. Restrict to the
+        // known canvas comment modules so an unknown module falls through to null (session-scoped).
+        if ($module === 'article' || $module === 'idea' || str_ends_with($module, 'canvasitem')) {
+            $projectId = $this->db->table('zp_canvas_items')
+                ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
+                ->where('zp_canvas_items.id', $moduleId)
+                ->value('zp_canvas.projectId');
 
-        return $projectId !== null ? (int) $projectId : null;
+            return $projectId !== null ? (int) $projectId : null;
+        }
+
+        return null;
     }
 
     public function addComment(array $values, string $module): false|string

--- a/app/Domain/Comments/Repositories/Comments.php
+++ b/app/Domain/Comments/Repositories/Comments.php
@@ -93,6 +93,7 @@ class Comments
                 'comment.id',
                 'comment.text',
                 'comment.date',
+                'comment.module',
                 'comment.moduleId',
                 'comment.userId',
                 'comment.commentParent',
@@ -105,6 +106,49 @@ class Comments
             ->first();
 
         return $result ? (array) $result : false;
+    }
+
+    /**
+     * Resolve the owning project of a comment target (module + entity id) for authorization.
+     *
+     * Comments are cross-module; each module maps to a project differently:
+     *  - project        -> the moduleId IS the project id
+     *  - ticket         -> zp_tickets.projectId
+     *  - canvas family  -> the moduleId is a zp_canvas_items row; project via its canvas
+     *    (article, goalcanvasitem, idea, and every "<type>canvasitem")
+     *  - client / other -> null (company-scoped or unknown; the caller falls back to a
+     *    session-scoped capability check so behavior is unchanged for those targets)
+     *
+     * Direct table reads are used deliberately (no cross-domain service calls) to keep this a
+     * decoupled, side-effect-free authorization lookup that cannot recurse into other gates.
+     */
+    public function resolveModuleProjectId(string $module, int $moduleId): ?int
+    {
+        if ($moduleId <= 0) {
+            return null;
+        }
+
+        if ($module === 'project') {
+            return $moduleId;
+        }
+
+        if ($module === 'client') {
+            return null;
+        }
+
+        if ($module === 'ticket') {
+            $projectId = $this->db->table('zp_tickets')->where('id', $moduleId)->value('projectId');
+
+            return $projectId !== null ? (int) $projectId : null;
+        }
+
+        // Canvas-family comment targets store the canvas-item id as the moduleId.
+        $projectId = $this->db->table('zp_canvas_items')
+            ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
+            ->where('zp_canvas_items.id', $moduleId)
+            ->value('zp_canvas.projectId');
+
+        return $projectId !== null ? (int) $projectId : null;
     }
 
     public function addComment(array $values, string $module): false|string

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -308,19 +308,23 @@ class Comments extends BaseService
             return false;
         }
 
-        // IDOR fence: authorize against the comment's OWN project (null -> session-scoped fallback),
-        // so reactions can't be toggled on another project's comment by id.
+        // IDOR fence: gate against the comment's OWN project (null -> session-scoped fallback), so
+        // reactions can't be toggled on another project's comment by id. SOFT-deny (same false
+        // return as a missing comment) rather than throw, so a denied cross-project comment is
+        // indistinguishable from a non-existent one — no commentId existence oracle.
         $comment = $this->commentRepository->getComment($commentId);
         if (! $comment) {
             return false;
         }
-        $this->authorize(
+        if (! $this->can(
             CommentsPermissions::CREATE,
             $this->commentRepository->resolveModuleProjectId(
                 (string) ($comment['module'] ?? ''),
                 (int) ($comment['moduleId'] ?? 0)
             )
-        );
+        )) {
+            return false;
+        }
 
         // Check if user already has this exact reaction
         $existingSameReaction = $this->reactionsService->getUserReactions($userId, 'comment', $commentId, $reaction);
@@ -363,21 +367,23 @@ class Comments extends BaseService
     #[RequiresPermission(CommentsPermissions::VIEW, entityScoped: true)]
     public function getCommentReactions(int $commentId, int $userId): array
     {
-        // IDOR fence: authorize VIEW against the comment's OWN project before exposing reactor
-        // identities/sentiment (a null project — client/company-scoped or unknown module — falls
-        // back to a session-scoped role check). Closes the cross-project reaction-read leak by
-        // comment id on both the RPC and the Hx surfaces (which route through this method).
+        // IDOR fence: gate VIEW against the comment's OWN project before exposing reactor
+        // identities/sentiment, closing the cross-project reaction-read leak by comment id (RPC +
+        // Hx). SOFT-deny (same empty payload as a missing comment) rather than throw, so a denied
+        // cross-project comment is indistinguishable from a non-existent one — no existence oracle.
         $comment = $this->commentRepository->getComment($commentId);
         if (! $comment) {
             return ['reactions' => [], 'userReactions' => []];
         }
-        $this->authorize(
+        if (! $this->can(
             CommentsPermissions::VIEW,
             $this->commentRepository->resolveModuleProjectId(
                 (string) ($comment['module'] ?? ''),
                 (int) ($comment['moduleId'] ?? 0)
             )
-        );
+        )) {
+            return ['reactions' => [], 'userReactions' => []];
+        }
 
         // Get reactions with user names for tooltips
         $reactionsWithUsers = $this->reactionsService->getEntityReactionsWithUsers('comment', $commentId);

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -286,7 +286,8 @@ class Comments extends BaseService
      * existing reactions first, then adds the new one. Unknown reaction
      * types are rejected.
      *
-     * @param  int  $userId  The reacting user's id
+     * @param  int  $userId  Ignored — reactions always act as the session user (kept for RPC
+     *                       signature compatibility). See the in-body session pin.
      * @param  int  $commentId  The comment being reacted to
      * @param  string  $reaction  The reaction code (e.g. an emoji key)
      * @return bool True when the toggle was applied, false when the reaction
@@ -359,9 +360,25 @@ class Comments extends BaseService
      *
      * @api
      */
-    #[RequiresPermission(CommentsPermissions::VIEW)]
+    #[RequiresPermission(CommentsPermissions::VIEW, entityScoped: true)]
     public function getCommentReactions(int $commentId, int $userId): array
     {
+        // IDOR fence: authorize VIEW against the comment's OWN project before exposing reactor
+        // identities/sentiment (a null project — client/company-scoped or unknown module — falls
+        // back to a session-scoped role check). Closes the cross-project reaction-read leak by
+        // comment id on both the RPC and the Hx surfaces (which route through this method).
+        $comment = $this->commentRepository->getComment($commentId);
+        if (! $comment) {
+            return ['reactions' => [], 'userReactions' => []];
+        }
+        $this->authorize(
+            CommentsPermissions::VIEW,
+            $this->commentRepository->resolveModuleProjectId(
+                (string) ($comment['module'] ?? ''),
+                (int) ($comment['moduleId'] ?? 0)
+            )
+        );
+
         // Get reactions with user names for tooltips
         $reactionsWithUsers = $this->reactionsService->getEntityReactionsWithUsers('comment', $commentId);
 

--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -67,9 +67,16 @@ class Comments extends BaseService
     /**
      * @api
      */
-    #[RequiresPermission(CommentsPermissions::VIEW)]
+    #[RequiresPermission(CommentsPermissions::VIEW, entityScoped: true)]
     public function getComments($module, $entityId, int $commentOrder = 0, int $parent = 0): false|array
     {
+        // IDOR fence: comments are read by (module, entityId) with no project scoping in the repo,
+        // so authorize VIEW against the host entity's REAL project — a foreign id can no longer leak
+        // another project's comment thread over RPC. A null project (client/company-scoped target or
+        // an unknown module) falls back to a session-scoped capability check (unchanged behavior).
+        $projectId = $this->commentRepository->resolveModuleProjectId((string) $module, (int) $entityId);
+        $this->authorize(CommentsPermissions::VIEW, $projectId);
+
         return $this->commentRepository->getComments($module, $entityId, $parent, $commentOrder);
     }
 
@@ -93,6 +100,12 @@ class Comments extends BaseService
         $projectId = is_object($entity) && isset($entity->projectId)
             ? (int) $entity->projectId
             : ($module === 'project' ? (int) $entityId : null);
+
+        // Fall back to resolving the host entity's project by (module, id) so canvas-family and
+        // other targets (whose $entity may be an array or unloaded) are also project-fenced.
+        if ($projectId === null) {
+            $projectId = $this->commentRepository->resolveModuleProjectId((string) $module, (int) $entityId);
+        }
 
         $this->authorize(CommentsPermissions::CREATE, $projectId);
 
@@ -196,9 +209,16 @@ class Comments extends BaseService
             return true;
         }
 
-        // Otherwise moderation (editing/deleting someone else's comment) is a manager+
-        // capability, expressed as the comments.moderate permission.
-        return $this->can(CommentsPermissions::MODERATE);
+        // Otherwise moderation (editing/deleting someone else's comment) is a manager+ capability,
+        // scoped to the comment's OWN project so a manager in project A cannot moderate a comment on
+        // an entity in project B by id. A null project (client/company-scoped or unknown module)
+        // falls back to a session-scoped moderate check (unchanged behavior for those targets).
+        $projectId = $this->commentRepository->resolveModuleProjectId(
+            (string) ($comment['module'] ?? ''),
+            (int) ($comment['moduleId'] ?? 0)
+        );
+
+        return $this->can(CommentsPermissions::MODERATE, $projectId);
     }
 
     /**
@@ -274,13 +294,32 @@ class Comments extends BaseService
      *
      * @api
      */
-    #[RequiresPermission(CommentsPermissions::CREATE)]
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function toggleCommentReaction(int $userId, int $commentId, string $reaction): bool
     {
+        // Reactions act on behalf of the SESSION user only. Ignore any caller-supplied id so a
+        // client cannot toggle reactions as another user (the $userId param is kept for RPC
+        // signature compatibility but is not trusted).
+        $userId = (int) session('userdata.id');
+
         // Validate reaction against known types
         if ($this->reactionsService->getReactionType($reaction) === false) {
             return false;
         }
+
+        // IDOR fence: authorize against the comment's OWN project (null -> session-scoped fallback),
+        // so reactions can't be toggled on another project's comment by id.
+        $comment = $this->commentRepository->getComment($commentId);
+        if (! $comment) {
+            return false;
+        }
+        $this->authorize(
+            CommentsPermissions::CREATE,
+            $this->commentRepository->resolveModuleProjectId(
+                (string) ($comment['module'] ?? ''),
+                (int) ($comment['moduleId'] ?? 0)
+            )
+        );
 
         // Check if user already has this exact reaction
         $existingSameReaction = $this->reactionsService->getUserReactions($userId, 'comment', $commentId, $reaction);

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -146,4 +146,27 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
     }
+
+    /**
+     * Regression: a rule that combines an explicit `keys` allow-list with an `exclude` list must
+     * still honor the exclude. matches() previously returned early for `keys` rules and bypassed
+     * the exclude entirely, which could over-grant an excluded permission.
+     */
+    public function test_keys_rule_still_honors_exclude(): void
+    {
+        $matches = new \ReflectionMethod(DefaultRolePermissions::class, 'matches');
+        $matches->setAccessible(true);
+
+        $rule = [
+            'scope' => 'global',
+            'keys' => ['company.settings.view', 'company.settings.edit'],
+            'exclude' => ['company.settings.edit'],
+        ];
+
+        $included = new Permission('company.settings.view', 'View', false);
+        $excluded = new Permission('company.settings.edit', 'Edit', false);
+
+        $this->assertTrue($matches->invoke(null, $included, $rule), 'A keys-listed, non-excluded permission still matches');
+        $this->assertFalse($matches->invoke(null, $excluded, $rule), 'A keys-listed permission that is also excluded must NOT match');
+    }
 }

--- a/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
+++ b/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
@@ -250,13 +250,12 @@ class CommentsServiceTest extends TestCase
 
     public function test_toggle_reaction_is_denied_for_a_foreign_project(): void
     {
-        // Valid reaction type so the method reaches the project fence (not the type guard).
+        // Valid reaction type so the method reaches the project fence (not the type guard). A denied
+        // cross-project comment returns false — same as a missing comment, so no existence oracle.
         $reactions = $this->make(ReactionsService::class, ['getReactionType' => fn () => 'positive']);
         $service = $this->makeService($reactions, $this->defaultRepo(), $this->denyingPermissions());
 
-        $this->expectException(AuthorizationException::class);
-
-        $service->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup');
+        $this->assertFalse($service->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup'));
     }
 
     public function test_get_comments_is_denied_for_a_foreign_project(): void
@@ -308,17 +307,18 @@ class CommentsServiceTest extends TestCase
 
     public function test_get_comment_reactions_is_denied_for_a_foreign_project(): void
     {
-        // Reaction reads expose reactor identities/sentiment, so they fence to the comment's project.
+        // A denied cross-project comment returns the SAME empty payload as a missing comment
+        // (soft-deny), so reactor identities/sentiment never leak AND missing vs unauthorized are
+        // indistinguishable — no commentId existence oracle.
         $service = $this->makeService($this->noopReactions(), $this->defaultRepo(), $this->denyingPermissions());
 
-        $this->expectException(AuthorizationException::class);
-
-        $service->getCommentReactions(99, self::SESSION_USER);
+        $this->assertSame(['reactions' => [], 'userReactions' => []], $service->getCommentReactions(99, self::SESSION_USER));
     }
 
     public function test_get_comment_reactions_returns_empty_for_missing_comment(): void
     {
-        // A missing comment yields empty view data BEFORE authorize — no enumeration oracle.
+        // A missing comment yields the same empty payload a DENIED comment does (see above), so the
+        // two are indistinguishable — no commentId existence oracle.
         $repo = $this->make(CommentRepository::class, [
             'getComment' => fn () => false,
             'resolveModuleProjectId' => fn () => 9,

--- a/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
+++ b/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Unit\app\Domain\Comments\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Comments\Services\Comments;
@@ -10,22 +12,76 @@ use Leantime\Domain\Reactions\Services\Reactions as ReactionsService;
 use Unit\TestCase;
 
 /**
- * Unit tests for the comment-reaction orchestration extracted from the
- * Comments/Reactions HxController into the Comments service.
+ * Unit tests for the Comments service: reaction orchestration plus the project-scoped
+ * authorization fences (comments are read/moderated against the host entity's REAL project).
  */
 class CommentsServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
 
-    private function makeService(ReactionsService $reactionsService): Comments
+    /** The session user used across the reaction tests. */
+    private const SESSION_USER = 5;
+
+    protected function setUp(): void
     {
-        return new Comments(
-            $this->make(CommentRepository::class),
+        parent::setUp();
+        session(['userdata.id' => self::SESSION_USER]);
+    }
+
+    /**
+     * Build the service. By default the comment repository resolves a real (ticket) comment in
+     * project 9 and the permission engine allows everything; pass overrides to exercise denials.
+     */
+    private function makeService(
+        ReactionsService $reactionsService,
+        ?CommentRepository $repo = null,
+        ?PermissionService $permissions = null,
+    ): Comments {
+        $service = new Comments(
+            $repo ?? $this->defaultRepo(),
             $this->make(ProjectService::class),
             $this->make(LanguageCore::class),
             $reactionsService,
         );
+        $service->setPermissionService($permissions ?? $this->allowingPermissions());
+
+        return $service;
     }
+
+    private function defaultRepo(): CommentRepository
+    {
+        return $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 99, 'userId' => self::SESSION_USER, 'module' => 'ticket', 'moduleId' => 1],
+            'resolveModuleProjectId' => fn () => 9,
+        ]);
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+            'currentUserCan' => fn () => false,
+        ]);
+    }
+
+    private function noopReactions(): ReactionsService
+    {
+        return $this->make(ReactionsService::class, []);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reaction orchestration (existing behaviour, now session-pinned).
+    // ---------------------------------------------------------------------
 
     public function test_toggle_rejects_unknown_reaction_type(): void
     {
@@ -46,7 +102,7 @@ class CommentsServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService($reactionsService)->toggleCommentReaction(5, 99, 'bogus');
+        $result = $this->makeService($reactionsService)->toggleCommentReaction(self::SESSION_USER, 99, 'bogus');
 
         $this->assertFalse($result);
         $this->assertFalse($added, 'No reaction should be added for an unknown type');
@@ -60,8 +116,6 @@ class CommentsServiceTest extends TestCase
 
         $reactionsService = $this->make(ReactionsService::class, [
             'getReactionType' => fn () => 'positive',
-            // The targeted lookup for the clicked reaction returns the
-            // existing same reaction, so the toggle removes it.
             'getUserReactions' => fn () => [['reaction' => 'thumbsup']],
             'removeReaction' => function ($userId, $module, $moduleId, $reaction) use (&$removeCalls) {
                 $removeCalls[] = [$userId, $module, $moduleId, $reaction];
@@ -75,11 +129,11 @@ class CommentsServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService($reactionsService)->toggleCommentReaction(5, 99, 'thumbsup');
+        $result = $this->makeService($reactionsService)->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup');
 
         $this->assertTrue($result);
         $this->assertFalse($added, 'Toggling off should not add a reaction');
-        $this->assertSame([[5, 'comment', 99, 'thumbsup']], $removeCalls);
+        $this->assertSame([[self::SESSION_USER, 'comment', 99, 'thumbsup']], $removeCalls);
     }
 
     public function test_toggle_on_replaces_existing_sentiment(): void
@@ -90,12 +144,10 @@ class CommentsServiceTest extends TestCase
         $reactionsService = $this->make(ReactionsService::class, [
             'getReactionType' => fn () => 'positive',
             'getUserReactions' => function ($userId, $module, $moduleId, $reaction = '') {
-                // Targeted lookup for the clicked reaction: none yet.
                 if ($reaction !== '') {
                     return [];
                 }
 
-                // Broad lookup: user currently has a different reaction.
                 return [['reaction' => 'thumbsdown']];
             },
             'removeReaction' => function ($userId, $module, $moduleId, $reaction) use (&$removeCalls) {
@@ -110,12 +162,11 @@ class CommentsServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService($reactionsService)->toggleCommentReaction(5, 99, 'thumbsup');
+        $result = $this->makeService($reactionsService)->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup');
 
         $this->assertTrue($result);
-        // Existing different reaction removed first, new one added.
-        $this->assertSame([[5, 'comment', 99, 'thumbsdown']], $removeCalls);
-        $this->assertSame([[5, 'comment', 99, 'thumbsup']], $addCalls);
+        $this->assertSame([[self::SESSION_USER, 'comment', 99, 'thumbsdown']], $removeCalls);
+        $this->assertSame([[self::SESSION_USER, 'comment', 99, 'thumbsup']], $addCalls);
     }
 
     public function test_toggle_on_with_no_existing_reactions_just_adds(): void
@@ -125,7 +176,6 @@ class CommentsServiceTest extends TestCase
 
         $reactionsService = $this->make(ReactionsService::class, [
             'getReactionType' => fn () => 'positive',
-            // No existing reactions at all (false is a valid repo return).
             'getUserReactions' => fn () => false,
             'removeReaction' => function (...$args) use (&$removeCalls) {
                 $removeCalls[] = $args;
@@ -139,11 +189,11 @@ class CommentsServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService($reactionsService)->toggleCommentReaction(5, 99, 'thumbsup');
+        $result = $this->makeService($reactionsService)->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup');
 
         $this->assertTrue($result);
         $this->assertSame([], $removeCalls, 'Nothing to remove when there are no existing reactions');
-        $this->assertSame([[5, 'comment', 99, 'thumbsup']], $addCalls);
+        $this->assertSame([[self::SESSION_USER, 'comment', 99, 'thumbsup']], $addCalls);
     }
 
     public function test_get_comment_reactions_flattens_user_reaction_codes(): void
@@ -171,8 +221,88 @@ class CommentsServiceTest extends TestCase
 
         $result = $this->makeService($reactionsService)->getCommentReactions(99, 0);
 
-        // No user id => no user reaction lookup, empty list, and empty reactions normalised to [].
         $this->assertSame([], $result['reactions']);
         $this->assertSame([], $result['userReactions']);
+    }
+
+    // ---------------------------------------------------------------------
+    // Project-scoped authorization fences (the IDOR hardening).
+    // ---------------------------------------------------------------------
+
+    public function test_toggle_reaction_uses_session_user_not_caller_supplied_id(): void
+    {
+        // A caller passes someone else's id; the service must react as the SESSION user only.
+        $addCalls = [];
+        $reactionsService = $this->make(ReactionsService::class, [
+            'getReactionType' => fn () => 'positive',
+            'getUserReactions' => fn () => false,
+            'addReaction' => function ($userId, $module, $moduleId, $reaction) use (&$addCalls) {
+                $addCalls[] = [$userId, $module, $moduleId, $reaction];
+
+                return true;
+            },
+        ]);
+
+        $this->makeService($reactionsService)->toggleCommentReaction(999, 99, 'thumbsup');
+
+        $this->assertSame([[self::SESSION_USER, 'comment', 99, 'thumbsup']], $addCalls, 'Reaction must use the session user, not the caller-supplied id');
+    }
+
+    public function test_toggle_reaction_is_denied_for_a_foreign_project(): void
+    {
+        // Valid reaction type so the method reaches the project fence (not the type guard).
+        $reactions = $this->make(ReactionsService::class, ['getReactionType' => fn () => 'positive']);
+        $service = $this->makeService($reactions, $this->defaultRepo(), $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->toggleCommentReaction(self::SESSION_USER, 99, 'thumbsup');
+    }
+
+    public function test_get_comments_is_denied_for_a_foreign_project(): void
+    {
+        // getComments resolves the host entity's project and authorizes VIEW there; a denying
+        // engine must throw before any comment data is returned.
+        $service = $this->makeService($this->noopReactions(), $this->defaultRepo(), $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getComments('ticket', 123);
+    }
+
+    public function test_delete_comment_denies_non_author_moderation_cross_project(): void
+    {
+        // Comment belongs to another user; the session user is NOT a moderator in the comment's
+        // project (denying engine) -> deleteComment must refuse and never reach the repo delete.
+        $repo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 99, 'userId' => 7, 'module' => 'ticket', 'moduleId' => 1],
+            'resolveModuleProjectId' => fn () => 9,
+            'deleteComment' => function (): bool {
+                throw new \RuntimeException('delete must not run when moderation is denied');
+            },
+        ]);
+        $service = $this->makeService($this->noopReactions(), $repo, $this->denyingPermissions());
+
+        $this->assertFalse($service->deleteComment(99));
+    }
+
+    public function test_delete_comment_allows_the_author_without_moderation(): void
+    {
+        $deleted = null;
+        $repo = $this->make(CommentRepository::class, [
+            // Authored by the session user -> author branch, no moderation check needed.
+            'getComment' => fn () => ['id' => 99, 'userId' => self::SESSION_USER, 'module' => 'ticket', 'moduleId' => 1],
+            'resolveModuleProjectId' => fn () => 9,
+            'deleteComment' => function ($id) use (&$deleted): bool {
+                $deleted = $id;
+
+                return true;
+            },
+        ]);
+        // Denying engine proves the author path does NOT depend on comments.moderate.
+        $service = $this->makeService($this->noopReactions(), $repo, $this->denyingPermissions());
+
+        $this->assertTrue($service->deleteComment(99));
+        $this->assertSame(99, $deleted);
     }
 }

--- a/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
+++ b/tests/Unit/app/Domain/Comments/Services/CommentsServiceTest.php
@@ -305,4 +305,26 @@ class CommentsServiceTest extends TestCase
         $this->assertTrue($service->deleteComment(99));
         $this->assertSame(99, $deleted);
     }
+
+    public function test_get_comment_reactions_is_denied_for_a_foreign_project(): void
+    {
+        // Reaction reads expose reactor identities/sentiment, so they fence to the comment's project.
+        $service = $this->makeService($this->noopReactions(), $this->defaultRepo(), $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getCommentReactions(99, self::SESSION_USER);
+    }
+
+    public function test_get_comment_reactions_returns_empty_for_missing_comment(): void
+    {
+        // A missing comment yields empty view data BEFORE authorize — no enumeration oracle.
+        $repo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => false,
+            'resolveModuleProjectId' => fn () => 9,
+        ]);
+        $service = $this->makeService($this->noopReactions(), $repo, $this->denyingPermissions());
+
+        $this->assertSame(['reactions' => [], 'userReactions' => []], $service->getCommentReactions(404, self::SESSION_USER));
+    }
 }


### PR DESCRIPTION
Follow-up hardening for the Comments pilot (**#3469**), addressing the cross-project IDORs Copilot's automated review flagged. The pilot put Comments on the engine, but its checks were **session/role-scoped** rather than scoped to the comment's **host-entity project** — which narrowed the holes but didn't close them. This brings Comments up to the entity-scoped standard now used by Sprints/Wiki.

## The gaps (verified live against current code)
| Method | Was | Now |
|--------|-----|-----|
| `getComments` | dispatch `VIEW` → session project; repo has no project filter → RPC could read any entity's comment thread by id | `entityScoped` → `authorize(VIEW, hostProject)` |
| `canModifyComment` → `editComment`/`deleteComment` | non-author path `can(MODERATE)` with **no project** → a manager in project A could moderate a comment on an entity in project B | `can(MODERATE, commentProject)` |
| `toggleCommentReaction` | trusted caller-supplied `$userId`; `CREATE` session-scoped | ignores `$userId`, acts as the **session user**; `entityScoped` against the comment's project |
| `addComment` | resolved project only from an object entity | falls back to `resolveModuleProjectId` (covers canvas-family / array / unloaded entities) |

## How a cross-module domain is fenced
Comments span `ticket` / `project` / `client` / canvas-family items, so a new repository helper `resolveModuleProjectId(module, moduleId)` maps a target to its owning project with **direct table reads** (no cross-domain service calls — can't recurse into other gates):
- `project` → the id itself; `ticket` → `zp_tickets.projectId`
- canvas family (`article`/`goalcanvasitem`/`idea`/…) → `zp_canvas_items → zp_canvas`
- `client`/unknown → `null` → **session-scoped fallback** (unchanged behavior; never *un*gated — a null project means "not project-scoped", never "skip the check")

Internal callers all pass the current page's (accessible) entity, so the entity-scoped fence on the high-traffic `getComments` does not lock out legitimate reads.

## Also
`DefaultRolePermissions::matches()` (flagged on #3469): a rule combining `keys` + `exclude` returned early and **bypassed the exclude**. The exclude now applies to key-based rules too. No current rule combines them, so seeded grants are unchanged (matrix tests still pass) — regression test added.

## Verification
`CommentsServiceTest` extended with the fence/denial cases (existing reaction tests session-pinned). Full unit suite **427 tests / 1042 assertions** green; pint + phpstan clean. **Code-only** — `comments.*` already exist, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)