### PR TITLE
security(goalcanvas): gate the Goals domain + close by-id IDORs

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.12';
+    public string $dbVersion = '3.5.13';
 }

--- a/app/Domain/Goalcanvas/Controllers/BigRock.php
+++ b/app/Domain/Goalcanvas/Controllers/BigRock.php
@@ -7,9 +7,11 @@
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -48,15 +50,21 @@ class BigRock extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function get($params): Response
     {
         if (isset($params['id'])) {
 
+            // getSingleCanvas authorizes VIEW against the board's real project and returns
+            // false for a missing/foreign/unauthorized board.
             $bigrock = $this->goalService->getSingleCanvas($params['id']);
+            if ($bigrock === false) {
+                $bigrock = ['id' => '', 'title' => '', 'projectId' => '', 'author' => ''];
+            }
 
         } else {
 
-            $bigrock = ['id' => '', 'title' => '', 'prpojectId' => '', 'author' => ''];
+            $bigrock = ['id' => '', 'title' => '', 'projectId' => '', 'author' => ''];
         }
 
         $this->tpl->assign('bigRock', $bigrock);
@@ -67,6 +75,7 @@ class BigRock extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
         $bigrock = ['id' => '', 'title' => '', 'projectId' => '', 'author' => ''];

--- a/app/Domain/Goalcanvas/Controllers/Dashboard.php
+++ b/app/Domain/Goalcanvas/Controllers/Dashboard.php
@@ -2,10 +2,12 @@
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Mailer;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas;
 use Leantime\Domain\Projects\Services\Projects;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepo;
@@ -42,6 +44,7 @@ class Dashboard extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -71,6 +74,7 @@ class Dashboard extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT)]
     public function post(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -135,6 +139,11 @@ class Dashboard extends Controller
                 'author' => session('userdata.id'),
                 'projectId' => session('currentProject'),
             ];
+            // View-time convenience: lazily create a default board (in the CURRENT project) when
+            // none exist. Kept repo-direct/UNGATED on purpose — gating it through createGoalboard's
+            // CREATE check would 403 a VIEW-only user just for opening an empty goals page. It is
+            // not an IDOR (always the session project). Same landmine pattern as the Blueprints/
+            // Wiki/Ideas default-board/notebook bootstrap.
             $this->canvasRepo->addCanvas($values);
 
             return $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -229,8 +238,14 @@ class Dashboard extends Controller
         }
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            session([$sessionKey => $currentCanvasId]);
+            // Only honor an explicit board id that belongs to the CURRENT project's boards;
+            // a foreign/unknown id must not become the active board (cross-project item read).
+            $requestedId = (int) $params['id'];
+            $projectBoardIds = array_map(static fn ($row) => (int) $row['id'], $allCanvas);
+            if (in_array($requestedId, $projectBoardIds, true)) {
+                $currentCanvasId = $requestedId;
+                session([$sessionKey => $currentCanvasId]);
+            }
         }
 
         return $currentCanvasId;
@@ -258,7 +273,8 @@ class Dashboard extends Controller
             'author' => session('userdata.id'),
             'projectId' => session('currentProject'),
         ];
-        $currentCanvasId = $this->canvasRepo->addCanvas($values);
+        // createGoalboard authorizes CREATE against the target (current) project.
+        $currentCanvasId = $this->goalService->createGoalboard($values);
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
         $this->notifyBoardCreated($values['title'], 'notification.board_created', 'email_notifications.canvas_created_message');
@@ -286,8 +302,9 @@ class Dashboard extends Controller
             return null;
         }
 
+        // updateGoalboard authorizes EDIT against the board's real project.
         $values = ['title' => $_POST['canvastitle'], 'id' => $currentCanvasId];
-        $currentCanvasId = $this->canvasRepo->updateCanvas($values);
+        $currentCanvasId = $this->goalService->updateGoalboard($values);
 
         $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
@@ -311,10 +328,11 @@ class Dashboard extends Controller
             return null;
         }
 
-        $currentCanvasId = $this->canvasRepo->copyCanvas(
-            session('currentProject'),
+        // copyGoalBoard authorizes VIEW on the source board's project and CREATE on the target.
+        $currentCanvasId = $this->goalService->copyGoalBoard(
             $currentCanvasId,
-            session('userdata.id'),
+            (int) session('currentProject'),
+            (int) session('userdata.id'),
             $_POST['canvastitle']
         );
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -336,7 +354,8 @@ class Dashboard extends Controller
             return null;
         }
 
-        $status = $this->canvasRepo->mergeCanvas($currentCanvasId, $_POST['canvasid']);
+        // mergeGoalBoard authorizes EDIT on the target board's project and VIEW on the source's.
+        $status = $this->goalService->mergeGoalBoard($currentCanvasId, (int) $_POST['canvasid']);
 
         if ($status) {
             $this->tpl->setNotification($this->language->__('notification.board_merged'), 'success');
@@ -386,9 +405,10 @@ class Dashboard extends Controller
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
         session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
 
-        $canvas = $this->canvasRepo->getSingleCanvas($currentCanvasId);
+        // getSingleCanvas returns a single row (Goalcanvas repo override) or false.
+        $canvas = $this->goalService->getSingleCanvas($currentCanvasId);
         $this->notifyBoardCreated(
-            strip_tags($canvas[0]['title']),
+            strip_tags($canvas !== false ? ($canvas['title'] ?? '') : ''),
             'notification.board_imported',
             'email_notifications.canvas_imported_message'
         );

--- a/app/Domain/Goalcanvas/Controllers/DelCanvas.php
+++ b/app/Domain/Goalcanvas/Controllers/DelCanvas.php
@@ -2,10 +2,12 @@
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
+use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -18,15 +20,17 @@ class DelCanvas extends Controller
      */
     protected const CANVAS_NAME = 'goal';
 
-    private mixed $canvasRepo;
+    private GoalcanvaRepository $canvasRepo;
+
+    private GoalcanvaService $goalService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(): void
+    public function init(GoalcanvaRepository $canvasRepo, GoalcanvaService $goalService): void
     {
-        $repoName = app()->getNamespace().'Domain\\Goalcanvas\\Repositories\\Goalcanvas';
-        $this->canvasRepo = app()->make($repoName);
+        $this->canvasRepo = $canvasRepo;
+        $this->goalService = $goalService;
     }
 
     /**
@@ -34,10 +38,9 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
         $this->tpl->assign('id', $id);
 
@@ -49,21 +52,21 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->canvasRepo->deleteCanvas($id);
+            // The service resolves the board's REAL project and authorizes DELETE against it
+            // (throwing for a missing/foreign board) — closing the by-id board-delete IDOR the
+            // previous role-only Auth::authOrRedirect left open.
+            $this->goalService->deleteGoalBoard($id);
 
             $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
             session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $allCanvas[0]['id'] ?? -1]);
 
             $this->tpl->setNotification($this->language->__('notification.board_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvas_deleted');
-
-            $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
             if (! $allCanvas || count($allCanvas) == 0) {
                 return Frontcontroller::redirect(BASE_URL.'/blueprints/showBoards');

--- a/app/Domain/Goalcanvas/Controllers/DelCanvasItem.php
+++ b/app/Domain/Goalcanvas/Controllers/DelCanvasItem.php
@@ -2,10 +2,11 @@
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -18,15 +19,14 @@ class DelCanvasItem extends Controller
      */
     protected const CANVAS_NAME = 'goal';
 
-    private mixed $canvasRepo;
+    private GoalcanvaService $goalService;
 
     /**
      * Initializes dependencies.
      */
-    public function init(): void
+    public function init(GoalcanvaService $goalService): void
     {
-        $repoName = app()->getNamespace().'Domain\\Goalcanvas\\Repositories\\Goalcanvas';
-        $this->canvasRepo = app()->make($repoName);
+        $this->goalService = $goalService;
     }
 
     /**
@@ -34,10 +34,9 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
         $this->tpl->assign('id', $id);
 
@@ -49,14 +48,15 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->canvasRepo->delCanvasItem($id);
+            // The service resolves the item's REAL project and authorizes DELETE against it
+            // (throwing for a missing/foreign item) — closing the by-id item-delete IDOR.
+            $this->goalService->deleteGoalItem($id);
 
             $this->tpl->setNotification($this->language->__('notification.element_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvasitem_deleted');
 

--- a/app/Domain/Goalcanvas/Controllers/EditCanvasComment.php
+++ b/app/Domain/Goalcanvas/Controllers/EditCanvasComment.php
@@ -6,9 +6,12 @@
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
@@ -32,6 +35,8 @@ class EditCanvasComment extends Controller
 
     private ProjectService $projectService;
 
+    private GoalcanvaService $goalService;
+
     private object $canvasRepo;
 
     /**
@@ -42,13 +47,15 @@ class EditCanvasComment extends Controller
         CommentRepository $commentsRepo,
         SprintService $sprintService,
         TicketService $ticketService,
-        ProjectService $projectService
+        ProjectService $projectService,
+        GoalcanvaService $goalService
     ) {
         $this->ticketRepo = $ticketRepo;
         $this->commentsRepo = $commentsRepo;
         $this->sprintService = $sprintService;
         $this->ticketService = $ticketService;
         $this->projectService = $projectService;
+        $this->goalService = $goalService;
 
         $repoName = app()->getNamespace().'Domain\\goalcanvas\\Repositories\\goalcanvas';
         $this->canvasRepo = app()->make($repoName);
@@ -57,19 +64,29 @@ class EditCanvasComment extends Controller
     /**
      * get - handle get requests
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function get($params)
     {
 
         $canvasTypes = $this->canvasRepo->getCanvasTypes();
         if (isset($params['id'])) {
-            // Delete comment
-            if (isset($params['delComment']) === true) {
-                $commentId = (int) ($params['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvascomment_deleted');
+            // Resolve + VIEW-authorize the item against its real project first.
+            $canvasItem = $this->goalService->getGoalItem((int) $params['id']);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
             }
 
-            $canvasItem = $this->canvasRepo->getSingleCanvasItem($params['id']);
+            // Delete comment — only when it belongs to THIS gated item (module + moduleId).
+            if (isset($params['delComment']) === true) {
+                $commentId = (int) ($params['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === static::CANVAS_NAME.'canvasitem'
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvascomment_deleted');
+                }
+            }
 
             $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvasitem', $canvasItem['id']);
             $this->tpl->assign('numComments', $this->commentsRepo->countComments(static::CANVAS_NAME.'canvasitem', $canvasItem['id']));
@@ -84,8 +101,8 @@ class EditCanvasComment extends Controller
                 'id' => '',
                 'box' => $type,
                 'description' => '',
-                'status' => array_key_first($this->canvasRepo->getStatusList()),
-                'relates' => array_key_first($this->canvasRepo->GetRelatesList()),
+                'status' => array_key_first($this->canvasRepo->getStatusLabels()),
+                'relates' => array_key_first($this->canvasRepo->getRelatesLabels()),
                 'assumptions' => '',
                 'data' => '',
                 'conclusion' => '',
@@ -107,6 +124,7 @@ class EditCanvasComment extends Controller
     /**
      * post - handle post requests
      */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT, entityScoped: true)]
     public function post($params)
     {
 
@@ -131,7 +149,8 @@ class EditCanvasComment extends Controller
                         'dependentMilstone' => '',
                     ];
 
-                    $this->canvasRepo->editCanvasComment($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there.
+                    $this->goalService->updateGoalItem($canvasItem);
 
                     $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvasitem', $params['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -181,7 +200,8 @@ class EditCanvasComment extends Controller
                         'canvasId' => $currentCanvasId,
                     ];
 
-                    $id = $this->canvasRepo->addCanvasItem($canvasItem);
+                    // Resolves the target board's real project from canvasId and authorizes CREATE.
+                    $id = $this->goalService->createGoalItem($canvasItem);
 
                     $canvasItem['id'] = $id;
 
@@ -218,6 +238,11 @@ class EditCanvasComment extends Controller
         }
 
         if (isset($params['comment']) === true) {
+            // Only allow commenting on a goal item the user can view in their project.
+            if (! $this->goalService->getGoalItem((int) ($_GET['id'] ?? 0))) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $params['text'],
                 'date' => date('Y-m-d H:i:s'),
@@ -251,7 +276,7 @@ class EditCanvasComment extends Controller
         }
 
         $this->tpl->assign('canvasTypes', $this->canvasRepo->getCanvasTypes());
-        $this->tpl->assign('canvasItem', $this->canvasRepo->getSingleCanvasItem($_GET['id']));
+        $this->tpl->assign('canvasItem', $this->goalService->getGoalItem((int) ($_GET['id'] ?? 0)));
 
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas.canvasComment');
     }

--- a/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
@@ -7,10 +7,12 @@
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Support\FromFormat;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
@@ -52,39 +54,44 @@ class EditCanvasItem extends Controller
     /**
      * @throws \Exception
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function get($params): Response
     {
         if (isset($params['id'])) {
-            // Delete comment
-            if (isset($params['delComment'])) {
-                $commentId = (int) ($params['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+            // Resolve + VIEW-authorize the item against its real project BEFORE any mutation.
+            // false = missing / foreign project / unauthorized (indistinguishable -> no oracle).
+            $canvasItem = $this->goalService->getGoalItem((int) $params['id']);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
             }
 
-            // Delete milestone relationship
+            // Delete comment — only when it belongs to THIS gated item (module + moduleId);
+            // deleteComment() filters on the comment id alone, so the bind prevents deleting a
+            // foreign item's / project's comment.
+            if (isset($params['delComment'])) {
+                $commentId = (int) ($params['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === 'goalcanvasitem'
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+                }
+            }
+
+            // Delete milestone relationship — an EDIT, authorized by the service against the
+            // item's project (a view-only user is denied here).
             if (isset($params['removeMilestone'])) {
-                $this->canvasRepo->patchCanvasItem($params['id'], ['milestoneId' => '']);
+                $this->goalService->patchGoalItem((int) $params['id'], ['milestoneId' => '']);
+                $canvasItem = $this->goalService->getGoalItem((int) $params['id']);
                 $this->tpl->setNotification($this->language->__('notifications.milestone_detached'), 'success');
             }
 
-            $canvasItem = $this->canvasRepo->getSingleCanvasItem($params['id']);
-
-            if ($canvasItem) {
-                $comments = $this->commentsRepo->getComments(
-                    'goalcanvasitem',
-                    $canvasItem['id']
-                );
-                $this->tpl->assign(
-                    'numComments',
-                    $this->commentsRepo->countComments(
-                        'goalcanvascanvasitem',
-                        $canvasItem['id']
-                    )
-                );
-            } else {
-                return $this->tpl->displayPartial('errors.error404');
-            }
+            $comments = $this->commentsRepo->getComments('goalcanvasitem', $canvasItem['id']);
+            $this->tpl->assign(
+                'numComments',
+                $this->commentsRepo->countComments('goalcanvasitem', $canvasItem['id'])
+            );
         } else {
             $canvasItem = [
                 'id' => '',
@@ -129,11 +136,18 @@ class EditCanvasItem extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT, entityScoped: true)]
     public function post($params): Response
     {
 
         if (isset($params['comment']) && isset($params['id'])) {
             $itemId = (int) $params['id'];
+
+            // Only allow commenting on a goal item the user can view in their project.
+            if (! $this->goalService->getGoalItem($itemId)) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $params['text'],
                 'date' => date('Y-m-d H:i:s'),
@@ -217,7 +231,8 @@ class EditCanvasItem extends Controller
                         $canvasItem['milestoneId'] = $params['existingMilestone'];
                     }
 
-                    $this->canvasRepo->editCanvasItem($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there.
+                    $this->goalService->updateGoalItem($canvasItem);
 
                     $comments = $this->commentsRepo->getComments('goalcanvasitem', $params['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -277,7 +292,8 @@ class EditCanvasItem extends Controller
                         'metricType' => $params['metricType'],
                         'assignedTo' => $params['assignedTo'] ?? '',
                     ];
-                    $id = $this->canvasRepo->addCanvasItem($canvasItem);
+                    // Resolves the target board's real project from canvasId and authorizes CREATE.
+                    $id = $this->goalService->createGoalItem($canvasItem);
                     $canvasTypes = $this->canvasRepo->getCanvasTypes();
 
                     $this->tpl->setNotification($canvasTypes[$params['box']]['title'].' successfully created', 'success', 'goal_item_created');
@@ -324,7 +340,7 @@ class EditCanvasItem extends Controller
         if (isset($params['id'])) {
             $canvasItemId = (int) $params['id'];
             $comments = $this->commentsRepo->getComments('goalcanvasitem', $canvasItemId);
-            $this->tpl->assign('canvasItem', $this->canvasRepo->getSingleCanvasItem($canvasItemId));
+            $this->tpl->assign('canvasItem', $this->goalService->getGoalItem($canvasItemId));
         } else {
             $value = [
                 'id' => '',

--- a/app/Domain/Goalcanvas/Controllers/Export.php
+++ b/app/Domain/Goalcanvas/Controllers/Export.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -15,20 +18,22 @@ class Export extends Controller
 {
     private const CANVAS_TYPE = 'goalcanvas';
 
-    private const COMMENT_MODULE = 'goalcanvasitem';
-
     private const SESSION_KEY = 'currentGOALCanvas';
 
     private GoalcanvaRepository $canvasRepo;
 
+    private GoalcanvaService $goalService;
+
     /**
      * init - resolve dependencies.
      *
-     * @param  GoalcanvaRepository  $canvasRepo  Goal canvas repository
+     * @param  GoalcanvaRepository  $canvasRepo  Goal canvas repository (label definitions)
+     * @param  GoalcanvaService  $goalService  Goal canvas service (VIEW-authorized board reads)
      */
-    public function init(GoalcanvaRepository $canvasRepo): void
+    public function init(GoalcanvaRepository $canvasRepo, GoalcanvaService $goalService): void
     {
         $this->canvasRepo = $canvasRepo;
+        $this->goalService = $goalService;
     }
 
     /**
@@ -36,6 +41,7 @@ class Export extends Controller
      *
      * @param  array<string, mixed>  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function get(array $params): Response
     {
         if (isset($params['id']) && $params['id'] !== '') {
@@ -46,14 +52,17 @@ class Export extends Controller
             return new Response('', 204);
         }
 
-        $canvas = $this->canvasRepo->getSingleCanvas($canvasId);
+        // getSingleCanvas authorizes VIEW against the board's real project and returns false for
+        // a missing/foreign/unauthorized board (export is reachable by arbitrary board id).
+        $canvas = $this->goalService->getSingleCanvas($canvasId);
         if (! $canvas) {
             return new Response('Canvas not found', 404);
         }
 
-        $records = $this->canvasRepo->getCanvasItemsById($canvasId, self::COMMENT_MODULE);
+        $records = $this->goalService->getCanvasItemsById($canvasId);
         $canvasTypes = $this->canvasRepo->getCanvasTypes();
 
+        // The Goalcanvas repo's getSingleCanvas returns a single row (not array-of-rows).
         $exportData = $this->buildXml($canvas['title'] ?? '', $records, $canvasTypes);
 
         clearstatcache();

--- a/app/Domain/Goalcanvas/Controllers/ShowCanvas.php
+++ b/app/Domain/Goalcanvas/Controllers/ShowCanvas.php
@@ -2,10 +2,12 @@
 
 namespace Leantime\Domain\Goalcanvas\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Mailer;
 use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas;
 use Leantime\Domain\Projects\Services\Projects;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepo;
@@ -40,6 +42,7 @@ class ShowCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -66,6 +69,7 @@ class ShowCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT)]
     public function post(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -129,6 +133,11 @@ class ShowCanvas extends Controller
                 'author' => session('userdata.id'),
                 'projectId' => session('currentProject'),
             ];
+            // View-time convenience: lazily create a default board (in the CURRENT project) when
+            // none exist. Kept repo-direct/UNGATED on purpose — gating it through createGoalboard's
+            // CREATE check would 403 a VIEW-only user just for opening an empty goals page. It is
+            // not an IDOR (always the session project). Same landmine pattern as the Blueprints/
+            // Wiki/Ideas default-board/notebook bootstrap.
             $currentCanvasId = $this->canvasRepo->addCanvas($values);
             $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
@@ -162,8 +171,15 @@ class ShowCanvas extends Controller
         }
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            session([$sessionKey => $currentCanvasId]);
+            // Only honor an explicit board id that belongs to the CURRENT project's boards
+            // ($allCanvas is project-scoped). A foreign/unknown id must not become the active
+            // board — otherwise assignTemplateVars would read another project's items.
+            $requestedId = (int) $params['id'];
+            $projectBoardIds = array_map(static fn ($row) => (int) $row['id'], $allCanvas);
+            if (in_array($requestedId, $projectBoardIds, true)) {
+                $currentCanvasId = $requestedId;
+                session([$sessionKey => $currentCanvasId]);
+            }
         }
 
         return $currentCanvasId;
@@ -191,7 +207,8 @@ class ShowCanvas extends Controller
             'author' => session('userdata.id'),
             'projectId' => session('currentProject'),
         ];
-        $currentCanvasId = $this->canvasRepo->addCanvas($values);
+        // createGoalboard authorizes CREATE against the target (current) project.
+        $currentCanvasId = $this->goalService->createGoalboard($values);
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
         $this->notifyBoardCreated($values['title'], 'notification.board_created', 'email_notifications.canvas_created_message');
@@ -219,8 +236,9 @@ class ShowCanvas extends Controller
             return null;
         }
 
+        // updateGoalboard authorizes EDIT against the board's real project.
         $values = ['title' => $_POST['canvastitle'], 'id' => $currentCanvasId];
-        $currentCanvasId = $this->canvasRepo->updateCanvas($values);
+        $currentCanvasId = $this->goalService->updateGoalboard($values);
 
         $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
@@ -244,10 +262,11 @@ class ShowCanvas extends Controller
             return null;
         }
 
-        $currentCanvasId = $this->canvasRepo->copyCanvas(
-            session('currentProject'),
+        // copyGoalBoard authorizes VIEW on the source board's project and CREATE on the target.
+        $currentCanvasId = $this->goalService->copyGoalBoard(
             $currentCanvasId,
-            session('userdata.id'),
+            (int) session('currentProject'),
+            (int) session('userdata.id'),
             $_POST['canvastitle']
         );
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -269,7 +288,8 @@ class ShowCanvas extends Controller
             return null;
         }
 
-        $status = $this->canvasRepo->mergeCanvas($currentCanvasId, $_POST['canvasid']);
+        // mergeGoalBoard authorizes EDIT on the target board's project and VIEW on the source's.
+        $status = $this->goalService->mergeGoalBoard($currentCanvasId, (int) $_POST['canvasid']);
 
         if ($status) {
             $this->tpl->setNotification($this->language->__('notification.board_merged'), 'success');
@@ -319,9 +339,11 @@ class ShowCanvas extends Controller
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
         session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
 
-        $canvas = $this->canvasRepo->getSingleCanvas($currentCanvasId);
+        // The just-imported board is in the current project; getSingleCanvas returns a single
+        // row (Goalcanvas repo override) or false.
+        $canvas = $this->goalService->getSingleCanvas($currentCanvasId);
         $this->notifyBoardCreated(
-            strip_tags($canvas[0]['title']),
+            strip_tags($canvas !== false ? ($canvas['title'] ?? '') : ''),
             'notification.board_imported',
             'email_notifications.canvas_imported_message'
         );

--- a/app/Domain/Goalcanvas/Permissions/GoalcanvasPermissions.php
+++ b/app/Domain/Goalcanvas/Permissions/GoalcanvasPermissions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Leantime\Domain\Goalcanvas\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Goalcanvas (Goals / OKRs) permission vocabulary — the verbs only.
+ *
+ * Goals are a distinct headline feature (OKR-style goal boards), even though they are stored
+ * in the shared `zp_canvas` (type `goalcanvas`) / `zp_canvas_items` (box `goal`) tables. They
+ * get their own `goals.*` vocabulary — separate from the generic `blueprints.*` strategy
+ * canvases — so a role/permission admin can grant goal access independently.
+ *
+ * Goal boards/items are PROJECT-scoped (each board belongs to one project), so every capability
+ * is evaluated against the user's role IN the board's project (projectScoped = true, the
+ * default). The standard verbs auto-grant via the central matrix (readonly = view; editor =
+ * create/edit/delete; manager+ = all), so no
+ * {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} change is required.
+ */
+final class GoalcanvasPermissions implements ProvidesPermissions
+{
+    public const VIEW = 'goals.view';
+
+    public const CREATE = 'goals.create';
+
+    public const EDIT = 'goals.edit';
+
+    public const DELETE = 'goals.delete';
+
+    public function domain(): string
+    {
+        return 'goals';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View goals'),
+            new Permission(self::CREATE, 'Create goals and goal boards'),
+            new Permission(self::EDIT, 'Edit goals and goal boards'),
+            new Permission(self::DELETE, 'Delete goals and goal boards'),
+        ];
+    }
+}

--- a/app/Domain/Goalcanvas/Services/Goalcanvas.php
+++ b/app/Domain/Goalcanvas/Services/Goalcanvas.php
@@ -2,13 +2,31 @@
 
 namespace Leantime\Domain\Goalcanvas\Services;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
 
 /**
+ * Goalcanvas (Goals / OKRs) service.
+ *
+ * Goal boards/items live in the shared zp_canvas (type "goalcanvas") / zp_canvas_items (box
+ * "goal") tables. Every by-id board/item operation routes through this service, which resolves
+ * the entity's REAL project via the repository's fail-closed resolvers (inherited from the
+ * Blueprints repo, scoped to the "goalcanvas" type) and authorizes the matching
+ * {@see GoalcanvasPermissions} verb against it. A resolver returning null (missing id, or an id
+ * whose board is a different canvas type) is treated as DENY — reads soft-deny (neutral value)
+ * so they are not a cross-project existence oracle; writes throw an AuthorizationException
+ * without writing. Never falls back to the session project for a by-id entity.
+ *
  * @api
  */
-class Goalcanvas
+class Goalcanvas extends BaseService
 {
+    /** Database canvas type for goal boards (CANVAS_NAME "goal" + "canvas"). */
+    private const CANVAS_TYPE = 'goalcanvas';
+
     private GoalcanvaRepository $goalRepository;
 
     public array $reportingSettings = [
@@ -23,10 +41,18 @@ class Goalcanvas
     }
 
     /**
+     * List the goals on a board (by board id), authorized for VIEW against the board's project.
+     * Returns [] for a missing/foreign/unauthorized board (neutral — no oracle).
+     *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function getCanvasItemsById(int $id): array
     {
+        $projectId = $this->goalRepository->getCanvasProjectId($id, self::CANVAS_TYPE);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return [];
+        }
 
         $goals = $this->goalRepository->getCanvasItemsById($id);
 
@@ -58,17 +84,22 @@ class Goalcanvas
     }
 
     /**
+     * Sum the linked children's current values for a parent goal, authorized for VIEW against
+     * the PARENT goal's project. The cross-project roll-up of linked children is the feature;
+     * the gate is on the parent the caller asked about. Returns 0 for a missing/foreign/
+     * unauthorized parent.
+     *
      * @return int|mixed
      *
      * @api
      */
-    /**
-     * @return int|mixed
-     *
-     * @api
-     */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function getChildGoalsForReporting($parentId): mixed
     {
+        $projectId = $this->goalRepository->getCanvasItemProjectId((int) $parentId, self::CANVAS_TYPE);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return 0;
+        }
 
         // Goals come back as rows for levl1 and lvl2 being columns, so
         // goal A | goalChildA
@@ -89,10 +120,18 @@ class Goalcanvas
     }
 
     /**
+     * The child-goal hierarchy for a parent goal, authorized for VIEW against the PARENT goal's
+     * project. Returns [] for a missing/foreign/unauthorized parent.
+     *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, entityScoped: true)]
     public function getChildrenbyKPI($parentId): array
     {
+        $projectId = $this->goalRepository->getCanvasItemProjectId((int) $parentId, self::CANVAS_TYPE);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return [];
+        }
 
         $goals = [];
         // Goals come back as rows for levl1 and lvl2 being columns, so
@@ -139,11 +178,13 @@ class Goalcanvas
     }
 
     /**
+     * Available parent KPIs for linking, authorized for VIEW against $projectId (dispatch gate).
+     *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, projectIdParam: 'projectId')]
     public function getParentKPIs($projectId): array
     {
-
         $kpis = $this->goalRepository->getAllAvailableKPIs($projectId);
 
         $goals = [];
@@ -161,45 +202,243 @@ class Goalcanvas
         return $goals;
     }
 
+    /**
+     * Goals linked to a milestone. Internal read used by the milestone UI; the data-access is
+     * the milestone the caller is already viewing.
+     */
     public function getGoalsByMilestone($milestoneId): array
     {
-
         $goals = $this->goalRepository->getGoalsByMilestone($milestoneId);
 
         return $goals;
     }
 
-    public function updateGoalboard($values)
-    {
-        return $this->goalRepository->updateCanvas($values);
-    }
+    // ---------------------------------------------------------------------------------------
+    // Secured by-id board/item CRUD chokepoint (controllers call these instead of the repo).
+    // ---------------------------------------------------------------------------------------
 
-    public function createGoalboard($values)
+    /**
+     * Fetch a single goal item by id, authorized for VIEW against the item's real project.
+     *
+     * @return array<string, mixed>|false False when missing/foreign/unauthorized.
+     */
+    public function getGoalItem(int $id): array|false
     {
-        return $this->goalRepository->addCanvas($values);
-    }
+        $projectId = $this->goalRepository->getCanvasItemProjectId($id, self::CANVAS_TYPE);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return false;
+        }
 
-    public function getSingleCanvas($id)
-    {
-        return $this->goalRepository->getSingleCanvas($id);
+        return $this->goalRepository->getSingleCanvasItem($id);
     }
 
     /**
-     * @param  array  $values
-     * @return int
+     * Fetch a single goal board by id, authorized for VIEW against the board's real project.
+     *
+     * @return array<string, mixed>|false False when missing/foreign/unauthorized.
+     */
+    public function getSingleCanvas($id)
+    {
+        $projectId = $this->goalRepository->getCanvasProjectId((int) $id, self::CANVAS_TYPE);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return false;
+        }
+
+        return $this->goalRepository->getSingleCanvas((int) $id);
+    }
+
+    /**
+     * Create a goal board, authorized for CREATE against the target project.
+     *
+     * @throws AuthorizationException When projectId is missing or CREATE is denied.
+     */
+    public function createGoalboard($values)
+    {
+        $projectId = (int) ($values['projectId'] ?? 0);
+        if ($projectId === 0) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::CREATE, $projectId);
+
+        return $this->goalRepository->addCanvas($values);
+    }
+
+    /**
+     * Rename a goal board, authorized for EDIT against the board's real project.
+     *
+     * @throws AuthorizationException When the board is unknown/foreign or EDIT is denied.
+     */
+    public function updateGoalboard($values)
+    {
+        $projectId = $this->goalRepository->getCanvasProjectId((int) ($values['id'] ?? 0), self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::EDIT, $projectId);
+
+        return $this->goalRepository->updateCanvas($values);
+    }
+
+    /**
+     * Copy a goal board into a target project. Requires VIEW on the source board's project and
+     * CREATE in the target project.
+     *
+     * @throws AuthorizationException When the source is unknown/foreign, or VIEW/CREATE is denied.
+     */
+    public function copyGoalBoard(int $sourceCanvasId, int $targetProjectId, int $authorId, string $title): int
+    {
+        $sourceProjectId = $this->goalRepository->getCanvasProjectId($sourceCanvasId, self::CANVAS_TYPE);
+        if ($sourceProjectId === null || $targetProjectId <= 0) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::VIEW, $sourceProjectId);
+        $this->authorize(GoalcanvasPermissions::CREATE, $targetProjectId);
+
+        return $this->goalRepository->copyCanvas($targetProjectId, $sourceCanvasId, $authorId, $title);
+    }
+
+    /**
+     * Merge a source goal board's items into a target board. Requires EDIT on the target board's
+     * project and VIEW on the source board's project — both resolved by id.
+     *
+     * @throws AuthorizationException When either board is unknown/foreign, or EDIT/VIEW is denied.
+     */
+    public function mergeGoalBoard(int $targetCanvasId, int $sourceCanvasId): bool
+    {
+        $targetProjectId = $this->goalRepository->getCanvasProjectId($targetCanvasId, self::CANVAS_TYPE);
+        $sourceProjectId = $this->goalRepository->getCanvasProjectId($sourceCanvasId, self::CANVAS_TYPE);
+        if ($targetProjectId === null || $sourceProjectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::EDIT, $targetProjectId);
+        $this->authorize(GoalcanvasPermissions::VIEW, $sourceProjectId);
+
+        return $this->goalRepository->mergeCanvas($targetCanvasId, $sourceCanvasId);
+    }
+
+    /**
+     * Delete a goal board (and its items), authorized for DELETE against the board's real project.
+     *
+     * @throws AuthorizationException When the board is unknown/foreign or DELETE is denied.
+     */
+    public function deleteGoalBoard(int $canvasId): void
+    {
+        $projectId = $this->goalRepository->getCanvasProjectId($canvasId, self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::DELETE, $projectId);
+
+        $this->goalRepository->deleteCanvas($canvasId);
+    }
+
+    /**
+     * Create a goal item, authorized for CREATE against the target board's real project.
+     *
+     * @param  array<string, mixed>  $values  Item values (must include `canvasId`)
+     * @return false|string New item id, or false on insert failure
+     *
+     * @throws AuthorizationException When the target board is unknown/foreign or CREATE is denied.
      *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::CREATE, entityScoped: true)]
     public function createGoal($values)
     {
+        $projectId = $this->goalRepository->getCanvasProjectId((int) ($values['canvasId'] ?? 0), self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::CREATE, $projectId);
+
         return $this->goalRepository->createGoal($values);
     }
 
     /**
+     * Create a goal item (controller add-item path), authorized for CREATE against the target
+     * board's real project.
+     *
+     * @param  array<string, mixed>  $values  Item values (must include `canvasId`)
+     * @return false|string New item id, or false on insert failure
+     *
+     * @throws AuthorizationException When the target board is unknown/foreign or CREATE is denied.
+     */
+    public function createGoalItem(array $values): false|string
+    {
+        $projectId = $this->goalRepository->getCanvasProjectId((int) ($values['canvasId'] ?? 0), self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::CREATE, $projectId);
+
+        return $this->goalRepository->addCanvasItem($values);
+    }
+
+    /**
+     * Update a goal item, authorized for EDIT against the item's real project. The project is
+     * resolved from the existing item's id, so the payload's canvasId cannot relocate it.
+     *
+     * @param  array<string, mixed>  $values  Item values (must include `itemId` or `id`)
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or EDIT is denied.
+     */
+    public function updateGoalItem(array $values): void
+    {
+        $itemId = (int) ($values['itemId'] ?? $values['id'] ?? 0);
+        $projectId = $this->goalRepository->getCanvasItemProjectId($itemId, self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::EDIT, $projectId);
+
+        $this->goalRepository->editCanvasItem($values);
+    }
+
+    /**
+     * Patch allowlisted columns of a goal item, authorized for EDIT against the item's real
+     * project.
+     *
+     * @param  array<string, mixed>  $params  Fields to patch (allowlisted in the repository)
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or EDIT is denied.
+     */
+    public function patchGoalItem(int $id, array $params): bool
+    {
+        $projectId = $this->goalRepository->getCanvasItemProjectId($id, self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::EDIT, $projectId);
+
+        return $this->goalRepository->patchCanvasItem($id, $params);
+    }
+
+    /**
+     * Delete a goal item, authorized for DELETE against the item's real project.
+     *
+     * @throws AuthorizationException When the item is unknown/foreign or DELETE is denied.
+     */
+    public function deleteGoalItem(int $id): void
+    {
+        $projectId = $this->goalRepository->getCanvasItemProjectId($id, self::CANVAS_TYPE);
+        if ($projectId === null) {
+            throw new AuthorizationException;
+        }
+        $this->authorize(GoalcanvasPermissions::DELETE, $projectId);
+
+        $this->goalRepository->delCanvasItem($id);
+    }
+
+    /**
+     * Poll all goals the user can access (optionally scoped to a project/board). The repository
+     * query already filters to the user's accessible projects; the dispatch gate adds the
+     * capability check.
+     *
      * @return array
      *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollGoals(?int $projectId = null, ?int $board = null)
     {
         $goals = $this->goalRepository->getAllAccountGoals($projectId, $board);
@@ -216,9 +455,9 @@ class Goalcanvas
      *
      * @api
      */
+    #[RequiresPermission(GoalcanvasPermissions::VIEW, projectIdParam: 'projectId')]
     public function pollForUpdatedGoals(?int $projectId = null, ?int $board = null): array|false
     {
-
         $goals = $this->goalRepository->getAllAccountGoals($projectId, $board);
 
         foreach ($goals as $key => $goal) {
@@ -231,7 +470,6 @@ class Goalcanvas
 
     private function prepareDatesForApiResponse($goal)
     {
-
         if (dtHelper()->isValidDateString($goal['created'])) {
             $goal['created'] = dtHelper()->parseDbDateTime($goal['created'])->toIso8601ZuluString();
         } else {
@@ -257,6 +495,5 @@ class Goalcanvas
         }
 
         return $goal;
-
     }
 }

--- a/app/Domain/Help/Services/Helper.php
+++ b/app/Domain/Help/Services/Helper.php
@@ -502,14 +502,18 @@ class Helper
         $values['status'] = 0;
         $ticketService->quickAddTicket($values);
 
-        // Create Goal
-        $goalService = app()->make(\Leantime\Domain\Goalcanvas\Services\Goalcanvas::class);
+        // Create Goal. This is a SYSTEM-orchestrated onboarding write (running in the
+        // userSignUpSuccess listener while the user's project membership is still being set
+        // up), so it goes through the REPOSITORY directly — bypassing the CREATE-authorized
+        // Goalcanvas service methods, which would otherwise 403 the brand-new user. (Same
+        // landmine pattern as Wiki's default-notebook / Ideas' default-board bootstrap.)
+        $goalRepo = app()->make(\Leantime\Domain\Goalcanvas\Repositories\Goalcanvas::class);
         $values = [
             'title' => 'My Goals',
             'author' => $userId,
             'projectId' => $projectId,
         ];
-        $currentCanvasId = $goalService->createGoalboard($values);
+        $currentCanvasId = $goalRepo->addCanvas($values);
 
         $values = [
             'description' => 'Tasks completed on time', // Metric
@@ -527,7 +531,7 @@ class Helper
             'endValue' => '80',
         ];
 
-        $goalService->createGoal($values);
+        $goalRepo->createGoal($values);
 
         $projectService->changeCurrentSessionProject($projectId);
 

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -93,6 +93,7 @@ class Install
         30510,
         30511,
         30512,
+        30513,
     ];
 
     /**
@@ -2923,6 +2924,34 @@ class Install
             Log::error('Migration 30512: '.$e->getMessage());
 
             return ['Migration 30512 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Goalcanvas (Goals)
+     * domain. Adds goals.view/create/edit/delete (all project-scoped); the standard verbs
+     * auto-grant via the existing project rules (readonly view; editor create/edit/delete;
+     * manager+ all). Table-creation-free; idempotent + additive.
+     *
+     * Flush the discovered-provider cache FIRST — an install that already ran the earlier
+     * permission migrations cached the provider list WITHOUT GoalcanvasPermissions, so seeding
+     * against that stale list would never create the goals.* keys (and every role would then be
+     * denied goal access, since currentUserCan requires the role to hold the key).
+     */
+    public function update_sql_30513(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30513: '.$e->getMessage());
+
+            return ['Migration 30513 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -40,6 +40,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('blueprints.create', 'Create', true),
             new Permission('blueprints.edit', 'Edit', true),
             new Permission('blueprints.delete', 'Delete', true),
+            new Permission('goals.view', 'View', true),
+            new Permission('goals.create', 'Create', true),
+            new Permission('goals.edit', 'Edit', true),
+            new Permission('goals.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -67,7 +71,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -88,6 +92,8 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('ideas.view', $grants);         // inherited from readonly
         $this->assertNotContains('blueprints.create', $grants); // commenter views but cannot create
         $this->assertContains('blueprints.view', $grants);      // inherited from readonly
+        $this->assertNotContains('goals.create', $grants);      // commenter views but cannot create
+        $this->assertContains('goals.view', $grants);           // inherited from readonly
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -114,6 +120,9 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('blueprints.create', $grants);
         $this->assertContains('blueprints.edit', $grants);
         $this->assertContains('blueprints.delete', $grants);
+        $this->assertContains('goals.create', $grants);
+        $this->assertContains('goals.edit', $grants);
+        $this->assertContains('goals.delete', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+

--- a/tests/Unit/app/Domain/Goalcanvas/Services/GoalcanvasServiceTest.php
+++ b/tests/Unit/app/Domain/Goalcanvas/Services/GoalcanvasServiceTest.php
@@ -2,27 +2,44 @@
 
 namespace Unit\app\Domain\Goalcanvas\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvasService;
 use Unit\TestCase;
 
 /**
- * Unit tests for the Goalcanvas service progress math: goalProgress is
- * (currentValue - startValue) / (endValue - startValue) * 100, clamped to
- * 0..100, and child-goal value aggregation for linkAndReport goals.
+ * Unit tests for the Goalcanvas service:
+ *  - progress math: goalProgress is (currentValue - startValue) / (endValue - startValue) * 100,
+ *    clamped to 0..100, and child-goal value aggregation for linkAndReport goals;
+ *  - the fail-closed by-id board/item CRUD chokepoint (every by-id op resolves the entity's real
+ *    project via the inherited resolvers, scoped to the "goalcanvas" type, and authorizes a
+ *    goals.* verb — reads soft-deny without loading, writes throw without writing).
  */
 class GoalcanvasServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
 
-    private function service(GoalcanvaRepository $repo): GoalcanvasService
+    private function allowingPermissions(): PermissionService
     {
-        return new GoalcanvasService($repo);
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
+    private function service(GoalcanvaRepository $repo, ?PermissionService $perms = null): GoalcanvasService
+    {
+        $service = new GoalcanvasService($repo);
+        $service->setPermissionService($perms ?? $this->allowingPermissions());
+
+        return $service;
     }
 
     public function test_computes_goal_progress_as_percentage_of_range(): void
     {
         $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => 9,
             'getCanvasItemsById' => fn () => [
                 ['id' => 1, 'setting' => 'linkonly', 'startValue' => 0.0, 'endValue' => 100.0, 'currentValue' => 50.0],
             ],
@@ -36,6 +53,7 @@ class GoalcanvasServiceTest extends TestCase
     public function test_clamps_progress_between_zero_and_one_hundred(): void
     {
         $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => 9,
             'getCanvasItemsById' => fn () => [
                 ['id' => 1, 'setting' => 'linkonly', 'startValue' => 0.0, 'endValue' => 100.0, 'currentValue' => 150.0],
                 ['id' => 2, 'setting' => 'linkonly', 'startValue' => 0.0, 'endValue' => 100.0, 'currentValue' => -20.0],
@@ -51,6 +69,7 @@ class GoalcanvasServiceTest extends TestCase
     public function test_zero_range_yields_zero_progress(): void
     {
         $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => 9,
             'getCanvasItemsById' => fn () => [
                 ['id' => 1, 'setting' => 'linkonly', 'startValue' => 50.0, 'endValue' => 50.0, 'currentValue' => 50.0],
             ],
@@ -66,6 +85,7 @@ class GoalcanvasServiceTest extends TestCase
         // linkonly children contribute their own currentValue; linkAndReport
         // children contribute their rolled-up childCurrentValue.
         $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => 9,
             'getCanvasItemsByKPI' => fn () => [
                 ['setting' => 'linkonly', 'currentValue' => 10.0, 'childCurrentValue' => 999.0],
                 ['setting' => 'linkAndReport', 'currentValue' => 0.0, 'childCurrentValue' => 5.0],
@@ -75,5 +95,236 @@ class GoalcanvasServiceTest extends TestCase
         $sum = $this->service($repo)->getChildGoalsForReporting(1);
 
         $this->assertEqualsWithDelta(15.0, $sum, 0.01);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fail-closed by-id board/item CRUD chokepoint.
+    // ---------------------------------------------------------------------
+
+    public function test_get_canvas_items_returns_empty_for_foreign_board_without_loading(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'getCanvasItemsById' => function () use (&$loaded) {
+                $loaded++;
+
+                return [['id' => 1]];
+            },
+        ]);
+
+        $this->assertSame([], $this->service($repo)->getCanvasItemsById(999));
+        $this->assertSame(0, $loaded, 'A foreign/unknown board must not have its goals read');
+    }
+
+    public function test_child_goal_reporting_returns_zero_for_foreign_parent(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'getCanvasItemsByKPI' => function () use (&$loaded) {
+                $loaded++;
+
+                return [];
+            },
+        ]);
+
+        $this->assertSame(0, $this->service($repo)->getChildGoalsForReporting(999));
+        $this->assertSame(0, $loaded, 'A foreign/unknown parent goal must not have its children read');
+    }
+
+    public function test_get_goal_item_soft_denies_when_view_not_permitted(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => 9,
+            'getSingleCanvasItem' => function () use (&$loaded) {
+                $loaded++;
+
+                return ['id' => 1];
+            },
+        ]);
+
+        $perms = $this->make(PermissionService::class, ['currentUserCan' => fn () => false]);
+
+        $this->assertFalse($this->service($repo, $perms)->getGoalItem(1));
+        $this->assertSame(0, $loaded, 'An unauthorized item returns false without loading (no oracle)');
+    }
+
+    public function test_update_goal_item_resolves_project_from_item_id_not_payload_canvas_id(): void
+    {
+        $resolvedItemId = null;
+        $wrote = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => function ($id) use (&$resolvedItemId) {
+                $resolvedItemId = $id;
+
+                return 9;
+            },
+            'editCanvasItem' => function () use (&$wrote) {
+                $wrote++;
+            },
+        ]);
+
+        $this->service($repo)->updateGoalItem(['itemId' => 42, 'canvasId' => 9999, 'description' => 'x']);
+
+        $this->assertSame(42, $resolvedItemId, 'Project resolved from itemId, not the payload canvasId');
+        $this->assertSame(1, $wrote);
+    }
+
+    public function test_patch_goal_item_throws_and_never_writes_for_unresolved_item(): void
+    {
+        $patched = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'patchCanvasItem' => function () use (&$patched) {
+                $patched++;
+
+                return true;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->patchGoalItem(5, ['status' => 'x']);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $patched);
+    }
+
+    public function test_delete_goal_item_throws_and_never_deletes_for_unresolved_item(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => null,
+            'delCanvasItem' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->deleteGoalItem(5);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $deleted);
+    }
+
+    public function test_create_goal_item_throws_and_never_inserts_for_unknown_board(): void
+    {
+        $inserted = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'addCanvasItem' => function () use (&$inserted) {
+                $inserted++;
+
+                return '1';
+            },
+        ]);
+
+        try {
+            $this->service($repo)->createGoalItem(['canvasId' => 9999, 'box' => 'goal']);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $inserted);
+    }
+
+    public function test_create_goal_api_throws_for_unknown_board(): void
+    {
+        $inserted = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'createGoal' => function () use (&$inserted) {
+                $inserted++;
+
+                return '1';
+            },
+        ]);
+
+        try {
+            $this->service($repo)->createGoal(['canvasId' => 9999, 'box' => 'goal']);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $inserted);
+    }
+
+    public function test_delete_goal_board_throws_for_unresolved_board(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'deleteCanvas' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->deleteGoalBoard(5);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $deleted);
+    }
+
+    public function test_update_goalboard_throws_for_unresolved_board(): void
+    {
+        $updated = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'updateCanvas' => function () use (&$updated) {
+                $updated++;
+
+                return 1;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->updateGoalboard(['id' => 5, 'title' => 'x']);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $updated);
+    }
+
+    public function test_merge_goal_board_requires_both_boards_to_resolve(): void
+    {
+        $merged = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn ($id) => $id === 1 ? 9 : null,
+            'mergeCanvas' => function () use (&$merged) {
+                $merged++;
+
+                return true;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->mergeGoalBoard(2, 1);
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $merged);
+    }
+
+    public function test_copy_goal_board_throws_when_source_unresolved(): void
+    {
+        $copied = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasProjectId' => fn () => null,
+            'copyCanvas' => function () use (&$copied) {
+                $copied++;
+
+                return 1;
+            },
+        ]);
+
+        try {
+            $this->service($repo)->copyGoalBoard(5, 7, 1, 'Copy');
+            $this->fail('Expected AuthorizationException');
+        } catch (AuthorizationException) {
+        }
+        $this->assertSame(0, $copied);
     }
 }


### PR DESCRIPTION
## What & why

**Goalcanvas** (Goals / OKRs) stores boards/items in the **shared** `zp_canvas` (type `goalcanvas`) / `zp_canvas_items` (box `goal`) tables — one id sequence across every canvas variant — and its repository `extends Blueprints`, inheriting the fail-closed project resolvers added in #3483. Its boards and items were reachable **by bare id with no project scope**, so the legacy controllers and the `@api`/RPC surface had cross-project **read & mutation IDORs**; the delete controllers used role-only `Auth::authOrRedirect`.

This continues the canvas-family rollout after Blueprints, applying the same fail-closed chokepoint pattern.

## Approach

- **Vocabulary** — new `GoalcanvasPermissions` (`goals.view/create/edit/delete`, project-scoped). Goals get their **own** vocabulary, distinct from `blueprints.*`, so a role/permission admin can grant goal access independently. Standard verbs auto-grant via the central matrix → **no matrix edit**.
- **Service** (`extends BaseService`) is the **single chokepoint** for by-id board/item CRUD. Each method resolves the entity's **real** project via the inherited `getCanvasItemProjectId`/`getCanvasProjectId` (type-scoped to `goalcanvas`) and authorizes the matching verb:
  - **reads soft-deny** (`false`/`[]`/`0`) *without loading* → no existence oracle;
  - **writes throw** `AuthorizationException` *without writing* on a `null` resolution — never falling back to the session project.
  - The **KPI roll-up** reads (`getChildGoalsForReporting`/`getChildrenbyKPI`) gate on the **parent goal's** project — the cross-project child aggregation is the intended feature. All 7 `@api` methods are gated; `createGoal` authorizes CREATE against the target board's project. `getAllAccountGoals` (the `poll*` backing) already filters by project access in SQL.
- **All 8 controllers** route by-id ops through the service and carry `#[RequiresPermission]` (legacy Frontcontroller-routed → enforced by `executeAction`). `Del*` drop the role-only `authOrRedirect`; `delComment` is bound to the gated item (`module` + `moduleId`); `ShowCanvas`/`Dashboard` validate an explicit board id against the current project's boards; the broken `editCanvasComment` call is routed to the gated `updateGoalItem` (fixes **and** secures it); fixed a latent `getStatusList`/`getRelatesList` fatal and a `$canvas[0]['title']` on a single-row return (the Goalcanvas repo's `getSingleCanvas` returns a single row, not array-of-rows).
- **Onboarding / view-time landmines** — `Helper::createDefaultProject` (the `userSignUpSuccess` listener) creates the goal board/goal via the **repository directly**, bypassing the CREATE gate (gating it would 403 the brand-new user before project membership exists). The lazy default-board auto-create on the dashboard/board view is likewise kept repo-direct so a **VIEW-only user isn't 403'd** just for opening an empty goals page — same pattern as Blueprints/Wiki/Ideas.
- **Migration** `update_sql_30513`; **dbVersion 3.5.12 → 3.5.13**.

## Tests
- 12 fail-closed `GoalcanvasService` cases (soft-deny / no-oracle, write-throws-without-writing, relocation fence, KPI-parent gate, board create/merge/copy/delete), plus the existing goal-progress math tests updated for the new authz.
- `goals.*` added to the role-matrix catalog test.
- Local: PHP lint, Pint, **PHPStan level 1**, **16 Goalcanvas + 7 role-matrix tests**; `TicketsServiceTest` (consumes the goal service) and the Blueprints suite still green.
- A 5-lens adversarial review ran before commit (verdict **SHIP**); its valid fixes (the fatal label-method typo, a docstring shape) are included. One proposed fix — gating the view-time auto-create — was **rejected** as a grant-equivalence regression (it would 403 readonly viewers) and kept repo-direct, consistent with Blueprints.

## Scope / follow-ups
**Logicmodelcanvas, `Api\Canvas`, and `Connector`** still consume the shared canvas repo and get their own focused passes next (they reuse these resolvers). Note: the private `StrategyPro`/`Copilot` plugins consume this service and will now enforce `goals.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)