### PR TITLE
feat(stageflow): spotlight non-hovered stages on row hover

### DIFF
--- a/app/Views/Templates/components/stageflow/styles.blade.php
+++ b/app/Views/Templates/components/stageflow/styles.blade.php
@@ -59,12 +59,17 @@
    presenting the board — useful when walking stakeholders through one
    stage at a time without losing the surrounding context. No state change,
    no persistence; the moment the mouse leaves the row, everything
-   rebalances back to the default everything-prominent state. */
-.sf-flow:hover .sf-stage:not(:hover) {
+   rebalances back to the default everything-prominent state.
+
+   Scoped to `.sf-stage.active` to avoid compounding with the inactive-stage
+   opacity rules below (`:not(.active) .sf-name { opacity: 0.5 }` etc.) — a
+   plain `.sf-stage` selector here would multiply 0.4 × 0.5 = 0.2 and make
+   text on inactive stages unreadable during a row hover. */
+.sf-flow:hover .sf-stage.active:not(:hover) {
     opacity: 0.4;
 }
 .sf-flow:hover .sf-stage:hover {
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--large-shadow);
     z-index: 11;
 }
 

--- a/app/Views/Templates/components/stageflow/styles.blade.php
+++ b/app/Views/Templates/components/stageflow/styles.blade.php
@@ -31,7 +31,8 @@
     background: var(--secondary-background);
     transition: box-shadow 350ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
                 background 350ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
-                border-color 350ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+                border-color 350ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                opacity 200ms ease;
     position: relative;
     box-shadow: var(--min-shadow);
     border: 1px solid var(--main-border-color);
@@ -49,6 +50,22 @@
     box-shadow: var(--large-shadow);
     border-color: transparent;
     background: linear-gradient(180deg, var(--stage-bg) 0%, var(--secondary-background) 100px);
+}
+
+/* ── Spotlight on hover ──
+   When the user mouses over any stage in the flow, fade the others to ~40%
+   opacity (still readable, just secondary) and lift the hovered card with
+   extra shadow. Pure visual aid for guiding attention while reviewing or
+   presenting the board — useful when walking stakeholders through one
+   stage at a time without losing the surrounding context. No state change,
+   no persistence; the moment the mouse leaves the row, everything
+   rebalances back to the default everything-prominent state. */
+.sf-flow:hover .sf-stage:not(:hover) {
+    opacity: 0.4;
+}
+.sf-flow:hover .sf-stage:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+    z-index: 11;
 }
 
 /* ── Current Focus flag ── */


### PR DESCRIPTION
## Summary
Adds a soft hover spotlight to the `stageflow` component used by Logic Model and other blueprint boards.

- Mouse over any stage in the row → other stages fade to 40% opacity, hovered card gets extra shadow + a small z-index lift.
- Pure CSS (`.sf-flow:hover .sf-stage:not(:hover)` + `.sf-flow:hover .sf-stage:hover`). No state, no persistence, no JS.
- Sits alongside the existing `.active` pricing-card pattern — doesn't replace it.

The use case: a non-profit leader walking a board through with stakeholders or the team. The full board is overwhelming at a glance; hover lets them direct the eye to one column at a time while still keeping the rest visible. The moment the cursor leaves the row, everything snaps back.

This replaces the more invasive derivation-based approach in #3477 (will close that one).

## Test plan
- [ ] Hover each stage column on a Logic Model board → other columns fade, hovered column lifts.
- [ ] Leave the row → all stages return to full opacity.
- [ ] Verify no regression to the `.active` pricing-card collapse pattern when a stage is marked active.
- [ ] Confirm print stylesheet still ignores the hover state (no opacity in printed output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)