### PR TITLE
security(canvas): gate the legacy Canvas-base controllers (Logicmodelcanvas) + Api\Canvas

### DIFF
--- a/app/Domain/Api/Controllers/Canvas.php
+++ b/app/Domain/Api/Controllers/Canvas.php
@@ -6,11 +6,10 @@
 
 namespace Leantime\Domain\Api\Controllers;
 
-use Closure;
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -23,27 +22,14 @@ class Canvas extends Controller
      */
     protected const CANVAS_NAME = '??';
 
-    private ProjectRepository $projects;
+    private BlueprintsService $blueprintsService;
 
     /**
-     * @var Closure|mixed|object|null
+     * init - initialize private variables
      */
-    private mixed $canvasRepo;
-
-    /**
-     * constructor - initialize private variables
-     *
-     *
-     *
-     * @throws BindingResolutionException
-     */
-    public function init(ProjectRepository $projects): void
+    public function init(): void
     {
-        // @TODO: project are never used in this class?
-        $this->projects = $projects;
-        $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
-        $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
-        $this->canvasRepo = app()->make($repoName);
+        $this->blueprintsService = app()->make(BlueprintsService::class);
     }
 
     /**
@@ -65,33 +51,18 @@ class Canvas extends Controller
     /**
      * patch - handle patch requests with authorization check
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function patch(array $params): Response
     {
         if (! isset($params['id'])) {
             return $this->tpl->displayJson(['status' => 'failure'], 400);
         }
 
-        // Verify the canvas item exists and user has access to its project
-        $canvasItem = $this->canvasRepo->getSingleCanvasItem($params['id']);
-        if ($canvasItem === false) {
-            return $this->tpl->displayJson(['status' => 'not found'], 404);
-        }
-
-        $canvas = $this->canvasRepo->getSingleCanvas($canvasItem['canvasId']);
-        if ($canvas === false || empty($canvas)) {
-            return $this->tpl->displayJson(['status' => 'not found'], 404);
-        }
-
-        $projectId = $canvas[0]['projectId'] ?? null;
-        if ($projectId === null || ! $this->projects->isUserAssignedToProject(session('userdata.id'), $projectId)) {
-            return $this->tpl->displayJson(['status' => 'unauthorized'], 403);
-        }
-
-        $result = $this->canvasRepo->patchCanvasItem($params['id'], $params);
-
-        if ($result === false) {
-            // patchCanvasItem returns false when no whitelisted columns are present
-            // or no rows were affected — this is a client error, not a server error
+        // The service resolves the item's REAL project and authorizes EDIT against it (throwing
+        // 403 for a missing/foreign item or an insufficient role) before patching — replacing
+        // the previous membership-only check with the permission framework. A false return means
+        // no allowlisted columns were present (a client error, not a denial).
+        if ($this->blueprintsService->patchCanvasItem((int) $params['id'], $params, static::CANVAS_NAME.'canvas') === false) {
             return $this->tpl->displayJson(['status' => 'no valid fields to update'], 400);
         }
 

--- a/app/Domain/Api/Controllers/Goalcanvas.php
+++ b/app/Domain/Api/Controllers/Goalcanvas.php
@@ -1,12 +1,39 @@
 <?php
 
 /**
- * - smcanvas class - Controller API
+ * Goalcanvas class - Controller API
  */
 
 namespace Leantime\Domain\Api\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
+use Symfony\Component\HttpFoundation\Response;
+
 class Goalcanvas extends Canvas
 {
     protected const CANVAS_NAME = 'goal';
+
+    /**
+     * patch - inline goal-item update.
+     *
+     * Overrides the generic Canvas base so goal items are authorized with goals.* (the Goals
+     * vocabulary) rather than the generic blueprints.* — the Goalcanvas service resolves the
+     * item's real project and authorizes goals.edit before patching (throws 403 for a
+     * missing/foreign item or insufficient role; false = no allowlisted columns).
+     */
+    #[RequiresPermission(GoalcanvasPermissions::EDIT, entityScoped: true)]
+    public function patch(array $params): Response
+    {
+        if (! isset($params['id'])) {
+            return $this->tpl->displayJson(['status' => 'failure'], 400);
+        }
+
+        if (app()->make(GoalcanvaService::class)->patchGoalItem((int) $params['id'], $params) === false) {
+            return $this->tpl->displayJson(['status' => 'no valid fields to update'], 400);
+        }
+
+        return $this->tpl->displayJson(['status' => 'ok']);
+    }
 }

--- a/app/Domain/Canvas/Controllers/BoardDialog.php
+++ b/app/Domain/Canvas/Controllers/BoardDialog.php
@@ -3,9 +3,12 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Mailer as MailerCore;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepository;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +25,8 @@ class BoardDialog extends Controller
 
     private ProjectService $projectService;
 
+    private BlueprintsService $blueprintsService;
+
     private object $canvasRepo;
 
     /**
@@ -30,6 +35,7 @@ class BoardDialog extends Controller
     public function init(ProjectService $projectService): void
     {
         $this->projectService = $projectService;
+        $this->blueprintsService = app()->make(BlueprintsService::class);
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
         $this->canvasRepo = app()->make($repoName);
@@ -40,16 +46,21 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(array $params): Response
     {
         $currentCanvasId = '';
         $canvasTitle = '';
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            $singleCanvas = $this->canvasRepo->getSingleCanvas($currentCanvasId);
-            $canvasTitle = $singleCanvas[0]['title'] ?? '';
-            session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
+            // getBoard authorizes VIEW against the board's real project; false = missing/foreign/
+            // unauthorized — don't expose the title or switch the active board (no session poison).
+            $singleCanvas = $this->blueprintsService->getBoard((int) $params['id'], static::CANVAS_NAME.'canvas');
+            if ($singleCanvas !== false) {
+                $currentCanvasId = (int) $params['id'];
+                $canvasTitle = $singleCanvas[0]['title'] ?? '';
+                session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
+            }
         }
 
         $this->assignTemplateVars($currentCanvasId, $canvasTitle);
@@ -66,16 +77,19 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post(array $params): Response
     {
         $currentCanvasId = '';
         $canvasTitle = '';
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            $singleCanvas = $this->canvasRepo->getSingleCanvas($currentCanvasId);
-            $canvasTitle = $singleCanvas[0]['title'] ?? '';
-            session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
+            $singleCanvas = $this->blueprintsService->getBoard((int) $params['id'], static::CANVAS_NAME.'canvas');
+            if ($singleCanvas !== false) {
+                $currentCanvasId = (int) $params['id'];
+                $canvasTitle = $singleCanvas[0]['title'] ?? '';
+                session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
+            }
         }
 
         if (isset($_POST['newCanvas'])) {
@@ -123,7 +137,8 @@ class BoardDialog extends Controller
             'author' => session('userdata.id'),
             'projectId' => session('currentProject'),
         ];
-        $currentCanvasId = $this->canvasRepo->addCanvas($values);
+        // createBoard authorizes CREATE against the target (current) project.
+        $currentCanvasId = $this->blueprintsService->createBoard($values, static::CANVAS_NAME.'canvas');
 
         $this->notifyBoardCreated($values['title']);
 
@@ -150,12 +165,12 @@ class BoardDialog extends Controller
             return null;
         }
 
-        $values = ['title' => $_POST['canvastitle'], 'id' => $currentCanvasId];
-        $this->canvasRepo->updateCanvas($values);
+        // renameBoard authorizes EDIT against the board's real project.
+        $this->blueprintsService->renameBoard($currentCanvasId, $_POST['canvastitle'], static::CANVAS_NAME.'canvas');
 
         $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
-        return Frontcontroller::redirect(BASE_URL.'/'.static::CANVAS_NAME.'canvas/boardDialog/'.$values['id']);
+        return Frontcontroller::redirect(BASE_URL.'/'.static::CANVAS_NAME.'canvas/boardDialog/'.$currentCanvasId);
     }
 
     /**

--- a/app/Domain/Canvas/Controllers/DelCanvas.php
+++ b/app/Domain/Canvas/Controllers/DelCanvas.php
@@ -3,10 +3,11 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,6 +22,8 @@ class DelCanvas extends Controller
 
     private mixed $canvasRepo;
 
+    private BlueprintsService $blueprintsService;
+
     /**
      * Initializes dependencies.
      *
@@ -30,6 +33,7 @@ class DelCanvas extends Controller
      */
     public function init()
     {
+        $this->blueprintsService = app()->make(BlueprintsService::class);
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
         $this->canvasRepo = app()->make($repoName);
@@ -40,10 +44,9 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas.delCanvas');
     }
 
@@ -52,21 +55,21 @@ class DelCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->canvasRepo->deleteCanvas($id);
+            // The service resolves the board's REAL project and authorizes DELETE against it
+            // (throwing for a missing/foreign board) — closing the by-id board-delete IDOR the
+            // previous role-only Auth::authOrRedirect left open.
+            $this->blueprintsService->deleteBoard($id, static::CANVAS_NAME.'canvas');
 
             $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
             session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $allCanvas[0]['id'] ?? -1]);
 
             $this->tpl->setNotification($this->language->__('notification.board_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvas_deleted');
-
-            $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
             if (! $allCanvas || count($allCanvas) == 0) {
                 return Frontcontroller::redirect(BASE_URL.'/blueprints/showBoards');

--- a/app/Domain/Canvas/Controllers/DelCanvasItem.php
+++ b/app/Domain/Canvas/Controllers/DelCanvasItem.php
@@ -3,10 +3,11 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,11 +22,14 @@ class DelCanvasItem extends Controller
 
     private mixed $canvasRepo;
 
+    private BlueprintsService $blueprintsService;
+
     /**
      * Initializes dependencies.
      */
     public function init(): void
     {
+        $this->blueprintsService = app()->make(BlueprintsService::class);
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
         $this->canvasRepo = app()->make($repoName);
@@ -36,10 +40,9 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas.delCanvasItem');
     }
 
@@ -48,14 +51,15 @@ class DelCanvasItem extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $id = (int) ($params['id'] ?? $_GET['id'] ?? 0);
 
         if (isset($_POST['del']) && $id > 0) {
-            $this->canvasRepo->delCanvasItem($id);
+            // The service resolves the item's REAL project and authorizes DELETE against it
+            // (throwing for a missing/foreign item) — closing the by-id item-delete IDOR.
+            $this->blueprintsService->deleteCanvasItem($id, static::CANVAS_NAME.'canvas');
 
             $this->tpl->setNotification($this->language->__('notification.element_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvasitem_deleted');
 

--- a/app/Domain/Canvas/Controllers/EditCanvasComment.php
+++ b/app/Domain/Canvas/Controllers/EditCanvasComment.php
@@ -7,8 +7,11 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -33,6 +36,8 @@ class EditCanvasComment extends Controller
 
     private ProjectService $projectService;
 
+    private BlueprintsService $blueprintsService;
+
     private object $canvasRepo;
 
     /**
@@ -50,6 +55,7 @@ class EditCanvasComment extends Controller
         $this->sprintService = $sprintService;
         $this->ticketService = $ticketService;
         $this->projectService = $projectService;
+        $this->blueprintsService = app()->make(BlueprintsService::class);
 
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
@@ -59,19 +65,30 @@ class EditCanvasComment extends Controller
     /**
      * get - handle get requests
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get($params)
     {
+        $canvasType = static::CANVAS_NAME.'canvas';
 
         $canvasTypes = $this->canvasRepo->getCanvasTypes();
         if (isset($params['id'])) {
-            // Delete comment
-            if (isset($params['delComment']) === true) {
-                $commentId = (int) ($params['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvascomment_deleted');
+            // Resolve + VIEW-authorize the item against its real project first.
+            $canvasItem = $this->blueprintsService->getCanvasItem((int) $params['id'], $canvasType);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
             }
 
-            $canvasItem = $this->canvasRepo->getSingleCanvasItem($params['id']);
+            // Delete comment — only when it belongs to THIS gated item (module + moduleId).
+            if (isset($params['delComment']) === true) {
+                $commentId = (int) ($params['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === static::CANVAS_NAME.'canvasitem'
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvascomment_deleted');
+                }
+            }
 
             $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvasitem', $canvasItem['id']);
             $this->tpl->assign('numComments', $this->commentsRepo->countComments(static::CANVAS_NAME.'canvasitem', $canvasItem['id']));
@@ -86,8 +103,8 @@ class EditCanvasComment extends Controller
                 'id' => '',
                 'box' => $type,
                 'description' => '',
-                'status' => array_key_first($this->canvasRepo->getStatusList()),
-                'relates' => array_key_first($this->canvasRepo->GetRelatesList()),
+                'status' => array_key_first($this->canvasRepo->getStatusLabels()),
+                'relates' => array_key_first($this->canvasRepo->getRelatesLabels()),
                 'assumptions' => '',
                 'data' => '',
                 'conclusion' => '',
@@ -109,8 +126,10 @@ class EditCanvasComment extends Controller
     /**
      * post - handle post requests
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post($params)
     {
+        $canvasType = static::CANVAS_NAME.'canvas';
 
         if (isset($params['changeItem'])) {
             if (isset($params['itemId']) && $params['itemId'] != '') {
@@ -133,7 +152,8 @@ class EditCanvasComment extends Controller
                         'dependentMilstone' => '',
                     ];
 
-                    $this->canvasRepo->editCanvasComment($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there.
+                    $this->blueprintsService->updateCanvasItem($canvasItem, $canvasType);
 
                     $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvasitem', $params['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -183,7 +203,8 @@ class EditCanvasComment extends Controller
                         'canvasId' => $currentCanvasId,
                     ];
 
-                    $id = $this->canvasRepo->addCanvasItem($canvasItem);
+                    // Resolves the target board's real project from canvasId and authorizes CREATE.
+                    $id = $this->blueprintsService->createCanvasItem($canvasItem, $canvasType);
 
                     $canvasItem['id'] = $id;
 
@@ -193,7 +214,7 @@ class EditCanvasComment extends Controller
 
                     $notification = app()->make(NotificationModel::class);
                     $notification->url = [
-                        'url' => BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.(int) $params['itemId'],
+                        'url' => BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.(int) ($params['itemId'] ?? $id),
                         'text' => $this->language->__('email_notifications.canvas_item_update_cta'),
                     ];
                     $notification->entity = $canvasItem;
@@ -220,11 +241,18 @@ class EditCanvasComment extends Controller
         }
 
         if (isset($params['comment']) === true) {
+            $itemId = (int) ($_GET['id'] ?? 0);
+
+            // Only allow commenting on an item the user can view in their project.
+            if (! $this->blueprintsService->getCanvasItem($itemId, $canvasType)) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $params['text'],
                 'date' => date('Y-m-d H:i:s'),
                 'userId' => (session('userdata.id')),
-                'moduleId' => $_GET['id'],
+                'moduleId' => $itemId,
                 'commentParent' => ($params['father']),
             ];
 
@@ -233,7 +261,7 @@ class EditCanvasComment extends Controller
 
             $notification = app()->make(NotificationModel::class);
             $notification->url = [
-                'url' => BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.(int) $_GET['id'],
+                'url' => BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.$itemId,
                 'text' => $this->language->__('email_notifications.canvas_item_update_cta'),
             ];
             $notification->entity = $values;
@@ -249,12 +277,19 @@ class EditCanvasComment extends Controller
 
             $this->projectService->notifyProjectUsers($notification);
 
-            return Frontcontroller::redirect(BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.$_GET['id']);
+            return Frontcontroller::redirect(BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'/editCanvasComment/'.$itemId);
         }
 
-        $this->tpl->assign('id', $_GET['id']);
+        // Fallback re-display: VIEW-authorize the item; false = missing/foreign/unauthorized -> 404.
+        $itemId = (int) ($_GET['id'] ?? 0);
+        $canvasItem = $this->blueprintsService->getCanvasItem($itemId, $canvasType);
+        if ($itemId > 0 && ! $canvasItem) {
+            return $this->tpl->displayPartial('errors.error404');
+        }
+
+        $this->tpl->assign('id', $itemId);
         $this->tpl->assign('canvasTypes', $this->canvasRepo->getCanvasTypes());
-        $this->tpl->assign('canvasItem', $this->canvasRepo->getSingleCanvasItem($_GET['id']));
+        $this->tpl->assign('canvasItem', $canvasItem ?: []);
 
         return $this->tpl->displayPartial(static::CANVAS_NAME.'canvas.canvasComment');
     }

--- a/app/Domain/Canvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Canvas/Controllers/EditCanvasItem.php
@@ -3,18 +3,26 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 
 /**
- * editCanvasItem class - Generic canvas controller / Edit Canvas Item
+ * editCanvasItem class - Generic canvas controller / Edit Canvas Item.
+ *
+ * By-id canvas item access routes through the Blueprints service (scoped to this canvas type,
+ * static::CANVAS_NAME.'canvas') so it is authorized against the item's real project; the
+ * per-variant repo is used only for label/config reads. The base canvas type ('??canvas') has
+ * no data — these controllers are reached via subclasses (e.g. Logicmodelcanvas).
  */
 class EditCanvasItem extends Controller
 {
@@ -31,6 +39,8 @@ class EditCanvasItem extends Controller
 
     private CommentRepository $commentsRepo;
 
+    private BlueprintsService $blueprintsService;
+
     private object $canvasRepo;
 
     /**
@@ -44,6 +54,7 @@ class EditCanvasItem extends Controller
         $this->ticketService = app()->make(TicketService::class);
         $this->projectService = app()->make(ProjectService::class);
         $this->commentsRepo = app()->make(CommentRepository::class);
+        $this->blueprintsService = app()->make(BlueprintsService::class);
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
         $this->canvasRepo = app()->make($repoName);
@@ -54,39 +65,45 @@ class EditCanvasItem extends Controller
     /**
      * get - handle get requests
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get($params)
     {
+        $canvasType = static::CANVAS_NAME.'canvas';
+        $commentModule = static::CANVAS_NAME.'canvas'.'item';
+
         if (isset($params['id'])) {
-            // Delete comment
-            if (isset($params['delComment'])) {
-                $commentId = (int) ($params['delComment']);
-                $this->commentsRepo->deleteComment($commentId);
-                $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+            // Resolve + VIEW-authorize the item against its real project BEFORE any mutation.
+            $canvasItem = $this->blueprintsService->getCanvasItem((int) $params['id'], $canvasType);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
             }
 
-            // Delete milestone relationship
+            // Delete comment — only when it belongs to THIS gated item (module + moduleId);
+            // deleteComment() filters on the comment id alone, so the bind prevents deleting a
+            // foreign item's / project's comment.
+            if (isset($params['delComment'])) {
+                $commentId = (int) ($params['delComment']);
+                $comment = $this->commentsRepo->getComment($commentId);
+                if ($comment !== false
+                    && (string) $comment['module'] === $commentModule
+                    && (int) $comment['moduleId'] === (int) $canvasItem['id']) {
+                    $this->commentsRepo->deleteComment($commentId);
+                    $this->tpl->setNotification($this->language->__('notifications.comment_deleted'), 'success');
+                }
+            }
+
+            // Delete milestone relationship — an EDIT, authorized by the service.
             if (isset($params['removeMilestone'])) {
-                $this->canvasRepo->patchCanvasItem($params['id'], ['milestoneId' => '']);
+                $this->blueprintsService->patchCanvasItem((int) $params['id'], ['milestoneId' => ''], $canvasType);
+                $canvasItem = $this->blueprintsService->getCanvasItem((int) $params['id'], $canvasType);
                 $this->tpl->setNotification($this->language->__('notifications.milestone_detached'), 'success');
             }
 
-            $canvasItem = $this->canvasRepo->getSingleCanvasItem($params['id']);
-
-            if ($canvasItem) {
-                $comments = $this->commentsRepo->getComments(
-                    static::CANVAS_NAME.'canvas'.'item',
-                    $canvasItem['id']
-                );
-                $this->tpl->assign(
-                    'numComments',
-                    $this->commentsRepo->countComments(
-                        static::CANVAS_NAME.'canvas'.'item',
-                        $canvasItem['id']
-                    )
-                );
-            } else {
-                return $this->tpl->displayPartial('errors.error404');
-            }
+            $comments = $this->commentsRepo->getComments($commentModule, $canvasItem['id']);
+            $this->tpl->assign(
+                'numComments',
+                $this->commentsRepo->countComments($commentModule, $canvasItem['id'])
+            );
         } else {
             if (isset($params['type'])) {
                 $type = strip_tags($params['type']);
@@ -128,8 +145,10 @@ class EditCanvasItem extends Controller
     /**
      * post - handle post requests
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post($params)
     {
+        $canvasType = static::CANVAS_NAME.'canvas';
 
         if (isset($params['changeItem'])) {
 
@@ -169,7 +188,8 @@ class EditCanvasItem extends Controller
                         $canvasItem['milestoneId'] = $params['existingMilestone'];
                     }
 
-                    $this->canvasRepo->editCanvasItem($canvasItem);
+                    // Resolves the item's real project from itemId and authorizes EDIT there.
+                    $this->blueprintsService->updateCanvasItem($canvasItem, $canvasType);
 
                     $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvas'.'item', $params['itemId']);
                     $this->tpl->assign('numComments', $this->commentsRepo->countComments(
@@ -228,13 +248,14 @@ class EditCanvasItem extends Controller
                         'canvasId' => $currentCanvasId,
                     ];
 
-                    $id = $this->canvasRepo->addCanvasItem($canvasItem);
+                    // Resolves the target board's real project from canvasId and authorizes CREATE.
+                    $id = $this->blueprintsService->createCanvasItem($canvasItem, $canvasType);
                     $canvasTypes = $this->canvasRepo->getCanvasTypes();
 
                     $this->tpl->setNotification($canvasTypes[$params['box']]['title'].' successfully created', 'success', ''.$params['box'].'_item_created');
 
                     $subject = $this->language->__('email_notifications.canvas_board_item_created');
-                    $actual_link = BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'#/editCanvasItem/'.(int) $params['itemId'];
+                    $actual_link = BASE_URL.'/'.static::CANVAS_NAME.'canvas'.'#/editCanvasItem/'.(int) ($params['itemId'] ?? $id);
                     $message = sprintf(
                         $this->language->__('email_notifications.canvas_item_created_message'),
                         session('userdata.name'),
@@ -273,6 +294,12 @@ class EditCanvasItem extends Controller
 
         if (isset($params['comment']) && isset($params['id'])) {
             $itemId = (int) $params['id'];
+
+            // Only allow commenting on an item the user can view in their project.
+            if (! $this->blueprintsService->getCanvasItem($itemId, $canvasType)) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $values = [
                 'text' => $params['text'],
                 'date' => date('Y-m-d H:i:s'),
@@ -318,8 +345,13 @@ class EditCanvasItem extends Controller
         $this->tpl->assign('dataLabels', $this->canvasRepo->getDataLabels());
         if (isset($params['id'])) {
             $canvasItemId = (int) $params['id'];
+            // VIEW-authorize before re-displaying; false = missing/foreign/unauthorized -> 404.
+            $canvasItem = $this->blueprintsService->getCanvasItem($canvasItemId, $canvasType);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
             $comments = $this->commentsRepo->getComments(static::CANVAS_NAME.'canvas'.'item', $canvasItemId);
-            $this->tpl->assign('canvasItem', $this->canvasRepo->getSingleCanvasItem($canvasItemId));
+            $this->tpl->assign('canvasItem', $canvasItem);
         } else {
             $value = [
                 'id' => '',

--- a/app/Domain/Canvas/Controllers/Export.php
+++ b/app/Domain/Canvas/Controllers/Export.php
@@ -5,9 +5,12 @@ namespace Leantime\Domain\Canvas\Controllers;
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,6 +32,8 @@ class Export extends Controller
 
     protected mixed $canvasRepo;
 
+    protected BlueprintsService $blueprintsService;
+
     protected array $canvasTypes;
 
     protected array $statusLabels;
@@ -46,6 +51,7 @@ class Export extends Controller
     ): void {
         $this->config = $config;
         $this->language = $language;
+        $this->blueprintsService = app()->make(BlueprintsService::class);
 
         $canvasName = Str::studly(static::CANVAS_NAME).static::CANVAS_TYPE;
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
@@ -62,6 +68,7 @@ class Export extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
     public function get(array $params): Response
     {
         $canvasId = (int) ($params['id'] ?? $_GET['id'] ?? 0);
@@ -97,11 +104,13 @@ class Export extends Controller
      */
     protected function export(int $id): string
     {
-        $canvasAry = $this->canvasRepo->getSingleCanvas($id);
+        // getBoard authorizes VIEW against the board's real project and returns false for a
+        // missing/foreign/unauthorized board (export is reachable by arbitrary board id).
+        $canvasAry = $this->blueprintsService->getBoard($id, static::CANVAS_NAME.static::CANVAS_TYPE);
         ! empty($canvasAry) || throw new Exception("Cannot find canvas with id '$id'");
 
         $projectId = $canvasAry[0]['projectId'];
-        $recordsAry = $this->canvasRepo->getCanvasItemsById($id);
+        $recordsAry = $this->blueprintsService->getBoardItems($id, static::CANVAS_NAME.static::CANVAS_TYPE, static::CANVAS_NAME.'canvasitem');
 
         $projectService = app()->make(ProjectService::class);
         $projectAry = $projectService->getProject($projectId);

--- a/app/Domain/Canvas/Controllers/ShowCanvas.php
+++ b/app/Domain/Canvas/Controllers/ShowCanvas.php
@@ -3,9 +3,12 @@
 namespace Leantime\Domain\Canvas\Controllers;
 
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Mailer as MailerCore;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Canvas\Services\Canvas as CanvaService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepository;
@@ -20,6 +23,8 @@ class ShowCanvas extends Controller
 
     private ProjectService $projectService;
 
+    private BlueprintsService $blueprintsService;
+
     private object $canvasRepo;
 
     /**
@@ -28,6 +33,7 @@ class ShowCanvas extends Controller
     public function init(ProjectService $projectService): void
     {
         $this->projectService = $projectService;
+        $this->blueprintsService = app()->make(BlueprintsService::class);
         $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
         $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
         $this->canvasRepo = app()->make($repoName);
@@ -38,6 +44,7 @@ class ShowCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::VIEW)]
     public function get(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -64,6 +71,7 @@ class ShowCanvas extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT)]
     public function post(array $params): Response
     {
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
@@ -160,8 +168,15 @@ class ShowCanvas extends Controller
         }
 
         if (isset($params['id'])) {
-            $currentCanvasId = (int) $params['id'];
-            session([$sessionKey => $currentCanvasId]);
+            // Only honor an explicit board id that belongs to the CURRENT project's boards
+            // ($allCanvas is project-scoped). A foreign/unknown id must not become the active
+            // board — otherwise assignTemplateVars would read another project's items.
+            $requestedId = (int) $params['id'];
+            $projectBoardIds = array_map(static fn ($row) => (int) $row['id'], $allCanvas);
+            if (in_array($requestedId, $projectBoardIds, true)) {
+                $currentCanvasId = $requestedId;
+                session([$sessionKey => $currentCanvasId]);
+            }
         }
 
         return $currentCanvasId;
@@ -189,7 +204,8 @@ class ShowCanvas extends Controller
             'author' => session('userdata.id'),
             'projectId' => session('currentProject'),
         ];
-        $currentCanvasId = $this->canvasRepo->addCanvas($values);
+        // createBoard authorizes CREATE against the target (current) project.
+        $currentCanvasId = $this->blueprintsService->createBoard($values, static::CANVAS_NAME.'canvas');
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
         $this->notifyBoardCreated($values['title'], 'notification.board_created', 'email_notifications.canvas_created_message');
@@ -217,8 +233,8 @@ class ShowCanvas extends Controller
             return null;
         }
 
-        $values = ['title' => $_POST['canvastitle'], 'id' => $currentCanvasId];
-        $currentCanvasId = $this->canvasRepo->updateCanvas($values);
+        // renameBoard authorizes EDIT against the board's real project.
+        $currentCanvasId = $this->blueprintsService->renameBoard($currentCanvasId, $_POST['canvastitle'], static::CANVAS_NAME.'canvas');
 
         $this->tpl->setNotification($this->language->__('notification.board_edited'), 'success');
 
@@ -242,11 +258,13 @@ class ShowCanvas extends Controller
             return null;
         }
 
-        $currentCanvasId = $this->canvasRepo->copyCanvas(
-            session('currentProject'),
+        // copyBoard authorizes VIEW on the source board's project and CREATE on the target.
+        $currentCanvasId = $this->blueprintsService->copyBoard(
             $currentCanvasId,
-            session('userdata.id'),
-            $_POST['canvastitle']
+            (int) session('currentProject'),
+            (int) session('userdata.id'),
+            $_POST['canvastitle'],
+            static::CANVAS_NAME.'canvas'
         );
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
 
@@ -267,7 +285,8 @@ class ShowCanvas extends Controller
             return null;
         }
 
-        $status = $this->canvasRepo->mergeCanvas($currentCanvasId, $_POST['canvasid']);
+        // mergeBoard authorizes EDIT on the target board's project and VIEW on the source's.
+        $status = $this->blueprintsService->mergeBoard($currentCanvasId, (int) $_POST['canvasid'], static::CANVAS_NAME.'canvas');
 
         if ($status) {
             $this->tpl->setNotification($this->language->__('notification.board_merged'), 'success');
@@ -316,9 +335,9 @@ class ShowCanvas extends Controller
         $allCanvas = $this->canvasRepo->getAllCanvas(session('currentProject'));
         session(['current'.strtoupper(static::CANVAS_NAME).'Canvas' => $currentCanvasId]);
 
-        $canvas = $this->canvasRepo->getSingleCanvas($currentCanvasId);
+        $canvas = $this->blueprintsService->getBoard($currentCanvasId, static::CANVAS_NAME.'canvas');
         $this->notifyBoardCreated(
-            strip_tags($canvas[0]['title']),
+            strip_tags($canvas !== false ? ($canvas[0]['title'] ?? '') : ''),
             'notification.board_imported',
             'email_notifications.canvas_imported_message'
         );
@@ -372,7 +391,8 @@ class ShowCanvas extends Controller
         $this->tpl->assign('dataLabels', $this->canvasRepo->getDataLabels());
         $this->tpl->assign('disclaimer', $this->canvasRepo->getDisclaimer());
         $this->tpl->assign('allCanvas', $allCanvas);
-        $this->tpl->assign('canvasItems', $this->canvasRepo->getCanvasItemsById($currentCanvasId));
+        // getBoardItems authorizes VIEW against the board's real project; [] for foreign/unknown.
+        $this->tpl->assign('canvasItems', $this->blueprintsService->getBoardItems($currentCanvasId, static::CANVAS_NAME.'canvas', static::CANVAS_NAME.'canvasitem'));
         $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
     }
 }

--- a/app/Domain/Logicmodelcanvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Logicmodelcanvas/Controllers/EditCanvasItem.php
@@ -6,7 +6,9 @@
 
 namespace Leantime\Domain\Logicmodelcanvas\Controllers;
 
-use Leantime\Domain\Logicmodelcanvas\Repositories\Logicmodelcanvas as LogicmodelcanvasRepository;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
+use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 
 class EditCanvasItem extends \Leantime\Domain\Canvas\Controllers\EditCanvasItem
 {
@@ -15,14 +17,18 @@ class EditCanvasItem extends \Leantime\Domain\Canvas\Controllers\EditCanvasItem
     /**
      * Persist the Stage (box) and Priority (impact) selects on save.
      *
-     * The shared Canvas save path (parent::post → repo::editCanvasItem) never
+     * The shared Canvas save path (parent::post → service::updateCanvasItem) never
      * writes `box` and does not forward `impact`, so without this the Stage
      * dropdown would be a no-op and saving would reset Priority. Patch both
      * after the base save for existing items; new items already receive their
-     * box on insert via addCanvasItem.
+     * box on insert via the create path.
+     *
+     * The base post() already EDIT-authorizes the item against its real project; the extra
+     * patch is routed through the same project-authorized service method for consistency.
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
     public function post($params)
     {
         $response = parent::post($params);
@@ -43,8 +49,8 @@ class EditCanvasItem extends \Leantime\Domain\Canvas\Controllers\EditCanvasItem
             }
 
             if ($patch !== []) {
-                app()->make(LogicmodelcanvasRepository::class)
-                    ->patchCanvasItem((int) $params['itemId'], $patch);
+                app()->make(BlueprintsService::class)
+                    ->patchCanvasItem((int) $params['itemId'], $patch, static::CANVAS_NAME.'canvas');
             }
         }
 


### PR DESCRIPTION
## What & why

Finishes the canvas-family permission rollout (after Blueprints #3483 and Goalcanvas #3485). The legacy **`Canvas\Controllers\*` base controllers** are the real controllers behind **Logicmodelcanvas** — every Logicmodelcanvas controller just `extends` them and overrides `CANVAS_NAME = 'logicmodel'`. They were reachable **by bare id with no project scope** (cross-project read & mutation IDORs), and the delete controllers used role-only `Auth::authOrRedirect`. The deprecated `Api\Controllers\Canvas` REST patch (live via `Api\Goalcanvas`) had a membership-only check but no permission granularity.

## Approach

- **All 7 Canvas base controllers** (`ShowCanvas`, `EditCanvasItem`, `EditCanvasComment`, `BoardDialog`, `DelCanvas`, `DelCanvasItem`, `Export`) route by-id board/item ops through the already-merged **Blueprints service**, passing the canvas type `static::CANVAS_NAME.'canvas'` (e.g. `logicmodelcanvas` via late static binding). Each op resolves the entity's real project (type-scoped) and authorizes a `blueprints.*` verb — **reads soft-deny** (`false`/`[]`) without loading, **writes throw** without writing. The per-variant repo is used only for labels/config + the currentProject board list.
- **Attribute inheritance:** the `#[RequiresPermission]` attributes on the base methods are inherited by the Logicmodelcanvas subclasses — verified the enforcer reads them via `ReflectionMethod` on the inherited method. `Logicmodelcanvas\EditCanvasItem` overrides `post()`, so it carries its own attribute and routes its extra box/impact patch through the service too.
- `delComment` bound to the gated item (`module` + `moduleId`); `ShowCanvas` page `get`/`post` use real **non-`entityScoped`** session-project gates (`blueprints.view`/`edit`) while the item/board-by-id controllers are `entityScoped` + self-authorize; the view-time default-board auto-create stays **repo-direct** so a VIEW-only user isn't 403'd opening an empty canvas. Also fixed a dead `getStatusList`/`getRelatesList` fatal, the broken `editCanvasComment` call (→ gated `updateCanvasItem`), and a couple of pre-existing notification-URL / fallback-render robustness bugs.
- **`Api\Controllers\Canvas::patch`** routes through the EDIT-authorized service; **`Api\Controllers\Goalcanvas`** overrides `patch()` to authorize **`goals.edit`** via the Goalcanvas service (the items are goal items — keeps the `goals.*` vocabulary, avoiding a grant-equivalence regression for custom roles). Dropped the now-unused `$projects`/`$canvasRepo` from the `Api\Canvas` base.

**No migration / dbVersion bump** — reuses the `blueprints.*` (and `goals.*`) vocab already synced by the Blueprints/Goalcanvas migrations.

## Tests / verification
- PHP lint, Pint, **PHPStan level 1**, an attribute-inheritance reflection check, and the Blueprints unit suite — all green. (No new service logic — all by-id ops delegate to the already-tested Blueprints/Goalcanvas services; controllers aren't unit-tested in this codebase.)
- A 5-lens adversarial review ran before commit (verdict **FIX FIRST** → all addressed: the `Api\Goalcanvas` `goals.edit` override, fallback-render 404s, notification-URL/`$_GET` hygiene; its synthesis agent was read-only this time).

## Scope / follow-ups
This completes the canvas family (Blueprints + Goalcanvas + Logicmodelcanvas/Canvas + `Api\Canvas`). **`Connector`** (a system importer that writes canvas/idea items repo-direct) is left as-is — unaffected by these changes; its own import-authz is a separate Connector-domain concern. Remaining permission-rollout domains: **Timesheets → Files → Reports → Calendar → Projects (last)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)