### PR TITLE
fix(logicmodelcanvas): left-align status filter dropdown menu

### DIFF
--- a/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
+++ b/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
@@ -96,9 +96,13 @@
                             $statusFilterLabel = '<i class="fas fa-fw ' . $statusLabels[$filter['status']]['icon'] . '" style="color:' . $sc . '"></i> ' . $statusLabels[$filter['status']]['title'];
                         }
                     @endphp
+                    {{-- viewDropDown right-aligns the menu (left:auto; right:0). On
+                         this board the button sits at the left edge of the toolbar, so
+                         a 240px menu extends back under the sidebar and gets clipped
+                         by .primaryContent's overflow-x:hidden. Left-align it locally. --}}
                     <div class="btn-group viewDropDown">
                         <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{!! $statusFilterLabel !!}</button>
-                        <ul class="dropdown-menu">
+                        <ul class="dropdown-menu" style="left:0; right:auto;">
                             <li><a href="{{ BASE_URL }}/{{ $canvasName }}canvas/showCanvas?filter_status=all" @if ($filter['status'] == 'all') class="active" @endif><i class="fas fa-globe"></i> {{ $tpl->__('status.all') }}</a></li>
                             @foreach ($statusLabels as $key => $data)
                                 @php $iconColor = $statusColorMap[$data['color']] ?? '#666'; @endphp


### PR DESCRIPTION
## Summary
On the Logic Model board, opening the "All status" filter dropdown produced a near-blank menu — only the trailing "s" of "All status" was visible at the left edge of the content area, with the rest of the menu hiding behind the sidebar.

## Root cause
The button sits at the LEFT edge of the toolbar. The shared rule \`.viewDropDown .dropdown-menu { left: auto; right: 0 }\` (in \`public/assets/css/components/dropdowns.css\`) right-aligns the menu — intended for toolbars where the dropdown lives at the right (e.g. \`Timesheets/showMy.blade.php\` which uses \`pull-right\` for that pattern). On the Logic Model board, right-aligning a 240px menu to a button at x=255 pushes the menu's left edge to ~x=120 — behind the sidebar (\`.primaryContent\` starts at x=225) — and \`.primaryContent\`'s \`overflow-x: hidden\` clips it.

## Fix
Inline-override \`left:0; right:auto\` on the menu \`<ul>\` in the Logic Model template only. Same scope as the bug; doesn't change the global rule.

## What about other canvases?

\`Canvas/Templates/showCanvasTop.blade.php\` and \`Blueprints/Templates/showCanvasTop.blade.php\` use the same \`.viewDropDown\` class — but their dropdowns are wrapped in \`<div class=\"pull-right\">\` at the right edge of the toolbar. There, right-aligning the menu is correct (the menu extends leftward INTO the content area, not off-screen). Verified the Blueprints Lean Canvas board renders correctly (menu opens at the expected position, all items visible). **No change needed for Blueprints / Canvas base** — the bug only manifests when the button is on the LEFT edge of the toolbar, which is unique to the Logic Model template.

## Test plan
- [ ] Open a Logic Model board → click the "All status" filter pill → menu opens directly under the button with all 6 items visible (All status, Hypothesis, Testing, Validated, Paused, Invalid).
- [ ] Open a Blueprints board (Lean Canvas / SWOT / etc.) → click the status filter → menu opens right-aligned to the button (no regression — still works as before).
- [ ] Confirm Timesheets / Canvas / Blueprints filter dropdowns are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)