### PR TITLE
chore(logicmodelcanvas): drop unused snapshot mount div

### DIFF
--- a/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
+++ b/app/Domain/Logicmodelcanvas/Templates/showCanvas.blade.php
@@ -223,7 +223,6 @@
 
         {{-- Plugin panel containers (filled by HTMX when plugin is active) --}}
         <div id="templateSelectorContainer"></div>
-        <div id="snapshotListContainer"></div>
 
     </div>
 </div>


### PR DESCRIPTION
## Summary
The StrategyPro plugin's Logic Model snapshot feature was removed (see Leantime/plugins#46). This core template kept an empty \`<div id=\"snapshotListContainer\"></div>\` as the plugin's HTMX swap target. With the plugin feature gone, the div is dead code.

One-line removal, no functional change.

## Coordinated
- Plugins repo PR Leantime/plugins#46 includes the snapshot removal commit. This PR is the matching tiny core cleanup.

## Test plan
- [ ] Logic Model board renders normally (no visible change — the div was always empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)