### PR TITLE
feat(logicmodelcanvas): restore current-focus pricing-card behaviour

### DIFF
--- a/app/Domain/Logicmodelcanvas/Repositories/Logicmodelcanvas.php
+++ b/app/Domain/Logicmodelcanvas/Repositories/Logicmodelcanvas.php
@@ -186,4 +186,51 @@ class Logicmodelcanvas extends Canvas
 
         return $grouped;
     }
+
+    /**
+     * Derive which stage is the "current focus" for the board.
+     *
+     * Returns the box key (e.g. `lm_outputs`) of the stage containing the
+     * most-recently-modified item, or null if the canvas is empty.
+     *
+     * Rationale: the original design had a single active stage at a time with
+     * the others rendered compactly (pricing-card pattern — see stageflow CSS).
+     * Rather than persist an explicit `current_focus` column on `zp_canvas`,
+     * derive the focus from real activity: whichever stage the user touched
+     * last is the one they're working on. The result naturally follows the
+     * user around the board as they edit.
+     *
+     * Falls back to null when no items exist; the view should treat null as
+     * "no focus" and render every stage in the compact / inactive state.
+     *
+     * @param  int  $canvasId  Canvas board ID.
+     * @return string|null Box key (matching the keys in BOX_TO_STAGE), or null.
+     *
+     * @api
+     */
+    public function getCurrentFocus(int $canvasId): ?string
+    {
+        $sql = 'SELECT box
+                FROM zp_canvas_items
+                WHERE canvasId = :canvasId AND box IS NOT NULL
+                ORDER BY modified DESC, id DESC
+                LIMIT 1';
+
+        try {
+            $stmn = $this->db->database->prepare($sql);
+            $stmn->bindValue(':canvasId', $canvasId, \PDO::PARAM_INT);
+            $stmn->execute();
+            $row = $stmn->fetch(\PDO::FETCH_ASSOC);
+            $stmn->closeCursor();
+        } catch (\PDOException $e) {
+            return null;
+        }
+
+        $box = $row['box'] ?? null;
+
+        // Only honour boxes that belong to the Logic Model canvas's known
+        // stages — anything else is data from another canvas type sharing the
+        // same items table.
+        return isset(self::BOX_TO_STAGE[$box]) ? $box : null;
+    }
 }

--- a/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
+++ b/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
@@ -21,6 +21,15 @@
     // Logic model board does not use relates filter — force to 'all'
     $filter['relates'] = 'all';
 
+    // Current-focus stage: derived from the most-recently-edited item so the
+    // pricing-card "active" stage follows the user's last action. Null when
+    // the canvas is empty — in that case every stage renders in the compact
+    // inactive state.
+    $currentFocusBox = null;
+    if (! empty($currentCanvas)) {
+        $currentFocusBox = app()->make(Logicmodelcanvas::class)->getCurrentFocus((int) $currentCanvas);
+    }
+
     $canvasTitle = '';
     foreach ($allCanvas as $canvasRow) {
         if ($canvasRow['id'] == $currentCanvas) {
@@ -128,6 +137,9 @@
                         $itemCount = count($stageItems);
                     @endphp
 
+                    @php
+                        $isFocus = $currentFocusBox === $boxKey;
+                    @endphp
                     <x-global::stageflow.card
                         :stageKey="$boxKey"
                         :stageNum="$num"
@@ -136,9 +148,9 @@
                         :icon="$stage['icon']"
                         :title="$tpl->__($stage['title'])"
                         :subtitle="$tpl->__($stage['subtitle'])"
-                        :active="true"
+                        :active="$isFocus"
                         :itemCount="$itemCount"
-                        :focusLabel="''"
+                        :focusLabel="$isFocus ? $tpl->__('logicmodel.current_focus') : ''"
                     >
                         <x-slot:headerExtra>
                             @dispatchEvent('logicmodel.afterStageHeader', ['stageNum' => $num, 'stage' => $stage, 'canvasId' => $currentCanvas, 'stageItems' => $stageItems])

--- a/app/Views/Templates/components/stageflow/styles.blade.php
+++ b/app/Views/Templates/components/stageflow/styles.blade.php
@@ -38,13 +38,15 @@
     overflow: visible;
     z-index: 1;
 }
-.sf-stage:not(.active) {
+.sf-stage:not(.active):not(:hover) {
     cursor: pointer;
 }
-.sf-stage:not(.active):hover {
-    box-shadow: var(--regular-shadow);
-}
-.sf-stage.active {
+/* Both the persistent "current focus" stage AND any stage being hovered get
+   the prominent visual treatment — so users can peek at any column with the
+   mouse without losing the long-running focus indicator. The .sf-flag below
+   is the one exception: it only appears on the persisted focus, never on
+   hover, so hover never falsely advertises itself as the active stage. */
+.sf-stage:is(.active, :hover) {
     z-index: 10;
     box-shadow: var(--large-shadow);
     border-color: transparent;
@@ -84,7 +86,7 @@
     transition: border-color 300ms, padding 300ms;
     position: relative;
 }
-.sf-stage.active .sf-hd {
+.sf-stage:is(.active, :hover) .sf-hd {
     padding-top: 18px;
     border-bottom-width: 3px;
     border-bottom-color: var(--stage-color);
@@ -104,13 +106,13 @@
     background: var(--stage-bg);
     color: var(--stage-color);
 }
-.sf-stage:not(.active) .sf-icon {
+.sf-stage:not(.active):not(:hover) .sf-icon {
     width: 30px;
     height: 30px;
     font-size: var(--font-size-m);
     margin-bottom: 5px;
 }
-.sf-stage.active .sf-icon {
+.sf-stage:is(.active, :hover) .sf-icon {
     background: var(--stage-color);
     color: white;
 }
@@ -130,7 +132,7 @@
     line-height: 1.2;
     color: var(--primary-font-color);
 }
-.sf-stage:not(.active) .sf-name {
+.sf-stage:not(.active):not(:hover) .sf-name {
     font-size: var(--font-size-m);
     font-weight: 600;
     opacity: 0.5;
@@ -142,7 +144,7 @@
     font-weight: 700;
     line-height: 1.2;
 }
-.sf-stage:not(.active) .sf-count {
+.sf-stage:not(.active):not(:hover) .sf-count {
     font-size: var(--font-size-m);
     opacity: 0.4;
 }
@@ -155,7 +157,7 @@
     transition: font-size 300ms;
     text-align: center;
 }
-.sf-stage:not(.active) .sf-sub {
+.sf-stage:not(.active):not(:hover) .sf-sub {
     font-size: var(--font-size-xs);
     opacity: 0.5;
 }
@@ -179,7 +181,7 @@
     position: relative;
 }
 .sf-item:hover { background: rgba(0,0,0,0.02); }
-.sf-stage.active .sf-item { border-left-color: var(--stage-color); }
+.sf-stage:is(.active, :hover) .sf-item { border-left-color: var(--stage-color); }
 
 /* Item title */
 .sf-item-title {
@@ -263,12 +265,15 @@
     vertical-align: middle;
 }
 
-/* ── Inactive stage: compact view ── */
-.sf-stage:not(.active) .sf-item {
+/* ── Inactive stage: compact view ──
+   "Inactive" here means: not the persisted focus AND not currently hovered.
+   Hovering a non-focus stage lifts it out of the compact state so the user
+   can peek at its full content, without changing what's persisted. */
+.sf-stage:not(.active):not(:hover) .sf-item {
     padding: 4px 8px;
     border-left-color: transparent;
 }
-.sf-stage:not(.active) .sf-item-title {
+.sf-stage:not(.active):not(:hover) .sf-item-title {
     font-size: var(--font-size-s);
     font-weight: 500;
     color: var(--primary-font-color);
@@ -276,19 +281,21 @@
     display: flex;
     align-items: center;
 }
-.sf-stage:not(.active) .sf-item-title .sf-dot {
+.sf-stage:not(.active):not(:hover) .sf-item-title .sf-dot {
     width: 6px;
     height: 6px;
     margin-right: 4px;
 }
-.sf-stage:not(.active) .sf-item-desc { display: none; }
-.sf-stage:not(.active) .sf-item-foot { display: none; }
-.sf-stage:not(.active) .sf-item .inlineDropDownContainer { display: none; }
+.sf-stage:not(.active):not(:hover) .sf-item-desc { display: none; }
+.sf-stage:not(.active):not(:hover) .sf-item-foot { display: none; }
+.sf-stage:not(.active):not(:hover) .sf-item .inlineDropDownContainer { display: none; }
 
-/* Disable interactive elements in inactive stages */
-.sf-stage:not(.active) a,
-.sf-stage:not(.active) button,
-.sf-stage:not(.active) .dropdown-toggle {
+/* Disable interactive elements only in the truly-compact state. Hovered
+   stages get full interactivity so the user can click items and open
+   dropdowns during peek. */
+.sf-stage:not(.active):not(:hover) a,
+.sf-stage:not(.active):not(:hover) button,
+.sf-stage:not(.active):not(:hover) .dropdown-toggle {
     pointer-events: none;
 }
 
@@ -306,7 +313,7 @@
     margin-bottom: 6px;
     display: block;
 }
-.sf-stage:not(.active) .sf-empty { display: none; }
+.sf-stage:not(.active):not(:hover) .sf-empty { display: none; }
 
 /* ── Add item button ── */
 .sf-add {
@@ -332,7 +339,7 @@
     color: var(--accent1);
     background: rgba(0,69,110,0.04);
 }
-.sf-stage:not(.active) .sf-add { display: none; }
+.sf-stage:not(.active):not(:hover) .sf-add { display: none; }
 
 /* ── Responsive ── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
> Draft — implementation per design conversation with @marcel-sutter. No new schema, no migration, no JS. Three small files.

## Why

The stageflow component was designed for a pricing-card layout — one stage prominent (the "current focus"), others compact and faded. The CSS for both states has always shipped with the component (~15 rules under \`.sf-stage:not(.active)\` for the compact state, matching rules under \`.sf-stage.active\` for the prominent state), and \`card.blade.php\` defaults \`active=false\`.

Two lines in \`showCanvas.blade.php\` were forcing every stage on:

\`\`\`blade
:active=\"true\"
:focusLabel=\"''\"
\`\`\`

These look like a stop-gap from the Phase 0 modernization work — kept the canvas usable while the activation/persistence logic was missing, but the result is a permanently flat hierarchy. Every stage shouts; nothing focuses.

## The shape

Per Marcel:
- No new column on \`zp_canvas\`
- Reuse existing item state
- Hover for transient peek (CSS only, no JS)

So focus is **derived**, not persisted:

> Whichever stage contains the most-recently-modified canvas item is the current focus.

The user touches an item → that stage takes focus → the others fade. Naturally follows the work.

## Files

| File | Change |
|---|---|
| \`app/Domain/Logicmodelcanvas/Repositories/Logicmodelcanvas.php\` | New \`getCurrentFocus(int \$canvasId): ?string\` — single SQL ordered by \`modified DESC LIMIT 1\`. Null when canvas is empty. |
| \`app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php\` | Compute \`\$currentFocusBox\` once at the top, then pass dynamic \`:active=\"\$isFocus\"\` and \`:focusLabel=\"\$isFocus ? 'Current Focus' : ''\"\` per stage. |
| \`app/Views/Templates/components/stageflow/styles.blade.php\` | \`.sf-stage:not(.active)\` → \`.sf-stage:not(.active):not(:hover)\` so hover peeks. \`.sf-stage.active\` → \`.sf-stage:is(.active, :hover)\` so hover matches active styling. The \`.sf-flag\` \"Current Focus\" pill stays bound to \`.active\` alone — hover never falsely advertises itself as the persisted focus. \`pointer-events: none\` on inactive items also lifts on hover so peek is fully interactive. |

## What you get

| State | Visual |
|---|---|
| Default focus (last-edited stage) | Large shadow, full-strength header, prominent count, full item details, \"+ Add\" visible, **\"Current Focus\" pill above** |
| Hovered non-focus stage | Same large shadow / full header / details / +Add — but no \"Current Focus\" pill |
| Other stages while you hover one | Compact (faded icon, dimmed count, hidden descriptions/footers/+Add, items show as title-only) |
| Empty canvas (no items) | Every stage compact (no focus until first item exists) |

## Blast radius

Only \`Logicmodelcanvas\` uses the stageflow component today — other Blueprints canvases (Lean, SWOT, Risk, etc.) are still legacy \`.tpl.php\` templates. CSS changes don't affect them.

## Test plan

- [ ] Open a Logic Model canvas with items in multiple stages. Confirm the stage containing the most-recently-edited item shows as active (large, focused) with \"Current Focus\" pill, and the rest are compact.
- [ ] Hover a non-focus stage. Confirm it lifts visually (same active treatment) but does NOT show the \"Current Focus\" pill, and the persisted focus stage stays styled as active.
- [ ] Edit/add an item in a different stage. Confirm focus moves to that stage on next render.
- [ ] Open an empty canvas (no items). Confirm every stage renders compact, no focus.
- [ ] Confirm other canvas types (Lean Canvas, SWOT, etc.) render identically to current behaviour (they don't use stageflow).
- [ ] Pint passes on all three files (verified locally).

## Future paths (deliberately out of scope)

- Click-to-pin a focus (override the derived one) — small JS + canvas-settings storage, separate PR if wanted
- Other canvas types adopting the stageflow component — separate per-canvas modernization
- Workflow-driven focus (e.g. wizard sets it) — would need explicit storage, separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)