### PR TITLE
security(blueprints): gate the consolidated canvas domain + close by-id IDORs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ These are ongoing architectural efforts. None need to be fixed proactively -- th
 
 ### 1. HTMX Migration (In Progress)
 **Goal**: Replace jQuery AJAX and full-page reloads with HTMX partial updates.
-**Status**: 8 of 56 domains have dedicated `Hxcontrollers/` with 19 total HxControllers. ~57 Blade templates and ~14 tpl.php files use HTMX attributes.
+**Status**: 8 of 42 domains have dedicated `Hxcontrollers/` with 19 total HxControllers. ~57 Blade templates and ~14 tpl.php files use HTMX attributes.
 **Domains with HxControllers**: Tickets, Projects, Timesheets, Widgets, Menu, Notifications, Plugins, Help.
 **Pattern**: Main page controllers load minimal data + skeleton; content loads via HTMX partials. New async work should use HTMX, not jQuery AJAX.
 
@@ -21,7 +21,7 @@ These are ongoing architectural efforts. None need to be fixed proactively -- th
 **Status**: ~198 `.tpl.php` files (legacy) vs ~91 `.blade.php` files in domains + ~33 in shared Views. About 30% migrated.
 - **Fully modernized (Blade-only)**: Dashboard, Gamecenter, Goalcanvas, Menu, Notifications, Plugins, Widgets
 - **Partially modernized (mix)**: Auth, Calendar, Comments, Help, Projects, Tickets, Timesheets, Users
-- **Fully legacy (TPL-only)**: All other canvas variants, Clients, Files, Ideas, Wiki, Sprints, Setting, etc.
+- **Fully legacy (TPL-only)**: Blueprints/Canvas, Clients, Files, Ideas, Wiki, Sprints, Setting, etc.
 **Pattern**: Main page views tend to stay `.tpl.php` while new partials and HTMX fragments use `.blade.php`. When touching templates, prefer Blade for new work.
 
 ### 3. Service Layer / JSON-RPC
@@ -137,7 +137,7 @@ Common commands:
     - `Routing/` - Route loading
     - `Support/` - Helper utilities (CarbonMacros, DateTimeHelper, Format, Cast)
     - `UI/` - Template handling (Template, Theme, ViewsServiceProvider)
-  - `Domain/` - Application domains (56 modules), organized by feature
+  - `Domain/` - Application domains (~42 modules, after the canvas-variant consolidation into Blueprints), organized by feature
     - Each domain typically contains:
       - `Controllers/` - HTTP endpoints
       - `Hxcontrollers/` - HTMX-specific controllers
@@ -180,7 +180,7 @@ Core manages all shared functionality and base features.
 
 **Domain**
 
-56 domain modules in `app/Domain/`. Each module has several layers representing one domain:
+~42 domain modules in `app/Domain/`. Each module has several layers representing one domain:
 
 1. **Controllers** handle HTTP requests and delegate to services
 2. **Services** contain business logic and orchestrate operations
@@ -199,20 +199,17 @@ Plugins can be managed as folders or pre-packaged phar files.
 
 **Core Feature Domains**: Tickets, Projects, Users, Sprints, Timesheets, Calendar, Comments, Files, Wiki, Ideas, Reports, Notifications, Dashboard, Widgets, Menu, Tags, Reactions, Entityrelations, Audit, Read
 
-**Canvas Domains** (14 variants extending `Canvas` base): Canvas (base), Cpcanvas, Dbmcanvas, Eacanvas, Emcanvas, Goalcanvas, Insightscanvas, Lbmcanvas, Leancanvas, Minempathycanvas, Obmcanvas, Retroscanvas, Riskscanvas, Sbcanvas, Smcanvas, Sqcanvas, Swotcanvas, Valuecanvas
+**Canvas Domains**: The ~14 individual canvas-variant domains (Cpcanvas, Dbmcanvas, Leancanvas, Swotcanvas, etc.) were **consolidated into a single `Blueprints` domain**. The variants no longer exist as separate domains — they are YAML-defined and selected by slug at runtime. Remaining canvas-family domains:
+- **Blueprints** — the consolidated canvas framework and current base. Native routes `/blueprints/{canvasSlug}/...` ({canvasSlug} = swot/lean/goal/etc.); legacy `/{x}canvas/...` paths 301-redirect here. All canvas data lives in the shared `zp_canvas` (boards, `type` column) + `zp_canvas_items` (items, `box` column) tables, keyed by `canvasId`. `Wiki` and `Goalcanvas` both `extend Blueprints`; the old `Canvas` repo `extends BlueprintsRepository`.
+- **Goalcanvas** — extends Blueprints; fully Blade with its own service.
+- **Logicmodelcanvas** — newer canvas type; still routed through the legacy `Canvas` controllers (Frontcontroller).
+- **Canvas** — the *old* base, now semi-legacy/dead. Only `Logicmodelcanvas` still rides on its controllers; otherwise a deprecated shim layer over Blueprints. New canvas work should target Blueprints, never the old `Canvas` domain.
 
-**System Domains**: Api, Auth, Cron, CsvImport, Connector, Environment, Errors, Install, Ldap, Modulemanager, Oidc, Plugins, Queue, Setting, Strategy, TwoFA
+**System Domains**: Api, Auth, Cron, CsvImport, Connector, Environment, Errors, Install, Ldap, Modulemanager, Oidc, Plugins, Queue, Setting, TwoFA
 
 **Backend-only Domains** (no UI): Audit, Entityrelations, Ldap, Reactions, Read, Tags, Queue
 
-**Canvas Inheritance Pattern**: The `Canvas` base domain provides generic controllers, services, and repositories. Each variant extends the base with minimal code -- typically just overriding a `CANVAS_NAME` constant:
-```php
-class ShowCanvas extends \Leantime\Domain\Canvas\Controllers\ShowCanvas
-{
-    protected const CANVAS_NAME = 'cp';
-}
-```
-Goalcanvas is the exception, having been fully modernized to Blade with its own service.
+**Shared canvas tables (IDOR caution)**: `zp_canvas` and `zp_canvas_items` are shared across **every** canvas type with one id sequence. A bare-id repository read/write can therefore land on a *foreign* canvas type or project. Canvas-family service/repo methods must fail **closed** — resolve the entity's real project (returning false/null/0 when the id doesn't match the expected `type`/`box`) and authorize against that, never falling back to `session('currentProject')`. (See Wiki/Ideas for the established pattern.)
 
 ### Architecture Details
 

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.11';
+    public string $dbVersion = '3.5.12';
 }

--- a/app/Domain/Blueprints/Controllers/ApiCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ApiCanvas.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
-use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -31,16 +32,14 @@ class ApiCanvas
      * @param  IncomingRequest  $request  Incoming request
      * @param  Template  $tpl  Template handler
      * @param  Language  $language  Language handler
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  ProjectRepository  $projects  Project repository (for access checks)
+     * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized item CRUD)
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
     public function __construct(
         private IncomingRequest $request,
         private Template $tpl,
         private Language $language,
-        private BlueprintsRepository $blueprintsRepo,
-        private ProjectRepository $projects,
+        private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,
     ) {
         $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
@@ -53,6 +52,7 @@ class ApiCanvas
      * Supports updating status, relates, and author fields on individual
      * canvas items via AJAX calls from the board view dropdowns.
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function patch(): Response
     {
         $data = $this->request->getRequestParams();
@@ -65,24 +65,11 @@ class ApiCanvas
             return $this->tpl->displayJson(['status' => 'failure'], 400);
         }
 
-        // Verify the item exists and the user has access to its project before patching.
-        $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
-        if ($canvasItem === false) {
-            return $this->tpl->displayJson(['status' => 'not found'], 404);
-        }
-
-        $canvas = $this->blueprintsRepo->getSingleCanvas((int) $canvasItem['canvasId'], $this->template->getDatabaseType());
-        if ($canvas === false || empty($canvas)) {
-            return $this->tpl->displayJson(['status' => 'not found'], 404);
-        }
-
-        $projectId = $canvas[0]['projectId'] ?? null;
-        if ($projectId === null || ! $this->projects->isUserAssignedToProject(session('userdata.id'), $projectId)) {
-            return $this->tpl->displayJson(['status' => 'unauthorized'], 403);
-        }
-
-        // patchCanvasItem returns false when no allowlisted columns are present — a client error.
-        if (! $this->blueprintsRepo->patchCanvasItem((int) $data['id'], $data)) {
+        // The service resolves the item's REAL project and authorizes EDIT against it before
+        // patching — closing the by-id cross-project mutation IDOR (a missing/foreign item or
+        // an insufficient role throws AuthorizationException -> 403). A false return means no
+        // allowlisted columns were present, which is a client error, not a denial.
+        if (! $this->blueprintsService->patchCanvasItem((int) $data['id'], $data, $this->template->getDatabaseType())) {
             return $this->tpl->displayJson(['status' => 'no valid fields to update'], 400);
         }
 

--- a/app/Domain/Blueprints/Controllers/BoardDialog.php
+++ b/app/Domain/Blueprints/Controllers/BoardDialog.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\Mailer as MailerCore;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepository;
@@ -35,7 +38,8 @@ class BoardDialog
      * @param  Template  $tpl  Template engine
      * @param  Language  $language  Language service
      * @param  ProjectService  $projectService  Project service
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
+     * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized board CRUD)
+     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository (currentProject-scoped existence check)
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
     public function __construct(
@@ -43,6 +47,7 @@ class BoardDialog
         private Template $tpl,
         private Language $language,
         private ProjectService $projectService,
+        private BlueprintsService $blueprintsService,
         private BlueprintsRepository $blueprintsRepo,
         TemplateRegistry $templateRegistry,
     ) {
@@ -55,6 +60,7 @@ class BoardDialog
      *
      * @param  string|null  $id  Current board id
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(?string $id = null): Response
     {
         if ($this->template === null) {
@@ -65,10 +71,15 @@ class BoardDialog
         $canvasTitle = '';
 
         if ($id !== null) {
-            $currentCanvasId = (int) $id;
-            $singleCanvas = $this->blueprintsRepo->getSingleCanvas($currentCanvasId, $this->template->getDatabaseType());
-            $canvasTitle = $singleCanvas[0]['title'] ?? '';
-            session([$this->template->getSessionKey() => $currentCanvasId]);
+            // getBoard authorizes VIEW against the board's real project; false = missing /
+            // foreign / unauthorized, in which case we neither expose the title nor switch
+            // the active board (no session poisoning with a foreign id).
+            $singleCanvas = $this->blueprintsService->getBoard((int) $id, $this->template->getDatabaseType());
+            if ($singleCanvas !== false) {
+                $currentCanvasId = (int) $id;
+                $canvasTitle = $singleCanvas[0]['title'] ?? '';
+                session([$this->template->getSessionKey() => $currentCanvasId]);
+            }
         }
 
         return $this->renderDialog($currentCanvasId, $canvasTitle);
@@ -79,6 +90,7 @@ class BoardDialog
      *
      * @param  string|null  $id  Current board id
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         if ($this->template === null) {
@@ -92,9 +104,11 @@ class BoardDialog
         $currentCanvasId = ($id !== null && $id !== '') ? (int) $id : '';
         $canvasTitle = '';
         if (is_int($currentCanvasId) && $currentCanvasId > 0) {
-            $singleCanvas = $this->blueprintsRepo->getSingleCanvas($currentCanvasId, $canvasType);
-            $canvasTitle = $singleCanvas[0]['title'] ?? '';
-            session([$sessionKey => $currentCanvasId]);
+            $singleCanvas = $this->blueprintsService->getBoard($currentCanvasId, $canvasType);
+            if ($singleCanvas !== false) {
+                $canvasTitle = $singleCanvas[0]['title'] ?? '';
+                session([$sessionKey => $currentCanvasId]);
+            }
         }
 
         // Add Canvas
@@ -106,7 +120,8 @@ class BoardDialog
                         'author' => session('userdata.id'),
                         'projectId' => session('currentProject'),
                     ];
-                    $currentCanvasId = $this->blueprintsRepo->addCanvas($values, $canvasType);
+                    // createBoard authorizes CREATE against the target (current) project.
+                    $currentCanvasId = $this->blueprintsService->createBoard($values, $canvasType);
 
                     $mailer = app()->make(MailerCore::class);
                     $users = $this->projectService->getUsersToNotify(session('currentProject'));
@@ -149,7 +164,8 @@ class BoardDialog
         if ($this->request->has('editCanvas') && is_int($currentCanvasId) && $currentCanvasId > 0) {
             if ($this->request->has('canvastitle') && ! empty($this->request->input('canvastitle'))) {
                 if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $this->request->input('canvastitle'), $canvasType)) {
-                    $this->blueprintsRepo->updateCanvas(['title' => $this->request->input('canvastitle'), 'id' => $currentCanvasId]);
+                    // renameBoard authorizes EDIT against the board's real project.
+                    $this->blueprintsService->renameBoard($currentCanvasId, $this->request->input('canvastitle'), $canvasType);
 
                     $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 

--- a/app/Domain/Blueprints/Controllers/DelCanvas.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvas.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -33,6 +34,7 @@ class DelCanvas
         private IncomingRequest $request,
         private Template $tpl,
         private Language $language,
+        private BlueprintsService $blueprintsService,
         private BlueprintsRepository $blueprintsRepo,
         TemplateRegistry $templateRegistry,
     ) {
@@ -45,13 +47,12 @@ class DelCanvas
      *
      * @param  string|null  $id  Board id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE)]
     public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
-
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
 
         $this->tpl->assign('canvasSlug', $this->canvasSlug);
 
@@ -63,20 +64,21 @@ class DelCanvas
      *
      * @param  string|null  $id  Board id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
 
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $canvasType = $this->template->getDatabaseType();
         $sessionKey = $this->template->getSessionKey();
 
         if ($this->request->has('del') && (int) $id > 0) {
-            $id = (int) $id;
-            $this->blueprintsRepo->deleteCanvas($id);
+            // The service resolves the board's REAL project and authorizes DELETE against it
+            // (throwing 403 for a missing/foreign board) — closing the by-id board-delete IDOR
+            // that the previous role-only Auth::authOrRedirect left open.
+            $this->blueprintsService->deleteBoard((int) $id, $canvasType);
 
             $allCanvas = $this->blueprintsRepo->getAllCanvas(session('currentProject'), $canvasType);
             session([$sessionKey => $allCanvas[0]['id'] ?? -1]);

--- a/app/Domain/Blueprints/Controllers/DelCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvasItem.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -33,37 +33,37 @@ class DelCanvasItem
         private IncomingRequest $request,
         private Template $tpl,
         private Language $language,
-        private BlueprintsRepository $blueprintsRepo,
+        private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,
     ) {
         $this->canvasSlug = strip_tags((string) ($request->route('canvasSlug') ?? ''));
         $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
+    #[RequiresPermission(BlueprintsPermissions::DELETE)]
     public function get(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
 
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->tpl->assign('canvasSlug', $this->canvasSlug);
 
         return $this->tpl->displayPartial('blueprints.delCanvasItem');
     }
 
+    #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
         }
 
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         if ($this->request->has('del') && (int) $id > 0) {
-            $id = (int) $id;
-            $this->blueprintsRepo->delCanvasItem($id);
+            // The service resolves the item's REAL project and authorizes DELETE against it
+            // (throwing 403 for a missing/foreign item) — closing the by-id delete IDOR that
+            // the previous role-only Auth::authOrRedirect left open.
+            $this->blueprintsService->deleteCanvasItem((int) $id, $this->template->getDatabaseType());
 
             $this->tpl->setNotification(
                 $this->language->__('notification.element_deleted'),

--- a/app/Domain/Blueprints/Controllers/EditCanvasComment.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasComment.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
@@ -25,6 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * Replaces the old per-variant Canvas\Controllers\EditCanvasComment subclasses.
  * The canvas type slug comes from the route instead of a class constant.
+ *
+ * All by-id item access goes through the Blueprints service, which authorizes against the
+ * item's real project — the controller never reads/writes canvas items via the repository.
  */
 class EditCanvasComment
 {
@@ -43,8 +47,7 @@ class EditCanvasComment
      * @param  SprintService  $sprintService  Sprint service
      * @param  TicketService  $ticketService  Ticket service
      * @param  ProjectService  $projectService  Project service
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  BlueprintsService  $blueprintsService  Blueprints service
+     * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized item CRUD)
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
     public function __construct(
@@ -56,7 +59,6 @@ class EditCanvasComment
         private SprintService $sprintService,
         private TicketService $ticketService,
         private ProjectService $projectService,
-        private BlueprintsRepository $blueprintsRepo,
         private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,
     ) {
@@ -69,6 +71,7 @@ class EditCanvasComment
      *
      * @param  string|null  $id  Canvas item id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -80,34 +83,42 @@ class EditCanvasComment
             return $this->tpl->displayPartial('errors.error404');
         }
 
+        $canvasType = $this->template->getDatabaseType();
         $commentModule = $this->template->getCommentModule();
         $canvasTypes = $this->blueprintsService->getTranslatedBoxes($this->template);
         $statusLabels = $this->blueprintsService->getTranslatedStatusLabels($this->template);
         $relatesLabels = $this->blueprintsService->getTranslatedRelatesLabels($this->template);
 
         if (isset($data['id'])) {
-            // Delete comment
-            if (isset($data['delComment']) === true) {
-                $commentId = (int) ($data['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification(
-                    $this->language->__('notifications.comment_deleted'),
-                    'success',
-                    strtoupper($this->canvasSlug).'canvascomment_deleted'
-                );
-            }
-
-            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
-
-            if ($canvasItem) {
-                $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
-                $this->tpl->assign(
-                    'numComments',
-                    $this->commentsRepo->countComments($commentModule, $canvasItem['id'])
-                );
-            } else {
+            // Resolve + VIEW-authorize the item against its real project before anything else.
+            $canvasItem = $this->blueprintsService->getCanvasItem((int) $data['id'], $canvasType);
+            if (! $canvasItem) {
                 return $this->tpl->displayPartial('errors.error404');
             }
+
+            // Delete comment — ONLY when it belongs to THIS gated item (module + moduleId).
+            // deleteComment() filters on the comment id alone, so without this bind a viewable
+            // item would let any global comment id be deleted (cross-item / cross-project).
+            if (isset($data['delComment']) === true) {
+                $commentId = (int) ($data['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === $commentModule
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification(
+                        $this->language->__('notifications.comment_deleted'),
+                        'success',
+                        strtoupper($this->canvasSlug).'canvascomment_deleted'
+                    );
+                }
+            }
+
+            $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
+            $this->tpl->assign(
+                'numComments',
+                $this->commentsRepo->countComments($commentModule, $canvasItem['id'])
+            );
         } else {
             if (isset($data['type'])) {
                 $type = strip_tags($data['type']);
@@ -144,6 +155,7 @@ class EditCanvasComment
      *
      * @param  string|null  $id  Canvas item id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -155,6 +167,7 @@ class EditCanvasComment
             return $this->tpl->displayPartial('errors.error404');
         }
 
+        $canvasType = $this->template->getDatabaseType();
         $commentModule = $this->template->getCommentModule();
         $sessionKey = $this->template->getSessionKey();
         $basePath = '/blueprints/'.$this->canvasSlug;
@@ -180,7 +193,8 @@ class EditCanvasComment
                         'dependentMilstone' => '',
                     ];
 
-                    $this->blueprintsRepo->editCanvasItem($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there.
+                    $this->blueprintsService->updateCanvasItem($canvasItem, $canvasType);
 
                     $comments = $this->commentsRepo->getComments($commentModule, $data['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -234,7 +248,8 @@ class EditCanvasComment
                         'canvasId' => $currentCanvasId,
                     ];
 
-                    $id = $this->blueprintsRepo->addCanvasItem($canvasItem);
+                    // Resolves the target board's real project from canvasId and authorizes CREATE.
+                    $id = $this->blueprintsService->createCanvasItem($canvasItem, $canvasType);
 
                     $canvasItem['id'] = $id;
 
@@ -280,6 +295,12 @@ class EditCanvasComment
 
         if (isset($data['comment']) === true) {
             $itemId = (int) ($data['id'] ?? 0);
+
+            // Only allow commenting on an item the user can view in their project.
+            if (! $this->blueprintsService->getCanvasItem($itemId, $canvasType)) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $data['text'],
                 'date' => date('Y-m-d H:i:s'),
@@ -319,7 +340,7 @@ class EditCanvasComment
         $itemId = (int) ($data['id'] ?? 0);
         $this->tpl->assign('id', $itemId);
         $this->tpl->assign('canvasTypes', $this->blueprintsService->getTranslatedBoxes($this->template));
-        $this->tpl->assign('canvasItem', $this->blueprintsRepo->getSingleCanvasItem($itemId));
+        $this->tpl->assign('canvasItem', $this->blueprintsService->getCanvasItem($itemId, $canvasType));
         $this->tpl->assign('canvasSlug', $this->canvasSlug);
 
         return $this->tpl->displayPartial('blueprints.canvasComment');

--- a/app/Domain/Blueprints/Controllers/EditCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasItem.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
@@ -25,6 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
  * arrive via the route (canvasSlug resolved in the constructor, id as a typed action arg),
  * and request input is read from the injected IncomingRequest instead of the legacy
  * merged-$params argument and superglobals.
+ *
+ * All by-id item access goes through the Blueprints service, which authorizes against the
+ * item's real project — the controller never reads/writes canvas items via the repository.
  */
 class EditCanvasItem
 {
@@ -41,8 +45,7 @@ class EditCanvasItem
      * @param  TicketService  $ticketService  Ticket service
      * @param  ProjectService  $projectService  Project service
      * @param  CommentRepository  $commentsRepo  Comments repository
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  BlueprintsService  $blueprintsService  Blueprints service
+     * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized item CRUD)
      * @param  TemplateRegistry  $templateRegistry  Canvas template registry
      */
     public function __construct(
@@ -52,7 +55,6 @@ class EditCanvasItem
         private TicketService $ticketService,
         private ProjectService $projectService,
         private CommentRepository $commentsRepo,
-        private BlueprintsRepository $blueprintsRepo,
         private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,
     ) {
@@ -65,6 +67,7 @@ class EditCanvasItem
      *
      * @param  string|null  $id  Canvas item id
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -76,36 +79,48 @@ class EditCanvasItem
             return $this->tpl->displayPartial('errors.error404');
         }
 
+        $canvasType = $this->template->getDatabaseType();
         $commentModule = $this->template->getCommentModule();
         $canvasTypes = $this->blueprintsService->getTranslatedBoxes($this->template);
         $statusLabels = $this->blueprintsService->getTranslatedStatusLabels($this->template);
         $relatesLabels = $this->blueprintsService->getTranslatedRelatesLabels($this->template);
 
         if (isset($data['id'])) {
-            // Delete comment
-            if (isset($data['delComment'])) {
-                $commentId = (int) ($data['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+            // Resolve + VIEW-authorize the item against its real project BEFORE any mutation.
+            // false = missing / foreign project / unauthorized (indistinguishable -> no oracle).
+            $canvasItem = $this->blueprintsService->getCanvasItem((int) $data['id'], $canvasType);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
             }
 
-            // Delete milestone relationship
+            // Delete comment — ONLY when it actually belongs to THIS gated item (same module +
+            // moduleId). The item being viewable is not enough: deleteComment() filters on the
+            // comment id alone, so without this bind any global comment id (a comment on another
+            // item, canvas type, or project — one shared id sequence) could be deleted.
+            if (isset($data['delComment'])) {
+                $commentId = (int) ($data['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === $commentModule
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+                }
+            }
+
+            // Delete milestone relationship — an EDIT, authorized by the service against the
+            // item's project (a view-only user is denied here).
             if (isset($data['removeMilestone'])) {
-                $this->blueprintsRepo->patchCanvasItem((int) $data['id'], ['milestoneId' => '']);
+                $this->blueprintsService->patchCanvasItem((int) $data['id'], ['milestoneId' => ''], $canvasType);
+                $canvasItem = $this->blueprintsService->getCanvasItem((int) $data['id'], $canvasType);
                 $this->tpl->setNotification($this->language->__('notifications.milestone_detached'), 'success');
             }
 
-            $canvasItem = $this->blueprintsRepo->getSingleCanvasItem((int) $data['id']);
-
-            if ($canvasItem) {
-                $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
-                $this->tpl->assign(
-                    'numComments',
-                    $this->commentsRepo->countComments($commentModule, $canvasItem['id'])
-                );
-            } else {
-                return $this->tpl->displayPartial('errors.error404');
-            }
+            $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
+            $this->tpl->assign(
+                'numComments',
+                $this->commentsRepo->countComments($commentModule, $canvasItem['id'])
+            );
         } else {
             if (isset($data['type'])) {
                 $type = strip_tags($data['type']);
@@ -153,6 +168,7 @@ class EditCanvasItem
      *
      * @param  string|null  $id  Canvas item id
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -164,6 +180,7 @@ class EditCanvasItem
             return $this->tpl->displayPartial('errors.error404');
         }
 
+        $canvasType = $this->template->getDatabaseType();
         $commentModule = $this->template->getCommentModule();
         $sessionKey = $this->template->getSessionKey();
         $basePath = '/blueprints/'.$this->canvasSlug;
@@ -205,7 +222,9 @@ class EditCanvasItem
                         $canvasItem['milestoneId'] = $data['existingMilestone'];
                     }
 
-                    $this->blueprintsRepo->editCanvasItem($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there;
+                    // the payload's canvasId can't relocate the item across projects.
+                    $this->blueprintsService->updateCanvasItem($canvasItem, $canvasType);
 
                     $comments = $this->commentsRepo->getComments($commentModule, $data['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -264,7 +283,10 @@ class EditCanvasItem
                         'canvasId' => $currentCanvasId,
                     ];
 
-                    $id = $this->blueprintsRepo->addCanvasItem($canvasItem);
+                    // Resolves the TARGET board's real project from canvasId and authorizes
+                    // CREATE there (the board must exist and belong to a project the user can
+                    // create in) before inserting.
+                    $id = $this->blueprintsService->createCanvasItem($canvasItem, $canvasType);
                     $canvasTypes = $this->blueprintsService->getTranslatedBoxes($this->template);
 
                     $this->tpl->setNotification(
@@ -312,6 +334,12 @@ class EditCanvasItem
 
         if (isset($data['comment']) && isset($data['id'])) {
             $itemId = (int) $data['id'];
+
+            // Only allow commenting on an item the user can view in their project.
+            if (! $this->blueprintsService->getCanvasItem($itemId, $canvasType)) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $data['text'],
                 'date' => date('Y-m-d H:i:s'),
@@ -365,7 +393,7 @@ class EditCanvasItem
         if (isset($data['id'])) {
             $canvasItemId = (int) $data['id'];
             $comments = $this->commentsRepo->getComments($commentModule, $canvasItemId);
-            $this->tpl->assign('canvasItem', $this->blueprintsRepo->getSingleCanvasItem($canvasItemId));
+            $this->tpl->assign('canvasItem', $this->blueprintsService->getCanvasItem($canvasItemId, $canvasType));
         } else {
             $value = [
                 'id' => '',

--- a/app/Domain/Blueprints/Controllers/Export.php
+++ b/app/Domain/Blueprints/Controllers/Export.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\BlueprintsExport;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,6 +51,7 @@ class Export
      *
      * @param  string|null  $id  Board id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(?string $id = null): Response
     {
         if ($this->template === null) {

--- a/app/Domain/Blueprints/Controllers/ShowBoards.php
+++ b/app/Domain/Blueprints/Controllers/ShowBoards.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\UI\Template;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,6 +34,7 @@ class ShowBoards
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW)]
     public function get(): Response
     {
         $overview = $this->blueprintsService->getBoardsOverview((int) session('currentProject'));

--- a/app/Domain/Blueprints/Controllers/ShowCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ShowCanvas.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\Mailer as MailerCore;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
@@ -63,6 +65,7 @@ class ShowCanvas
      *
      * @param  string|null  $id  Active board id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -94,6 +97,7 @@ class ShowCanvas
      *
      * @param  string|null  $id  Active board id from the route
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post(?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
@@ -119,7 +123,8 @@ class ShowCanvas
                         'author' => session('userdata.id'),
                         'projectId' => session('currentProject'),
                     ];
-                    $currentCanvasId = $this->blueprintsRepo->addCanvas($values, $canvasType);
+                    // createBoard authorizes CREATE against the target (current) project.
+                    $currentCanvasId = $this->blueprintsService->createBoard($values, $canvasType);
 
                     $this->notifyBoardChange(
                         'email_notifications.canvas_created_message',
@@ -148,7 +153,8 @@ class ShowCanvas
         if (isset($data['editCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
             if (isset($data['canvastitle']) && ! empty($data['canvastitle'])) {
                 if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $data['canvastitle'], $canvasType)) {
-                    $this->blueprintsRepo->updateCanvas(['title' => $data['canvastitle'], 'id' => $currentCanvasId]);
+                    // renameBoard authorizes EDIT against the board's real project.
+                    $this->blueprintsService->renameBoard($currentCanvasId, $data['canvastitle'], $canvasType);
 
                     $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
@@ -165,10 +171,12 @@ class ShowCanvas
         if (isset($data['cloneCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
             if (isset($data['canvastitle']) && ! empty($data['canvastitle'])) {
                 if (! $this->blueprintsRepo->existCanvas(session('currentProject'), $data['canvastitle'], $canvasType)) {
-                    $currentCanvasId = $this->blueprintsRepo->copyCanvas(
-                        session('currentProject'),
+                    // copyBoard authorizes VIEW on the source board's real project and CREATE
+                    // on the target (current) project.
+                    $currentCanvasId = $this->blueprintsService->copyBoard(
                         $currentCanvasId,
-                        session('userdata.id'),
+                        (int) session('currentProject'),
+                        (int) session('userdata.id'),
                         $data['canvastitle'],
                         $canvasType
                     );
@@ -189,7 +197,9 @@ class ShowCanvas
         // Merge board
         if (isset($data['mergeCanvas']) && is_int($currentCanvasId) && $currentCanvasId > 0) {
             if (isset($data['canvasid']) && $data['canvasid'] > 0) {
-                if ($this->blueprintsRepo->mergeCanvas($currentCanvasId, $data['canvasid'])) {
+                // mergeBoard authorizes EDIT on the target board's project and VIEW on the
+                // source board's project — both resolved by id, so neither can cross projects.
+                if ($this->blueprintsService->mergeBoard($currentCanvasId, (int) $data['canvasid'], $canvasType)) {
                     $this->tpl->setNotification($this->language->__('notification.board_merged'), 'success');
 
                     return Frontcontroller::redirect(BASE_URL.'/blueprints/'.$this->canvasSlug.'/showCanvas/');
@@ -216,12 +226,12 @@ class ShowCanvas
 
                 if ($importCanvasId !== false) {
                     session([$sessionKey => $importCanvasId]);
-                    $canvas = $this->blueprintsRepo->getSingleCanvas((int) $importCanvasId, $canvasType);
+                    $canvas = $this->blueprintsService->getBoard((int) $importCanvasId, $canvasType);
 
                     $this->notifyBoardChange(
                         'email_notifications.canvas_imported_message',
                         'notification.board_imported',
-                        $canvas[0]['title'] ?? ''
+                        $canvas !== false ? ($canvas[0]['title'] ?? '') : ''
                     );
 
                     $this->tpl->setNotification($this->language->__('notification.board_imported'), 'success');
@@ -289,8 +299,15 @@ class ShowCanvas
         }
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            session([$sessionKey => $currentCanvasId]);
+            // Only honor an explicit board id that belongs to the CURRENT project's boards
+            // ($allCanvas is project-scoped). A foreign/unknown id must not become the active
+            // board — otherwise renderCanvas would read another project's items (IDOR).
+            $requestedId = (int) $params['id'];
+            $projectBoardIds = array_map(static fn ($row) => (int) $row['id'], $allCanvas);
+            if (in_array($requestedId, $projectBoardIds, true)) {
+                $currentCanvasId = $requestedId;
+                session([$sessionKey => $currentCanvasId]);
+            }
         }
 
         return [$allCanvas, $currentCanvasId];
@@ -321,7 +338,9 @@ class ShowCanvas
         $this->tpl->assign('dataLabels', $this->blueprintsService->getTranslatedDataLabels($this->template));
         $this->tpl->assign('disclaimer', $this->blueprintsService->getTranslatedDisclaimer($this->template));
         $this->tpl->assign('allCanvas', $allCanvas);
-        $this->tpl->assign('canvasItems', $this->blueprintsRepo->getCanvasItemsById($currentCanvasId, $this->template->getCommentModule()));
+        // getBoardItems authorizes VIEW against the board's real project and returns [] for a
+        // foreign/unknown board, so a board id from another project can't leak its items here.
+        $this->tpl->assign('canvasItems', $this->blueprintsService->getBoardItems($currentCanvasId, $this->template->getDatabaseType(), $this->template->getCommentModule()));
         $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
 
         return $this->tpl->display('blueprints.showCanvas');

--- a/app/Domain/Blueprints/Permissions/BlueprintsPermissions.php
+++ b/app/Domain/Blueprints/Permissions/BlueprintsPermissions.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Leantime\Domain\Blueprints\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Blueprints (canvas) permission vocabulary — the verbs only.
+ *
+ * Blueprints is the consolidated canvas system: every canvas variant (SWOT, Lean, Value, …)
+ * is a row in the shared `zp_canvas`/`zp_canvas_items` tables, distinguished by a `type`
+ * column, and each board belongs to exactly one project. Capabilities are therefore
+ * PROJECT-scoped (projectScoped = true, the default) — evaluated against the user's role IN
+ * the board's project.
+ *
+ * One vocabulary covers the whole canvas family (Blueprints + the deprecated Canvas shim, and
+ * later Goalcanvas/Logicmodelcanvas): a "canvas" capability is the same regardless of variant.
+ *
+ * The standard verbs auto-grant via the central matrix (readonly = view; editor =
+ * create/edit/delete; manager+ = all), so no {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions}
+ * change is required.
+ */
+final class BlueprintsPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'blueprints.view';
+
+    public const CREATE = 'blueprints.create';
+
+    public const EDIT = 'blueprints.edit';
+
+    public const DELETE = 'blueprints.delete';
+
+    public function domain(): string
+    {
+        return 'blueprints';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View canvas boards'),
+            new Permission(self::CREATE, 'Create canvas boards and items'),
+            new Permission(self::EDIT, 'Edit canvas boards and items'),
+            new Permission(self::DELETE, 'Delete canvas boards and items'),
+        ];
+    }
+}

--- a/app/Domain/Blueprints/Repositories/Blueprints.php
+++ b/app/Domain/Blueprints/Repositories/Blueprints.php
@@ -110,6 +110,56 @@ class Blueprints extends Repository
     }
 
     /**
+     * Resolve the project id a canvas ITEM ultimately belongs to (item → board → project),
+     * optionally constrained to a canvas $canvasType. Returns null when the item does not exist
+     * OR its board is of a different type.
+     *
+     * This is a fail-CLOSED primitive: the service layer uses it to authorize by-id item
+     * operations against the item's REAL project, never the caller's session project. A
+     * `null` return must be treated as "deny" — never as "fall back to currentProject".
+     *
+     * @param  int  $itemId  Canvas item id
+     * @param  string|null  $canvasType  Constrain to this board type (e.g. "swotcanvas"); null = any type
+     */
+    public function getCanvasItemProjectId(int $itemId, ?string $canvasType = null): ?int
+    {
+        $query = $this->connection->table('zp_canvas_items')
+            ->leftJoin('zp_canvas', 'zp_canvas.id', '=', 'zp_canvas_items.canvasId')
+            ->where('zp_canvas_items.id', $itemId);
+
+        if ($canvasType !== null) {
+            $query->where('zp_canvas.type', $canvasType);
+        }
+
+        $projectId = $query->value('zp_canvas.projectId');
+
+        return $projectId !== null ? (int) $projectId : null;
+    }
+
+    /**
+     * Resolve the project id a canvas BOARD belongs to, optionally constrained to a canvas
+     * $canvasType. Returns null when the board does not exist OR is of a different type.
+     *
+     * Fail-CLOSED companion to {@see getCanvasItemProjectId()} for by-id board operations.
+     *
+     * @param  int  $canvasId  Canvas board id
+     * @param  string|null  $canvasType  Constrain to this board type; null = any type
+     */
+    public function getCanvasProjectId(int $canvasId, ?string $canvasType = null): ?int
+    {
+        $query = $this->connection->table('zp_canvas')
+            ->where('id', $canvasId);
+
+        if ($canvasType !== null) {
+            $query->where('type', $canvasType);
+        }
+
+        $projectId = $query->value('projectId');
+
+        return $projectId !== null ? (int) $projectId : null;
+    }
+
+    /**
      * @param  int  $id  Canvas board ID
      */
     public function deleteCanvas(int $id): void

--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -7,8 +7,12 @@ namespace Leantime\Domain\Blueprints\Services;
 use DOMDocument;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
@@ -18,9 +22,18 @@ use Leantime\Domain\Users\Repositories\Users as UserRepository;
  * Replaces the old Canvas\Services\Canvas by using the Blueprints repo
  * and TemplateRegistry directly instead of dynamically resolving variant repos.
  *
+ * Authorization: canvas boards and items are PROJECT-scoped (each board belongs to one
+ * project; items belong to a board). Every by-id board/item operation routes through this
+ * service, which resolves the entity's REAL project via the repository's fail-closed
+ * resolvers and authorizes the matching {@see BlueprintsPermissions} verb against it. A
+ * resolver returning null (missing id, or an id whose board is a different canvas type — the
+ * shared `zp_canvas`/`zp_canvas_items` tables hold every variant under one id sequence) is
+ * treated as DENY, never as "fall back to the session project". Controllers therefore call
+ * these methods instead of the repository directly.
+ *
  * @api
  */
-class Blueprints
+class Blueprints extends BaseService
 {
     private BlueprintsRepository $blueprintsRepo;
 
@@ -43,6 +56,262 @@ class Blueprints
         $this->language = $language;
     }
 
+    // ---------------------------------------------------------------------------------------
+    // Secured by-id board/item CRUD chokepoint.
+    //
+    // Controllers call these instead of the repository so authorization happens against the
+    // entity's REAL project. Reads soft-deny (return the same neutral value as "missing") so
+    // they never become a cross-project existence oracle; writes fail closed with an
+    // AuthorizationException. These are intentionally NOT @api — they are the canvas
+    // controllers' write surface, not part of the JSON-RPC API.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Fetch a single canvas item by id, authorized for VIEW against the item's real project.
+     *
+     * @param  int  $id  Canvas item id
+     * @param  string  $canvasType  Board type the item must belong to (e.g. "swotcanvas")
+     * @return array<string, mixed>|false The item, or false when missing/foreign/unauthorized
+     */
+    public function getCanvasItem(int $id, string $canvasType): array|false
+    {
+        $projectId = $this->blueprintsRepo->getCanvasItemProjectId($id, $canvasType);
+        if ($projectId === null || ! $this->can(BlueprintsPermissions::VIEW, $projectId)) {
+            return false;
+        }
+
+        return $this->blueprintsRepo->getSingleCanvasItem($id);
+    }
+
+    /**
+     * Fetch a single canvas board by id, authorized for VIEW against the board's real project.
+     *
+     * @param  int  $canvasId  Canvas board id
+     * @param  string  $canvasType  Board type the board must be of
+     * @return array<int, array<string, mixed>>|false Board rows, or false when missing/foreign/unauthorized
+     */
+    public function getBoard(int $canvasId, string $canvasType): array|false
+    {
+        $projectId = $this->blueprintsRepo->getCanvasProjectId($canvasId, $canvasType);
+        if ($projectId === null || ! $this->can(BlueprintsPermissions::VIEW, $projectId)) {
+            return false;
+        }
+
+        return $this->blueprintsRepo->getSingleCanvas($canvasId, $canvasType);
+    }
+
+    /**
+     * List the items of a canvas board, authorized for VIEW against the board's real project.
+     * Returns an empty array (the neutral "no items" value) for a missing/foreign/unauthorized
+     * board, so a foreign board id is indistinguishable from an empty one.
+     *
+     * @param  int  $canvasId  Canvas board id
+     * @param  string  $canvasType  Board type the board must be of
+     * @param  string  $commentModule  Comment module key for the item comment count join
+     * @return array<int, array<string, mixed>>
+     */
+    public function getBoardItems(int $canvasId, string $canvasType, string $commentModule): array
+    {
+        $projectId = $this->blueprintsRepo->getCanvasProjectId($canvasId, $canvasType);
+        if ($projectId === null || ! $this->can(BlueprintsPermissions::VIEW, $projectId)) {
+            return [];
+        }
+
+        return $this->blueprintsRepo->getCanvasItemsById($canvasId, $commentModule);
+    }
+
+    /**
+     * Create a canvas item, authorized for CREATE against the target board's real project.
+     *
+     * @param  array<string, mixed>  $values  Item values (must include `canvasId`)
+     * @param  string  $canvasType  Board type the target board must be of
+     * @return false|string New item id, or false on insert failure
+     *
+     * @throws AuthorizationException When the target board is unknown/foreign or CREATE is denied.
+     */
+    public function createCanvasItem(array $values, string $canvasType): false|string
+    {
+        $projectId = $this->blueprintsRepo->getCanvasProjectId((int) ($values['canvasId'] ?? 0), $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::CREATE, $projectId);
+
+        return $this->blueprintsRepo->addCanvasItem($values);
+    }
+
+    /**
+     * Update a canvas item, authorized for EDIT against the item's real project. The board id
+     * is resolved from the existing item — `canvasId` in the payload is ignored for scope, so
+     * an item cannot be relocated into another project.
+     *
+     * @param  array<string, mixed>  $values  Item values (must include `itemId` or `id`)
+     * @param  string  $canvasType  Board type the item must belong to
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or EDIT is denied.
+     */
+    public function updateCanvasItem(array $values, string $canvasType): void
+    {
+        $itemId = (int) ($values['itemId'] ?? $values['id'] ?? 0);
+        $projectId = $this->blueprintsRepo->getCanvasItemProjectId($itemId, $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::EDIT, $projectId);
+
+        $this->blueprintsRepo->editCanvasItem($values);
+    }
+
+    /**
+     * Patch allowlisted columns of a canvas item, authorized for EDIT against the item's real
+     * project. Used by the inline board-update API.
+     *
+     * @param  int  $id  Canvas item id
+     * @param  array<string, mixed>  $params  Fields to patch (allowlisted in the repository)
+     * @param  string  $canvasType  Board type the item must belong to
+     * @return bool False when no allowlisted columns were present (a client error, not a denial)
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or EDIT is denied.
+     */
+    public function patchCanvasItem(int $id, array $params, string $canvasType): bool
+    {
+        $projectId = $this->blueprintsRepo->getCanvasItemProjectId($id, $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::EDIT, $projectId);
+
+        return $this->blueprintsRepo->patchCanvasItem($id, $params);
+    }
+
+    /**
+     * Delete a canvas item, authorized for DELETE against the item's real project.
+     *
+     * @param  int  $id  Canvas item id
+     * @param  string  $canvasType  Board type the item must belong to
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or DELETE is denied.
+     */
+    public function deleteCanvasItem(int $id, string $canvasType): void
+    {
+        $projectId = $this->blueprintsRepo->getCanvasItemProjectId($id, $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::DELETE, $projectId);
+
+        $this->blueprintsRepo->delCanvasItem($id);
+    }
+
+    /**
+     * Create a canvas board, authorized for CREATE against the target project.
+     *
+     * @param  array<string, mixed>  $values  Board values (must include `projectId`)
+     * @param  string  $canvasType  Board type to create
+     * @return false|string New board id, or false on insert failure
+     *
+     * @throws AuthorizationException When projectId is missing or CREATE is denied.
+     */
+    public function createBoard(array $values, string $canvasType): false|string
+    {
+        $projectId = (int) ($values['projectId'] ?? 0);
+        if ($projectId === 0) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::CREATE, $projectId);
+
+        return $this->blueprintsRepo->addCanvas($values, $canvasType);
+    }
+
+    /**
+     * Rename a canvas board, authorized for EDIT against the board's real project.
+     *
+     * @param  int  $canvasId  Canvas board id
+     * @param  string  $title  New title
+     * @param  string  $canvasType  Board type the board must be of
+     *
+     * @throws AuthorizationException When the board is unknown/foreign or EDIT is denied.
+     */
+    public function renameBoard(int $canvasId, string $title, string $canvasType): mixed
+    {
+        $projectId = $this->blueprintsRepo->getCanvasProjectId($canvasId, $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::EDIT, $projectId);
+
+        return $this->blueprintsRepo->updateCanvas(['id' => $canvasId, 'title' => $title]);
+    }
+
+    /**
+     * Copy a canvas board into a target project. Requires VIEW on the SOURCE board's real
+     * project (you must be able to read what you copy) AND CREATE in the target project.
+     *
+     * @param  int  $sourceCanvasId  Source board id
+     * @param  int  $targetProjectId  Destination project id
+     * @param  int  $authorId  Author of the new board
+     * @param  string  $title  New board title
+     * @param  string  $canvasType  Board type the source must be of (and the copy will be)
+     * @return int New board id
+     *
+     * @throws AuthorizationException When the source is unknown/foreign, or VIEW/CREATE is denied.
+     */
+    public function copyBoard(int $sourceCanvasId, int $targetProjectId, int $authorId, string $title, string $canvasType): int
+    {
+        $sourceProjectId = $this->blueprintsRepo->getCanvasProjectId($sourceCanvasId, $canvasType);
+        if ($sourceProjectId === null || $targetProjectId <= 0) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::VIEW, $sourceProjectId);
+        $this->authorize(BlueprintsPermissions::CREATE, $targetProjectId);
+
+        return $this->blueprintsRepo->copyCanvas($targetProjectId, $sourceCanvasId, $authorId, $title, $canvasType);
+    }
+
+    /**
+     * Merge a source board's items into a target board. Requires EDIT on the TARGET board's
+     * real project and VIEW on the SOURCE board's real project — both resolved by id, so
+     * neither can cross a project boundary.
+     *
+     * @param  int  $targetCanvasId  Board receiving the items
+     * @param  int  $sourceCanvasId  Board whose items are copied
+     * @param  string  $canvasType  Board type both boards must be of
+     *
+     * @throws AuthorizationException When either board is unknown/foreign, or EDIT/VIEW is denied.
+     */
+    public function mergeBoard(int $targetCanvasId, int $sourceCanvasId, string $canvasType): bool
+    {
+        $targetProjectId = $this->blueprintsRepo->getCanvasProjectId($targetCanvasId, $canvasType);
+        $sourceProjectId = $this->blueprintsRepo->getCanvasProjectId($sourceCanvasId, $canvasType);
+        if ($targetProjectId === null || $sourceProjectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::EDIT, $targetProjectId);
+        $this->authorize(BlueprintsPermissions::VIEW, $sourceProjectId);
+
+        return $this->blueprintsRepo->mergeCanvas($targetCanvasId, $sourceCanvasId);
+    }
+
+    /**
+     * Delete a canvas board (and its items), authorized for DELETE against the board's real
+     * project.
+     *
+     * @param  int  $canvasId  Canvas board id
+     * @param  string  $canvasType  Board type the board must be of
+     *
+     * @throws AuthorizationException When the board is unknown/foreign or DELETE is denied.
+     */
+    public function deleteBoard(int $canvasId, string $canvasType): void
+    {
+        $projectId = $this->blueprintsRepo->getCanvasProjectId($canvasId, $canvasType);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(BlueprintsPermissions::DELETE, $projectId);
+
+        $this->blueprintsRepo->deleteCanvas($canvasId);
+    }
+
     /**
      * Import a canvas board from an XML file.
      *
@@ -56,11 +325,17 @@ class Blueprints
      * @return bool|int False on failure, or the new canvas board ID on success
      *
      * @throws BindingResolutionException
+     * @throws AuthorizationException When the user cannot create canvases in $projectId.
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::CREATE, entityScoped: true)]
     public function import(string $filename, string $canvasSlug, int $projectId, int $authorId): bool|int
     {
+        // Authorize CREATE against the TARGET project (the destination of the import), not the
+        // session project — import is reachable via RPC with an arbitrary projectId.
+        $this->authorize(BlueprintsPermissions::CREATE, $projectId);
+
         $template = $this->templateRegistry->get($canvasSlug);
         if ($template === null) {
             Log::error("Blueprints import failed: unknown canvas slug '{$canvasSlug}'");
@@ -229,6 +504,7 @@ class Blueprints
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getBoardProgress(string $projectId = '', array $boards = []): array
     {
         $values = $this->blueprintsRepo->getCanvasProgressCount((int) $projectId, $boards);
@@ -299,6 +575,7 @@ class Blueprints
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getLastUpdatedCanvas(?int $projectId = null, array $boards = []): array
     {
         return $this->blueprintsRepo->getLastUpdatedCanvas((int) $projectId, $boards);

--- a/app/Domain/Blueprints/Services/BlueprintsExport.php
+++ b/app/Domain/Blueprints/Services/BlueprintsExport.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Blueprints\Services;
 
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
-
 /**
  * BlueprintsExport service - builds the XML export for a blueprint canvas board.
  *
@@ -17,12 +15,10 @@ use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 class BlueprintsExport
 {
     /**
-     * @param  BlueprintsRepository  $blueprintsRepo  Blueprints repository
-     * @param  Blueprints  $blueprintsService  Blueprints service (label translation)
+     * @param  Blueprints  $blueprintsService  Blueprints service (VIEW-authorized board reads + label translation)
      * @param  TemplateRegistry  $templateRegistry  Canvas template registry
      */
     public function __construct(
-        private BlueprintsRepository $blueprintsRepo,
         private Blueprints $blueprintsService,
         private TemplateRegistry $templateRegistry,
     ) {}
@@ -32,7 +28,9 @@ class BlueprintsExport
      *
      * @param  int  $canvasId  Canvas board identifier
      * @param  string  $canvasSlug  Canvas type slug (e.g. "swot")
-     * @return string|null XML document, or null if the canvas type or board does not exist
+     * @return string|null XML document, or null if the canvas type or board does not exist,
+     *                     or the user cannot view it (export is reachable via JSON-RPC with
+     *                     an arbitrary board id, so the VIEW authorization happens here).
      *
      * @api
      */
@@ -44,12 +42,15 @@ class BlueprintsExport
         }
 
         $canvasType = $template->getDatabaseType();
-        $canvasAry = $this->blueprintsRepo->getSingleCanvas($canvasId, $canvasType);
-        if (empty($canvasAry)) {
+        // getBoard authorizes VIEW against the board's real project and returns false for a
+        // missing/foreign/unauthorized board — so a foreign id is indistinguishable from a
+        // non-existent one (no cross-project existence oracle).
+        $canvasAry = $this->blueprintsService->getBoard($canvasId, $canvasType);
+        if ($canvasAry === false || empty($canvasAry)) {
             return null;
         }
 
-        $records = $this->blueprintsRepo->getCanvasItemsById($canvasId, $template->getCommentModule());
+        $records = $this->blueprintsService->getBoardItems($canvasId, $canvasType, $template->getCommentModule());
         $canvasTypes = $this->blueprintsService->getTranslatedBoxes($template);
 
         $xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>'.PHP_EOL.PHP_EOL;

--- a/app/Domain/Canvas/Services/Canvas.php
+++ b/app/Domain/Canvas/Services/Canvas.php
@@ -2,6 +2,8 @@
 
 namespace Leantime\Domain\Canvas\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 
 /**
@@ -31,6 +33,7 @@ class Canvas
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::CREATE, projectIdParam: 'projectId')]
     public function import(string $filename, string $canvasName, int $projectId, int $authorId): bool|int
     {
         // Old callers pass the full type ("swotcanvas"); Blueprints works on the slug ("swot").
@@ -52,6 +55,7 @@ class Canvas
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getBoardProgress(string $projectId = '', array $boards = []): array
     {
         return app(BlueprintsService::class)->getBoardProgress($projectId, $boards);
@@ -68,6 +72,7 @@ class Canvas
      *
      * @api
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getLastUpdatedCanvas(?int $projectId = null, array $boards = []): array
     {
         return app(BlueprintsService::class)->getLastUpdatedCanvas($projectId, $boards);

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -92,6 +92,7 @@ class Install
         30509,
         30510,
         30511,
+        30512,
     ];
 
     /**
@@ -2894,6 +2895,34 @@ class Install
             Log::error('Migration 30511: '.$e->getMessage());
 
             return ['Migration 30511 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Blueprints (canvas)
+     * domain. Adds blueprints.view/create/edit/delete (all project-scoped); the standard verbs
+     * auto-grant via the existing project rules (readonly view; editor create/edit/delete;
+     * manager+ all). Table-creation-free; idempotent + additive.
+     *
+     * Flush the discovered-provider cache FIRST — an install that already ran the earlier
+     * permission migrations cached the provider list WITHOUT BlueprintsPermissions, so seeding
+     * against that stale list would never create the blueprints.* keys (and every role would
+     * then be denied canvas access, since currentUserCan requires the role to hold the key).
+     */
+    public function update_sql_30512(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30512: '.$e->getMessage());
+
+            return ['Migration 30512 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -36,6 +36,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('ideas.create', 'Create', true),
             new Permission('ideas.edit', 'Edit', true),
             new Permission('ideas.delete', 'Delete', true),
+            new Permission('blueprints.view', 'View', true),
+            new Permission('blueprints.create', 'Create', true),
+            new Permission('blueprints.edit', 'Edit', true),
+            new Permission('blueprints.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -63,7 +67,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -82,6 +86,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('wiki.view', $grants);          // inherited from readonly
         $this->assertNotContains('ideas.create', $grants);    // commenter views but cannot create
         $this->assertContains('ideas.view', $grants);         // inherited from readonly
+        $this->assertNotContains('blueprints.create', $grants); // commenter views but cannot create
+        $this->assertContains('blueprints.view', $grants);      // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -104,6 +110,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('ideas.create', $grants);
         $this->assertContains('ideas.edit', $grants);
         $this->assertContains('ideas.delete', $grants);
+        // Blueprints (canvas) uses the same standard project verbs, so editor auto-gets create/edit/delete.
+        $this->assertContains('blueprints.create', $grants);
+        $this->assertContains('blueprints.edit', $grants);
+        $this->assertContains('blueprints.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsExportTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsExportTest.php
@@ -2,7 +2,6 @@
 
 namespace Unit\app\Domain\Blueprints\Services;
 
-use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Blueprints\Services\BlueprintsExport;
 use Leantime\Domain\Blueprints\Services\TemplateRegistry;
@@ -10,6 +9,10 @@ use Unit\TestCase;
 
 /**
  * Unit tests for the BlueprintsExport service (XML generation).
+ *
+ * exportToXml reads the board + items through the Blueprints SERVICE (getBoard / getBoardItems),
+ * which authorizes VIEW against the board's real project and returns false / [] for a
+ * missing/foreign/unauthorized board — so these stub the service, not the repository.
  */
 class BlueprintsExportTest extends TestCase
 {
@@ -17,9 +20,9 @@ class BlueprintsExportTest extends TestCase
 
     public function test_exports_a_canvas_board_to_xml(): void
     {
-        $repo = $this->make(BlueprintsRepository::class, [
-            'getSingleCanvas' => fn () => [['title' => 'My SWOT', 'projectId' => 1]],
-            'getCanvasItemsById' => fn () => [
+        $service = $this->make(BlueprintsService::class, [
+            'getBoard' => fn () => [['title' => 'My SWOT', 'projectId' => 1]],
+            'getBoardItems' => fn () => [
                 [
                     'box' => 'swot_strengths', 'description' => 'Strong brand', 'author' => 5,
                     'status' => '', 'relates' => '', 'assumptions' => '', 'data' => '', 'conclusion' => '',
@@ -27,15 +30,13 @@ class BlueprintsExportTest extends TestCase
                     'authorFirstname' => 'Jo', 'authorLastname' => 'Doe',
                 ],
             ],
-        ]);
-        $service = $this->make(BlueprintsService::class, [
             'getTranslatedBoxes' => fn () => [
                 'swot_strengths' => ['title' => 'Strengths'],
                 'swot_weaknesses' => ['title' => 'Weaknesses'],
             ],
         ]);
 
-        $xml = (new BlueprintsExport($repo, $service, new TemplateRegistry))->exportToXml(7, 'swot');
+        $xml = (new BlueprintsExport($service, new TemplateRegistry))->exportToXml(7, 'swot');
 
         $this->assertNotNull($xml);
         $this->assertStringContainsString('<canvas key="swotcanvas">', $xml);
@@ -49,7 +50,6 @@ class BlueprintsExportTest extends TestCase
     public function test_returns_null_for_unknown_canvas_type(): void
     {
         $export = new BlueprintsExport(
-            $this->make(BlueprintsRepository::class),
             $this->make(BlueprintsService::class),
             new TemplateRegistry,
         );
@@ -59,9 +59,10 @@ class BlueprintsExportTest extends TestCase
 
     public function test_returns_null_when_board_does_not_exist(): void
     {
-        $repo = $this->make(BlueprintsRepository::class, ['getSingleCanvas' => fn () => []]);
+        // getBoard returns false for a missing/foreign/unauthorized board.
+        $service = $this->make(BlueprintsService::class, ['getBoard' => fn () => false]);
 
-        $export = new BlueprintsExport($repo, $this->make(BlueprintsService::class), new TemplateRegistry);
+        $export = new BlueprintsExport($service, new TemplateRegistry);
 
         $this->assertNull($export->exportToXml(7, 'swot'));
     }

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Unit\app\Domain\Blueprints\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
@@ -216,5 +218,292 @@ class BlueprintsServiceTest extends TestCase
 
         $this->assertSame(7, $capturedLastUpdatedId);
         $this->assertSame('7', $capturedProgressId, 'getBoardProgress receives the project id cast to string');
+    }
+
+    // ---------------------------------------------------------------------
+    // Secured by-id board/item CRUD chokepoint.
+    //
+    // Canvas boards/items live in the shared zp_canvas / zp_canvas_items tables (one id
+    // sequence across every variant). Every by-id operation must authorize against the
+    // entity's REAL project (resolved by id + canvas type), never the session project. Reads
+    // soft-deny (return the neutral "missing" value) so they are not a cross-project existence
+    // oracle; writes fail CLOSED with an AuthorizationException and never touch the repo.
+    // ---------------------------------------------------------------------
+
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+            'currentUserCan' => fn () => false,
+        ]);
+    }
+
+    private function securedService(BlueprintsRepository $repo, PermissionService $perms): BlueprintsService
+    {
+        $service = $this->service($repo);
+        $service->setPermissionService($perms);
+
+        return $service;
+    }
+
+    public function test_get_canvas_item_returns_false_for_missing_or_foreign_item_without_loading_it(): void
+    {
+        // Resolver null = missing id OR an id whose board is a different canvas type. Must
+        // return false WITHOUT loading the item — no cross-project existence oracle.
+        $loaded = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'getSingleCanvasItem' => function () use (&$loaded) {
+                $loaded++;
+
+                return ['id' => 1];
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        $this->assertFalse($service->getCanvasItem(123, 'swotcanvas'));
+        $this->assertSame(0, $loaded, 'A missing/foreign item must not be loaded');
+    }
+
+    public function test_get_canvas_item_soft_denies_when_view_not_permitted(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => fn () => 9,
+            'getSingleCanvasItem' => function () use (&$loaded) {
+                $loaded++;
+
+                return ['id' => 1];
+            },
+        ]);
+        $service = $this->securedService($repo, $this->make(PermissionService::class, ['currentUserCan' => fn () => false]));
+
+        $this->assertFalse($service->getCanvasItem(1, 'swotcanvas'));
+        $this->assertSame(0, $loaded, 'An unauthorized item returns the same neutral result as a missing one');
+    }
+
+    public function test_get_canvas_item_is_type_scoped_and_returns_item_when_authorized(): void
+    {
+        $resolvedType = null;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => function ($id, $type) use (&$resolvedType) {
+                $resolvedType = $type;
+
+                return 9;
+            },
+            'getSingleCanvasItem' => fn () => ['id' => 7, 'canvasId' => 3],
+        ]);
+        $service = $this->securedService($repo, $this->make(PermissionService::class, ['currentUserCan' => fn () => true]));
+
+        $item = $service->getCanvasItem(7, 'swotcanvas');
+
+        $this->assertSame(7, $item['id']);
+        $this->assertSame('swotcanvas', $resolvedType, 'The resolver must be type-scoped so a foreign canvas type cannot match');
+    }
+
+    public function test_get_board_items_returns_empty_for_foreign_board(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'getCanvasItemsById' => function () use (&$loaded) {
+                $loaded++;
+
+                return [['id' => 1]];
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        $this->assertSame([], $service->getBoardItems(999, 'swotcanvas', 'swotcanvasitem'));
+        $this->assertSame(0, $loaded, 'A foreign/unknown board must not have its items read');
+    }
+
+    public function test_patch_canvas_item_throws_and_never_writes_for_unresolved_item(): void
+    {
+        $patched = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'patchCanvasItem' => function () use (&$patched) {
+                $patched++;
+
+                return true;
+            },
+        ]);
+        // allow-all permissions: the deny must come from the null resolution, not the role.
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->patchCanvasItem(5, ['status' => 'x'], 'swotcanvas');
+            $this->fail('Expected AuthorizationException for an unresolved item');
+        } catch (AuthorizationException) {
+            // expected
+        }
+        $this->assertSame(0, $patched, 'A missing/foreign item must never be patched');
+    }
+
+    public function test_patch_canvas_item_throws_when_edit_denied(): void
+    {
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => fn () => 9,
+            'patchCanvasItem' => fn () => true,
+        ]);
+        $service = $this->securedService($repo, $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+        $service->patchCanvasItem(5, ['status' => 'x'], 'swotcanvas');
+    }
+
+    public function test_update_canvas_item_resolves_project_from_item_id_not_payload_canvas_id(): void
+    {
+        // Relocation fence: the project is resolved from the EXISTING item's id, not from the
+        // attacker-supplied canvasId in the payload.
+        $resolvedItemId = null;
+        $wrote = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => function ($id) use (&$resolvedItemId) {
+                $resolvedItemId = $id;
+
+                return 9;
+            },
+            'editCanvasItem' => function () use (&$wrote) {
+                $wrote++;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        $service->updateCanvasItem(['itemId' => 42, 'canvasId' => 9999, 'description' => 'x'], 'swotcanvas');
+
+        $this->assertSame(42, $resolvedItemId, 'Project must be resolved from itemId, not the payload canvasId');
+        $this->assertSame(1, $wrote);
+    }
+
+    public function test_create_canvas_item_throws_and_never_inserts_for_unknown_board(): void
+    {
+        $inserted = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'addCanvasItem' => function () use (&$inserted) {
+                $inserted++;
+
+                return '1';
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->createCanvasItem(['canvasId' => 9999, 'box' => 'x'], 'swotcanvas');
+            $this->fail('Expected AuthorizationException for an unknown target board');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $inserted, 'An item must never be created into an unknown/foreign board');
+    }
+
+    public function test_delete_canvas_item_throws_and_never_deletes_for_unresolved_item(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'delCanvasItem' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->deleteCanvasItem(5, 'swotcanvas');
+            $this->fail('Expected AuthorizationException for an unresolved item');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $deleted, 'A missing/foreign item must never be deleted');
+    }
+
+    public function test_delete_board_throws_and_never_deletes_for_unresolved_board(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'deleteCanvas' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->deleteBoard(5, 'swotcanvas');
+            $this->fail('Expected AuthorizationException for an unresolved board');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $deleted, 'A missing/foreign board must never be deleted');
+    }
+
+    public function test_copy_board_throws_when_source_unresolved_and_never_copies(): void
+    {
+        $copied = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'copyCanvas' => function () use (&$copied) {
+                $copied++;
+
+                return 1;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->copyBoard(5, 7, 1, 'Copy', 'swotcanvas');
+            $this->fail('Expected AuthorizationException for an unresolved source board');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $copied, 'A board must never be copied from an unknown/foreign source');
+    }
+
+    public function test_merge_board_requires_both_boards_to_resolve(): void
+    {
+        // Source (1) resolves but target (2) does not -> deny, never merge.
+        $merged = 0;
+        $repo = $this->make(BlueprintsRepository::class, [
+            'getCanvasProjectId' => fn ($id) => $id === 1 ? 9 : null,
+            'mergeCanvas' => function () use (&$merged) {
+                $merged++;
+
+                return true;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->allowingPermissions());
+
+        try {
+            $service->mergeBoard(2, 1, 'swotcanvas');
+            $this->fail('Expected AuthorizationException when a board does not resolve');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $merged, 'Merge must not run unless BOTH boards resolve');
+    }
+
+    public function test_import_authorizes_create_on_target_project_before_doing_anything(): void
+    {
+        // import() authorizes CREATE against the passed projectId first — a denial throws
+        // before the file/template/repo are ever touched (it is reachable via JSON-RPC with an
+        // arbitrary projectId).
+        $repo = $this->make(BlueprintsRepository::class, [
+            'existCanvas' => function (): bool {
+                $this->fail('import must deny before touching the repository');
+
+                return false;
+            },
+        ]);
+        $service = $this->securedService($repo, $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+        $service->import('/tmp/does-not-matter.xml', 'swot', 55, 1);
     }
 }


### PR DESCRIPTION
## What & why

**Blueprints** is the consolidated canvas system — every variant (SWOT, Lean, Value, …) is a row in the **shared** `zp_canvas` / `zp_canvas_items` tables, distinguished by a `type`/`box` column, under **one id sequence**. Its boards and items were reachable by bare id with **no project scope**, so the legacy controllers and the `@api` service/RPC surface had cross-project **read & mutation IDORs**. The deletion controllers used role-only `Auth::authOrRedirect` (no project check at all).

This continues the native permission rollout (after Sprints / Comments / Wiki / Ideas), applying the same fail-closed pattern to the canvas family's live, native-routed domain.

## Approach (the established fail-closed chokepoint)

- **Vocabulary** — new `BlueprintsPermissions` (`blueprints.view/create/edit/delete`, project-scoped). Standard verbs auto-grant via the central matrix (readonly=view, editor=create/edit/delete, manager+=all) → **no `DefaultRolePermissions` edit**.
- **Repository** — two additive fail-closed resolvers `getCanvasItemProjectId(id, type)` / `getCanvasProjectId(id, type)` (type-scoped; `?int`, `null` = missing **or** wrong canvas type). No existing signatures changed, so the rest of the canvas family is untouched and can reuse them.
- **Service** (`extends BaseService`) is now the **single chokepoint** for by-id board/item CRUD (12 methods). Each resolves the entity's **real** project and authorizes the matching verb against it:
  - **reads soft-deny** (`false`/`[]`) *without loading* → no cross-project existence oracle;
  - **writes throw** `AuthorizationException` *without writing* on a `null` resolution — never falling back to `session('currentProject')` (the recurring fail-open trap).
  - The 3 `@api` methods (`import` / `getBoardProgress` / `getLastUpdatedCanvas`) are gated; `import` authorizes `CREATE` in-body against its target `projectId`. `BlueprintsExport::exportToXml` routes its by-id reads through the VIEW-authorized service (it's `@api` → RPC-reachable).
- **Controllers (all 9)** call the service instead of the repository for canvas entities and carry `#[RequiresPermission]`. The role-only `Auth::authOrRedirect` deletes are replaced; `ShowCanvas` validates an explicit board id against the **current project's** boards; `BoardDialog` no longer poisons the session with a foreign board id.
- **delComment** is bound to the gated item (`module` + `moduleId`) before deletion — closing a cross-item / cross-project comment-deletion IDOR (`deleteComment` filters on the comment id alone).
- **`Canvas` shim** `@api` methods gated too — `leantime.rpc.canvas.canvas.*` is a separate RPC entry point.
- **Migration** `update_sql_30512` (flush registry + sync + seed); **dbVersion 3.5.11 → 3.5.12**.

## Tests
- 13 new fail-closed `BlueprintsService` cases: soft-deny / no-oracle, write-throws-without-writing, relocation fence (project resolved from `itemId`, not the payload `canvasId`), type-scoping, import authz.
- `blueprints.*` added to the role-matrix catalog test.
- Local: PHP lint, Pint, **PHPStan level 1**, **23 BlueprintsService + 7 role-matrix tests pass**; Wiki/Ideas/Comments/Sprints suites still green.
- Ran a 5-lens adversarial review before commit; its one HIGH finding (the comment-deletion IDOR above) is fixed, two findings adjudicated as false positives.

## CLAUDE.md
Corrected the stale "Canvas base + 14 variants" section → the Blueprints consolidation, a shared-table IDOR caution, and the accurate domain count.

## Scope / follow-ups
**Goalcanvas, Logicmodelcanvas, `Api\Canvas`, and `Connector`** share the same repository and get their own focused, adversarially-reviewed passes next — they'll reuse the resolvers added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)