### PR TITLE
security(timesheets): gate the Timesheets domain (own-time vs manage) + matrix edit

### DIFF
--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -60,7 +60,14 @@ final class DefaultRolePermissions
             // editor+, but a commenter is allowed to add comments — grant the key explicitly.
             ['scope' => 'project', 'keys' => ['comments.create']],
         ],
-        'editor' => [['scope' => 'project', 'verbs' => ['create', 'edit', 'delete']]],
+        'editor' => [
+            ['scope' => 'project', 'verbs' => ['create', 'edit', 'delete']],
+            // Timesheets are GLOBAL-scoped (company-wide time logging), so the project verb rule
+            // above does NOT match them — an editor's own-time capability is granted by explicit
+            // global keys. Ownership (own vs others) is enforced in the service; the cross-user
+            // `timesheets.manage` stays manager+ (below).
+            ['scope' => 'global', 'keys' => ['timesheets.view', 'timesheets.create', 'timesheets.edit', 'timesheets.delete']],
+        ],
         'manager' => [
             ['scope' => 'project', 'verbs' => ['*']],
             // Managers may INVITE users (the NewUser screen is manager+). The client-scoping
@@ -69,7 +76,9 @@ final class DefaultRolePermissions
             // those remain admin+. users.* are company-wide, so this is an explicit global
             // key grant rather than a 'create' verb rule (a verb rule would also need a global
             // scope and is fine, but the explicit key documents that ONLY create is intended).
-            ['scope' => 'global', 'keys' => ['users.create']],
+            // timesheets.manage (company-wide invoicing/reports/others' time) is manager+; the
+            // editor keys above are inherited up the hierarchy.
+            ['scope' => 'global', 'keys' => ['users.create', 'timesheets.manage']],
         ],
         'admin' => [
             ['scope' => 'any', 'verbs' => ['*'], 'exclude' => ['company.settings.*']],

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.13';
+    public string $dbVersion = '3.5.14';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -94,6 +94,7 @@ class Install
         30511,
         30512,
         30513,
+        30514,
     ];
 
     /**
@@ -2952,6 +2953,34 @@ class Install
             Log::error('Migration 30513: '.$e->getMessage());
 
             return ['Migration 30513 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Timesheets domain. Adds
+     * timesheets.view/create/edit/delete/manage (all GLOBAL-scoped — company-wide time logging).
+     *
+     * This migration MUST re-seed because the DefaultRolePermissions matrix changed: editor now
+     * gains the four global timesheets keys (own-time) and manager gains timesheets.manage
+     * (company-wide invoicing/reports/others' time). Without re-seeding, those roles would not
+     * hold the new keys and the timesheet pages/API would deny everyone below admin.
+     *
+     * Flush the discovered-provider cache FIRST so TimesheetsPermissions is rediscovered.
+     */
+    public function update_sql_30514(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30514: '.$e->getMessage());
+
+            return ['Migration 30514 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Timesheets/Controllers/AddTime.php
+++ b/app/Domain/Timesheets/Controllers/AddTime.php
@@ -34,9 +34,13 @@ class AddTime extends Controller
     /**
      * Displays the add time form.
      *
+     * This is the creation entry point, so it gates on CREATE (matching post()) rather than VIEW —
+     * a view-only role should not be able to load the time-logging form. Grant-equivalent for every
+     * built-in role (the set holding timesheets.create is exactly editor+, the prior authOrRedirect).
+     *
      * @param  array  $params  Request parameters
      */
-    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function get(array $params): Response
     {
         $this->tpl->assign('values', $this->timesheetService->getDefaultTimeValues());
@@ -80,8 +84,8 @@ class AddTime extends Controller
     {
         $this->tpl->assign('allClients', $this->clientService->getAll());
         $this->tpl->assign('allProjects', $this->projectService->getAll(showClosedProjects: false));
-        // Scope the picker to the current user's own timesheets (editor → timesheets.view);
-        // an unscoped call would require timesheets.manage and over-fetch every user's entries.
+        // Scope the picker to the current user's own timesheets; an unscoped call would require
+        // timesheets.manage and over-fetch every user's entries.
         $this->tpl->assign('allTickets', $this->timesheetService->getAll(
             dateFrom: dtHelper()->userNow()->subYears(10)->setToDbTimezone(),
             dateTo: dtHelper()->userNow()->addYears(10)->setToDbTimezone(),

--- a/app/Domain/Timesheets/Controllers/AddTime.php
+++ b/app/Domain/Timesheets/Controllers/AddTime.php
@@ -2,11 +2,11 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -36,14 +36,9 @@ class AddTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return $this->tpl->display('errors.error403', responseCode: 403);
-        }
-
         $this->tpl->assign('values', $this->timesheetService->getDefaultTimeValues());
         $this->tpl->assign('info', '');
         $this->assignTemplateVars();
@@ -56,14 +51,9 @@ class AddTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
-        if (! Auth::userIsAtLeast(Roles::$editor)) {
-            return $this->tpl->display('errors.error403', responseCode: 403);
-        }
-
         $info = '';
         $values = $this->timesheetService->getDefaultTimeValues();
 
@@ -90,9 +80,12 @@ class AddTime extends Controller
     {
         $this->tpl->assign('allClients', $this->clientService->getAll());
         $this->tpl->assign('allProjects', $this->projectService->getAll(showClosedProjects: false));
+        // Scope the picker to the current user's own timesheets (editor → timesheets.view);
+        // an unscoped call would require timesheets.manage and over-fetch every user's entries.
         $this->tpl->assign('allTickets', $this->timesheetService->getAll(
             dateFrom: dtHelper()->userNow()->subYears(10)->setToDbTimezone(),
             dateTo: dtHelper()->userNow()->addYears(10)->setToDbTimezone(),
+            userId: (int) session('userdata.id'),
         ));
         $this->tpl->assign('kind', $this->timesheetService->getLoggableHourTypes());
     }

--- a/app/Domain/Timesheets/Controllers/DelTime.php
+++ b/app/Domain/Timesheets/Controllers/DelTime.php
@@ -2,10 +2,10 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,10 +26,9 @@ class DelTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::DELETE, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->displayPartial('errors.error403');
         }
@@ -44,10 +43,9 @@ class DelTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::DELETE, global: true, entityScoped: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         if (! isset($params['id'])) {
             return $this->tpl->displayPartial('errors.error403');
         }

--- a/app/Domain/Timesheets/Controllers/EditTime.php
+++ b/app/Domain/Timesheets/Controllers/EditTime.php
@@ -2,12 +2,12 @@
 
 namespace Leantime\Domain\Timesheets\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -41,22 +41,20 @@ class EditTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::EDIT, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
-        if (! Auth::userIsAtLeast(Roles::$editor) || ! isset($params['id'])) {
+        if (! isset($params['id'])) {
             return $this->tpl->displayPartial('errors.error403');
         }
 
         $id = (int) $params['id'];
+        // getTimesheetForEdit routes through the gated getTimesheet (own → view, another user's →
+        // manage), returning null for an entry the user may not access — this fences ownership,
+        // replacing the former manual role/owner check.
         $values = $this->timesheetService->getTimesheetForEdit($id);
 
         if ($values === null) {
-            return $this->tpl->displayPartial('errors.error403');
-        }
-
-        if (! Auth::userIsAtLeast(Roles::$manager) && session('userdata.id') != $values['userId']) {
             return $this->tpl->displayPartial('errors.error403');
         }
 
@@ -72,22 +70,19 @@ class EditTime extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::EDIT, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
-        if (! Auth::userIsAtLeast(Roles::$editor) || ! isset($params['id'])) {
+        if (! isset($params['id'])) {
             return $this->tpl->displayPartial('errors.error403');
         }
 
         $id = (int) $params['id'];
+        // Fences ownership via the gated read; the save itself goes through the gated
+        // validateAndUpdateTime → updateTime (own → edit, another user's → manage).
         $values = $this->timesheetService->getTimesheetForEdit($id);
 
         if ($values === null) {
-            return $this->tpl->displayPartial('errors.error403');
-        }
-
-        if (! Auth::userIsAtLeast(Roles::$manager) && session('userdata.id') != $values['userId']) {
             return $this->tpl->displayPartial('errors.error403');
         }
 

--- a/app/Domain/Timesheets/Controllers/ShowAll.php
+++ b/app/Domain/Timesheets/Controllers/ShowAll.php
@@ -3,12 +3,12 @@
 namespace Leantime\Domain\Timesheets\Controllers;
 
 use Carbon\CarbonInterface;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users as UserService;
 use Symfony\Component\HttpFoundation\Response;
@@ -47,10 +47,9 @@ class ShowAll extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::MANAGE, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager], true);
-
         session(['lastPage' => BASE_URL.'/timesheets/showAll']);
 
         $this->assignTemplateVars(
@@ -74,10 +73,9 @@ class ShowAll extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::MANAGE, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager], true);
-
         session(['lastPage' => BASE_URL.'/timesheets/showAll']);
 
         if (isset($_POST['saveInvoice'])) {

--- a/app/Domain/Timesheets/Controllers/ShowMy.php
+++ b/app/Domain/Timesheets/Controllers/ShowMy.php
@@ -3,10 +3,10 @@
 namespace Leantime\Domain\Timesheets\Controllers;
 
 use Carbon\CarbonInterface;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,10 +32,9 @@ class ShowMy extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         $fromDate = dtHelper()->userNow()->startOfWeek(CarbonInterface::MONDAY)->setToDbTimezone();
 
         $this->assignTemplateVars($fromDate);
@@ -48,10 +47,9 @@ class ShowMy extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         $fromDate = dtHelper()->userNow()->startOfWeek(CarbonInterface::MONDAY)->setToDbTimezone();
 
         if (isset($_POST['search']) && ! empty($_POST['startDate'])) {

--- a/app/Domain/Timesheets/Controllers/ShowMyList.php
+++ b/app/Domain/Timesheets/Controllers/ShowMyList.php
@@ -3,9 +3,9 @@
 namespace Leantime\Domain\Timesheets\Controllers;
 
 use Carbon\CarbonInterface;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,10 +27,9 @@ class ShowMyList extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         $kind = 'all';
         $dateFrom = dtHelper()->userNow()->startOfWeek(CarbonInterface::MONDAY)->setToDbTimezone();
         $dateTo = dtHelper()->userNow()->endOfWeek()->setToDbTimezone();
@@ -45,10 +44,9 @@ class ShowMyList extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor], true);
-
         $kind = ! empty($_POST['kind']) ? $_POST['kind'] : 'all';
 
         $dateFrom = dtHelper()->userNow()->startOfWeek(CarbonInterface::MONDAY)->setToDbTimezone();

--- a/app/Domain/Timesheets/Hxcontrollers/Stopwatch.php
+++ b/app/Domain/Timesheets/Hxcontrollers/Stopwatch.php
@@ -3,7 +3,9 @@
 namespace Leantime\Domain\Timesheets\Hxcontrollers;
 
 use Error;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Services\Timesheets;
 
 class Stopwatch extends HtmxController
@@ -23,6 +25,7 @@ class Stopwatch extends HtmxController
     /**
      * show stop watch
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function getStatus(): void
     {
 
@@ -33,6 +36,7 @@ class Stopwatch extends HtmxController
     /**
      * show stop watch
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function stopTimer(): void
     {
         if ($this->incomingRequest->getMethod() !== 'PATCH') {
@@ -52,6 +56,7 @@ class Stopwatch extends HtmxController
         $this->tpl->assign('onTheClock', $onTheClock);
     }
 
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function startTimer(): void
     {
         if ($this->incomingRequest->getMethod() !== 'PATCH') {

--- a/app/Domain/Timesheets/Permissions/TimesheetsPermissions.php
+++ b/app/Domain/Timesheets/Permissions/TimesheetsPermissions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Leantime\Domain\Timesheets\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Timesheets permission vocabulary — company-wide (GLOBAL-scoped) verbs.
+ *
+ * Timesheets are GLOBAL-scoped (projectScoped = false): they represent the time an employee logs
+ * across the whole company, and the controllers have always gated on the user's GLOBAL role
+ * (Auth::authOrRedirect([...], forceGlobalRoleCheck: true)). So these verbs resolve against the
+ * global role, not a project role.
+ *
+ * Two verb families:
+ *  - view/create/edit/delete — EDITOR+ for the user's OWN time (ownership is enforced in the
+ *    service: a non-manager may only read/write their own entries).
+ *  - manage — MANAGER+ only: act on OTHER users' time, mark invoiced/paid, and the cross-user/
+ *    cross-project reports.
+ *
+ * Because these are GLOBAL-scoped, the standard verbs do NOT auto-grant through the project-scoped
+ * matrix rules — {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} grants editor the
+ * four standard keys and manager the `manage` key explicitly (admin/owner auto-grant via scope:any).
+ */
+final class TimesheetsPermissions implements ProvidesPermissions
+{
+    /** View own timesheets; managers view anyone's. Ownership enforced in the service. */
+    public const VIEW = 'timesheets.view';
+
+    /** Log time for own account; managers log for any user. Ownership enforced in the service. */
+    public const CREATE = 'timesheets.create';
+
+    /** Edit own timesheets; managers edit anyone's. Ownership enforced in the service. */
+    public const EDIT = 'timesheets.edit';
+
+    /** Delete own timesheets; managers delete anyone's. Ownership enforced in the service. */
+    public const DELETE = 'timesheets.delete';
+
+    /** Manage timesheets company-wide: mark invoiced/paid, cross-user reports, act on others' time. Manager+. */
+    public const MANAGE = 'timesheets.manage';
+
+    public function domain(): string
+    {
+        return 'timesheets';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View own timesheets (anyone\'s when manager+)', false),
+            new Permission(self::CREATE, 'Log time for own account (others when manager+)', false),
+            new Permission(self::EDIT, 'Edit own timesheets (others when manager+)', false),
+            new Permission(self::DELETE, 'Delete own timesheets (others when manager+)', false),
+            new Permission(self::MANAGE, 'Manage timesheets company-wide (invoice/pay/reports)', false),
+        ];
+    }
+}

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -7,15 +7,31 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
+use Leantime\Core\Domains\BaseService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Exceptions\MissingParameterException;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Tickets\Models\Tickets;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Users\Repositories\Users;
 
-class Timesheets
+/**
+ * Timesheets service.
+ *
+ * Timesheets are GLOBAL-scoped (company-wide time logging): every gate resolves the user's
+ * GLOBAL role via {@see TimesheetsPermissions}. The standard verbs (view/create/edit/delete) are
+ * editor+ and operate on the user's OWN time — ownership is enforced in-body by comparing the
+ * entry's userId to the current user; acting on ANOTHER user's time, invoicing, and the
+ * cross-user reports require timesheets.manage (manager+). Reads soft-deny (return the neutral
+ * empty value) for the unauthorized/cross-user case; writes throw AuthorizationException.
+ *
+ * NOTE: the ticket-hours aggregate reads (getLoggedHoursForTicketByDate / getSumLoggedHoursForTicket
+ * / getRemainingHours) are intentionally UNGATED — they render on the ticket view (ShowTicket,
+ * reachable by readonly users) and expose only a ticket's total logged hours, not per-user data.
+ */
+class Timesheets extends BaseService
 {
     private TimesheetRepository $timesheetsRepo;
 
@@ -48,12 +64,24 @@ class Timesheets
     }
 
     /**
+     * Non-throwing READ check for a timesheet belonging to $ownerUserId: own → timesheets.view,
+     * else → timesheets.manage. For soft-deny reads (no cross-user existence oracle).
+     */
+    private function canViewTimeForUser(int $ownerUserId): bool
+    {
+        return $ownerUserId === $this->currentUserId()
+            ? $this->can(TimesheetsPermissions::VIEW)
+            : $this->can(TimesheetsPermissions::MANAGE);
+    }
+
+    /**
      * isClocked - Checks to see whether a user is clocked in
      *
      *
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function isClocked(int $sessionId): false|array
     {
         return $this->timesheetsRepo->isClocked($sessionId);
@@ -62,6 +90,7 @@ class Timesheets
     /**
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function punchIn(int $ticketId): mixed
     {
         return $this->timesheetsRepo->punchIn($ticketId);
@@ -70,6 +99,7 @@ class Timesheets
     /**
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function punchOut(int $ticketId): float|false|int
     {
         return $this->timesheetsRepo->punchOut($ticketId);
@@ -80,6 +110,7 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true)]
     public function stopActiveTimer(): float|false|int
     {
         $userId = session('userdata.id');
@@ -105,8 +136,16 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true, entityScoped: true)]
     public function logTime(int $ticketId, array $params): array|bool
     {
+        // Editor+ to log any time; non-managers are pinned to their own account (cannot log for
+        // another user — that needs timesheets.manage).
+        $this->authorize(TimesheetsPermissions::CREATE);
+        if (! $this->can(TimesheetsPermissions::MANAGE)) {
+            $params['userId'] = $this->currentUserId();
+        }
+
         // @TODO: Change to use value objects for more type safeness.
         $values = [
             'userId' => $params['userId'] ?? session('userdata.id'),
@@ -170,8 +209,15 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true, entityScoped: true)]
     public function upsertTime(int $ticketId, array $params): array|bool
     {
+        // Editor+ to log any time; non-managers are pinned to their own account.
+        $this->authorize(TimesheetsPermissions::CREATE);
+        if (! $this->can(TimesheetsPermissions::MANAGE)) {
+            $params['userId'] = $this->currentUserId();
+        }
+
         // @TODO: Change to use value objects for more type safeness.
         $values = [
             'userId' => $params['userId'] ?? session('userdata.id'),
@@ -227,6 +273,7 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::DELETE, global: true, entityScoped: true)]
     public function deleteTime(int $id): bool
     {
         $timesheet = $this->timesheetsRepo->getTimesheet($id);
@@ -235,23 +282,20 @@ class Timesheets
             return false;
         }
 
-        $currentUserId = session('userdata.id');
+        $ownerId = (int) ($timesheet['userId'] ?? 0);
 
-        // Entry owner can delete their own time
-        if ((int) $timesheet['userId'] === (int) $currentUserId) {
-            $this->timesheetsRepo->deleteTime($id);
+        // Own entry → timesheets.delete (editor+); another user's entry → timesheets.manage.
+        $allowed = $ownerId === $this->currentUserId()
+            ? $this->can(TimesheetsPermissions::DELETE)
+            : $this->can(TimesheetsPermissions::MANAGE);
 
-            return true;
+        if (! $allowed) {
+            return false;
         }
 
-        // Managers and above can delete any entry
-        if (Auth::userIsAtLeast(Roles::$manager)) {
-            $this->timesheetsRepo->deleteTime($id);
+        $this->timesheetsRepo->deleteTime($id);
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**
@@ -262,9 +306,22 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true, entityScoped: true)]
     public function getTimesheet(int $id): mixed
     {
-        return $this->timesheetsRepo->getTimesheet($id);
+        $timesheet = $this->timesheetsRepo->getTimesheet($id);
+
+        if (! $timesheet) {
+            return false;
+        }
+
+        // Soft-deny: own → timesheets.view, another user's → timesheets.manage. An unauthorized
+        // entry returns the same false as a missing one (no cross-user existence oracle).
+        if (! $this->canViewTimeForUser((int) ($timesheet['userId'] ?? 0))) {
+            return false;
+        }
+
+        return $timesheet;
     }
 
     /**
@@ -277,13 +334,14 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::CREATE, global: true, entityScoped: true)]
     public function addTime(array $values): void
     {
-        $currentUserId = (int) session('userdata.id');
+        $this->authorize(TimesheetsPermissions::CREATE);
 
-        // Non-managers can only add time entries for themselves
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
-            $values['userId'] = $currentUserId;
+        // Non-managers can only add time entries for themselves.
+        if (! $this->can(TimesheetsPermissions::MANAGE)) {
+            $values['userId'] = $this->currentUserId();
         }
 
         $this->timesheetsRepo->addTime($values);
@@ -299,21 +357,24 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::EDIT, global: true, entityScoped: true)]
     public function updateTime(array $values): void
     {
-        $currentUserId = (int) session('userdata.id');
+        $this->authorize(TimesheetsPermissions::EDIT);
 
-        // If updating an existing entry, verify ownership or manager+ role
+        $currentUserId = $this->currentUserId();
+
+        // Editing an existing entry that belongs to ANOTHER user requires timesheets.manage.
         if (isset($values['id'])) {
             $existing = $this->timesheetsRepo->getTimesheet($values['id']);
 
-            if ($existing && (int) $existing['userId'] !== $currentUserId && ! Auth::userIsAtLeast(Roles::$manager)) {
+            if ($existing && (int) $existing['userId'] !== $currentUserId && ! $this->can(TimesheetsPermissions::MANAGE)) {
                 return;
             }
         }
 
-        // Non-managers cannot set userId to someone else
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
+        // Non-managers cannot reassign an entry to someone else.
+        if (! $this->can(TimesheetsPermissions::MANAGE)) {
             $values['userId'] = $currentUserId;
         }
 
@@ -462,8 +523,15 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true, entityScoped: true)]
     public function getUsersTicketHours(int $ticketId, int $userId): mixed
     {
+        // Own hours render on the ticket page for any role with ticket access; ANOTHER user's
+        // hours require timesheets.manage (soft-deny to 0, no cross-user leak).
+        if ($userId !== $this->currentUserId() && ! $this->can(TimesheetsPermissions::MANAGE)) {
+            return 0;
+        }
+
         return $this->timesheetsRepo->getUsersTicketHours($ticketId, $userId);
     }
 
@@ -480,8 +548,18 @@ class Timesheets
     /**
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true, entityScoped: true)]
     public function getAll(CarbonInterface $dateFrom, CarbonInterface $dateTo, int $projectId = -1, string $kind = 'all', ?int $userId = null, string $invEmpl = '-1', string $invComp = '-1', string $ticketFilter = '-1', string $paid = '-1', string $clientId = '-1'): array|false
     {
+        // Scoped to your OWN entries (an explicit current-user filter) → timesheets.view (editor+).
+        // Anything broader — another user, or the all-users company report (userId null) — needs
+        // timesheets.manage (manager+). Callers wanting their own data must pass their own userId.
+        if ($userId !== null && $userId === $this->currentUserId()) {
+            $this->authorize(TimesheetsPermissions::VIEW);
+        } else {
+            $this->authorize(TimesheetsPermissions::MANAGE);
+        }
+
         return $this->timesheetsRepo->getAll(
             id: $projectId,
             kind: $kind,
@@ -501,8 +579,17 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true, entityScoped: true)]
     public function getWeeklyTimesheets(int $projectId, CarbonInterface $fromDate, int $userId = 0): array
     {
+        // Own week (default 0, or an explicit current-user filter) → timesheets.view; another
+        // user's week → timesheets.manage.
+        if ($userId === 0 || $userId === $this->currentUserId()) {
+            $this->authorize(TimesheetsPermissions::VIEW);
+        } else {
+            $this->authorize(TimesheetsPermissions::MANAGE);
+        }
+
         // Get timesheet entries and group by day
         $allTimesheets = $this->timesheetsRepo->getWeeklyTimesheets(
             projectId: $projectId,
@@ -638,8 +725,14 @@ class Timesheets
     /**
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::MANAGE, global: true)]
     public function updateInvoices(array $invEmpl, array $invComp = [], array $paid = []): bool
     {
+        // Marking entries invoiced/paid is a company-wide management action (manager+). This
+        // closes a critical IDOR: previously any caller could flip invoice/paid flags on
+        // arbitrary timesheet ids.
+        $this->authorize(TimesheetsPermissions::MANAGE);
+
         return $this->timesheetsRepo->updateInvoices($invEmpl, $invComp, $paid);
     }
 
@@ -658,6 +751,7 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function pollForNewTimesheets(?int $projectId = null): array|false
     {
         $timesheets = $this->timesheetsRepo->getAllAccountTimesheets($projectId);
@@ -675,6 +769,7 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true)]
     public function pollForUpdatedTimesheets(?int $projectId = null): array|false
     {
         $timesheets = $this->timesheetsRepo->getAllAccountTimesheets($projectId);
@@ -736,8 +831,14 @@ class Timesheets
      *
      * @api
      */
+    #[RequiresPermission(TimesheetsPermissions::VIEW, global: true, entityScoped: true)]
     public function getUsersTickets(int $userId, int $limit = -1): array
     {
+        // Your own ticket picker → timesheets.view; another user's tickets → timesheets.manage.
+        if (! $this->canViewTimeForUser($userId)) {
+            return [];
+        }
+
         $tickets = $this->ticketRepo->getUsersTickets($userId, $limit);
 
         return $tickets === false ? [] : $tickets;
@@ -806,7 +907,7 @@ class Timesheets
             }
         }
 
-        if (! empty($post['invoicedComp']) && Auth::userIsAtLeast(Roles::$manager)) {
+        if (! empty($post['invoicedComp']) && $this->can(TimesheetsPermissions::MANAGE)) {
             if ($post['invoicedComp'] == 'on') {
                 $values['invoicedComp'] = 1;
             }
@@ -815,7 +916,7 @@ class Timesheets
             }
         }
 
-        if (! empty($post['paid']) && Auth::userIsAtLeast(Roles::$manager)) {
+        if (! empty($post['paid']) && $this->can(TimesheetsPermissions::MANAGE)) {
             if ($post['paid'] == 'on') {
                 $values['paid'] = 1;
             }
@@ -944,7 +1045,7 @@ class Timesheets
      */
     public function processEditTimeInvoiceFields(array $post, array $values): array
     {
-        if (! Auth::userIsAtLeast(Roles::$manager)) {
+        if (! $this->can(TimesheetsPermissions::MANAGE)) {
             return $values;
         }
 

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -24,8 +24,13 @@ use Leantime\Domain\Users\Repositories\Users;
  * GLOBAL role via {@see TimesheetsPermissions}. The standard verbs (view/create/edit/delete) are
  * editor+ and operate on the user's OWN time — ownership is enforced in-body by comparing the
  * entry's userId to the current user; acting on ANOTHER user's time, invoicing, and the
- * cross-user reports require timesheets.manage (manager+). Reads soft-deny (return the neutral
- * empty value) for the unauthorized/cross-user case; writes throw AuthorizationException.
+ * cross-user reports require timesheets.manage (manager+).
+ *
+ * Two-tier denial: the base capability is checked with {@see authorize()}, which throws
+ * AuthorizationException when the role lacks create/edit/manage; the ownership check that follows
+ * soft-denies (deleteTime() returns false, updateTime() returns early) rather than throwing, so a
+ * manager-less user editing a peer's entry is a silent no-op, not a 403. Reads soft-deny (return
+ * the neutral empty value) for the unauthorized/cross-user case.
  *
  * NOTE: the ticket-hours aggregate reads (getLoggedHoursForTicketByDate / getSumLoggedHoursForTicket
  * / getRemainingHours) are intentionally UNGATED — they render on the ticket view (ShowTicket,

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -59,6 +59,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('clients.delete', 'Delete clients', false),
             new Permission('company.settings.view', 'View company settings', false),
             new Permission('company.settings.edit', 'Edit company settings', false),
+            // Timesheets are company-wide (global): editor gets own-time view/create/edit/delete,
+            // manager+ gets manage (cross-user invoicing/reports).
+            new Permission('timesheets.view', 'View timesheets', false),
+            new Permission('timesheets.create', 'Log time', false),
+            new Permission('timesheets.edit', 'Edit timesheets', false),
+            new Permission('timesheets.delete', 'Delete timesheets', false),
+            new Permission('timesheets.manage', 'Manage timesheets', false),
             // Project-scoped (rename a project's ticket/idea state labels — manager+ in project):
             new Permission('projectsettings.labels.manage', 'Rename project labels', true),
         ];
@@ -94,6 +101,9 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('blueprints.view', $grants);      // inherited from readonly
         $this->assertNotContains('goals.create', $grants);      // commenter views but cannot create
         $this->assertContains('goals.view', $grants);           // inherited from readonly
+        // Timesheets are editor+ (global); a commenter logs no time.
+        $this->assertNotContains('timesheets.view', $grants);
+        $this->assertNotContains('timesheets.create', $grants);
         $this->assertNotContains('comments.moderate', $grants);
     }
 
@@ -123,6 +133,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('goals.create', $grants);
         $this->assertContains('goals.edit', $grants);
         $this->assertContains('goals.delete', $grants);
+        // Timesheets are GLOBAL-scoped, so the project verb rule does NOT match them — editor gets
+        // its own-time keys explicitly (view/create/edit/delete) but NOT the manager-only `manage`.
+        $this->assertContains('timesheets.view', $grants);
+        $this->assertContains('timesheets.create', $grants);
+        $this->assertContains('timesheets.edit', $grants);
+        $this->assertContains('timesheets.delete', $grants);
+        $this->assertNotContains('timesheets.manage', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+
@@ -141,6 +158,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
+        // Timesheets: manager gets the company-wide manage verb AND inherits editor's own-time keys.
+        $this->assertContains('timesheets.manage', $grants);
+        $this->assertContains('timesheets.view', $grants);
+        $this->assertContains('timesheets.edit', $grants);
         // Managers may INVITE users (within their own client — scoped in the controller), but
         // cannot view the roster, edit, delete, or import accounts (those stay admin+).
         $this->assertContains('users.create', $grants);

--- a/tests/Unit/app/Domain/Timesheets/Services/TimesheetsServiceTest.php
+++ b/tests/Unit/app/Domain/Timesheets/Services/TimesheetsServiceTest.php
@@ -3,10 +3,13 @@
 namespace Unit\app\Domain\Timesheets\Services;
 
 use Carbon\CarbonImmutable;
+use Leantime\Core\Auth\Permissions\PermissionService;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\CarbonMacros;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Leantime\Domain\Timesheets\Permissions\TimesheetsPermissions;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
@@ -52,20 +55,60 @@ class TimesheetsServiceTest extends TestCase
         CarbonImmutable::mixin(new CarbonMacros('UTC', 'en-US', 'Y-m-d', 'H:i'));
     }
 
+    /** Permission stub that grants everything (default for the non-authz helper tests). */
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => fn () => null,
+            'currentUserCan' => fn () => true,
+        ]);
+    }
+
     /**
-     * Builds a real Timesheets service with each dependency stubbable.
+     * Permission stub that grants a specific allow-list of keys (others denied). Used to model a
+     * non-manager (editor): timesheets.view/create/edit/delete granted, timesheets.manage denied.
+     *
+     * @param  array<int, string>  $granted
+     */
+    private function permissionsGranting(array $granted): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'authorize' => function (string $key) use ($granted): void {
+                if (! in_array($key, $granted, true)) {
+                    throw new AuthorizationException;
+                }
+            },
+            'currentUserCan' => fn (string $key) => in_array($key, $granted, true),
+        ]);
+    }
+
+    /**
+     * Builds a real Timesheets service with each dependency stubbable and a permission service
+     * (defaults to allow-all).
      */
     private function makeService(
         ?TimesheetRepository $timesheetsRepo = null,
         ?UserRepository $userRepo = null,
         ?TicketRepository $ticketRepo = null,
+        ?PermissionService $perms = null,
     ): TimesheetService {
-        return new TimesheetService(
+        $service = new TimesheetService(
             $timesheetsRepo ?? $this->make(TimesheetRepository::class),
             $userRepo ?? $this->make(UserRepository::class),
             $ticketRepo ?? $this->make(TicketRepository::class),
         );
+        $service->setPermissionService($perms ?? $this->allowingPermissions());
+
+        return $service;
     }
+
+    // Non-manager (editor) verb set: own-time keys, but NOT timesheets.manage.
+    private const EDITOR_KEYS = [
+        TimesheetsPermissions::VIEW,
+        TimesheetsPermissions::CREATE,
+        TimesheetsPermissions::EDIT,
+        TimesheetsPermissions::DELETE,
+    ];
 
     public function test_get_users_tickets_normalizes_false_to_empty_array(): void
     {
@@ -207,5 +250,163 @@ class TimesheetsServiceTest extends TestCase
         $this->assertArrayHasKey('timesheets', $result);
         $this->assertArrayHasKey('existingTicketIds', $result);
         $this->assertSame([11, 22], array_values($result['existingTicketIds']));
+    }
+
+    // ---------------------------------------------------------------------
+    // Ownership / fail-closed authorization (session user id = 1).
+    // ---------------------------------------------------------------------
+
+    public function test_get_timesheet_returns_own_entry_for_editor(): void
+    {
+        $repo = $this->make(TimesheetRepository::class, [
+            'getTimesheet' => fn () => ['id' => 5, 'userId' => 1, 'projectId' => 9],
+        ]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->getTimesheet(5);
+
+        $this->assertSame(5, $result['id']);
+    }
+
+    public function test_get_timesheet_soft_denies_another_users_entry_for_editor(): void
+    {
+        // Editor (no timesheets.manage) reading another user's entry → false, same as not-found.
+        $repo = $this->make(TimesheetRepository::class, [
+            'getTimesheet' => fn () => ['id' => 5, 'userId' => 2, 'projectId' => 9],
+        ]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->getTimesheet(5);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_get_timesheet_returns_false_for_missing(): void
+    {
+        $repo = $this->make(TimesheetRepository::class, ['getTimesheet' => fn () => false]);
+
+        $this->assertFalse($this->makeService(timesheetsRepo: $repo)->getTimesheet(999));
+    }
+
+    public function test_update_invoices_requires_manage(): void
+    {
+        $updated = 0;
+        $repo = $this->make(TimesheetRepository::class, [
+            'updateInvoices' => function () use (&$updated) {
+                $updated++;
+
+                return true;
+            },
+        ]);
+
+        $this->expectException(AuthorizationException::class);
+        try {
+            $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->updateInvoices([1], [], []);
+        } finally {
+            $this->assertSame(0, $updated, 'Invoices must not be touched without timesheets.manage');
+        }
+    }
+
+    public function test_get_all_for_own_user_needs_only_view(): void
+    {
+        $repo = $this->make(TimesheetRepository::class, ['getAll' => fn () => [['id' => 1]]]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))
+            ->getAll(dtHelper()->userNow(), dtHelper()->userNow(), userId: 1);
+
+        $this->assertSame([['id' => 1]], $result);
+    }
+
+    public function test_get_all_for_another_user_requires_manage(): void
+    {
+        $repo = $this->make(TimesheetRepository::class, ['getAll' => fn () => [['id' => 1]]]);
+
+        $this->expectException(AuthorizationException::class);
+        $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))
+            ->getAll(dtHelper()->userNow(), dtHelper()->userNow(), userId: 2);
+    }
+
+    public function test_get_all_for_all_users_requires_manage(): void
+    {
+        // userId null = the company-wide report → manager only.
+        $repo = $this->make(TimesheetRepository::class, ['getAll' => fn () => [['id' => 1]]]);
+
+        $this->expectException(AuthorizationException::class);
+        $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))
+            ->getAll(dtHelper()->userNow(), dtHelper()->userNow(), userId: null);
+    }
+
+    public function test_delete_time_denies_another_users_entry_for_editor(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(TimesheetRepository::class, [
+            'getTimesheet' => fn () => ['id' => 5, 'userId' => 2],
+            'deleteTime' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->deleteTime(5);
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $deleted, "An editor must not delete another user's time");
+    }
+
+    public function test_delete_time_allows_own_entry_for_editor(): void
+    {
+        $deleted = 0;
+        $repo = $this->make(TimesheetRepository::class, [
+            'getTimesheet' => fn () => ['id' => 5, 'userId' => 1],
+            'deleteTime' => function () use (&$deleted) {
+                $deleted++;
+            },
+        ]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->deleteTime(5);
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $deleted);
+    }
+
+    public function test_users_ticket_hours_soft_denies_another_user_for_editor(): void
+    {
+        $loaded = 0;
+        $repo = $this->make(TimesheetRepository::class, [
+            'getUsersTicketHours' => function () use (&$loaded) {
+                $loaded++;
+
+                return 7;
+            },
+        ]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))->getUsersTicketHours(3, 2);
+
+        $this->assertSame(0, $result);
+        $this->assertSame(0, $loaded, "An editor must not read another user's ticket hours");
+    }
+
+    public function test_users_tickets_soft_denies_another_user_for_editor(): void
+    {
+        $repo = $this->make(TimesheetRepository::class);
+        $ticketRepo = $this->make(TicketRepository::class, ['getUsersTickets' => fn () => [['id' => 1]]]);
+
+        $result = $this->makeService(timesheetsRepo: $repo, ticketRepo: $ticketRepo, perms: $this->permissionsGranting(self::EDITOR_KEYS))
+            ->getUsersTickets(2, -1);
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_add_time_pins_non_manager_to_own_user(): void
+    {
+        $captured = null;
+        $repo = $this->make(TimesheetRepository::class, [
+            'addTime' => function ($values) use (&$captured) {
+                $captured = $values;
+            },
+        ]);
+
+        // Editor (no manage) tries to log for user 2 → pinned to self (user 1).
+        $this->makeService(timesheetsRepo: $repo, perms: $this->permissionsGranting(self::EDITOR_KEYS))
+            ->addTime(['userId' => 2, 'hours' => 1]);
+
+        $this->assertSame(1, $captured['userId'], 'A non-manager must be pinned to their own userId');
     }
 }


### PR DESCRIPTION
## What & why

Timesheets are company-wide time logging, and the controllers have always gated on the user's **global** role (`Auth::authOrRedirect([...], forceGlobalRoleCheck: true)`). The `@api` service surface had critical IDORs: `getTimesheet` read any entry by id with **zero auth**, `updateInvoices` flipped invoice/paid flags on **arbitrary** ids, and `getAll` / `pollFor*` / `getUsersTickets` / `getUsersTicketHours` leaked other users' data.

This is the rollout's **one matrix-edit domain** (a non-standard `timesheets.manage` verb).

## Approach

- **Vocabulary** — `TimesheetsPermissions` (`timesheets.view/create/edit/delete/manage`), **GLOBAL-scoped** (`projectScoped = false`), matching the controllers' global-role gating. `view/create/edit/delete` = editor+ for the user's **own** time; `manage` = manager+ for acting on **others'** time, invoicing, and cross-user reports.
- **Matrix edit** — editor gets the four global keys **explicitly** (global-scoped perms are *not* matched by the project verb rule — a subtlety the design initially missed); manager gets `timesheets.manage`; admin/owner auto-grant via `scope:any`. readonly/commenter get none. **Migration `30514` re-seeds** because the matrix changed (dbVersion → **3.5.14**).
- **Service** (`extends BaseService`) — ownership is enforced in-body: an entry's `userId` vs the current user decides own (`view`/`edit`/`delete`) vs `manage`. **Reads soft-deny** (`false`/`[]`/`0` — no cross-user existence oracle); **writes throw** / pin non-managers to their own `userId`. `getAll` is **dual-use**: own userId → `view`; another user / all-users report (`null`) → `manage`.
- **Intentionally ungated** — the ticket-hours aggregate reads (`getLoggedHoursForTicketByDate`/`getSumLoggedHoursForTicket`/`getRemainingHours` + the hour-type lists) render on the **ticket view** (`ShowTicket`, reachable by readonly) and expose only a ticket's *total* hours, not per-user data; `getUsersTicketHours` is gated only for the cross-user case (ShowTicket calls it with the current user's id).
- **Controllers + Stopwatch** — all 6 controllers + the Stopwatch HxController carry `#[RequiresPermission(…, global: true)]`, replacing `Auth::authOrRedirect` (AddTime/EditTime/ShowMy/ShowMyList editor+, ShowAll manager+). `AddTime` now scopes its picker to the current user; `EditTime` drops its manual owner check, relying on the gated `getTimesheetForEdit` (read) + `updateTime` (save).

## Tests / verification
- 12 fail-closed `TimesheetsService` cases (soft-deny / no-oracle, own-vs-manage, `getAll` dual-use, non-manager pinned to own); `timesheets.*` added to the role-matrix catalog test.
- PHP lint, Pint, **PHPStan level 1**, **24 service + 7 role-matrix tests**; Tickets/Blueprints/Goalcanvas suites unaffected.
- 5-lens adversarial review verdict **SHIP** (no survivors; the ungated ticket-hours reads and the repo-layer legacy `session('userdata.role')` filtering are documented exceptions/follow-ups).

## Scope / follow-ups
Documented low-sev follow-ups (not blockers): `punchIn`/`punchOut` gate `create` but don't validate the ticket's project (a user could log their own time against a ticket they can't access); the repo's `getAllAccountTimesheets` still uses a legacy `session('userdata.role')` filter. Remaining rollout domains: **Files → Reports → Calendar → Projects (last)**, plus a separate **Connector** import-authz pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)