### PR TITLE
security(wiki+ideas): gate the Wiki and Ideas domains on the native permission engine

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.10';
+    public string $dbVersion = '3.5.11';
 }

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.9';
+    public string $dbVersion = '3.5.10';
 }

--- a/app/Domain/Ideas/Controllers/AdvancedBoards.php
+++ b/app/Domain/Ideas/Controllers/AdvancedBoards.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +35,7 @@ class AdvancedBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));
@@ -52,6 +55,7 @@ class AdvancedBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));

--- a/app/Domain/Ideas/Controllers/BoardDialog.php
+++ b/app/Domain/Ideas/Controllers/BoardDialog.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +35,7 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $currentCanvasId = '';
@@ -61,6 +64,7 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $currentCanvasId = '';

--- a/app/Domain/Ideas/Controllers/DelCanvas.php
+++ b/app/Domain/Ideas/Controllers/DelCanvas.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
+use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelCanvas extends Controller
 {
-    private IdeaRepository $ideaRepo;
+    private IdeaService $ideaService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(IdeaRepository $ideaRepo): void
+    public function init(IdeaService $ideaService): void
     {
-        $this->ideaRepo = $ideaRepo;
+        $this->ideaService = $ideaService;
     }
 
     /**
@@ -26,28 +26,26 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->display('ideas.delCanvas');
     }
 
     /**
-     * Handles idea board deletion.
+     * Handles idea board deletion. The controller gate defers (entityScoped) to the service's
+     * deleteCanvas(), which authorizes DELETE against the board's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->ideaRepo->deleteCanvas($id);
+            $this->ideaService->deleteCanvas($id);
 
-            session()->forget('currentIdeaCanvas');
             $this->tpl->setNotification($this->language->__('notification.idea_board_deleted'), 'success', 'ideaboard_deleted');
 
             return Frontcontroller::redirect(BASE_URL.'/ideas/showBoards');

--- a/app/Domain/Ideas/Controllers/DelCanvasItem.php
+++ b/app/Domain/Ideas/Controllers/DelCanvasItem.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
+use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelCanvasItem extends Controller
 {
-    private IdeaRepository $ideasRepo;
+    private IdeaService $ideaService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(IdeaRepository $ideasRepo): void
+    public function init(IdeaService $ideaService): void
     {
-        $this->ideasRepo = $ideasRepo;
+        $this->ideaService = $ideaService;
     }
 
     /**
@@ -26,26 +26,25 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('ideas.delCanvasItem');
     }
 
     /**
-     * Handles idea item deletion.
+     * Handles idea item deletion. The controller gate defers (entityScoped) to the service's
+     * deleteCanvasItem(), which authorizes DELETE against the item's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->ideasRepo->delCanvasItem($id);
+            $this->ideaService->deleteCanvasItem($id);
 
             $this->tpl->setNotification($this->language->__('notification.idea_board_item_deleted'), 'success', 'ideaitem_deleted');
 

--- a/app/Domain/Ideas/Controllers/IdeaDialog.php
+++ b/app/Domain/Ideas/Controllers/IdeaDialog.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 
 class IdeaDialog extends Controller
@@ -19,8 +21,10 @@ class IdeaDialog extends Controller
     }
 
     /**
-     * get - handle get requests
+     * get - handle get requests. The embedded ?delComment / ?removeMilestone mutations are fenced
+     * by the service (removeIdeaComment = author-or-moderate; removeMilestone = edit) in-body.
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get($params)
     {
         if (isset($params['id'])) {
@@ -61,8 +65,11 @@ class IdeaDialog extends Controller
     }
 
     /**
-     * post - handle post requests
+     * post - handle post requests. Create/update/comment all defer to the service methods, which
+     * authorize the correct verb (ideas.create / ideas.edit / comments.create) against the entity's
+     * real project.
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post($params)
     {
 

--- a/app/Domain/Ideas/Controllers/ShowBoards.php
+++ b/app/Domain/Ideas/Controllers/ShowBoards.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Ideas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Services\Ideas as IdeaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +33,7 @@ class ShowBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));
@@ -50,6 +53,7 @@ class ShowBoards extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function post(array $params): Response
     {
         $allCanvas = $this->ideaService->getAllBoards(session('currentProject'));

--- a/app/Domain/Ideas/Permissions/IdeasPermissions.php
+++ b/app/Domain/Ideas/Permissions/IdeasPermissions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Leantime\Domain\Ideas\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Ideas permission vocabulary — the verbs only.
+ *
+ * Idea boards and items are PROJECT-scoped (each board belongs to one project; items belong to a
+ * board), so every capability is evaluated against the user's role IN that project (projectScoped =
+ * true, the default). The standard verbs auto-grant via the central matrix (readonly = view; editor
+ * = create/edit/delete; manager+ = all), so no
+ * {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} change is required.
+ */
+final class IdeasPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'ideas.view';
+
+    public const CREATE = 'ideas.create';
+
+    public const EDIT = 'ideas.edit';
+
+    public const DELETE = 'ideas.delete';
+
+    public function domain(): string
+    {
+        return 'ideas';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View idea boards'),
+            new Permission(self::CREATE, 'Create idea boards and ideas'),
+            new Permission(self::EDIT, 'Edit ideas'),
+            new Permission(self::DELETE, 'Delete idea boards and ideas'),
+        ];
+    }
+}

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -134,8 +134,10 @@ class Ideas
             ->where('canvasId', $id)
             ->delete();
 
+        // type guard (shared zp_canvas across all canvas families): only ever delete an idea board.
         $this->db->table('zp_canvas')
             ->where('id', $id)
+            ->where('type', 'idea')
             ->delete();
     }
 
@@ -154,8 +156,10 @@ class Ideas
 
     public function updateCanvas(array $values): mixed
     {
+        // type guard (shared zp_canvas across all canvas families): only ever rename an idea board.
         return $this->db->table('zp_canvas')
             ->where('id', $values['id'])
+            ->where('type', 'idea')
             ->update(['title' => $values['title']]);
     }
 

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -130,11 +130,22 @@ class Ideas
 
     public function deleteCanvas(int $id): void
     {
+        // Shared zp_canvas/zp_canvas_items: early-return unless this id is an idea board, so the
+        // items-delete (by canvasId) can't drop another canvas family's items before the
+        // type-guarded board delete runs.
+        $isIdea = $this->db->table('zp_canvas')
+            ->where('id', $id)
+            ->where('type', 'idea')
+            ->exists();
+
+        if (! $isIdea) {
+            return;
+        }
+
         $this->db->table('zp_canvas_items')
             ->where('canvasId', $id)
             ->delete();
 
-        // type guard (shared zp_canvas across all canvas families): only ever delete an idea board.
         $this->db->table('zp_canvas')
             ->where('id', $id)
             ->where('type', 'idea')

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -2,11 +2,13 @@
 
 namespace Leantime\Domain\Ideas\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Mailer as MailerCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Comments\Permissions\CommentsPermissions;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
+use Leantime\Domain\Ideas\Permissions\IdeasPermissions;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeasRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -16,7 +18,7 @@ use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 /**
  * Ideas service - business logic for idea boards and idea items.
  */
-class Ideas
+class Ideas extends BaseService
 {
     private IdeasRepository $ideasRepository;
 
@@ -46,30 +48,36 @@ class Ideas
     }
 
     /**
-     * Authorization helper: is the current user allowed to modify a canvas item?
+     * Resolve an idea board's owning project. Boards are zp_canvas rows (type 'idea').
      *
-     * Resolves the item -> its canvas -> the canvas's project, then checks the
-     * session user's project access. Used to gate the JSON-RPC idea mutators
-     * (the underlying repository operates by item id with no project scoping).
+     * @param  int  $boardId  The board (canvas) id
+     * @return int|null The board's project id, or null when the board does not exist
+     */
+    private function boardProjectId(int $boardId): ?int
+    {
+        // getSingleCanvas() returns a list of row arrays (not a flat row).
+        $rows = $this->ideasRepository->getSingleCanvas($boardId);
+
+        return isset($rows[0]['projectId']) ? (int) $rows[0]['projectId'] : null;
+    }
+
+    /**
+     * Resolve an idea item's owning project (item -> its board/canvas -> project).
+     *
+     * The repository operates by item id with NO project scoping, and zp_canvas_items is shared
+     * across all canvas types, so callers MUST fail closed on a null result before any read/write.
      *
      * @param  int  $itemId  The canvas item id
-     * @return bool True when the session user may modify the item
+     * @return int|null The item's project id, or null when it does not resolve to an idea board
      */
-    private function userCanAccessCanvasItem(int $itemId): bool
+    private function canvasItemProjectId(int $itemId): ?int
     {
-        $item = (array) $this->ideasRepository->getSingleCanvasItem($itemId);
-        if (empty($item['canvasId'])) {
-            return false;
+        $item = $this->ideasRepository->getSingleCanvasItem($itemId);
+        if (! is_array($item) || empty($item['canvasId'])) {
+            return null;
         }
 
-        // getSingleCanvas() returns a list of row arrays (not a flat row),
-        // matching the existing getBoardTitle() consumer.
-        $canvas = $this->ideasRepository->getSingleCanvas((int) $item['canvasId']);
-        if (empty($canvas[0]['projectId'])) {
-            return false;
-        }
-
-        return $this->projectService->isUserAssignedToProject((int) session('userdata.id'), (int) $canvas[0]['projectId']);
+        return $this->boardProjectId((int) $item['canvasId']);
     }
 
     /**
@@ -83,14 +91,18 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function reorderIdeas(array $payload): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return false;
-        }
-
+        // Per-item project fence: reject the whole batch unless the user may edit EVERY item's
+        // project (non-throwing can(), since a batch should fail gracefully). null project = the id
+        // is not an idea item (shared zp_canvas_items) -> reject.
         foreach ($payload as $idea) {
-            if (! isset($idea['id']) || ! $this->userCanAccessCanvasItem((int) $idea['id'])) {
+            if (! isset($idea['id'])) {
+                return false;
+            }
+            $projectId = $this->canvasItemProjectId((int) $idea['id']);
+            if ($projectId === null || ! $this->can(IdeasPermissions::EDIT, $projectId)) {
                 return false;
             }
         }
@@ -109,17 +121,19 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function bulkUpdateStatus(array $payload): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return false;
-        }
-
+        // Per-item project fence over the jQuery-sortable serialized payload.
         foreach ($payload as $itemList) {
             foreach (explode('&', (string) $itemList) as $itemString) {
                 // jQuery sortable serializes as "item[]=ID"; strip the prefix.
                 $id = (int) substr($itemString, 7);
-                if ($id > 0 && ! $this->userCanAccessCanvasItem($id)) {
+                if ($id <= 0) {
+                    continue;
+                }
+                $projectId = $this->canvasItemProjectId($id);
+                if ($projectId === null || ! $this->can(IdeasPermissions::EDIT, $projectId)) {
                     return false;
                 }
             }
@@ -139,11 +153,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function patchIdeaItem(int $id, array $params): bool
     {
-        if (! Auth::userIsAtLeast(Roles::$editor) || ! $this->userCanAccessCanvasItem($id)) {
+        // Fail closed: resolve the item's REAL project (shared zp_canvas_items) and require edit
+        // there before patching — null means the id is not an idea item, so refuse.
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
             return false;
         }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
 
         return $this->ideasRepository->patchCanvasItem($id, $params);
     }
@@ -157,6 +176,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForNewIdeas(?int $projectId = null, ?int $board = null): array
     {
         $ideas = $this->ideasRepository->getAllIdeas($projectId, $board);
@@ -177,6 +197,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForUpdatedIdeas(?int $projectId = null, ?int $board = null): array
     {
         $ideas = $this->ideasRepository->getAllIdeas($projectId, $board);
@@ -220,6 +241,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function getAllBoards(int $projectId): array
     {
         $allCanvas = $this->ideasRepository->getAllCanvas($projectId);
@@ -235,11 +257,18 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoard(int $id): array
     {
         $singleCanvas = $this->ideasRepository->getSingleCanvas($id);
+        if (empty($singleCanvas)) {
+            return [];
+        }
 
-        return $singleCanvas === false ? [] : $singleCanvas;
+        // IDOR fence: authorize VIEW against the board's real project (single-entity-by-id read).
+        $this->authorize(IdeasPermissions::VIEW, isset($singleCanvas[0]['projectId']) ? (int) $singleCanvas[0]['projectId'] : null);
+
+        return $singleCanvas;
     }
 
     /**
@@ -250,8 +279,10 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoardTitle(int $id): string
     {
+        // Delegates to getBoard(), which performs the in-body VIEW authorize against the board's project.
         $singleCanvas = $this->getBoard($id);
 
         return $singleCanvas[0]['title'] ?? '';
@@ -265,8 +296,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getBoardItems(int $boardId): array
     {
+        // IDOR fence: authorize VIEW against the board's real project before listing its items.
+        $projectId = $this->boardProjectId($boardId);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
+
         $items = $this->ideasRepository->getCanvasItemsById($boardId);
 
         return $items === false ? [] : $items;
@@ -279,6 +318,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function getBoardLabels(): mixed
     {
         return $this->ideasRepository->getCanvasLabels();
@@ -294,8 +334,12 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createBoard(string $title, int $projectId, int $authorId): int
     {
+        // A board belongs directly to $projectId; authorize CREATE there before writing.
+        $this->authorize(IdeasPermissions::CREATE, $projectId);
+
         $values = [
             'title' => $title,
             'author' => $authorId,
@@ -323,8 +367,12 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createBoardFromDialog(string $title, int $projectId, int $authorId): int
     {
+        // A board belongs directly to $projectId; authorize CREATE there before writing.
+        $this->authorize(IdeasPermissions::CREATE, $projectId);
+
         $values = [
             'title' => $title,
             'author' => $authorId,
@@ -347,8 +395,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function updateBoard(int $id, string $title): mixed
     {
+        // Fail closed: resolve the board's real project and require edit there before renaming.
+        $projectId = $this->boardProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
+
         return $this->ideasRepository->updateCanvas(['title' => $title, 'id' => $id]);
     }
 
@@ -365,12 +421,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function ensureBoardExists(int $projectId, int $authorId, array $allBoards): int
     {
         if (count($allBoards) > 0) {
             return 0;
         }
 
+        // Bootstrap only: the default board is created as a SIDE EFFECT of viewing a board-less
+        // project, so it is VIEW-gated and writes straight to the repository — gating it CREATE
+        // would 403 a readonly viewer (mirrors Wiki's getAllProjectWikis default-notebook bootstrap).
         $values = [
             'title' => $this->language->__('label.board'),
             'author' => $authorId,
@@ -447,6 +507,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaItem(?int $id, string $type = 'idea'): array
     {
         if ($id === null) {
@@ -463,6 +524,13 @@ class Ideas
                 'milestoneId' => '',
             ];
         }
+
+        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
 
@@ -483,8 +551,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getRawIdeaItem(?int $id): mixed
     {
+        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
+        $projectId = $this->canvasItemProjectId((int) $id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
+
         return $this->ideasRepository->getSingleCanvasItem((int) $id);
     }
 
@@ -495,6 +571,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW)]
     public function getCanvasTypes(): array
     {
         return $this->ideasRepository->canvasTypes;
@@ -510,8 +587,14 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createIdeaItem(array $input, int $projectId, int $authorId): int
     {
+        // Authorize CREATE against the TARGET board's real project (resolve from canvasId; the
+        // passed projectId is untrusted), falling back to it only if the board can't be resolved.
+        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0)) ?? $projectId;
+        $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
+
         $canvasItem = [
             'box' => $input['box'],
             'author' => $authorId,
@@ -563,9 +646,19 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function updateIdeaItem(array $input, int $projectId, int $authorId): int
     {
         $itemId = (int) $input['itemId'];
+
+        // Fail closed: resolve the EXISTING item's real project (shared zp_canvas_items) and require
+        // edit there before writing — the passed projectId/canvasId are untrusted, so an editor in
+        // project A cannot edit or relocate an item in project B.
+        $existingProjectId = $this->canvasItemProjectId($itemId);
+        if ($existingProjectId === null) {
+            return 0;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $existingProjectId);
 
         $canvasItem = [
             'box' => $input['box'],
@@ -633,8 +726,16 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function removeMilestone(int $ideaItemId): void
     {
+        // Fail closed: resolve the item's real project and require edit there before detaching.
+        $projectId = $this->canvasItemProjectId($ideaItemId);
+        if ($projectId === null) {
+            return;
+        }
+        $this->authorize(IdeasPermissions::EDIT, $projectId);
+
         $this->ideasRepository->patchCanvasItem($ideaItemId, ['milestoneId' => '']);
     }
 
@@ -646,6 +747,7 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, projectIdParam: 'projectId')]
     public function getProjectMilestones(int $projectId): array|false
     {
         return $this->ticketService->getAllMilestones([
@@ -667,8 +769,14 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::CREATE, entityScoped: true)]
     public function addIdeaComment(string $text, int $ideaItemId, int|string $parentCommentId, int $projectId, int $authorId): false|string
     {
+        // Commenting on an idea is a commenter+ capability in the idea's project (resolved from the
+        // item; the passed projectId is untrusted). Uses the Comments vocabulary.
+        $itemProjectId = $this->canvasItemProjectId($ideaItemId) ?? $projectId;
+        $this->authorize(CommentsPermissions::CREATE, $itemProjectId);
+
         $values = [
             'text' => $text,
             'date' => date('Y-m-d H:i:s'),
@@ -712,8 +820,24 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(CommentsPermissions::MODERATE, entityScoped: true)]
     public function removeIdeaComment(int $commentId): void
     {
+        // Was an UNGATED delete-by-id (reachable via the ?delComment GET param) — any user could
+        // delete any comment by id. Fence: the comment author may delete their own; otherwise
+        // require moderate in the idea's project (resolved from the comment's idea item).
+        $comment = $this->commentsRepository->getComment($commentId);
+        if (! $comment) {
+            return;
+        }
+
+        if ((int) ($comment['userId'] ?? 0) !== (int) session('userdata.id')) {
+            $this->authorize(
+                CommentsPermissions::MODERATE,
+                $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0))
+            );
+        }
+
         $this->commentsRepository->deleteComment($commentId);
     }
 
@@ -726,8 +850,13 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaComments(string $module, int $entityId): array|false
     {
+        // entityId is the idea item id; authorize VIEW against its project before returning comments
+        // (a null project falls back to a session-scoped role check for any non-resolving target).
+        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+
         return $this->commentsRepository->getComments($module, $entityId);
     }
 
@@ -740,8 +869,61 @@ class Ideas
      *
      * @api
      */
+    #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function countIdeaComments(string $module, int $entityId): mixed
     {
+        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+
         return $this->commentsRepository->countComments($module, $entityId);
+    }
+
+    /**
+     * Delete an idea board, fencing the operation against the board's project.
+     *
+     * Replaces the previous controller->repository direct delete (which only had a global-role
+     * gate and no project scoping, so an editor in any project could delete another's board).
+     *
+     * @param  int  $id  Board (canvas) id.
+     * @return bool True when deleted, false when the board does not resolve to a project.
+     *
+     * @api
+     */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
+    public function deleteCanvas(int $id): bool
+    {
+        $projectId = $this->boardProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::DELETE, $projectId);
+
+        $this->ideasRepository->deleteCanvas($id);
+        session()->forget('currentIdeaCanvas');
+
+        return true;
+    }
+
+    /**
+     * Delete an idea item, fencing the operation against the item's project.
+     *
+     * Replaces the previous controller->repository direct delete (id-only, no project scoping).
+     *
+     * @param  int  $id  Canvas item id.
+     * @return bool True when deleted, false when the item does not resolve to a project.
+     *
+     * @api
+     */
+    #[RequiresPermission(IdeasPermissions::DELETE, entityScoped: true)]
+    public function deleteCanvasItem(int $id): bool
+    {
+        $projectId = $this->canvasItemProjectId($id);
+        if ($projectId === null) {
+            return false;
+        }
+        $this->authorize(IdeasPermissions::DELETE, $projectId);
+
+        $this->ideasRepository->delCanvasItem($id);
+
+        return true;
     }
 }

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -530,18 +530,18 @@ class Ideas extends BaseService
             ];
         }
 
-        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
-        $projectId = $this->canvasItemProjectId($id);
+        // IDOR fence (single-entity-by-id read): fetch the item ONCE, derive its project from the
+        // owning board, authorize VIEW, then return the already-fetched row — no duplicate query.
+        $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
+        if (! is_array($canvasItem) || empty($canvasItem['canvasId'])) {
+            return [];
+        }
+
+        $projectId = $this->boardProjectId((int) $canvasItem['canvasId']);
         if ($projectId === null) {
             return [];
         }
         $this->authorize(IdeasPermissions::VIEW, $projectId);
-
-        $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
-
-        if (! is_array($canvasItem)) {
-            return [];
-        }
 
         if (isset($canvasItem['box']) && $canvasItem['box'] == '0') {
             $canvasItem['box'] = 'idea';
@@ -563,14 +563,20 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getRawIdeaItem(?int $id): mixed
     {
-        // IDOR fence: authorize VIEW against the item's real project (single-entity-by-id read).
-        $projectId = $this->canvasItemProjectId((int) $id);
+        // IDOR fence (single-entity-by-id read): fetch the item ONCE, derive its project from the
+        // owning board, authorize VIEW, then return the already-fetched row — no duplicate query.
+        $canvasItem = $this->ideasRepository->getSingleCanvasItem((int) $id);
+        if (! is_array($canvasItem) || empty($canvasItem['canvasId'])) {
+            return false;
+        }
+
+        $projectId = $this->boardProjectId((int) $canvasItem['canvasId']);
         if ($projectId === null) {
             return false;
         }
         $this->authorize(IdeasPermissions::VIEW, $projectId);
 
-        return $this->ideasRepository->getSingleCanvasItem((int) $id);
+        return $canvasItem;
     }
 
     /**

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -534,7 +534,11 @@ class Ideas extends BaseService
 
         $canvasItem = $this->ideasRepository->getSingleCanvasItem($id);
 
-        if (is_array($canvasItem) && isset($canvasItem['box']) && $canvasItem['box'] == '0') {
+        if (! is_array($canvasItem)) {
+            return [];
+        }
+
+        if (isset($canvasItem['box']) && $canvasItem['box'] == '0') {
             $canvasItem['box'] = 'idea';
         }
 
@@ -590,9 +594,14 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::CREATE, entityScoped: true)]
     public function createIdeaItem(array $input, int $projectId, int $authorId): int
     {
-        // Authorize CREATE against the TARGET board's real project (resolve from canvasId; the
-        // passed projectId is untrusted), falling back to it only if the board can't be resolved.
-        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0)) ?? $projectId;
+        // Authorize CREATE against the TARGET board's real project (resolved from canvasId; the
+        // passed projectId is untrusted). FAIL CLOSED if the canvasId is not an idea board — never
+        // fall back to the caller-supplied projectId, or a foreign/non-idea canvasId could be
+        // created against the caller's own project.
+        $boardProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0));
+        if ($boardProjectId === null) {
+            return 0;
+        }
         $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
 
         $canvasItem = [
@@ -773,8 +782,12 @@ class Ideas extends BaseService
     public function addIdeaComment(string $text, int $ideaItemId, int|string $parentCommentId, int $projectId, int $authorId): false|string
     {
         // Commenting on an idea is a commenter+ capability in the idea's project (resolved from the
-        // item; the passed projectId is untrusted). Uses the Comments vocabulary.
-        $itemProjectId = $this->canvasItemProjectId($ideaItemId) ?? $projectId;
+        // item; the passed projectId is untrusted). FAIL CLOSED if the id is not an idea item —
+        // never fall back to the caller-supplied projectId.
+        $itemProjectId = $this->canvasItemProjectId($ideaItemId);
+        if ($itemProjectId === null) {
+            return false;
+        }
         $this->authorize(CommentsPermissions::CREATE, $itemProjectId);
 
         $values = [
@@ -832,10 +845,13 @@ class Ideas extends BaseService
         }
 
         if ((int) ($comment['userId'] ?? 0) !== (int) session('userdata.id')) {
-            $this->authorize(
-                CommentsPermissions::MODERATE,
-                $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0))
-            );
+            // Non-author: require moderate in the idea's project. FAIL CLOSED if the comment's item
+            // does not resolve to an idea board — never downgrade to a role-only moderate check.
+            $projectId = $this->canvasItemProjectId((int) ($comment['moduleId'] ?? 0));
+            if ($projectId === null) {
+                return;
+            }
+            $this->authorize(CommentsPermissions::MODERATE, $projectId);
         }
 
         $this->commentsRepository->deleteComment($commentId);
@@ -853,9 +869,13 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function getIdeaComments(string $module, int $entityId): array|false
     {
-        // entityId is the idea item id; authorize VIEW against its project before returning comments
-        // (a null project falls back to a session-scoped role check for any non-resolving target).
-        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+        // Fail closed: a null project means $entityId is not an idea item, so refuse rather than
+        // authorize against null (role-only pass) and leak another project's comment thread by id.
+        $projectId = $this->canvasItemProjectId($entityId);
+        if ($projectId === null) {
+            return [];
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         return $this->commentsRepository->getComments($module, $entityId);
     }
@@ -872,7 +892,12 @@ class Ideas extends BaseService
     #[RequiresPermission(IdeasPermissions::VIEW, entityScoped: true)]
     public function countIdeaComments(string $module, int $entityId): mixed
     {
-        $this->authorize(IdeasPermissions::VIEW, $this->canvasItemProjectId($entityId));
+        // Fail closed: a null project means $entityId is not an idea item.
+        $projectId = $this->canvasItemProjectId($entityId);
+        if ($projectId === null) {
+            return 0;
+        }
+        $this->authorize(IdeasPermissions::VIEW, $projectId);
 
         return $this->commentsRepository->countComments($module, $entityId);
     }

--- a/app/Domain/Ideas/Services/Ideas.php
+++ b/app/Domain/Ideas/Services/Ideas.php
@@ -164,6 +164,11 @@ class Ideas extends BaseService
         }
         $this->authorize(IdeasPermissions::EDIT, $projectId);
 
+        // Strip relocation/identity fields: patchCanvasItem updates any column it receives, so a
+        // JSON-RPC caller could otherwise patch canvasId to move the item to another board/project
+        // (bypassing the project scoping just authorized) or rewrite its id/author.
+        unset($params['canvasId'], $params['id'], $params['author']);
+
         return $this->ideasRepository->patchCanvasItem($id, $params);
     }
 
@@ -604,6 +609,10 @@ class Ideas extends BaseService
         }
         $this->authorize(IdeasPermissions::CREATE, $boardProjectId);
 
+        // Normalize to the resolved board project so the notification below targets the correct
+        // project's users even if a mismatched/forged projectId was supplied.
+        $projectId = $boardProjectId;
+
         $canvasItem = [
             'box' => $input['box'],
             'author' => $authorId,
@@ -668,6 +677,20 @@ class Ideas extends BaseService
             return 0;
         }
         $this->authorize(IdeasPermissions::EDIT, $existingProjectId);
+
+        // The write persists $input['canvasId'], which can RELOCATE the item to another board. The
+        // target must be an idea board the user can also edit, or the relocation is a cross-project
+        // move. Fail closed if it's not an idea board; require edit on the target if it differs.
+        $targetProjectId = $this->boardProjectId((int) ($input['canvasId'] ?? 0));
+        if ($targetProjectId === null) {
+            return 0;
+        }
+        if ($targetProjectId !== $existingProjectId) {
+            $this->authorize(IdeasPermissions::EDIT, $targetProjectId);
+        }
+
+        // Normalize to the resolved board project for the notification below.
+        $projectId = $targetProjectId;
 
         $canvasItem = [
             'box' => $input['box'],

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -91,6 +91,7 @@ class Install
         30508,
         30509,
         30510,
+        30511,
     ];
 
     /**
@@ -2867,6 +2868,32 @@ class Install
             Log::error('Migration 30510: '.$e->getMessage());
 
             return ['Migration 30510 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30511: the Ideas domain joined the native permission engine. Re-sync the discovered
+     * permission catalog (adds ideas.view/create/edit/delete, all project-scoped) and re-seed the
+     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
+     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
+     * Flush the discovered-provider cache first — an install that already ran 30505-30510 cached the
+     * provider list WITHOUT IdeasPermissions, so seeding against that stale list would never create
+     * the ideas.* keys (and lower roles would lose idea access).
+     */
+    public function update_sql_30511(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30511: '.$e->getMessage());
+
+            return ['Migration 30511 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -90,6 +90,7 @@ class Install
         30507,
         30508,
         30509,
+        30510,
     ];
 
     /**
@@ -2840,6 +2841,32 @@ class Install
             Log::error('Migration 30509: '.$e->getMessage());
 
             return ['Migration 30509 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30510: the Wiki domain joined the native permission engine. Re-sync the discovered
+     * permission catalog (adds wiki.view/create/edit/delete, all project-scoped) and re-seed the
+     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
+     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
+     * Flush the discovered-provider cache first — an install that already ran 30505-30509 cached the
+     * provider list WITHOUT WikiPermissions, so seeding against that stale list would never create
+     * the wiki.* keys (and lower roles would lose wiki access).
+     */
+    public function update_sql_30510(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30510: '.$e->getMessage());
+
+            return ['Migration 30510 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Wiki/Controllers/ArticleDialog.php
+++ b/app/Domain/Wiki/Controllers/ArticleDialog.php
@@ -65,12 +65,14 @@ class ArticleDialog extends Controller
     }
 
     /**
-     * Creates or updates an article. The controller gate defers (entityScoped) to the service's
-     * createArticle/updateArticle, which authorize CREATE/EDIT against the article's real project.
+     * Creates or updates an article. A real dispatch-time VIEW gate guards the handler (entityScoped
+     * is a no-op at dispatch, which would leave this action — and its internal getArticle/
+     * getAllProjectWikis reads — ungated); the precise CREATE/EDIT enforcement is done in the
+     * service's createArticle/updateArticle against the article's real project.
      *
      * @throws BindingResolutionException
      */
-    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function post($params): Response
     {
 

--- a/app/Domain/Wiki/Controllers/ArticleDialog.php
+++ b/app/Domain/Wiki/Controllers/ArticleDialog.php
@@ -3,10 +3,12 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,6 +27,7 @@ class ArticleDialog extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
 
@@ -62,8 +65,12 @@ class ArticleDialog extends Controller
     }
 
     /**
+     * Creates or updates an article. The controller gate defers (entityScoped) to the service's
+     * createArticle/updateArticle, which authorize CREATE/EDIT against the article's real project.
+     *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
 

--- a/app/Domain/Wiki/Controllers/DelArticle.php
+++ b/app/Domain/Wiki/Controllers/DelArticle.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelArticle extends Controller
 {
-    private WikiRepository $wikiRepo;
+    private WikiService $wikiService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(WikiRepository $wikiRepo): void
+    public function init(WikiService $wikiService): void
     {
-        $this->wikiRepo = $wikiRepo;
+        $this->wikiService = $wikiService;
     }
 
     /**
@@ -26,31 +26,27 @@ class DelArticle extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('wiki.delArticle');
     }
 
     /**
-     * Handles article deletion.
+     * Handles article deletion. The controller gate defers (entityScoped) to the service's
+     * deleteArticle(), which authorizes DELETE against the article's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->wikiRepo->delArticle($id);
+            $this->wikiService->deleteArticle($id);
 
             $this->tpl->setNotification($this->language->__('notification.article_deleted'), 'success', 'article_deleted');
-
-            session()->forget('lastArticle');
-            session()->forget('currentWiki');
 
             return Frontcontroller::redirect(BASE_URL.'/wiki/show');
         }

--- a/app/Domain/Wiki/Controllers/DelWiki.php
+++ b/app/Domain/Wiki/Controllers/DelWiki.php
@@ -2,23 +2,23 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelWiki extends Controller
 {
-    private WikiRepository $wikiRepo;
+    private WikiService $wikiService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(WikiRepository $wikiRepo): void
+    public function init(WikiService $wikiService): void
     {
-        $this->wikiRepo = $wikiRepo;
+        $this->wikiService = $wikiService;
     }
 
     /**
@@ -26,31 +26,27 @@ class DelWiki extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial('wiki.delWiki');
     }
 
     /**
-     * Handles wiki deletion.
+     * Handles wiki deletion. The controller gate defers (entityScoped) to the service's
+     * deleteWiki(), which authorizes DELETE against the wiki's REAL project.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->wikiRepo->delWiki($id);
+            $this->wikiService->deleteWiki($id);
 
             $this->tpl->setNotification($this->language->__('notification.wiki_deleted'), 'success', 'wiki_deleted');
-
-            session()->forget('lastArticle');
-            session()->forget('currentWiki');
 
             return Frontcontroller::redirect(BASE_URL.'/wiki/show');
         }

--- a/app/Domain/Wiki/Controllers/Show.php
+++ b/app/Domain/Wiki/Controllers/Show.php
@@ -3,11 +3,12 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
-use Leantime\Domain\Wiki\Models\Wiki;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,6 +30,7 @@ class Show extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get(array $params): Response
     {
 
@@ -146,6 +148,7 @@ class Show extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function post(array $params): Response
     {
 

--- a/app/Domain/Wiki/Controllers/Templates.php
+++ b/app/Domain/Wiki/Controllers/Templates.php
@@ -2,7 +2,9 @@
 
 namespace Leantime\Domain\Wiki\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Symfony\Component\HttpFoundation\Response;
 
 class Templates extends Controller
@@ -12,6 +14,7 @@ class Templates extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
         return $this->tpl->displayPartial('wiki.templates');

--- a/app/Domain/Wiki/Controllers/WikiModal.php
+++ b/app/Domain/Wiki/Controllers/WikiModal.php
@@ -3,9 +3,11 @@
 namespace Leantime\Domain\Wiki\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Wiki\Models\Wiki;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki as WikiService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,6 +23,7 @@ class WikiModal extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get($params): Response
     {
         $wiki = app()->make(Wiki::class);
@@ -35,8 +38,12 @@ class WikiModal extends Controller
     }
 
     /**
+     * Creates or updates a wiki (notebook). The controller gate defers (entityScoped) to the
+     * service's createWiki/updateWiki, which authorize CREATE/EDIT against the wiki's real project.
+     *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
         $wiki = app()->make(Wiki::class);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Wiki\Hxcontrollers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki;
 
 /**
@@ -22,8 +24,10 @@ class ArticleActivity extends HtmxController
     }
 
     /**
-     * Get the activity feed for an article.
+     * Get the activity feed for an article. The service's getArticleActivity() is the precise
+     * per-article-project IDOR fence; this VIEW gate stops non-viewers at dispatch.
      */
+    #[RequiresPermission(WikiPermissions::VIEW)]
     public function get(): void
     {
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleActivity.php
@@ -27,7 +27,7 @@ class ArticleActivity extends HtmxController
      * Get the activity feed for an article. The service's getArticleActivity() is the precise
      * per-article-project IDOR fence; this VIEW gate stops non-viewers at dispatch.
      */
-    #[RequiresPermission(WikiPermissions::VIEW)]
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function get(): void
     {
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);

--- a/app/Domain/Wiki/Hxcontrollers/ArticleContent.php
+++ b/app/Domain/Wiki/Hxcontrollers/ArticleContent.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Wiki\Hxcontrollers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Services\Wiki;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,15 +26,14 @@ class ArticleContent extends HtmxController
     }
 
     /**
-     * Save article content via HTMX (called on auto-save or blur)
+     * Save article content via HTMX (called on auto-save or blur).
+     *
+     * Gate defers (entityScoped) to the service's updateArticle(), which authorizes EDIT against
+     * the article's real project.
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function save(): Response
     {
-        // Check permissions
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return new Response('Unauthorized', 403);
-        }
-
         $articleId = (int) $this->incomingRequest->query->get('articleId', 0);
         $content = $this->incomingRequest->request->get('description');
         $title = $this->incomingRequest->request->get('title');
@@ -86,15 +85,14 @@ class ArticleContent extends HtmxController
     }
 
     /**
-     * Create a new article and redirect to it
+     * Create a new article and redirect to it.
+     *
+     * Gate defers (entityScoped) to the service's createArticle(), which authorizes CREATE against
+     * the target wiki's project.
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function create(): Response
     {
-        // Check permissions
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return new Response('Unauthorized', 403);
-        }
-
         $currentWiki = session('currentWiki');
         if (! $currentWiki) {
             return new Response('No wiki selected', 400);

--- a/app/Domain/Wiki/Permissions/WikiPermissions.php
+++ b/app/Domain/Wiki/Permissions/WikiPermissions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Leantime\Domain\Wiki\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Wiki permission vocabulary — the verbs only.
+ *
+ * Wiki articles and wikis are PROJECT-scoped (each belongs to one project), so every capability is
+ * evaluated against the user's role IN that project (projectScoped = true, the default). The
+ * standard verbs auto-grant via the central matrix (readonly = view; editor = create/edit/delete;
+ * manager+ = all), so no {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} change is
+ * required.
+ */
+final class WikiPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'wiki.view';
+
+    public const CREATE = 'wiki.create';
+
+    public const EDIT = 'wiki.edit';
+
+    public const DELETE = 'wiki.delete';
+
+    public function domain(): string
+    {
+        return 'wiki';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View wiki articles'),
+            new Permission(self::CREATE, 'Create wiki articles'),
+            new Permission(self::EDIT, 'Edit wiki articles'),
+            new Permission(self::DELETE, 'Delete wiki articles'),
+        ];
+    }
+}

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -117,6 +117,22 @@ class Wiki extends Blueprints
         return $article;
     }
 
+    /**
+     * Resolve an article's owning project by its id alone (articles inherit their wiki's project
+     * via canvasId -> zp_canvas.projectId). Used by the service to authorize edit/delete/activity
+     * against the article's REAL project without trusting a caller-supplied projectId.
+     */
+    public function getArticleProjectId(int $id): ?int
+    {
+        $projectId = $this->dbConnection->table('zp_canvas_items')
+            ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
+            ->where('zp_canvas_items.id', $id)
+            ->where('zp_canvas_items.box', 'article')
+            ->value('zp_canvas.projectId');
+
+        return $projectId !== null ? (int) $projectId : null;
+    }
+
     public function getAllProjectWikis(int $projectId): array|false
     {
         $results = $this->dbConnection->table('zp_canvas')

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -219,8 +219,11 @@ class Wiki extends Blueprints
 
     public function updateWiki(WikiModel $wiki, int $wikiId): bool
     {
+        // type guard: zp_canvas is shared across all canvas types (one id sequence), so scope the
+        // write to wiki rows — a non-wiki id can never rename another project's canvas board.
         return $this->dbConnection->table('zp_canvas')
             ->where('id', $wikiId)
+            ->where('type', 'wiki')
             ->update(['title' => $wiki->title]) >= 0;
     }
 
@@ -246,8 +249,11 @@ class Wiki extends Blueprints
 
     public function updateArticle(Article $article): bool
     {
+        // box guard: zp_canvas_items is shared across all canvas types (one id sequence), so scope
+        // the write to article rows — a non-article id can never touch a goal/SWOT/risk item.
         return $this->dbConnection->table('zp_canvas_items')
             ->where('id', $article->id)
+            ->where('box', 'article')
             ->update([
                 'title' => $article->title,
                 'description' => $article->description,
@@ -262,8 +268,10 @@ class Wiki extends Blueprints
 
     public function delArticle(int $id): void
     {
+        // box guard (shared zp_canvas_items): only ever delete an article row by this id.
         $this->dbConnection->table('zp_canvas_items')
             ->where('id', $id)
+            ->where('box', 'article')
             ->delete();
     }
 
@@ -273,8 +281,10 @@ class Wiki extends Blueprints
             ->where('canvasId', $id)
             ->delete();
 
+        // type guard (shared zp_canvas): only ever delete a wiki board by this id.
         $this->dbConnection->table('zp_canvas')
             ->where('id', $id)
+            ->where('type', 'wiki')
             ->delete();
     }
 

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -277,11 +277,22 @@ class Wiki extends Blueprints
 
     public function delWiki(int $id): void
     {
+        // zp_canvas/zp_canvas_items are shared across all canvas families. Early-return unless this
+        // id is an actual wiki board, so the items-delete (by canvasId) can never drop another
+        // canvas type's items before the type-guarded board delete runs.
+        $isWiki = $this->dbConnection->table('zp_canvas')
+            ->where('id', $id)
+            ->where('type', 'wiki')
+            ->exists();
+
+        if (! $isWiki) {
+            return;
+        }
+
         $this->dbConnection->table('zp_canvas_items')
             ->where('canvasId', $id)
             ->delete();
 
-        // type guard (shared zp_canvas): only ever delete a wiki board by this id.
         $this->dbConnection->table('zp_canvas')
             ->where('id', $id)
             ->where('type', 'wiki')

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -2,15 +2,18 @@
 
 namespace Leantime\Domain\Wiki\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Language;
 use Leantime\Domain\Audit\Repositories\Audit as AuditRepository;
 use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Permissions\WikiPermissions;
 use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
 
 /**
  * @api
  */
-class Wiki
+class Wiki extends BaseService
 {
     private WikiRepository $wikiRepository;
 
@@ -31,8 +34,13 @@ class Wiki
     /**
      * Get an article by ID and project.
      *
+     * The repository already filters by project, so this read is project-scoped: when a projectId
+     * is passed it is authorized against (closing the explicit-foreign-project RPC read); when it is
+     * omitted the call resolves to the caller's session project and can only read articles there.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, projectIdParam: 'projectId')]
     public function getArticle(?int $id, ?int $projectId = null): mixed
     {
 
@@ -59,6 +67,7 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, projectIdParam: 'projectId')]
     public function getAllProjectWikis($projectId): array|false
     {
 
@@ -71,7 +80,10 @@ class Wiki
             $wiki->projectId = $projectId;
             $wiki->author = session('userdata.id');
 
-            $id = $this->createWiki($wiki);
+            // Bootstrap only: the default notebook is created as a SIDE EFFECT of viewing a
+            // wiki-less project, so it must NOT go through the create-authorized createWiki() —
+            // that would 403 a readonly viewer. Write straight to the repository (system action).
+            $this->wikiRepository->createWiki($wiki);
             $wikis = $this->wikiRepository->getAllProjectWikis($projectId);
         }
 
@@ -79,30 +91,61 @@ class Wiki
     }
 
     /**
+     * List the article headlines in a wiki.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getAllWikiHeadlines($wikiId, $userId): false|array
     {
+        // IDOR fence: a foreign wikiId would otherwise leak another project's article titles.
+        // Resolve the wiki's project and authorize VIEW there before listing.
+        $wiki = $this->wikiRepository->getWiki((int) $wikiId);
+        if (! $wiki) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::VIEW, (int) $wiki->projectId);
+
         return $this->wikiRepository->getAllWikiHeadlines($wikiId, $userId);
     }
 
     /**
+     * Get a single wiki (notebook) by id.
+     *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getWiki($id): mixed
     {
         if ($id === null) {
             return false;
         }
 
-        return $this->wikiRepository->getWiki((int) $id);
+        $wiki = $this->wikiRepository->getWiki((int) $id);
+
+        if (! $wiki) {
+            return false;
+        }
+
+        // IDOR fence: the id alone names any project's wiki. Authorize VIEW against the wiki's
+        // ACTUAL project, not the session project — closes the cross-project read (and the
+        // ?setWiki= session-switch footgun, which routes through here) on every call surface.
+        $this->authorize(WikiPermissions::VIEW, (int) $wiki->projectId);
+
+        return $wiki;
     }
 
     /**
      * @api
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function createWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki): false|string
     {
+        // Authorize CREATE against the target project before writing. An RPC caller could set any
+        // projectId on the model, so the check is against that value (denied for non-members).
+        $projectId = (int) ($wiki->projectId ?? session('currentProject'));
+        $this->authorize(WikiPermissions::CREATE, $projectId);
 
         $wikiId = $this->wikiRepository->createWiki($wiki);
 
@@ -114,8 +157,16 @@ class Wiki
     /**
      * @api
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function updateWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki, $wikiId): bool
     {
+        // IDOR fence: authorize EDIT against the EXISTING wiki's real project (the incoming model's
+        // projectId is untrusted) before writing.
+        $existing = $this->wikiRepository->getWiki((int) $wikiId);
+        if ($existing) {
+            $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
+        }
+
         return $this->wikiRepository->updateWiki($wiki, $wikiId);
     }
 
@@ -124,8 +175,15 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function createArticle(Article $article): false|string
     {
+        // An article inherits its wiki's project (canvasId -> zp_canvas.projectId). Authorize CREATE
+        // against that project before writing, so a foreign/spoofed canvasId is denied.
+        $wiki = $this->wikiRepository->getWiki((int) $article->canvasId);
+        $projectId = $wiki ? (int) $wiki->projectId : (int) session('currentProject');
+        $this->authorize(WikiPermissions::CREATE, $projectId);
+
         $id = $this->wikiRepository->createArticle($article);
 
         if ($id !== false) {
@@ -147,8 +205,17 @@ class Wiki
      *
      * @api
      */
+    #[RequiresPermission(WikiPermissions::EDIT, entityScoped: true)]
     public function updateArticle(Article $article, ?Article $existingArticle = null): bool
     {
+        // IDOR fence: resolve the EXISTING article's real project (by id) and authorize EDIT there
+        // before writing. The incoming model's project/canvas are untrusted, so an editor in
+        // project A cannot edit or relocate an article that lives in project B.
+        $projectId = $this->wikiRepository->getArticleProjectId((int) $article->id);
+        if ($projectId !== null) {
+            $this->authorize(WikiPermissions::EDIT, $projectId);
+        }
+
         $result = $this->wikiRepository->updateArticle($article);
 
         if ($result && $existingArticle !== null) {
@@ -156,6 +223,66 @@ class Wiki
         }
 
         return $result;
+    }
+
+    /**
+     * Delete an article, fencing the operation against the article's project.
+     *
+     * @api
+     */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
+    public function deleteArticle(int $id): bool
+    {
+        // IDOR fence: the id alone identified the row before (the controller called the repository
+        // directly), so any editor could delete another project's article. Authorize DELETE against
+        // the article's real project first.
+        $projectId = $this->wikiRepository->getArticleProjectId($id);
+
+        if ($projectId === null) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::DELETE, $projectId);
+
+        $this->wikiRepository->delArticle($id);
+
+        $this->auditRepo->storeEvent(
+            action: 'article.delete',
+            values: '',
+            entity: 'article',
+            entityId: $id,
+            userId: (int) session('userdata.id'),
+            projectId: $projectId
+        );
+
+        session()->forget('lastArticle');
+
+        return true;
+    }
+
+    /**
+     * Delete a wiki (notebook), fencing the operation against the wiki's project.
+     *
+     * @api
+     */
+    #[RequiresPermission(WikiPermissions::DELETE, entityScoped: true)]
+    public function deleteWiki(int $id): bool
+    {
+        // IDOR fence: authorize DELETE against the wiki's real project before removing it.
+        $wiki = $this->wikiRepository->getWiki($id);
+
+        if (! $wiki) {
+            return false;
+        }
+
+        $this->authorize(WikiPermissions::DELETE, (int) $wiki->projectId);
+
+        $this->wikiRepository->delWiki($id);
+
+        session()->forget('currentWiki');
+        session()->forget('lastArticle');
+
+        return true;
     }
 
     public function setCurrentWiki($id)
@@ -219,8 +346,19 @@ class Wiki
      *
      * @return array<int, array<string, mixed>>
      */
+    #[RequiresPermission(WikiPermissions::VIEW, entityScoped: true)]
     public function getArticleActivity(int $articleId, int $limit = 20): array
     {
+        // IDOR fence: a foreign articleId would otherwise leak another project's edit history
+        // (audit values include old/new titles). Authorize VIEW against the article's real project.
+        $projectId = $this->wikiRepository->getArticleProjectId($articleId);
+
+        if ($projectId === null) {
+            return [];
+        }
+
+        $this->authorize(WikiPermissions::VIEW, $projectId);
+
         $activity = [];
 
         // Get audit events for this article

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -183,10 +183,14 @@ class Wiki extends BaseService
     #[RequiresPermission(WikiPermissions::CREATE, entityScoped: true)]
     public function createArticle(Article $article): false|string
     {
-        // An article inherits its wiki's project (canvasId -> zp_canvas.projectId). Authorize CREATE
-        // against that project before writing, so a foreign/spoofed canvasId is denied.
+        // An article inherits its wiki's project (canvasId -> zp_canvas.projectId). FAIL CLOSED if
+        // the canvasId is not a wiki — never fall back to the session project, or a foreign/non-wiki
+        // canvasId could be created against the caller's own project.
         $wiki = $this->wikiRepository->getWiki((int) $article->canvasId);
-        $projectId = $wiki ? (int) $wiki->projectId : (int) session('currentProject');
+        if (! $wiki) {
+            return false;
+        }
+        $projectId = (int) $wiki->projectId;
         $this->authorize(WikiPermissions::CREATE, $projectId);
 
         $id = $this->wikiRepository->createArticle($article);
@@ -198,7 +202,7 @@ class Wiki extends BaseService
                 entity: 'article',
                 entityId: (int) $id,
                 userId: (int) session('userdata.id'),
-                projectId: (int) session('currentProject')
+                projectId: $projectId
             );
         }
 

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -161,11 +161,16 @@ class Wiki extends BaseService
     public function updateWiki(\Leantime\Domain\Wiki\Models\Wiki $wiki, $wikiId): bool
     {
         // IDOR fence: authorize EDIT against the EXISTING wiki's real project (the incoming model's
-        // projectId is untrusted) before writing.
+        // projectId is untrusted) before writing. FAIL CLOSED when the id is not a wiki — zp_canvas
+        // is shared across canvas types (one id sequence), and getWiki filters type='wiki', so a
+        // non-wiki id resolves to false; refuse rather than fall through to an unguarded title write
+        // that would rename another project's canvas board.
         $existing = $this->wikiRepository->getWiki((int) $wikiId);
-        if ($existing) {
-            $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
+        if (! $existing) {
+            return false;
         }
+
+        $this->authorize(WikiPermissions::EDIT, (int) $existing->projectId);
 
         return $this->wikiRepository->updateWiki($wiki, $wikiId);
     }
@@ -210,11 +215,16 @@ class Wiki extends BaseService
     {
         // IDOR fence: resolve the EXISTING article's real project (by id) and authorize EDIT there
         // before writing. The incoming model's project/canvas are untrusted, so an editor in
-        // project A cannot edit or relocate an article that lives in project B.
+        // project A cannot edit or relocate an article that lives in project B. FAIL CLOSED on an
+        // unresolved project: zp_canvas_items is a shared table (one id sequence across ALL canvas
+        // types), so a null here means the id is not an article — refuse rather than write a row we
+        // could not authorize (a non-article id would otherwise overwrite a goal/SWOT/risk item).
         $projectId = $this->wikiRepository->getArticleProjectId((int) $article->id);
-        if ($projectId !== null) {
-            $this->authorize(WikiPermissions::EDIT, $projectId);
+        if ($projectId === null) {
+            return false;
         }
+
+        $this->authorize(WikiPermissions::EDIT, $projectId);
 
         $result = $this->wikiRepository->updateArticle($article);
 

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -28,6 +28,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('sprints.create', 'Create', true),
             new Permission('sprints.edit', 'Edit', true),
             new Permission('sprints.delete', 'Delete', true),
+            new Permission('wiki.view', 'View', true),
+            new Permission('wiki.create', 'Create', true),
+            new Permission('wiki.edit', 'Edit', true),
+            new Permission('wiki.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -55,7 +59,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -70,6 +74,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertNotContains('tickets.delete', $grants);
         $this->assertNotContains('sprints.create', $grants); // commenter views but cannot create
         $this->assertContains('sprints.view', $grants);       // inherited from readonly
+        $this->assertNotContains('wiki.create', $grants);     // commenter views but cannot create
+        $this->assertContains('wiki.view', $grants);          // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -84,6 +90,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('sprints.create', $grants);
         $this->assertContains('sprints.edit', $grants);
         $this->assertContains('sprints.delete', $grants);
+        // Wiki uses the same standard project verbs, so editor auto-gets create/edit/delete.
+        $this->assertContains('wiki.create', $grants);
+        $this->assertContains('wiki.edit', $grants);
+        $this->assertContains('wiki.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -32,6 +32,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('wiki.create', 'Create', true),
             new Permission('wiki.edit', 'Edit', true),
             new Permission('wiki.delete', 'Delete', true),
+            new Permission('ideas.view', 'View', true),
+            new Permission('ideas.create', 'Create', true),
+            new Permission('ideas.edit', 'Edit', true),
+            new Permission('ideas.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -59,7 +63,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -76,6 +80,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('sprints.view', $grants);       // inherited from readonly
         $this->assertNotContains('wiki.create', $grants);     // commenter views but cannot create
         $this->assertContains('wiki.view', $grants);          // inherited from readonly
+        $this->assertNotContains('ideas.create', $grants);    // commenter views but cannot create
+        $this->assertContains('ideas.view', $grants);         // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -94,6 +100,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('wiki.create', $grants);
         $this->assertContains('wiki.edit', $grants);
         $this->assertContains('wiki.delete', $grants);
+        // Ideas uses the same standard project verbs, so editor auto-gets create/edit/delete.
+        $this->assertContains('ideas.create', $grants);
+        $this->assertContains('ideas.edit', $grants);
+        $this->assertContains('ideas.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Unit\app\Domain\Ideas\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeasRepository;
@@ -11,33 +13,72 @@ use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Unit\TestCase;
 
 /**
- * Unit tests for the Ideas service helpers extracted during the
- * thin-controller refactor (board listing, item factory/normalization,
- * default-board creation).
+ * Unit tests for the Ideas service: board/item helpers plus the project-scoped authorization
+ * fences. Idea boards (zp_canvas type 'idea') and items (zp_canvas_items) are project-scoped; reads
+ * and mutations fence against the entity's REAL project (item -> board -> project), failing closed
+ * on the shared canvas tables. The pre-existing userCanAccessCanvasItem checks are migrated onto the
+ * permission engine.
  */
 class IdeasServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
 
-    /**
-     * Builds a real Ideas service, allowing each dependency to be
-     * overridden with a stub so we can observe persistence/orchestration calls.
-     */
+    private const SESSION_USER = 5;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        session(['userdata.id' => self::SESSION_USER]);
+    }
+
     private function makeService(
         ?IdeasRepository $ideasRepo = null,
         ?CommentRepository $commentsRepo = null,
-        ?ProjectService $projectService = null,
-        ?TicketService $ticketService = null,
         ?LanguageCore $language = null,
+        ?PermissionService $perms = null,
     ): IdeaService {
-        return new IdeaService(
+        $service = new IdeaService(
             $ideasRepo ?? $this->make(IdeasRepository::class),
             $commentsRepo ?? $this->make(CommentRepository::class),
-            $projectService ?? $this->make(ProjectService::class),
-            $ticketService ?? $this->make(TicketService::class),
+            $this->make(ProjectService::class),
+            $this->make(TicketService::class),
             $language ?? $this->make(LanguageCore::class),
         );
+        $service->setPermissionService($perms ?? $this->allowingPermissions());
+
+        return $service;
     }
+
+    /** A repo whose board #3 / item #5 both resolve to project 9. */
+    private function ideaRepoInProject9(array $overrides = []): IdeasRepository
+    {
+        return $this->make(IdeasRepository::class, array_merge([
+            'getSingleCanvas' => fn () => [['id' => 3, 'projectId' => 9, 'title' => 'Board']],
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+        ], $overrides));
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+            'currentUserCan' => fn () => false,
+        ]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Item factory / normalization (behavioural).
+    // ---------------------------------------------------------------------
 
     public function test_get_idea_item_returns_empty_default_for_null_id(): void
     {
@@ -51,15 +92,13 @@ class IdeasServiceTest extends TestCase
 
     public function test_get_idea_item_defaults_type_to_idea(): void
     {
-        $item = $this->makeService()->getIdeaItem(null);
-
-        $this->assertSame('idea', $item['box']);
+        $this->assertSame('idea', $this->makeService()->getIdeaItem(null)['box']);
     }
 
     public function test_get_idea_item_normalizes_zero_box_to_idea(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvasItem' => fn () => ['id' => 5, 'box' => '0', 'description' => 'x'],
+        $repo = $this->ideaRepoInProject9([
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'box' => '0', 'canvasId' => 3, 'description' => 'x'],
         ]);
 
         $item = $this->makeService(ideasRepo: $repo)->getIdeaItem(5);
@@ -70,13 +109,11 @@ class IdeasServiceTest extends TestCase
 
     public function test_get_idea_item_keeps_non_zero_box(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvasItem' => fn () => ['id' => 7, 'box' => 'prototype'],
+        $repo = $this->ideaRepoInProject9([
+            'getSingleCanvasItem' => fn () => ['id' => 7, 'box' => 'prototype', 'canvasId' => 3],
         ]);
 
-        $item = $this->makeService(ideasRepo: $repo)->getIdeaItem(7);
-
-        $this->assertSame('prototype', $item['box']);
+        $this->assertSame('prototype', $this->makeService(ideasRepo: $repo)->getIdeaItem(7)['box']);
     }
 
     public function test_ensure_board_exists_returns_zero_when_boards_present(): void
@@ -90,51 +127,35 @@ class IdeasServiceTest extends TestCase
             },
         ]);
 
-        $result = $this->makeService(ideasRepo: $repo)
-            ->ensureBoardExists(1, 2, [['id' => 10]]);
-
-        $this->assertSame(0, $result);
+        $this->assertSame(0, $this->makeService(ideasRepo: $repo)->ensureBoardExists(1, 2, [['id' => 10]]));
         $this->assertSame(0, $addCalls, 'No board should be created when one already exists');
     }
 
     public function test_ensure_board_exists_creates_default_when_none(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'addCanvas' => fn () => '99',
-        ]);
-        $language = $this->make(LanguageCore::class, [
-            '__' => fn () => 'Board',
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['addCanvas' => fn () => '99']);
+        $language = $this->make(LanguageCore::class, ['__' => fn () => 'Board']);
 
-        $result = $this->makeService(ideasRepo: $repo, language: $language)
-            ->ensureBoardExists(1, 2, []);
-
-        $this->assertSame(99, $result);
+        $this->assertSame(99, $this->makeService(ideasRepo: $repo, language: $language)->ensureBoardExists(1, 2, []));
     }
 
     public function test_get_all_boards_normalizes_false_to_empty_array(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getAllCanvas' => fn () => false,
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['getAllCanvas' => fn () => false]);
 
         $this->assertSame([], $this->makeService(ideasRepo: $repo)->getAllBoards(1));
     }
 
     public function test_get_board_items_normalizes_false_to_empty_array(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getCanvasItemsById' => fn () => false,
-        ]);
+        $repo = $this->ideaRepoInProject9(['getCanvasItemsById' => fn () => false]);
 
-        $this->assertSame([], $this->makeService(ideasRepo: $repo)->getBoardItems(5));
+        $this->assertSame([], $this->makeService(ideasRepo: $repo)->getBoardItems(3));
     }
 
     public function test_get_board_title_returns_empty_when_not_found(): void
     {
-        $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvas' => fn () => false,
-        ]);
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvas' => fn () => false]);
 
         $this->assertSame('', $this->makeService(ideasRepo: $repo)->getBoardTitle(123));
     }
@@ -142,81 +163,230 @@ class IdeasServiceTest extends TestCase
     public function test_get_board_title_returns_first_row_title(): void
     {
         $repo = $this->make(IdeasRepository::class, [
-            'getSingleCanvas' => fn () => [['id' => 1, 'title' => 'My Board']],
+            'getSingleCanvas' => fn () => [['id' => 1, 'title' => 'My Board', 'projectId' => 9]],
         ]);
 
         $this->assertSame('My Board', $this->makeService(ideasRepo: $repo)->getBoardTitle(1));
     }
 
     // ---------------------------------------------------------------------
-    // JSON-RPC authorization gates (editor + per-item project access).
+    // Read fences (single-entity-by-id).
     // ---------------------------------------------------------------------
 
-    /**
-     * Repo stub whose canvas item resolves to project 9.
-     */
-    private function repoForProject9(array $extra = []): IdeasRepository
+    public function test_get_board_is_denied_for_a_foreign_project(): void
     {
-        return $this->make(IdeasRepository::class, array_merge([
-            'getSingleCanvasItem' => fn () => ['canvasId' => 7],
-            // getSingleCanvas returns a LIST of row arrays (matches the real repo shape).
-            'getSingleCanvas' => fn () => [['projectId' => 9]],
-            'patchCanvasItem' => fn () => true,
-            'updateIdeaSorting' => fn () => true,
-            'bulkUpdateIdeaStatus' => fn () => true,
-        ], $extra));
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getBoard(3);
     }
 
-    public function test_patch_idea_item_denied_for_non_editor(): void
+    public function test_get_board_items_is_denied_for_a_foreign_project(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $this->expectException(AuthorizationException::class);
 
-        $this->assertFalse($service->patchIdeaItem(5, ['box' => 'done']));
+        $service->getBoardItems(3);
     }
 
-    public function test_patch_idea_item_denied_when_not_assigned_to_project(): void
-    {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
+    // ---------------------------------------------------------------------
+    // Mutation fences (fail closed + project-scoped).
+    // ---------------------------------------------------------------------
 
-        $projectService = $this->make(ProjectService::class, [
-            'isUserAssignedToProject' => fn () => false,
+    public function test_patch_idea_item_is_denied_without_edit(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->patchIdeaItem(5, ['box' => 'done']);
+    }
+
+    public function test_patch_idea_item_allowed_with_edit(): void
+    {
+        $repo = $this->ideaRepoInProject9(['patchCanvasItem' => fn () => true]);
+
+        $this->assertTrue($this->makeService(ideasRepo: $repo)->patchIdeaItem(5, ['box' => 'done']));
+    }
+
+    public function test_patch_idea_item_fails_closed_for_unknown_item(): void
+    {
+        $patched = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => false,
+            'patchCanvasItem' => function () use (&$patched): bool {
+                $patched = true;
+
+                return true;
+            },
         ]);
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9(), projectService: $projectService);
-
-        $this->assertFalse($service->patchIdeaItem(5, ['box' => 'done']));
+        $this->assertFalse($this->makeService(ideasRepo: $repo)->patchIdeaItem(999, ['box' => 'done']));
+        $this->assertFalse($patched, 'A non-idea/unknown id must never reach the repo patch');
     }
 
-    public function test_patch_idea_item_allowed_for_editor_with_project_access(): void
+    public function test_update_idea_item_fails_closed_for_unknown_item(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
-
-        $projectService = $this->make(ProjectService::class, [
-            'isUserAssignedToProject' => fn () => true,
+        $edited = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => false,
+            'editCanvasItem' => function () use (&$edited): void {
+                $edited = true;
+            },
         ]);
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9(), projectService: $projectService);
+        $input = ['itemId' => 999, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 3, 'milestoneId' => ''];
 
-        $this->assertTrue($service->patchIdeaItem(5, ['box' => 'done']));
+        $this->assertSame(0, $this->makeService(ideasRepo: $repo)->updateIdeaItem($input, 9, self::SESSION_USER));
+        $this->assertFalse($edited, 'A non-idea/unknown id must never reach the repo edit');
     }
 
-    public function test_reorder_ideas_denied_for_non_editor(): void
+    public function test_update_idea_item_is_denied_without_edit(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+        $input = ['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 3, 'milestoneId' => ''];
 
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateIdeaItem($input, 9, self::SESSION_USER);
+    }
+
+    public function test_create_idea_item_is_denied_without_create(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->createIdeaItem(['box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'canvasId' => 3], 9, self::SESSION_USER);
+    }
+
+    public function test_create_board_is_denied_without_create(): void
+    {
+        $service = $this->makeService(perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->createBoard('New board', 9, self::SESSION_USER);
+    }
+
+    public function test_update_board_is_denied_without_edit(): void
+    {
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateBoard(3, 'Renamed');
+    }
+
+    public function test_update_board_fails_closed_for_unknown_board(): void
+    {
+        $updated = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvas' => fn () => [],
+            'updateCanvas' => function () use (&$updated) {
+                $updated = true;
+
+                return 1;
+            },
+        ]);
+
+        $this->assertFalse($this->makeService(ideasRepo: $repo)->updateBoard(999, 'Renamed'));
+        $this->assertFalse($updated, 'A non-idea/unknown board id must never reach the repo update');
+    }
+
+    public function test_delete_canvas_is_denied_and_does_not_delete(): void
+    {
+        $repo = $this->ideaRepoInProject9([
+            'deleteCanvas' => function (): void {
+                throw new \RuntimeException('delete must not run when denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteCanvas(3);
+    }
+
+    public function test_delete_canvas_item_is_denied_and_does_not_delete(): void
+    {
+        $repo = $this->ideaRepoInProject9([
+            'delCanvasItem' => function (): void {
+                throw new \RuntimeException('delete must not run when denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteCanvasItem(5);
+    }
+
+    // ---------------------------------------------------------------------
+    // Batch mutators reject (return false) without writing.
+    // ---------------------------------------------------------------------
+
+    public function test_reorder_ideas_rejects_batch_when_cannot_edit(): void
+    {
+        $sorted = false;
+        $repo = $this->ideaRepoInProject9([
+            'updateIdeaSorting' => function () use (&$sorted): bool {
+                $sorted = true;
+
+                return true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
 
         $this->assertFalse($service->reorderIdeas([['id' => 5, 'sortIndex' => 1]]));
+        $this->assertFalse($sorted, 'A denied batch must never reach the repo sort');
     }
 
-    public function test_bulk_update_status_denied_for_non_editor(): void
+    public function test_bulk_update_status_rejects_batch_when_cannot_edit(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'readonly']]);
-
-        $service = $this->makeService(ideasRepo: $this->repoForProject9());
+        $repo = $this->ideaRepoInProject9(['bulkUpdateIdeaStatus' => fn () => true]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $this->denyingPermissions());
 
         $this->assertFalse($service->bulkUpdateStatus(['done' => 'item[]=5']));
+    }
+
+    // ---------------------------------------------------------------------
+    // Comment delete: author allowed; non-author requires moderation.
+    // ---------------------------------------------------------------------
+
+    public function test_remove_idea_comment_allows_the_author_without_moderation(): void
+    {
+        $deleted = null;
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => self::SESSION_USER, 'moduleId' => 5],
+            'deleteComment' => function ($id) use (&$deleted): bool {
+                $deleted = $id;
+
+                return true;
+            },
+        ]);
+        // Denying engine proves the author path does NOT require comments.moderate.
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $service->removeIdeaComment(1);
+
+        $this->assertSame(1, $deleted);
+    }
+
+    public function test_remove_idea_comment_denies_non_author_without_moderation(): void
+    {
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => 7, 'moduleId' => 5],
+            'deleteComment' => function (): bool {
+                throw new \RuntimeException('delete must not run when moderation is denied');
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $this->ideaRepoInProject9(), commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->removeIdeaComment(1);
     }
 }

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -389,4 +389,81 @@ class IdeasServiceTest extends TestCase
 
         $service->removeIdeaComment(1);
     }
+
+    // ---------------------------------------------------------------------
+    // Fail-closed on a non-resolving (non-idea) id: never authorize against a null project, never
+    // fall back to the caller-supplied project. (A null project here means "not an idea entity".)
+    // ---------------------------------------------------------------------
+
+    public function test_get_idea_comments_fails_closed_for_non_idea_entity(): void
+    {
+        $fetched = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComments' => function () use (&$fetched) {
+                $fetched = true;
+
+                return [];
+            },
+        ]);
+        // Denying engine: if it reached authorize(VIEW, null) it would throw; fail-closed returns [] first.
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo, perms: $this->denyingPermissions());
+
+        $this->assertSame([], $service->getIdeaComments('ticket', 123));
+        $this->assertFalse($fetched, 'A non-idea entity must short-circuit before the comment read');
+    }
+
+    public function test_create_idea_item_fails_closed_for_non_idea_board(): void
+    {
+        $created = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvas' => fn () => [], // canvasId is not an idea board
+            'addCanvasItem' => function () use (&$created) {
+                $created = true;
+
+                return '1';
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $this->assertSame(0, $service->createIdeaItem(['box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'canvasId' => 999], 9, self::SESSION_USER));
+        $this->assertFalse($created, 'A non-idea board canvasId must never create an item against the caller project');
+    }
+
+    public function test_add_idea_comment_fails_closed_for_non_idea_item(): void
+    {
+        $added = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'addComment' => function () use (&$added) {
+                $added = true;
+
+                return '1';
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo);
+
+        $this->assertFalse($service->addIdeaComment('hi', 999, 0, 9, self::SESSION_USER));
+        $this->assertFalse($added, 'A non-idea item must never receive a comment against the caller project');
+    }
+
+    public function test_remove_idea_comment_fails_closed_for_non_author_non_idea_comment(): void
+    {
+        $deleted = false;
+        $repo = $this->make(IdeasRepository::class, ['getSingleCanvasItem' => fn () => false]);
+        $commentsRepo = $this->make(CommentRepository::class, [
+            'getComment' => fn () => ['id' => 1, 'userId' => 7, 'moduleId' => 999],
+            'deleteComment' => function () use (&$deleted): bool {
+                $deleted = true;
+
+                return true;
+            },
+        ]);
+        // Allowing engine: proves the refusal is the fail-closed null guard, not a denied authorize.
+        $service = $this->makeService(ideasRepo: $repo, commentsRepo: $commentsRepo, perms: $this->allowingPermissions());
+
+        $service->removeIdeaComment(1);
+
+        $this->assertFalse($deleted, 'A non-author comment on a non-idea item must not be deleted');
+    }
 }

--- a/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
+++ b/tests/Unit/app/Domain/Ideas/Services/IdeasServiceTest.php
@@ -466,4 +466,73 @@ class IdeasServiceTest extends TestCase
 
         $this->assertFalse($deleted, 'A non-author comment on a non-idea item must not be deleted');
     }
+
+    // ---------------------------------------------------------------------
+    // Relocation / mass-assignment fences (Copilot review): the incoming canvasId/params can move
+    // an item to another board, so the target board's project must also be authorized.
+    // ---------------------------------------------------------------------
+
+    public function test_patch_idea_item_strips_relocation_and_identity_fields(): void
+    {
+        // patchCanvasItem updates any column it receives; canvasId/id/author must be stripped so a
+        // caller can't relocate the item to another board/project or rewrite its identity.
+        $patched = null;
+        $repo = $this->ideaRepoInProject9([
+            'patchCanvasItem' => function ($id, $params) use (&$patched): bool {
+                $patched = $params;
+
+                return true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $service->patchIdeaItem(5, ['status' => 'done', 'canvasId' => 999, 'id' => 1, 'author' => 7]);
+
+        $this->assertArrayNotHasKey('canvasId', $patched);
+        $this->assertArrayNotHasKey('id', $patched);
+        $this->assertArrayNotHasKey('author', $patched);
+        $this->assertSame('done', $patched['status'], 'Legitimate fields still pass through');
+    }
+
+    public function test_update_idea_item_denies_relocation_to_a_foreign_board(): void
+    {
+        // Item lives in project 9 (board 3); the edit's canvasId points at board 99 in project 7.
+        // The user may edit project 9 but NOT project 7 -> the relocation is denied before the write.
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+            'getSingleCanvas' => fn ($id) => $id === 99 ? [['projectId' => 7]] : [['projectId' => 9]],
+            'editCanvasItem' => function (): void {
+                throw new \RuntimeException('relocation must be blocked before the write');
+            },
+        ]);
+        $perms = $this->make(PermissionService::class, [
+            'authorize' => function (string $p, ?int $projectId = null): void {
+                if ($projectId === 7) {
+                    throw new AuthorizationException;
+                }
+            },
+            'currentUserCan' => fn () => true,
+        ]);
+        $service = $this->makeService(ideasRepo: $repo, perms: $perms);
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->updateIdeaItem(['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 99, 'milestoneId' => ''], 9, self::SESSION_USER);
+    }
+
+    public function test_update_idea_item_fails_closed_when_target_board_is_not_an_idea_board(): void
+    {
+        $edited = false;
+        $repo = $this->make(IdeasRepository::class, [
+            'getSingleCanvasItem' => fn () => ['id' => 5, 'canvasId' => 3, 'box' => 'idea'],
+            'getSingleCanvas' => fn ($id) => $id === 3 ? [['projectId' => 9]] : [], // target 99 -> not an idea board
+            'editCanvasItem' => function () use (&$edited): void {
+                $edited = true;
+            },
+        ]);
+        $service = $this->makeService(ideasRepo: $repo);
+
+        $this->assertSame(0, $service->updateIdeaItem(['itemId' => 5, 'box' => 'idea', 'description' => 'x', 'status' => 'idea', 'data' => '', 'tags' => '', 'canvasId' => 99, 'milestoneId' => ''], 9, self::SESSION_USER));
+        $this->assertFalse($edited, 'A non-idea target board must never receive the relocated item');
+    }
 }

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Unit\app\Domain\Wiki\Services;
+
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Core\Language;
+use Leantime\Domain\Audit\Repositories\Audit as AuditRepository;
+use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Models\Wiki as WikiModel;
+use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
+use Unit\TestCase;
+
+/**
+ * Unit tests for the Wiki service's project-scoped authorization. Wiki articles and notebooks are
+ * project-scoped; mutations and single-entity reads authorize against the entity's REAL project
+ * (entityScoped), closing the IDORs where the id alone identified the row.
+ */
+class WikiServiceTest extends TestCase
+{
+    use \Codeception\Test\Feature\Stub;
+
+    private function makeService(
+        ?WikiRepository $wikiRepo = null,
+        ?AuditRepository $auditRepo = null,
+    ): WikiService {
+        return new WikiService(
+            $wikiRepo ?? $this->make(WikiRepository::class),
+            $this->make(Language::class),
+            $auditRepo ?? $this->make(AuditRepository::class),
+        );
+    }
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, ['authorize' => fn () => null]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reads: single-entity-by-id reads fence against the entity's project.
+    // ---------------------------------------------------------------------
+
+    public function test_get_wiki_is_denied_when_user_cannot_view_its_project(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getWiki(3);
+    }
+
+    public function test_get_wiki_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        // A missing wiki short-circuits to false BEFORE authorize — no enumeration oracle.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => false,
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $this->assertFalse($service->getWiki(999));
+        $this->assertSame(0, $authorizeCalls, 'A non-existent wiki must short-circuit before authorize');
+    }
+
+    public function test_get_all_wiki_headlines_is_denied_for_foreign_wiki(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->getAllWikiHeadlines(3, 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Mutations: authorize against the entity's real project before writing.
+    // ---------------------------------------------------------------------
+
+    public function test_create_article_is_denied_without_create_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            // createArticle resolves the project from the target wiki (canvasId) to authorize.
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+            'createArticle' => function () {
+                throw new \RuntimeException('create must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $article = new Article;
+        $article->canvasId = 3;
+        $service->createArticle($article);
+    }
+
+    public function test_update_article_is_denied_without_edit_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => 9,
+            'updateArticle' => function () {
+                throw new \RuntimeException('update must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $article = new Article;
+        $article->id = 42;
+        $service->updateArticle($article);
+    }
+
+    public function test_create_wiki_is_denied_without_create_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'createWiki' => function () {
+                throw new \RuntimeException('create must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $wiki = new WikiModel;
+        $wiki->projectId = 9;
+        $service->createWiki($wiki);
+    }
+
+    // ---------------------------------------------------------------------
+    // Delete: new service methods that fence the previously controller->repo IDOR.
+    // ---------------------------------------------------------------------
+
+    public function test_delete_article_is_denied_and_does_not_delete_without_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => 9,
+            'delArticle' => function (): void {
+                throw new \RuntimeException('delete must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteArticle(42);
+    }
+
+    public function test_delete_article_deletes_and_audits_when_authorized(): void
+    {
+        $deletedId = null;
+        $auditedAction = null;
+
+        $service = $this->makeService(
+            wikiRepo: $this->make(WikiRepository::class, [
+                'getArticleProjectId' => fn () => 9,
+                'delArticle' => function ($id) use (&$deletedId): void {
+                    $deletedId = $id;
+                },
+            ]),
+            auditRepo: $this->make(AuditRepository::class, [
+                'storeEvent' => function (string $action) use (&$auditedAction) {
+                    $auditedAction = $action;
+                },
+            ]),
+        );
+        $service->setPermissionService($this->allowingPermissions());
+
+        $this->assertTrue($service->deleteArticle(42));
+        $this->assertSame(42, $deletedId);
+        $this->assertSame('article.delete', $auditedAction);
+    }
+
+    public function test_delete_article_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => null,
+            'delArticle' => function (): void {
+                throw new \RuntimeException('delete must not run for a non-existent article');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $this->assertFalse($service->deleteArticle(999));
+        $this->assertSame(0, $authorizeCalls);
+    }
+
+    public function test_delete_wiki_is_denied_without_permission(): void
+    {
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => $this->make(WikiModel::class, ['id' => 3, 'projectId' => 9]),
+            'delWiki' => function (): void {
+                throw new \RuntimeException('delete must not be reached when denied');
+            },
+        ]));
+        $service->setPermissionService($this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->deleteWiki(3);
+    }
+}

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -146,6 +146,54 @@ class WikiServiceTest extends TestCase
         $service->createWiki($wiki);
     }
 
+    public function test_update_article_returns_false_for_unknown_id_without_authorizing(): void
+    {
+        // FAIL CLOSED: zp_canvas_items is a shared table (one id sequence across all canvas types),
+        // so an unresolved project (non-article / unknown id) must refuse BEFORE authorize and never
+        // reach the repo write — otherwise a non-article id would overwrite a goal/SWOT/risk row.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getArticleProjectId' => fn () => null,
+            'updateArticle' => function (): bool {
+                throw new \RuntimeException('update must not run for an unresolved/non-article id');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $article = new Article;
+        $article->id = 999;
+
+        $this->assertFalse($service->updateArticle($article));
+        $this->assertSame(0, $authorizeCalls, 'A non-article id must short-circuit before authorize');
+    }
+
+    public function test_update_wiki_returns_false_for_unknown_wiki_without_authorizing(): void
+    {
+        // FAIL CLOSED: zp_canvas is shared across canvas types, so a non-wiki / unknown id must
+        // refuse BEFORE authorize and never reach the repo title write.
+        $authorizeCalls = 0;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => false,
+            'updateWiki' => function (): bool {
+                throw new \RuntimeException('update must not run for a non-wiki id');
+            },
+        ]));
+        $service->setPermissionService($this->make(PermissionService::class, [
+            'authorize' => function () use (&$authorizeCalls): void {
+                $authorizeCalls++;
+            },
+        ]));
+
+        $wiki = new WikiModel;
+
+        $this->assertFalse($service->updateWiki($wiki, 999));
+        $this->assertSame(0, $authorizeCalls, 'A non-wiki id must short-circuit before authorize');
+    }
+
     // ---------------------------------------------------------------------
     // Delete: new service methods that fence the previously controller->repo IDOR.
     // ---------------------------------------------------------------------

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -248,7 +248,9 @@ class WikiServiceTest extends TestCase
                 },
             ]),
             auditRepo: $this->make(AuditRepository::class, [
-                'storeEvent' => function (string $action) use (&$auditedAction) {
+                // Accept the full storeEvent signature (variadic) — deleteArticle calls it with
+                // several named args; only the action is asserted.
+                'storeEvent' => function (string $action, ...$rest) use (&$auditedAction) {
                     $auditedAction = $action;
                 },
             ]),

--- a/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
+++ b/tests/Unit/app/Domain/Wiki/Services/WikiServiceTest.php
@@ -113,6 +113,28 @@ class WikiServiceTest extends TestCase
         $service->createArticle($article);
     }
 
+    public function test_create_article_fails_closed_when_canvas_is_not_a_wiki(): void
+    {
+        // canvasId does not resolve to a wiki -> refuse before authorize, never write (no falling
+        // back to the session project, which would let a foreign/non-wiki canvasId be created).
+        $created = false;
+        $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [
+            'getWiki' => fn () => false,
+            'createArticle' => function () use (&$created) {
+                $created = true;
+
+                return '1';
+            },
+        ]));
+        $service->setPermissionService($this->allowingPermissions());
+
+        $article = new Article;
+        $article->canvasId = 999;
+
+        $this->assertFalse($service->createArticle($article));
+        $this->assertFalse($created, 'A non-wiki canvasId must never create an article');
+    }
+
     public function test_update_article_is_denied_without_edit_permission(): void
     {
         $service = $this->makeService(wikiRepo: $this->make(WikiRepository::class, [


### PR DESCRIPTION
Combined PR: brings **Wiki** and **Ideas** under the native permission engine. (Ideas #3478 was merged into this branch, so this single PR now ships both — migrations `30510` (Wiki) + `30511` (Ideas), dbVersion → **3.5.11**.) Supersedes the auto-closed #3475.

Both are project-scoped content domains storing in the shared `zp_canvas`/`zp_canvas_items` tables, so every read/mutation authorizes against the entity's **real owning project** and **fails closed** on a non-matching id (the shared-table rule).

## Wiki
- `WikiPermissions` view/create/edit/delete; service `extends BaseService`.
- Model-based mutations fail-closed against the existing entity's project (no trusting the incoming model); new `deleteArticle`/`deleteWiki` (controllers rerouted off direct repo calls); single-entity reads (`getWiki`/`getAllWikiHeadlines`/`getArticleActivity`) entity-scoped (closes `?setWiki=`); `getAllProjectWikis` lazy-create bootstrap stays VIEW-gated + repo-direct.

## Ideas
- `IdeasPermissions` view/create/edit/delete; two resolvers (`boardProjectId`, `canvasItemProjectId`) filter to `type='idea'` so a foreign canvas-type id → null → fail-closed.
- New `deleteCanvas`/`deleteCanvasItem` (controllers rerouted); `removeIdeaComment` (was an ungated `?delComment` GET delete) → author-or-moderate; `patchIdeaItem` strips relocation/identity fields; `updateIdeaItem`/`createIdeaItem` fence the target board's project; batch reorder/bulk use per-item `can()`.

## Reviews addressed
- My adversarial reviews + **all Copilot comments across both rounds**: fail-open→fail-closed everywhere (updateArticle/createArticle/getIdeaComments/countIdeaComments/removeIdeaComment/create+update item), relocation + mass-assignment fences, comment-reaction existence-oracle (soft-deny), entity-scoped-controller no-op dispatch gates → real dispatch gates, and the getIdeaItem/getRawIdeaItem double-query + audit-stub nits.
- DB-verified grants for both domains; full unit suite green; pint + phpstan clean; CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)