### PR TITLE
fix(helm): correct session expiration units in Helm chart (fixes #3378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Full multi-collaborator support for task assignment. Tasks can now have multiple
 - **MarketplacePlugin Nullable Properties** — Made `MarketplacePlugin` model properties nullable for PHP 8.x strict type compatibility (#3356)
 - **Secondary Color Case Sensitivity** — Fixed case sensitivity issue in the secondary color setting (#3348)
 - **Referrer-Policy Header Syntax** — Fixed syntax error in the Referrer-Policy header assignment (#3347)
+- **Helm Chart Session Expiration Units** — Fixed `app.session.expiration` in `helm/values.yaml` defaulting to `28800` (seconds) while the application expects minutes (matching `LEAN_SESSION_EXPIRATION` and Laravel's `session.lifetime`); the default is now `480` minutes (8 hours) and the value is explicitly documented as minutes. Also clarified the unit in `config/sample.env` and `app/Core/Configuration/laravelConfig.php` so future contributors can't re-introduce the same mismatch (#3378)
 
 ## Localization
 - Added Arabic (ar-SA) language support (#3370)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ We use GitHub to host code, track issues and feature requests, and accept pull r
 2. Add/update tests for any new features
 3. Update documentation as needed
 4. Ensure all tests pass locally
-5. Run code style checks:
+5. Run code style checks (the project's `make` targets are `test-code-style` and `phpstan`, not `codesniffer`):
    ```bash
-   make codesniffer
+   make test-code-style
    make phpstan
    ```
 6. Include screenshots for user interface changes
@@ -62,7 +62,7 @@ People *love* thorough bug reports. I'm not even kidding.
    make install-deps-dev
    ```
 3. Set up your environment:
-   - Copy `.env.example` to `.env`
+   - Copy `config/sample.env` to `config/.env` (there is no `.env.example` in this repository — the sample configuration lives at `config/sample.env`)
    - Configure your database
    - Set up local development server
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ this will start the development server on port 5080.
 
 The dev environment provides a MySQL server, mail server, s3 server, and should be good to go for your needs out of the box. The basic configuration of the development environment is already defined in the composer file. You can create .env file inside of `config/.env` to augment the base configuration by setting some of the configs out of sample.env). **Important: Don't update the database information as this will disconnect the app from the docker database**. The applications you get are as follows
 
-* [http://localhost:8090](http://localhost:5080) : leantime
+* [http://localhost:5080](http://localhost:5080) : leantime
 * [http://localhost:8081](http://localhost:8081) : maildev - to check emails sent
 * [http://localhost:8082](http://localhost:8082) : phpMyAdmin(authentication ``leantime:leantime``) to check the DB schema and data
 * [http://localhost:8083](http://localhost:8083) : s3ninja - to check s3 uploads. You need to enable this in the ``.dev/.env`` file by enabling s3

--- a/app/Core/Configuration/laravelConfig.php
+++ b/app/Core/Configuration/laravelConfig.php
@@ -351,7 +351,7 @@ return [
         |
         */
 
-        'lifetime' => env('LEAN_SESSION_EXPIRATION', 480), // 8 hours
+        'lifetime' => env('LEAN_SESSION_EXPIRATION', 480), // Session lifetime in MINUTES (passed straight to Laravel's `session.lifetime`). 480 = 8 hours. The Helm chart (`app.session.expiration` in helm/values.yaml) must use the same unit.
 
         'expire_on_close' => false,
 

--- a/config/sample.env
+++ b/config/sample.env
@@ -33,7 +33,7 @@ LEAN_DB_IDLE_TIMEOUT = 300                         # Database idle timeout in se
 
 ## Session Management
 LEAN_SESSION_PASSWORD = '3evBlq9zdUEuzKvVJHWWx3QzsQhturBApxwcws2m'  # Salting sessions, replace with a strong password
-LEAN_SESSION_EXPIRATION = 480                      # How many minutes after inactivity should we logout?  480 minutes = 8 hours
+LEAN_SESSION_EXPIRATION = 480                      # Session idle timeout in MINUTES. Forwarded directly to Laravel's `session.lifetime` config (which is in minutes, not seconds). 480 minutes = 8 hours. The Helm chart (`helm/values.yaml` -> `app.session.expiration`) must use the same unit.
 ## Session & Security
 # LEAN_SESSION_SECURE=                              # Set to true to force secure cookies (auto-detected if not set)
 # LEAN_HSTS_ENABLED=false                           # Set to true to enable HSTS header (auto-enabled on HTTPS)

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -59,8 +59,12 @@ app:
   session:
     # -- Salting sessions. Replace with a strong password
     password: "changeme"
-    # -- Session expiration
-    expiration: 28800
+    # -- Session expiration in MINUTES (must match the LEAN_SESSION_EXPIRATION
+    # -- semantics used elsewhere in Leantime: Laravel's `session.lifetime` is
+    # -- expressed in minutes, NOT seconds). 480 = 8 hours of idle timeout.
+    # -- See: app/Core/Configuration/laravelConfig.php (`session.lifetime`) and
+    # -- config/sample.env (LEAN_SESSION_EXPIRATION).
+    expiration: 480
   email:
     # -- Set to true if you want to use SMTP. If set to false, the default php mail() function will be used
     enabled: false


### PR DESCRIPTION
## Summary

The Helm chart's `app.session.expiration` defaulted to `28800`, which is 8 hours expressed in **seconds**. However, the rest of Leantime treats `LEAN_SESSION_EXPIRATION` as **MINUTES** (Laravel's `session.lifetime` is minutes-based), with a default of `480`. As a result, fresh Helm-based deployments were creating sessions that lasted **28,800 minutes (~200 days)** instead of 8 hours of idle timeout.

This addresses the question raised in #3378: *"is LEAN_SESSION_EXPIRATION documented unit (seconds) consistent with how it's consumed in config/session.php?"* — the answer was "no, the Helm chart was using the wrong unit."

## Changes

- **`helm/values.yaml`** — Change `app.session.expiration` default from `28800` to `480` and add an explicit comment that the value is in **MINUTES**, cross-referencing `laravelConfig.php` and `sample.env`.
- **`config/sample.env`** — Clarify in the inline comment that `LEAN_SESSION_EXPIRATION` is minutes, not seconds, and that the Helm chart must use the same unit.
- **`app/Core/Configuration/laravelConfig.php`** — Replace the terse `// 8 hours` comment on `session.lifetime` with a note that the value is in minutes and must stay consistent with the Helm chart.
- **`README.md`** — Fix stale dev-server port link (display text said `8090` but the actual port is `5080`).
- **`CONTRIBUTING.md`** — Correct the make target for code-style checks (`test-code-style`, not `codesniffer`) and the env file location (`config/sample.env`, not `.env.example`).
- **`CHANGELOG.md`** — Document the fix under 3.8.0 bug fixes.

## Risk and Migration Notes

This is a **default value change**, not a code change. Operators who explicitly set `app.session.expiration` in their `values.yaml` are unaffected.

Operators relying on the previous default of `28800` will see their session idle timeout drop from ~200 days to 8 hours. If you actually wanted 200 days of sessions (you almost certainly don't), set `app.session.expiration: 28800` explicitly.

## Verification

```
git diff --stat
 CHANGELOG.md                             | 1 +
 CONTRIBUTING.md                          | 6 +++---
 README.md                                | 2 +-
 app/Core/Configuration/laravelConfig.php | 2 +-
 config/sample.env                        | 2 +-
 helm/values.yaml                         | 8 ++++++--
 6 files changed, 13 insertions(+), 8 deletions(-)
```

Fixes #3378
