### PR TITLE
security(ideas): gate Ideas domain on the native permission engine

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.10';
+    public string $dbVersion = '3.5.11';
 }

--- a/app/Domain/Ideas/Controllers/AdvancedBoards.php
+++ b/app/Domain/Ideas/Controllers/AdvancedBoards.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +35,7 @@ class AdvancedBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));
@@ -52,6 +55,7 @@ class AdvancedBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));

--- a/app/Domain/Ideas/Controllers/BoardDialog.php
+++ b/app/Domain/Ideas/Controllers/BoardDialog.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +35,7 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $currentCanvasId = '';
@@ -61,6 +64,7 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $currentCanvasId = '';

--- a/app/Domain/Ideas/Controllers/DelCanvas.php
+++ b/app/Domain/Ideas/Controllers/DelCanvas.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
+use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelCanvas extends Controller
 {
-    private IdeaRepository $ideaRepo;
+    private IdeaService $ideaService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(IdeaRepository $ideaRepo): void
+    public function init(IdeaService $ideaService): void
     {
-        $this->ideaRepo = $ideaRepo;
+        $this->ideaService = $ideaService;
     }
 
     /**
@@ -26,28 +26,26 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->display('ideas.delCanvas');
     }
 
     /**
-     * Handles idea board deletion.
+     * Handles idea board deletion. The controller gate defers (entityScoped) to the service's
+     * deleteCanvas(), which authorizes DELETE against the board's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->ideaRepo->deleteCanvas($id);
+            $this->ideaService->deleteCanvas($id);
 
-            session()->forget('currentIdeaCanvas');
             $this->tpl->setNotification($this->language->__('notification.idea_board_deleted'), 'success', 'ideaboard_deleted');
 
             return Frontcontroller::redirect(BASE_URL.'/ideas/showBoards');

--- a/app/Domain/Ideas/Controllers/DelCanvasItem.php
+++ b/app/Domain/Ideas/Controllers/DelCanvasItem.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
+use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelCanvasItem extends Controller
 {
-    private IdeaRepository $ideasRepo;
+    private IdeaService $ideaService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(IdeaRepository $ideasRepo): void
+    public function init(IdeaService $ideaService): void
     {
-        $this->ideasRepo = $ideasRepo;
+        $this->ideaService = $ideaService;
     }
 
     /**
@@ -26,26 +26,25 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('ideas.delCanvasItem');
     }
 
     /**
-     * Handles idea item deletion.
+     * Handles idea item deletion. The controller gate defers (entityScoped) to the service's
+     * deleteCanvasItem(), which authorizes DELETE against the item's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->ideasRepo->delCanvasItem($id);
+            $this->ideaService->deleteCanvasItem($id);
 
             $this->tpl->setNotification($this->language->__('notification.idea_board_item_deleted'), 'success', 'ideaitem_deleted');
 

--- a/app/Domain/Ideas/Controllers/IdeaDialog.php
+++ b/app/Domain/Ideas/Controllers/IdeaDialog.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 
 class IdeaDialog extends Controller
@@ -19,8 +21,10 @@ class IdeaDialog extends Controller
     }
 
     /**
-     * get - handle get requests
+     * get - handle get requests. The embedded ?delComment / ?removeMilestone mutations are fenced
+     * by the service (removeIdeaComment = author-or-moderate; removeMilestone = edit) in-body.
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get($params)
     {
         if (isset($params['id'])) {
@@ -61,8 +65,11 @@ class IdeaDialog extends Controller
     }
 
     /**
-     * post - handle post requests
+     * post - handle post requests. Create/update/comment all defer to the service methods, which
+     * authorize the correct verb (ideas.create / ideas.edit / comments.create) against the entity's
+     * real project.
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post($params)
     {
 

--- a/app/Domain/Ideas/Controllers/ShowBoards.php
+++ b/app/Domain/Ideas/Controllers/ShowBoards.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +33,7 @@ class ShowBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));
@@ -50,6 +53,7 @@ class ShowBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));

--- a/app/Domain/Ideas/Permissions/IdeasPermissions.php
+++ b/app/Domain/Ideas/Permissions/IdeasPermissions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Leantime\Domain\Ideas\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Ideas permission vocabulary — the verbs only.
+ *
+ * Idea boards and items are PROJECT-scoped (each board belongs to one project; items belong to a
+ * board), so every capability is evaluated against the user's role IN that project (projectScoped =
+ * true, the default). The standard verbs auto-grant via the central matrix (readonly = view; editor
+ * = create/edit/delete; manager+ = all), so no
+ * {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} change is required.
+ */
+final class IdeasPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'ideas.view';
+
+    public const CREATE = 'ideas.create';
+
+    public const EDIT = 'ideas.edit';
+
+    public const DELETE = 'ideas.delete';
+
+    public function domain(): string
+    {
+        return 'ideas';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View idea boards'),
+            new Permission(self::CREATE, 'Create idea boards and ideas'),
+            new Permission(self::EDIT, 'Edit ideas'),
+            new Permission(self::DELETE, 'Delete idea boards and ideas'),
+        ];
+    }
+}

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -134,8 +134,10 @@ class Ideas
             ->where('canvasId', $id)
             ->delete();
 
+        // type guard (shared zp_canvas across all canvas families): only ever delete an idea board.
         $this->db->table('zp_canvas')
             ->where('id', $id)
+            ->where('type', 'idea')
             ->delete();
     }
 
@@ -154,8 +156,10 @@ class Ideas
 
     public function updateCanvas(array $values): mixed
     {
+        // type guard (shared zp_canvas across all canvas families): only ever rename an idea board.
         return $this->db->table('zp_canvas')
             ->where('id', $values['id'])
+            ->where('type', 'idea')
             ->update(['title' => $values['title']]);
     }
 

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -130,11 +130,22 @@ class Ideas
 
     public function deleteCanvas(int $id): void
     {
+        // Shared zp_canvas/zp_canvas_items: early-return unless this id is an idea board, so the
+        // items-delete (by canvasId) can't drop another canvas family's items before the
+        // type-guarded board delete runs.
+        $isIdea = $this->db->table('zp_canvas')
+            ->where('id', $id)
+            ->where('type', 'idea')
+            ->exists();
+
+        if (! $isIdea) {
+            return;
+        }
+
         $this->db->table('zp_canvas_items')
             ->where('canvasId', $id)
             ->delete();
 
-        // type guard (shared zp_canvas across all canvas families): only ever delete an idea board.
         $this->db->table('zp_canvas')
             ->where('id', $id)
             ->where('type', 'idea')

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -2,11 +2,13 @@
 
 namespace Leantime\Domain\Ideas\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Mailer as MailerCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Comments\Permissions\CommentsPermissions;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeasRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -16,7 +18,7 @@ use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 /**
  * Ideas service - business logic for idea boards and idea items.
  */
-class Ideas
+class Ideas extends BaseService
 {
     private IdeasRepository $ideasRepository;
 
@@ -46,30 +48,36 @@ class Ideas
     }
 
     /**
-     * Authorization helper: is the current user allowed to modify a canvas item?
+     * Resolve an idea board's owning project. Boards are zp_canvas rows (type 'idea').
      *
-     * Resolves the item -> its canvas -> the canvas's project, then checks the
-     * session user's project access. Used to gate the JSON-RPC idea mutators
-     * (the underlying repository operates by item id with no project scoping).
+     * @param  int  $boardId  The board (canvas) id
+     * @return int|null The board's project id, or null when the board does not exist
+     */
+    private function boardProjectId(int $boardId): ?int
+    {
+        // getSingleCanvas() returns a list of row arrays (not a flat row).
+        $rows = $this->ideasRepository->getSingleCanvas($boardId);
+
+        return isset($rows[0]['projectId']) ? (int) $rows[0]['projectId'] : null;
+    }
+
+    /**
+     * Resolve an idea item's owning project (item -> its board/canvas -> project).
+     *
+     * The repository operates by item id with NO project scoping, and zp_canvas_items is shared
+     * across all canvas types, so callers MUST fail closed on a null result before any read/write.
      *
      * @param  int  $itemId  The canvas item id
-     * @return bool True when the session user may modify the item
+     * @return int|null The item's project id, or null when it does not resolve to an idea board
      */
-    private function userCanAccessCanvasItem(int $itemId): bool
+    private function canvasItemProjectId(int $itemId): ?int
     {
-        $item = (array) $this->ideasRepository->getSingleCanvasItem($itemId);
-        if (empty($item['canvasId'])) {
-            return false;
+        $item = $this->ideasRepository->getSingleCanvasItem($itemId);
+        if (! is_array($item) || empty($item['canvasId'])) {
+            return null;
         }
 
-        // getSingleCanvas() returns a list of row arrays (not a flat row),
-        // matching the existing getBoardTitle() consumer.
-        $canvas = $this->ideasRepository->getSingleCanvas((int) $item['canvasId']);
-        if (empty($canvas[0]['projectId'])) {
-            return false;
-        }
-
-        return $this->projectService->isUserAssignedToProject((int) session('userdata.id'), (int) $canvas[0]['projectId']);
+        return $this->boardProjectId((int) $item['canvasId']);
     }
 
     /**
@@ -83,14 +91,18 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function reorderIdeas(array $payload): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return false;
-        }
-
+        // Per-item project fence: reject the whole batch unless the user may edit EVERY item's
+        // project (non-throwing can(), since a batch should fail gracefully). null project = the id
+        // is not an idea item (shared zp_canvas_items) -> reject.
         foreach ($payload as $idea) {
-            if (! isset($idea['id']) || ! $this->userCanAccessCanvasItem((int) $idea['id'])) {
+            if (! isset($idea['id'])) {
+                return false;
+            }
+            $projectId = $this->canvasItemProjectId((int) $idea['id']);
+            if ($projectId === null || ! $this->can(IdeasPermissions::EDIT, $projectId)) {
                 return false;
             }
         }
@@ -109,17 +121,19 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function bulkUpdateStatus(array $payload): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return false;
-        }
-
+        // Per-item project fence over the jQuery-sortable serialized payload.
         foreach ($payload as $itemList) {
             foreach (explode('&', (string) $itemList) as $itemString) {
                 // jQuery sortable serializes as "item[]=ID"; strip the prefix.
                 $id = (int) substr($itemString, 7);
-                if ($id > 0 && ! $this->userCanAccessCanvasItem($id)) {
+                if ($id <= 0) {
+                    continue;
+                }
+                $projectId = $this->canvasItemProjectId($id);
+                if ($projectId === null || ! $this->can(IdeasPermissions::EDIT, $projectId)) {
                     return false;
                 }
             }
@@ -139,11 +153,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function patchIdeaItem(int $id, array $params): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor) || ! $this->userCanAccessCanvasItem($id)) {
+        // Fail closed: resolve the item's REAL project (shared zp_canvas_items) and require edit
+        // there before patching — null means the id is not an idea item, so refuse.
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
             return false;
         }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
 
         return $this->ideasRepository->patchCanvasItem($id, $params);
     }
@@ -157,6 +176,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForNewIdeas(?int $projectId = null, ?int $board = null): array
     {
         $ideas = $this->ideasRepository->getAllIdeas($projectId, $board);
@@ -177,6 +197,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForUpdatedIdeas(?int $projectId = null, ?int $board = null): array
     {
         $ideas = $this->ideasRepository->getAllIdeas($projectId, $board);
@@ -220,6 +241,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function getAllBoards(int $projectId): array
     {
         $allCanvas = $this->ideasRepository->getAllCanvas($projectId);
@@ -235,11 +257,18 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoard(int $id): array
     {
         $singleCanvas = $this->ideasRepository->getSingleCanvas($id);
+        if (empty($singleCanvas)) {
+            return [];
+        }
 
-        return $singleCanvas === false ? [] : $singleCanvas;
+        // IDOR fence: authorize VIEW against the board's real project (single-entity-by-id read).
+        $this->authorize(IdeasPermissions::VIEW, isset($singleCanvas[0]['projectId']) ? (int) $singleCanvas[0]['projectId'] : null);
+
+        return $singleCanvas;
     }
 
     /**
@@ -250,8 +279,10 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoardTitle(int $id): string
     {
+        // Delegates to getBoard(), which performs the in-body VIEW authorize against the board's project.
         $singleCanvas = $this->getBoard($id);
 
         return $singleCanvas[0]['title'] ?? '';
@@ -265,8 +296,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoardItems(int $boardId): array
     {
+        // IDOR fence: authorize VIEW against the board's real project before listing its items.
+        $projectId = $this->boardProjectId($boardId);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
+
         $items = $this->ideasRepository->getCanvasItemsById($boardId);
 
         return $items === false ? [] : $items;
@@ -279,6 +318,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function getBoardLabels(): mixed
     {
         return $this->ideasRepository->getCanvasLabels();
@@ -294,8 +334,12 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createBoard(string $title, int $projectId, int $authorId): int
     {
+        // A board belongs directly to $projectId; authorize CREATE there before writing.
+        $this->authorize(IdeasPermissions::CREATE, $projectId);
+
         $values = [
             'title' => $title,
             'author' => $authorId,
@@ -323,8 +367,12 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createBoardFromDialog(string $title, int $projectId, int $authorId): int
     {
+        // A board belongs directly to $projectId; authorize CREATE there before writing.
+        $this->authorize(IdeasPermissions::CREATE, $projectId);
+
         $values = [
             'title' => $title,
             'author' => $authorId,
@@ -347,8 +395,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function updateBoard(int $id, string $title): mixed
     {
+        // Fail closed: resolve the board's real project and require edit there before renaming.
+        $projectId = $this->boardProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
+
         return $this->ideasRepository->updateCanvas(['title' => $title, 'id' => $id]);
     }
 
@@ -365,12 +421,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function ensureBoardExists(int $projectId, int $authorId, array $allBoards): int
     {
         if (count($allBoards) > 0) {
             return 0;
         }
 
+        // Bootstrap only: the default board is created as a SIDE EFFECT of viewing a board-less
+        // project, so it is VIEW-gated and writes straight to the repository — gating it CREATE
+        // would 403 a readonly viewer (mirrors Wiki's getAllProjectWikis default-notebook bootstrap).
         $values = [
             'title' => $this->language->__('label.board'),
             'author' => $authorId,
@@ -447,6 +507,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaItem(?int $id, string $type = 'idea'): array
     {
         if ($id === null) {
@@ -463,6 +524,13 @@ class Ideas
                 'milestoneId' => '',
             ];
         }
+
+        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
 
@@ -483,8 +551,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getRawIdeaItem(?int $id): mixed
     {
+        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
+        $projectId = $this->canvasItemProjectId((int) $id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
+
         return $this->ideasRepository->getSingleCanvasItem((int) $id);
     }
 
@@ -495,6 +571,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function getCanvasTypes(): array
     {
         return $this->ideasRepository->canvasTypes;
@@ -510,8 +587,14 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createIdeaItem(array $input, int $projectId, int $authorId): int
     {
+        // Authorize CREATE against the TARGET board's real project (resolve from canvasId; the
+        // passed projectId is untrusted), falling back to it only if the board can't be resolved.
+        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0)) ?? $projectId;
+        $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
+
         $canvasItem = [
             'box' => $input['box'],
             'author' => $authorId,
@@ -563,9 +646,19 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function updateIdeaItem(array $input, int $projectId, int $authorId): int
     {
         $itemId = (int) $input['itemId'];
+
+        // Fail closed: resolve the EXISTING item's real project (shared zp_canvas_items) and require
+        // edit there before writing — the passed projectId/canvasId are untrusted, so an editor in
+        // project A cannot edit or relocate an item in project B.
+        $existingProjectId = $this->canvasItemProjectId($itemId);
+        if ($existingProjectId === null) {
+            return 0;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $existingProjectId);
 
         $canvasItem = [
             'box' => $input['box'],
@@ -633,8 +726,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function removeMilestone(int $ideaItemId): void
     {
+        // Fail closed: resolve the item's real project and require edit there before detaching.
+        $projectId = $this->canvasItemProjectId($ideaItemId);
+        if ($projectId === null) {
+            return;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
+
         $this->ideasRepository->patchCanvasItem($ideaItemId, ['milestoneId' => '']);
     }
 
@@ -646,6 +747,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function getProjectMilestones(int $projectId): array|false
     {
         return $this->ticketService->getAllMilestones([
@@ -667,8 +769,14 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function addIdeaComment(string $text, int $ideaItemId, int|string $parentCommentId, int $projectId, int $authorId): false|string
     {
+        // Commenting on an idea is a commenter+ capability in the idea's project (resolved from the
+        // item; the passed projectId is untrusted). Uses the Comments vocabulary.
+        $itemProjectId = $this->canvasItemProjectId($ideaItemId) ?? $projectId;
+        $this->authorize(CommentsPermissions::CREATE, $itemProjectId);
+
         $values = [
             'text' => $text,
             'date' => date('Y-m-d H:i:s'),
@@ -712,8 +820,24 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::MODERATE, entityScoped: true)]
     public function removeIdeaComment(int $commentId): void
     {
+        // Was an UNGATED delete-by-id (reachable via the ?delComment GET param) — any user could
+        // delete any comment by id. Fence: the comment author may delete their own; otherwise
+        // require moderate in the idea's project (resolved from the comment's idea item).
+        $comment = $this->commentsRepository->getComment($commentId);
+        if (! $comment) {
+            return;
+        }
+
+        if ((int) ($comment['userId'] ?? 0) !== (int) session('userdata.id')) {
+            $this->authorize(
+                CommentsPermissions::MODERATE,
+                $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0))
+            );
+        }
+
         $this->commentsRepository->deleteComment($commentId);
     }
 
@@ -726,8 +850,13 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaComments(string $module, int $entityId): array|false
     {
+        // entityId is the idea item id; authorize VIEW against its project before returning comments
+        // (a null project falls back to a session-scoped role check for any non-resolving target).
+        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+
         return $this->commentsRepository->getComments($module, $entityId);
     }
 
@@ -740,8 +869,61 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function countIdeaComments(string $module, int $entityId): mixed
     {
+        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+
         return $this->commentsRepository->countComments($module, $entityId);
+    }
+
+    /**
+     * Delete an idea board, fencing the operation against the board's project.
+     *
+     * Replaces the previous controller->repository direct delete (which only had a global-role
+     * gate and no project scoping, so an editor in any project could delete another's board).
+     *
+     * @param  int  $id  Board (canvas) id.
+     * @return bool True when deleted, false when the board does not resolve to a project.
+     *
+     * @api
+     */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
+    public function deleteCanvas(int $id): bool
+    {
+        $projectId = $this->boardProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::DELETE, $projectId);
+
+        $this->ideasRepository->deleteCanvas($id);
+        session()->forget('currentIdeaCanvas');
+
+        return true;
+    }
+
+    /**
+     * Delete an idea item, fencing the operation against the item's project.
+     *
+     * Replaces the previous controller->repository direct delete (id-only, no project scoping).
+     *
+     * @param  int  $id  Canvas item id.
+     * @return bool True when deleted, false when the item does not resolve to a project.
+     *
+     * @api
+     */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
+    public function deleteCanvasItem(int $id): bool
+    {
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::DELETE, $projectId);
+
+        $this->ideasRepository->delCanvasItem($id);
+
+        return true;
     }
 }

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -534,7 +534,11 @@ class Ideas extends BaseService
 
         $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
 
-        if (is_array($canvasItem) && isset($canvasItem['box']) && $canvasItem['box'] == '0') {
+        if (! is_array($canvasItem)) {
+            return [];
+        }
+
+        if (isset($canvasItem['box']) && $canvasItem['box'] == '0') {
             $canvasItem['box'] = 'idea';
         }
 
@@ -590,9 +594,14 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createIdeaItem(array $input, int $projectId, int $authorId): int
     {
-        // Authorize CREATE against the TARGET board's real project (resolve from canvasId; the
-        // passed projectId is untrusted), falling back to it only if the board can't be resolved.
-        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0)) ?? $projectId;
+        // Authorize CREATE against the TARGET board's real project (resolved from canvasId; the
+        // passed projectId is untrusted). FAIL CLOSED if the canvasId is not an idea board — never
+        // fall back to the caller-supplied projectId, or a foreign/non-idea canvasId could be
+        // created against the caller's own project.
+        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0));
+        if ($boardProjectId === null) {
+            return 0;
+        }
         $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
 
         $canvasItem = [
@@ -773,8 +782,12 @@ class Ideas extends BaseService
     public function addIdeaComment(string $text, int $ideaItemId, int|string $parentCommentId, int $projectId, int $authorId): false|string
     {
         // Commenting on an idea is a commenter+ capability in the idea's project (resolved from the
-        // item; the passed projectId is untrusted). Uses the Comments vocabulary.
-        $itemProjectId = $this->canvasItemProjectId($ideaItemId) ?? $projectId;
+        // item; the passed projectId is untrusted). FAIL CLOSED if the id is not an idea item —
+        // never fall back to the caller-supplied projectId.
+        $itemProjectId = $this->canvasItemProjectId($ideaItemId);
+        if ($itemProjectId === null) {
+            return false;
+        }
         $this->authorize(CommentsPermissions::CREATE, $itemProjectId);
 
         $values = [
@@ -832,10 +845,13 @@ class Ideas extends BaseService
         }
 
         if ((int) ($comment['userId'] ?? 0) !== (int) session('userdata.id')) {
-            $this->authorize(
-                CommentsPermissions::MODERATE,
-                $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0))
-            );
+            // Non-author: require moderate in the idea's project. FAIL CLOSED if the comment's item
+            // does not resolve to an idea board — never downgrade to a role-only moderate check.
+            $projectId = $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0));
+            if ($projectId === null) {
+                return;
+            }
+            $this->authorize(CommentsPermissions::MODERATE, $projectId);
         }
 
         $this->commentsRepository->deleteComment($commentId);
@@ -853,9 +869,13 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaComments(string $module, int $entityId): array|false
     {
-        // entityId is the idea item id; authorize VIEW against its project before returning comments
-        // (a null project falls back to a session-scoped role check for any non-resolving target).
-        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+        // Fail closed: a null project means $entityId is not an idea item, so refuse rather than
+        // authorize against null (role-only pass) and leak another project's comment thread by id.
+        $projectId = $this->canvasItemProjectId($entityId);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         return $this->commentsRepository->getComments($module, $entityId);
     }
@@ -872,7 +892,12 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function countIdeaComments(string $module, int $entityId): mixed
     {
-        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+        // Fail closed: a null project means $entityId is not an idea item.
+        $projectId = $this->canvasItemProjectId($entityId);
+        if ($projectId === null) {
+            return 0;
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         return $this->commentsRepository->countComments($module, $entityId);
     }

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -164,6 +164,11 @@ class Ideas extends BaseService
         }
         $this->authorize(IdeasPermissions::EDIT, $projectId);
 
+        // Strip relocation/identity fields: patchCanvasItem updates any column it receives, so a
+        // JSON-RPC caller could otherwise patch canvasId to move the item to another board/project
+        // (bypassing the project scoping just authorized) or rewrite its id/author.
+        unset($params['canvasId'], $params['id'], $params['author']);
+
         return $this->ideasRepository->patchCanvasItem($id, $params);
     }
 
@@ -604,6 +609,10 @@ class Ideas extends BaseService
         }
         $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
 
+        // Normalize to the resolved board project so the notification below targets the correct
+        // project's users even if a mismatched/forged projectId was supplied.
+        $projectId = $boardProjectId;
+
         $canvasItem = [
             'box' => $input['box'],
             'author' => $authorId,
@@ -668,6 +677,20 @@ class Ideas extends BaseService
             return 0;
         }
         $this->authorize(IdeasPermissions::EDIT, $existingProjectId);
+
+        // The write persists $input['canvasId'], which can RELOCATE the item to another board. The
+        // target must be an idea board the user can also edit, or the relocation is a cross-project
+        // move. Fail closed if it's not an idea board; require edit on the target if it differs.
+        $targetProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0));
+        if ($targetProjectId === null) {
+            return 0;
+        }
+        if ($targetProjectId !== $existingProjectId) {
+            $this->authorize(IdeasPermissions::EDIT, $targetProjectId);
+        }
+
+        // Normalize to the resolved board project for the notification below.
+        $projectId = $targetProjectId;
 
         $canvasItem = [
             'box' => $input['box'],

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -91,6 +91,7 @@ class Install
         30508,
         30509,
         30510,
+        30511,
     ];
 
     /**
@@ -2867,6 +2868,32 @@ class Install
             Log::error('Migration 30510: '.$e->getMessage());
 
             return ['Migration 30510 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30511: the Ideas domain joined the native permission engine. Re-sync the discovered
+     * permission catalog (adds ideas.view/create/edit/delete, all project-scoped) and re-seed the
+     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
+     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
+     * Flush the discovered-provider cache first — an install that already ran 30505-30510 cached the
+     * provider list WITHOUT IdeasPermissions, so seeding against that stale list would never create
+     * the ideas.* keys (and lower roles would lose idea access).
+     */
+    public function update_sql_30511(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30511: '.$e->getMessage());
+
+            return ['Migration 30511 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -32,6 +32,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('wiki.create', 'Create', true),
             new Permission('wiki.edit', 'Edit', true),
             new Permission('wiki.delete', 'Delete', true),
+            new Permission('ideas.view', 'View', true),
+            new Permission('ideas.create', 'Create', true),
+            new Permission('ideas.edit', 'Edit', true),
+            new Permission('ideas.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -59,7 +63,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -76,6 +80,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('sprints.view', $grants);       // inherited from readonly
         $this->assertNotContains('wiki.create', $grants);     // commenter views but cannot create
         $this->assertContains('wiki.view', $grants);          // inherited from readonly
+        $this->assertNotContains('ideas.create', $grants);    // commenter views but cannot create
+        $this->assertContains('ideas.view', $grants);         // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -94,6 +100,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('wiki.create', $grants);
         $this->assertContains('wiki.edit', $grants);
         $this->assertContains('wiki.delete', $grants);
+        // Ideas uses the same standard project verbs, so editor auto-gets create/edit/delete.
+        $this->assertContains('ideas.create', $grants);
+        $this->assertContains('ideas.edit', $grants);
+        $this->assertContains('ideas.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Unit\app\Domain\Ideas\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeasRepository;
@@ -11,33 +13,72 @@ use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Unit\TestCase;
 
 /**
- * Unit tests for the Ideas service helpers extracted during the
- * thin-controller refactor (board listing, item factory/normalization,
- * default-board creation).
+ * Unit tests for the Ideas service: board/item helpers plus the project-scoped authorization
+ * fences. Idea boards (zp_canvas type 'idea') and items (zp_canvas_items) are project-scoped; reads
+ * and mutations fence against the entity's REAL project (item -> board -> project), failing closed
+ * on the shared canvas tables. The pre-existing userCanAccessCanvasItem checks are migrated onto the
+ * permission engine.
  */
 class IdeasServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
 
-    /**
-     * Builds a real Ideas service, allowing each dependency to be
-     * overridden with a stub so we can observe persistence/orchestration calls.
-     */
+    private const SESSION_USER = 5;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        session(['userdata.id' => self::SESSION_USER]);
+    }
+
     private function makeService(
         ?IdeasRepository $ideasRepo = null,
         ?CommentRepository $commentsRepo = null,
-        ?ProjectService $projectService = null,
-        ?TicketService $ticketService = null,
         ?LanguageCore $language = null,
+        ?PermissionService $perms = null,
     ): IdeaService {
-        return new IdeaService(
+        $service = new IdeaService(
             $ideasRepo ?? $this->make(IdeasRepository::class),
             $commentsRepo ?? $this->make(CommentRepository::class),
-            $projectService ?? $this->make(ProjectService::class),
-            $ticketService ?? $this->make(TicketService::class),
+            $this->make(ProjectService::class),
+            $this->make(TicketService::class),
             $language ?? $this->make(LanguageCore::class),
         );
+        $service->setPermissionService($perms ?? $this->allowingPermissions());
+
+        return $service;
     }
+
+    /** A repo whose board #3 / item #5 both resolve to project 9. */
+    private function ideaRepoInProject9(array $overrides = []): IdeasRepository
+    {
+        return $this->make(IdeasRepository::class, array_merge([
+            'getSingleCanvas' => fn () => [['id' => 3, 'projectId' => 9, 'title' => 'Board']],
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+        ], $overrides));
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+            'currentUserCan' => fn () => false,
+        ]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Item factory / normalization (behavioural).
+    // ---------------------------------------------------------------------
 
     public function test_get_idea_item_returns_empty_default_for_null_id(): void
     {
@@ -51,15 +92,13 @@ class IdeasServiceTest extends TestCase
 
     public function test_get_idea_item_defaults_type_to_idea(): void
     {
-        $item = $this->makeService()->getIdeaItem(null);
-
-        $this->assertSame('idea', $item['box']);
+        $this->assertSame('idea', $this->makeService()->getIdeaItem(null)['box']);
     }
 
     public function test_get_idea_item_normalizes_zero_box_to_idea(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvasItem' => fn () => ['id' => 5, 'box' => '0', 'description' => 'x'],
+        $repo = $this->ideaRepoInProject9([
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'box' => '0', 'canvasId' => 3, 'description' => 'x'],
         ]);
 
         $item = $this->makeService(ideasRepo: $repo)->getIdeaItem(5);
@@ -70,13 +109,11 @@ class IdeasServiceTest extends TestCase
 
     public function test_get_idea_item_keeps_non_zero_box(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvasItem' => fn () => ['id' => 7, 'box' => 'prototype'],
+        $repo = $this->ideaRepoInProject9([
+            'getSingleCanvasItem' => fn () => ['id' => 7, 'box' => 'prototype', 'canvasId' => 3],
         ]);
 
-        $item = $this->makeService(ideasRepo: $repo)->getIdeaItem(7);
-
-        $this->assertSame('prototype', $item['box']);
+        $this->assertSame('prototype', $this->makeService(ideasRepo: $repo)->getIdeaItem(7)['box']);
     }
 
     public function test_ensure_board_exists_returns_zero_when_boards_present(): void
@@ -90,51 +127,35 @@ class IdeasServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService(ideasRepo: $repo)
-            ->ensureBoardExists(1, 2, [['id' => 10]]);
-
-        $this->assertSame(0, $result);
+        $this->assertSame(0, $this->makeService(ideasRepo: $repo)->ensureBoardExists(1, 2, [['id' => 10]]));
         $this->assertSame(0, $addCalls, 'No board should be created when one already exists');
     }
 
     public function test_ensure_board_exists_creates_default_when_none(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'addCanvas' => fn () => '99',
-        ]);
-        $language = $this->make(LanguageCore::class, [
-            '__' => fn () => 'Board',
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['addCanvas' => fn () => '99']);
+        $language = $this->make(LanguageCore::class, ['__' => fn () => 'Board']);
 
-        $result = $this->makeService(ideasRepo: $repo, language: $language)
-            ->ensureBoardExists(1, 2, []);
-
-        $this->assertSame(99, $result);
+        $this->assertSame(99, $this->makeService(ideasRepo: $repo, language: $language)->ensureBoardExists(1, 2, []));
     }
 
     public function test_get_all_boards_normalizes_false_to_empty_array(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getAllCanvas' => fn () => false,
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['getAllCanvas' => fn () => false]);
 
         $this->assertSame([], $this->makeService(ideasRepo: $repo)->getAllBoards(1));
     }
 
     public function test_get_board_items_normalizes_false_to_empty_array(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getCanvasItemsById' => fn () => false,
-        ]);
+        $repo = $this->ideaRepoInProject9(['getCanvasItemsById' => fn () => false]);
 
-        $this->assertSame([], $this->makeService(ideasRepo: $repo)->getBoardItems(5));
+        $this->assertSame([], $this->makeService(ideasRepo: $repo)->getBoardItems(3));
     }
 
     public function test_get_board_title_returns_empty_when_not_found(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvas' => fn () => false,
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvas' => fn () => false]);
 
         $this->assertSame('', $this->makeService(ideasRepo: $repo)->getBoardTitle(123));
     }
@@ -142,81 +163,230 @@ class IdeasServiceTest extends TestCase
     public function test_get_board_title_returns_first_row_title(): void
     {
         $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvas' => fn () => [['id' => 1, 'title' => 'My Board']],
+            'getSingleCanvas' => fn () => [['id' => 1, 'title' => 'My Board', 'projectId' => 9]],
         ]);
 
         $this->assertSame('My Board', $this->makeService(ideasRepo: $repo)->getBoardTitle(1));
     }
 
     // ---------------------------------------------------------------------
-    // JSON-RPC authorization gates (editor + per-item project access).
+    // Read fences (single-entity-by-id).
     // ---------------------------------------------------------------------
 
-    /**
-     * Repo stub whose canvas item resolves to project 9.
-     */
-    private function repoForProject9(array $extra = []): IdeasRepository
+    public function test_get_board_is_denied_for_a_foreign_project(): void
     {
-        return $this->make(IdeasRepository::class, array_merge([
-            'getSingleCanvasItem' => fn () => ['canvasId' => 7],
-            // getSingleCanvas returns a LIST of row arrays (matches the real repo shape).
-            'getSingleCanvas' => fn () => [['projectId' => 9]],
-            'patchCanvasItem' => fn () => true,
-            'updateIdeaSorting' => fn () => true,
-            'bulkUpdateIdeaStatus' => fn () => true,
-        ], $extra));
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getBoard(3);
     }
 
-    public function test_patch_idea_item_denied_for_non_editor(): void
+    public function test_get_board_items_is_denied_for_a_foreign_project(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $this->expectException(AuthorizationException::class);
 
-        $this->assertFalse($service->patchIdeaItem(5, ['box' => 'done']));
+        $service->getBoardItems(3);
     }
 
-    public function test_patch_idea_item_denied_when_not_assigned_to_project(): void
-    {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
+    // ---------------------------------------------------------------------
+    // Mutation fences (fail closed + project-scoped).
+    // ---------------------------------------------------------------------
 
-        $projectService = $this->make(ProjectService::class, [
-            'isUserAssignedToProject' => fn () => false,
+    public function test_patch_idea_item_is_denied_without_edit(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->patchIdeaItem(5, ['box' => 'done']);
+    }
+
+    public function test_patch_idea_item_allowed_with_edit(): void
+    {
+        $repo = $this->ideaRepoInProject9(['patchCanvasItem' => fn () => true]);
+
+        $this->assertTrue($this->makeService(ideasRepo: $repo)->patchIdeaItem(5, ['box' => 'done']));
+    }
+
+    public function test_patch_idea_item_fails_closed_for_unknown_item(): void
+    {
+        $patched = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => false,
+            'patchCanvasItem' => function () use (&$patched): bool {
+                $patched = true;
+
+                return true;
+            },
         ]);
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9(), projectService: $projectService);
-
-        $this->assertFalse($service->patchIdeaItem(5, ['box' => 'done']));
+        $this->assertFalse($this->makeService(ideasRepo: $repo)->patchIdeaItem(999, ['box' => 'done']));
+        $this->assertFalse($patched, 'A non-idea/unknown id must never reach the repo patch');
     }
 
-    public function test_patch_idea_item_allowed_for_editor_with_project_access(): void
+    public function test_update_idea_item_fails_closed_for_unknown_item(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
-
-        $projectService = $this->make(ProjectService::class, [
-            'isUserAssignedToProject' => fn () => true,
+        $edited = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => false,
+            'editCanvasItem' => function () use (&$edited): void {
+                $edited = true;
+            },
         ]);
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9(), projectService: $projectService);
+        $input = ['itemId' => 999, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 3, 'milestoneId' => ''];
 
-        $this->assertTrue($service->patchIdeaItem(5, ['box' => 'done']));
+        $this->assertSame(0, $this->makeService(ideasRepo: $repo)->updateIdeaItem($input, 9, self::SESSION_USER));
+        $this->assertFalse($edited, 'A non-idea/unknown id must never reach the repo edit');
     }
 
-    public function test_reorder_ideas_denied_for_non_editor(): void
+    public function test_update_idea_item_is_denied_without_edit(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+        $input = ['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 3, 'milestoneId' => ''];
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateIdeaItem($input, 9, self::SESSION_USER);
+    }
+
+    public function test_create_idea_item_is_denied_without_create(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->createIdeaItem(['box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'canvasId' => 3], 9, self::SESSION_USER);
+    }
+
+    public function test_create_board_is_denied_without_create(): void
+    {
+        $service = $this->makeService(perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->createBoard('New board', 9, self::SESSION_USER);
+    }
+
+    public function test_update_board_is_denied_without_edit(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateBoard(3, 'Renamed');
+    }
+
+    public function test_update_board_fails_closed_for_unknown_board(): void
+    {
+        $updated = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvas' => fn () => [],
+            'updateCanvas' => function () use (&$updated) {
+                $updated = true;
+
+                return 1;
+            },
+        ]);
+
+        $this->assertFalse($this->makeService(ideasRepo: $repo)->updateBoard(999, 'Renamed'));
+        $this->assertFalse($updated, 'A non-idea/unknown board id must never reach the repo update');
+    }
+
+    public function test_delete_canvas_is_denied_and_does_not_delete(): void
+    {
+        $repo = $this->ideaRepoInProject9([
+            'deleteCanvas' => function (): void {
+                throw new \RuntimeException('delete must not run when denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteCanvas(3);
+    }
+
+    public function test_delete_canvas_item_is_denied_and_does_not_delete(): void
+    {
+        $repo = $this->ideaRepoInProject9([
+            'delCanvasItem' => function (): void {
+                throw new \RuntimeException('delete must not run when denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteCanvasItem(5);
+    }
+
+    // ---------------------------------------------------------------------
+    // Batch mutators reject (return false) without writing.
+    // ---------------------------------------------------------------------
+
+    public function test_reorder_ideas_rejects_batch_when_cannot_edit(): void
+    {
+        $sorted = false;
+        $repo = $this->ideaRepoInProject9([
+            'updateIdeaSorting' => function () use (&$sorted): bool {
+                $sorted = true;
+
+                return true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
 
         $this->assertFalse($service->reorderIdeas([['id' => 5, 'sortIndex' => 1]]));
+        $this->assertFalse($sorted, 'A denied batch must never reach the repo sort');
     }
 
-    public function test_bulk_update_status_denied_for_non_editor(): void
+    public function test_bulk_update_status_rejects_batch_when_cannot_edit(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
-
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $repo = $this->ideaRepoInProject9(['bulkUpdateIdeaStatus' => fn () => true]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
 
         $this->assertFalse($service->bulkUpdateStatus(['done' => 'item[]=5']));
+    }
+
+    // ---------------------------------------------------------------------
+    // Comment delete: author allowed; non-author requires moderation.
+    // ---------------------------------------------------------------------
+
+    public function test_remove_idea_comment_allows_the_author_without_moderation(): void
+    {
+        $deleted = null;
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => self::SESSION_USER, 'moduleId' => 5],
+            'deleteComment' => function ($id) use (&$deleted): bool {
+                $deleted = $id;
+
+                return true;
+            },
+        ]);
+        // Denying engine proves the author path does NOT require comments.moderate.
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $service->removeIdeaComment(1);
+
+        $this->assertSame(1, $deleted);
+    }
+
+    public function test_remove_idea_comment_denies_non_author_without_moderation(): void
+    {
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => 7, 'moduleId' => 5],
+            'deleteComment' => function (): bool {
+                throw new \RuntimeException('delete must not run when moderation is denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->removeIdeaComment(1);
     }
 }

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -389,4 +389,81 @@ class IdeasServiceTest extends TestCase
 
         $service->removeIdeaComment(1);
     }
+
+    // ---------------------------------------------------------------------
+    // Fail-closed on a non-resolving (non-idea) id: never authorize against a null project, never
+    // fall back to the caller-supplied project. (A null project here means "not an idea entity".)
+    // ---------------------------------------------------------------------
+
+    public function test_get_idea_comments_fails_closed_for_non_idea_entity(): void
+    {
+        $fetched = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComments' => function () use (&$fetched) {
+                $fetched = true;
+
+                return [];
+            },
+        ]);
+        // Denying engine: if it reached authorize(VIEW, null) it would throw; fail-closed returns [] first.
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $this->assertSame([], $service->getIdeaComments('ticket', 123));
+        $this->assertFalse($fetched, 'A non-idea entity must short-circuit before the comment read');
+    }
+
+    public function test_create_idea_item_fails_closed_for_non_idea_board(): void
+    {
+        $created = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvas' => fn () => [], // canvasId is not an idea board
+            'addCanvasItem' => function () use (&$created) {
+                $created = true;
+
+                return '1';
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $this->assertSame(0, $service->createIdeaItem(['box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'canvasId' => 999], 9, self::SESSION_USER));
+        $this->assertFalse($created, 'A non-idea board canvasId must never create an item against the caller project');
+    }
+
+    public function test_add_idea_comment_fails_closed_for_non_idea_item(): void
+    {
+        $added = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'addComment' => function () use (&$added) {
+                $added = true;
+
+                return '1';
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo);
+
+        $this->assertFalse($service->addIdeaComment('hi', 999, 0, 9, self::SESSION_USER));
+        $this->assertFalse($added, 'A non-idea item must never receive a comment against the caller project');
+    }
+
+    public function test_remove_idea_comment_fails_closed_for_non_author_non_idea_comment(): void
+    {
+        $deleted = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => 7, 'moduleId' => 999],
+            'deleteComment' => function () use (&$deleted): bool {
+                $deleted = true;
+
+                return true;
+            },
+        ]);
+        // Allowing engine: proves the refusal is the fail-closed null guard, not a denied authorize.
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo, perms: $this->allowingPermissions());
+
+        $service->removeIdeaComment(1);
+
+        $this->assertFalse($deleted, 'A non-author comment on a non-idea item must not be deleted');
+    }
 }

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -466,4 +466,73 @@ class IdeasServiceTest extends TestCase
 
         $this->assertFalse($deleted, 'A non-author comment on a non-idea item must not be deleted');
     }
+
+    // ---------------------------------------------------------------------
+    // Relocation / mass-assignment fences (Copilot review): the incoming canvasId/params can move
+    // an item to another board, so the target board's project must also be authorized.
+    // ---------------------------------------------------------------------
+
+    public function test_patch_idea_item_strips_relocation_and_identity_fields(): void
+    {
+        // patchCanvasItem updates any column it receives; canvasId/id/author must be stripped so a
+        // caller can't relocate the item to another board/project or rewrite its identity.
+        $patched = null;
+        $repo = $this->ideaRepoInProject9([
+            'patchCanvasItem' => function ($id, $params) use (&$patched): bool {
+                $patched = $params;
+
+                return true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $service->patchIdeaItem(5, ['status' => 'done', 'canvasId' => 999, 'id' => 1, 'author' => 7]);
+
+        $this->assertArrayNotHasKey('canvasId', $patched);
+        $this->assertArrayNotHasKey('id', $patched);
+        $this->assertArrayNotHasKey('author', $patched);
+        $this->assertSame('done', $patched['status'], 'Legitimate fields still pass through');
+    }
+
+    public function test_update_idea_item_denies_relocation_to_a_foreign_board(): void
+    {
+        // Item lives in project 9 (board 3); the edit's canvasId points at board 99 in project 7.
+        // The user may edit project 9 but NOT project 7 -> the relocation is denied before the write.
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+            'getSingleCanvas' => fn ($id) => $id === 99 ? [['projectId' => 7]] : [['projectId' => 9]],
+            'editCanvasItem' => function (): void {
+                throw new \RuntimeException('relocation must be blocked before the write');
+            },
+        ]);
+        $perms = $this->make(PermissionService::class, [
+            'authorize' => function (string $p, ?int $projectId = null): void {
+                if ($projectId === 7) {
+                    throw new AuthorizationException;
+                }
+            },
+            'currentUserCan' => fn () => true,
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $perms);
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateIdeaItem(['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 99, 'milestoneId' => ''], 9, self::SESSION_USER);
+    }
+
+    public function test_update_idea_item_fails_closed_when_target_board_is_not_an_idea_board(): void
+    {
+        $edited = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+            'getSingleCanvas' => fn ($id) => $id === 3 ? [['projectId' => 9]] : [], // target 99 -> not an idea board
+            'editCanvasItem' => function () use (&$edited): void {
+                $edited = true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $this->assertSame(0, $service->updateIdeaItem(['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 99, 'milestoneId' => ''], 9, self::SESSION_USER));
+        $this->assertFalse($edited, 'A non-idea target board must never receive the relocated item');
+    }
 }


### PR DESCRIPTION
Stacked on #3475 (Wiki) for the migration-version sequence — base auto-retargets to `master` when #3475 merges. Review **Files changed** against the Wiki branch (only the Ideas diff).

## What & why
Ideas is the largest content domain (boards = `zp_canvas` type `idea`, items = `zp_canvas_items`, plus comments). It already had a *partial* IDOR fence (`userCanAccessCanvasItem` on reorder/bulk/patch); this migrates that onto the engine and closes the rest, applying the **shared-canvas-table fail-closed** rule from the Wiki review.

## Highlights
- **`IdeasPermissions`** view/create/edit/delete (project-scoped). Standard verbs auto-grant → no `DefaultRolePermissions` change.
- **Service (`extends BaseService`)** with two resolvers — `boardProjectId()` (board→project, `type='idea'`) and `canvasItemProjectId()` (item→board→project). Both filter to idea boards, so a **foreign canvas-type id resolves to null and every fence fails closed**.
  - Reorder/bulk → per-item `can(EDIT, project)` loop (batch rejects `false`). patch/update/remove-milestone → `authorize(EDIT)` against the item's real project, fail-closed.
  - `createIdeaItem` authorizes CREATE against the **target board's** project (resolved from `canvasId`, not the untrusted passed `projectId`); board create/update fenced.
  - Single-entity reads (`getBoard`/`getBoardItems`/`getIdeaItem`/`getRawIdeaItem`) entity-scoped VIEW; list reads → `projectIdParam`.
  - **`removeIdeaComment` was an ungated delete-by-id reachable via the `?delComment` GET param** (anyone could delete any comment) → now author-or-moderate against the idea's project. `addIdeaComment` → `comments.create`; `getIdeaComments`/`countIdeaComments` → view, all against the item's project.
  - **New** `deleteCanvas`/`deleteCanvasItem` service methods; `DelCanvas`/`DelCanvasItem` rerouted off their direct repo calls + dropped `Auth::authOrRedirect`.
  - **Landmine handled:** `ensureBoardExists` lazily creates a default board on view → VIEW-gated, writes straight to the repo (gating CREATE would 403 readonly — mirrors Wiki).
  - Defense-in-depth: repo `deleteCanvas`/`updateCanvas` scoped to `type='idea'`.
- Controllers `Show`/`Board`/`AdvancedBoards`/`IdeaDialog` gated VIEW (posts defer to the service per-verb fences).

## Migration & verification
`update_sql_30511` (flush registry → sync → seed) + `dbVersion` 3.5.11. **DB-verified:** `ideas.view`→all roles, `ideas.create/edit/delete`→editor+. `IdeasServiceTest` (27 tests) + matrix lock extended. Full unit suite **450/1089** green; pint + phpstan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)