### PR TITLE
security(files): gate the Files domain + close RPC IDORs

### DIFF
--- a/app/Core/Auth/Permissions/PermissionServiceProvider.php
+++ b/app/Core/Auth/Permissions/PermissionServiceProvider.php
@@ -74,14 +74,20 @@ class PermissionServiceProvider extends ServiceProvider
     }
 
     /**
-     * Inject PermissionService into every service that extends {@see BaseService}, without
-     * forcing subclass constructors to wire it. The afterResolving callback registered for
-     * the base type fires for any resolved instance that is `instanceof BaseService`.
+     * Wire PermissionService into every service that extends {@see BaseService}, without forcing
+     * subclass constructors to wire it. The afterResolving callback fires for any resolved instance
+     * that is `instanceof BaseService`.
+     *
+     * We wire a LAZY resolver, not the instance: a BaseService can sit inside PermissionService's
+     * own dependency graph (Files is reached via PermissionService → ChecksProjectAccess → Projects
+     * → Files), so eagerly calling `make(PermissionService)` here would re-enter PermissionService's
+     * half-built construction and recurse infinitely (stack overflow at boot). Resolving lazily on
+     * first authorize()/can() defers it until the singleton has been built.
      */
     protected function injectBaseServiceDependencies(): void
     {
         $this->app->afterResolving(BaseService::class, function (BaseService $service, $app) {
-            $service->setPermissionService($app->make(PermissionService::class));
+            $service->setPermissionServiceResolver(fn () => $app->make(PermissionService::class));
         });
     }
 }

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.14';
+    public string $dbVersion = '3.5.15';
 }

--- a/app/Core/Domains/BaseService.php
+++ b/app/Core/Domains/BaseService.php
@@ -13,21 +13,54 @@ use Leantime\Core\Exceptions\ValidationException;
  * unchanged).
  *
  * Dependency wiring is handled by {@see \Leantime\Core\Auth\Permissions\PermissionServiceProvider}:
- * an `afterResolving(BaseService::class, ...)` hook calls {@see setPermissionService()} on
+ * an `afterResolving(BaseService::class, ...)` hook wires a LAZY resolver (not the instance) on
  * every container-resolved subclass. That keeps the engine injected with zero constructor
- * boilerplate in subclasses (which all have their own repo-injecting constructors) and
- * without reaching for the `app()` helper inside service methods.
+ * boilerplate in subclasses (which all have their own repo-injecting constructors) and without
+ * reaching for the `app()` helper inside service methods. The resolver — rather than eager
+ * injection — is essential: a service can sit inside PermissionService's own dependency graph
+ * (the Files service is reached via PermissionService → ChecksProjectAccess → Projects → Files),
+ * so eagerly making PermissionService inside that service's afterResolving hook would re-enter
+ * PermissionService's half-built construction and recurse forever. Resolving lazily on first
+ * authorize()/can() defers it until the singleton exists.
  */
 abstract class BaseService implements DomainService
 {
     use DispatchesEvents;
 
-    protected PermissionService $permissions;
+    protected ?PermissionService $permissions = null;
 
-    /** Wired by PermissionServiceProvider when the service is resolved from the container. */
+    /** @var (\Closure(): PermissionService)|null Lazy resolver wired by PermissionServiceProvider. */
+    protected ?\Closure $permissionServiceResolver = null;
+
+    /**
+     * Set the engine instance directly. Used by unit tests; production uses the lazy resolver below.
+     */
     public function setPermissionService(PermissionService $permissions): void
     {
         $this->permissions = $permissions;
+    }
+
+    /**
+     * Wire a LAZY resolver instead of the instance (see the class docblock for why eager injection
+     * recurses). The engine is resolved on first authorize()/can().
+     */
+    public function setPermissionServiceResolver(\Closure $resolver): void
+    {
+        $this->permissionServiceResolver = $resolver;
+    }
+
+    /** Resolve the engine, preferring a directly-set instance (tests) then the lazy resolver. */
+    private function permissionService(): PermissionService
+    {
+        if ($this->permissions === null) {
+            if ($this->permissionServiceResolver === null) {
+                throw new \LogicException(static::class.' has no PermissionService: it was neither resolved through the container nor wired in a test.');
+            }
+
+            $this->permissions = ($this->permissionServiceResolver)();
+        }
+
+        return $this->permissions;
     }
 
     /**
@@ -39,13 +72,13 @@ abstract class BaseService implements DomainService
      */
     protected function authorize(string $permission, ?int $projectId = null, ?bool $forceGlobal = null): void
     {
-        $this->permissions->authorize($permission, $projectId, $forceGlobal);
+        $this->permissionService()->authorize($permission, $projectId, $forceGlobal);
     }
 
     /** Non-throwing capability check, for branching. */
     protected function can(string $permission, ?int $projectId = null, ?bool $forceGlobal = null): bool
     {
-        return $this->permissions->currentUserCan($permission, $projectId, $forceGlobal);
+        return $this->permissionService()->currentUserCan($permission, $projectId, $forceGlobal);
     }
 
     /** The authenticated user's id, or null when there is no session user. */

--- a/app/Domain/Files/Controllers/Browse.php
+++ b/app/Domain/Files/Controllers/Browse.php
@@ -2,8 +2,10 @@
 
 namespace Leantime\Domain\Files\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Files\Permissions\FilesPermissions;
 use Leantime\Domain\Files\Services\Files as FileService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,6 +29,7 @@ class Browse extends Controller
      *
      * @throws \Exception
      */
+    #[RequiresPermission(FilesPermissions::VIEW)]
     public function get(array $params): Response
     {
         $this->assignTemplateVars();
@@ -41,6 +44,7 @@ class Browse extends Controller
      *
      * @throws \Exception
      */
+    #[RequiresPermission(FilesPermissions::VIEW)]
     public function post(array $params): Response
     {
         $result = $this->filesService->handleFileAction($_POST, $_FILES, 'project', session('currentProject'));

--- a/app/Domain/Files/Controllers/ShowAll.php
+++ b/app/Domain/Files/Controllers/ShowAll.php
@@ -3,8 +3,10 @@
 namespace Leantime\Domain\Files\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Domain\Files\Permissions\FilesPermissions;
 use Leantime\Domain\Files\Services\Files as FileService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -28,6 +30,7 @@ class ShowAll extends Controller
      *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(FilesPermissions::VIEW)]
     public function get(array $params): Response
     {
         $currentModule = $params['id'] ?? $_GET['id'] ?? '';
@@ -44,6 +47,7 @@ class ShowAll extends Controller
      *
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(FilesPermissions::VIEW)]
     public function post(array $params): Response
     {
         $currentModule = $params['id'] ?? $_GET['id'] ?? '';

--- a/app/Domain/Files/Permissions/FilesPermissions.php
+++ b/app/Domain/Files/Permissions/FilesPermissions.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Leantime\Domain\Files\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Files permission vocabulary — standard project-scoped capabilities.
+ *
+ * A file's authority is the user's role *in the file's owning project*: project-module files
+ * use their moduleId as the projectId directly, ticket-module files resolve through the owning
+ * ticket. Both are resolved fail-closed by {@see \Leantime\Domain\Files\Repositories\Files::getProjectIdForFile()}
+ * (null when the id is missing or the module has no project context).
+ *
+ * All three verbs are standard, so they auto-grant through the project-scoped matrix rules in
+ * {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions} with NO matrix edit:
+ *  - view   → readonly+ (any project member may see/download a project's files)
+ *  - upload → commenter+ (the standard `upload` verb, same as ticket/comment attachments)
+ *  - delete → editor+ (manager+ via the project wildcard; admin/owner via scope:any)
+ *
+ * Two checks live in the service rather than the vocabulary:
+ *  - Ownership: a file's uploader may always delete their own file regardless of role.
+ *  - Owner-restricted modules (private/user/lead/export) have no project context — access is
+ *    gated by the uploader check instead of a project permission.
+ */
+final class FilesPermissions implements ProvidesPermissions
+{
+    /** View / download files attached to a project or project entity (ticket). Readonly+. */
+    public const VIEW = 'files.view';
+
+    /** Upload files to a project or project entity. Commenter+. */
+    public const UPLOAD = 'files.upload';
+
+    /** Delete another user's file in a project (the uploader may always delete their own). Editor+. */
+    public const DELETE = 'files.delete';
+
+    public function domain(): string
+    {
+        return 'files';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View and download project files', true),
+            new Permission(self::UPLOAD, 'Upload files to projects', true),
+            new Permission(self::DELETE, 'Delete project files', true),
+        ];
+    }
+}

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -5,6 +5,7 @@ namespace Leantime\Domain\Files\Services;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
 use Leantime\Core\Domains\BaseService;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Files\Exceptions\FileValidationException;
 use Leantime\Core\Files\FileManager;
 use Leantime\Core\Language as LanguageCore;
@@ -34,6 +35,15 @@ class Files extends BaseService
      * @var array<int, string>
      */
     private const OWNER_RESTRICTED_MODULES = ['private', 'user', 'lead', 'export'];
+
+    /**
+     * Module types whose files belong to a project (resolved by getProjectIdForFile). For these,
+     * an unresolvable project id — an invalid or deleted entity — must FAIL CLOSED rather than
+     * fall through to the non-project "allow upload" / "serve file" path.
+     *
+     * @var array<int, string>
+     */
+    private const PROJECT_SCOPED_MODULES = ['project', 'ticket'];
 
     public function __construct(
         protected FileRepository $fileRepository,
@@ -117,13 +127,19 @@ class Files extends BaseService
 
         // Authorize against the target's owning project before writing anything (commenter+;
         // admin/owner bypass). This guards the JSON-RPC path, which reaches the @api upload()
-        // directly, without the Upload controller's userCanUploadToModule pre-check. Non-project
-        // modules (user avatar, private, ...) have no project context and preserve prior behavior;
-        // their flows pin moduleId server-side (e.g. ProfileImage forces the session user's id).
+        // directly, without the Upload controller's userCanUploadToModule pre-check.
         $targetProjectId = $this->resolveProjectId(['module' => $module, 'moduleId' => $moduleId]);
-        if ($targetProjectId !== null) {
+        if (in_array($module, self::PROJECT_SCOPED_MODULES, true)) {
+            // Project-scoped target: an unresolvable project (invalid/deleted entity) fails closed,
+            // so a bogus id can't create an orphan file that bypasses files.upload.
+            if ($targetProjectId === null) {
+                throw new AuthorizationException;
+            }
+
             $this->authorize(FilesPermissions::UPLOAD, $targetProjectId);
         }
+        // Non-project modules (user avatar, private, ...) have no project context and preserve prior
+        // behavior; their flows pin moduleId server-side (e.g. ProfileImage forces the session user's id).
 
         try {
             // Validate file type with the enhanced validator
@@ -309,9 +325,10 @@ class Files extends BaseService
     {
         $projectId = $this->resolveProjectId(['module' => $module, 'moduleId' => $moduleId]);
 
-        if ($projectId !== null) {
-            // files.upload is commenter+; admin/owner bypass project membership.
-            return $this->can(FilesPermissions::UPLOAD, $projectId);
+        if (in_array($module, self::PROJECT_SCOPED_MODULES, true)) {
+            // Project-scoped: needs files.upload (commenter+) in the owning project; admin/owner
+            // bypass membership. An unresolvable id (invalid/deleted entity) fails closed.
+            return $projectId !== null && $this->can(FilesPermissions::UPLOAD, $projectId);
         }
 
         // Non-project modules (user avatar, private, ...) keep prior behavior; their flows pin
@@ -362,6 +379,16 @@ class Files extends BaseService
 
                 return new Response('', 403);
             }
+        } elseif (in_array($fileRecord['module'] ?? '', self::PROJECT_SCOPED_MODULES, true)) {
+            // Project-scoped file whose project can't be resolved (e.g. a deleted ticket) → deny,
+            // rather than fall through to the non-project serve path (fail closed).
+            Log::warning('Unauthorized file access attempt on orphaned project file', [
+                'userId' => $currentUserId,
+                'fileId' => $fileRecord['id'],
+                'module' => $fileRecord['module'] ?? '',
+            ]);
+
+            return new Response('', 403);
         } elseif ($this->isOwnerRestrictedModule($fileRecord)) {
             // For private/user files, only the file owner can access.
             if ((int) ($fileRecord['userId'] ?? 0) !== $currentUserId) {
@@ -417,9 +444,15 @@ class Files extends BaseService
 
         if (isset($post['upload']) || isset($files['file'])) {
             if (isset($files['file'])) {
-                $this->upload($files, $module, $moduleId);
+                try {
+                    $result = $this->upload($files, $module, $moduleId);
+                } catch (AuthorizationException) {
+                    // A denied upload becomes a clean "upload failed" notification, not a 403 page.
+                    return ['action' => 'upload', 'success' => false];
+                }
 
-                return ['action' => 'upload', 'success' => true];
+                // upload() returns the file metadata array on success, or a string/false on failure.
+                return ['action' => 'upload', 'success' => is_array($result)];
             }
 
             return ['action' => 'upload', 'success' => false];

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -49,7 +49,9 @@ class Files extends BaseService
      * files.view in it (readonly+); owner-restricted listings (private/user/lead/export) are
      * limited to the owner; an empty/unknown module returns [] rather than dumping the whole
      * table. The 'client' module has no project mapping and stays a Clients-domain concern
-     * (ShowClient is admin/manager-gated) — tracked as a follow-up with the Clients rollout.
+     * (ShowClient is admin-gated) — tracked as a follow-up with the Clients rollout; it requires
+     * a specific client id here so the @api method can't be called with no id to dump every
+     * client's files.
      *
      * @api
      */
@@ -66,9 +68,13 @@ class Files extends BaseService
             if ((int) $entityId !== $this->currentUserId()) {
                 return [];
             }
-        } elseif ($module !== 'client') {
-            // No project context and not an owner-restricted or client listing (e.g. an empty
-            // module): refuse rather than dump every file in the system.
+        } elseif ($module === 'client' && (int) $entityId > 0) {
+            // Client files have no project mapping; their authz is a Clients-domain concern
+            // (ShowClient is admin-gated) tracked as a follow-up. Require a SPECIFIC client id so
+            // this @api method can't be called with no id to dump every client's files at once.
+        } else {
+            // No project context (empty/unknown module, or 'client' with no id): refuse rather
+            // than dump rows.
             return [];
         }
 

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -4,14 +4,14 @@ namespace Leantime\Domain\Files\Services;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
-use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Files\Exceptions\FileValidationException;
 use Leantime\Core\Files\FileManager;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Files\Permissions\FilesPermissions;
 use Leantime\Domain\Files\Repositories\Files as FileRepository;
-use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,10 +19,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @api
  */
-class Files
+class Files extends BaseService
 {
-    use DispatchesEvents;
-
     /**
      * Image file extensions treated as previewable images across the file UI.
      *
@@ -41,14 +39,39 @@ class Files
         protected FileRepository $fileRepository,
         protected FileManager $fileManager,
         protected LanguageCore $language,
-        protected ProjectRepository $projectRepository,
     ) {}
 
     /**
+     * Lists files for a module/entity, fail-closed against the entity's owning project.
+     *
+     * Without this gate the @api method let any authenticated caller enumerate every project's
+     * files by guessing ids over JSON-RPC. We resolve the target's real project and require
+     * files.view in it (readonly+); owner-restricted listings (private/user/lead/export) are
+     * limited to the owner; an empty/unknown module returns [] rather than dumping the whole
+     * table. The 'client' module has no project mapping and stays a Clients-domain concern
+     * (ShowClient is admin/manager-gated) — tracked as a follow-up with the Clients rollout.
+     *
      * @api
      */
     public function getFilesByModule(string $module = '', $entityId = null, $userId = null): false|array
     {
+        $projectId = $this->resolveProjectId(['module' => $module, 'moduleId' => $entityId]);
+
+        if ($projectId !== null) {
+            if (! $this->can(FilesPermissions::VIEW, $projectId)) {
+                return [];
+            }
+        } elseif (in_array($module, self::OWNER_RESTRICTED_MODULES, true)) {
+            // Owner-restricted listing: only the owner may enumerate their own files.
+            if ((int) $entityId !== $this->currentUserId()) {
+                return [];
+            }
+        } elseif ($module !== 'client') {
+            // No project context and not an owner-restricted or client listing (e.g. an empty
+            // module): refuse rather than dump every file in the system.
+            return [];
+        }
+
         return $this->fileRepository->getFilesByModule($module, $entityId, $userId);
     }
 
@@ -84,6 +107,16 @@ class Files
         }
         if ($module === 'tickets') {
             $module = 'ticket';
+        }
+
+        // Authorize against the target's owning project before writing anything (commenter+;
+        // admin/owner bypass). This guards the JSON-RPC path, which reaches the @api upload()
+        // directly, without the Upload controller's userCanUploadToModule pre-check. Non-project
+        // modules (user avatar, private, ...) have no project context and preserve prior behavior;
+        // their flows pin moduleId server-side (e.g. ProfileImage forces the session user's id).
+        $targetProjectId = $this->resolveProjectId(['module' => $module, 'moduleId' => $moduleId]);
+        if ($targetProjectId !== null) {
+            $this->authorize(FilesPermissions::UPLOAD, $targetProjectId);
         }
 
         try {
@@ -148,7 +181,14 @@ class Files
     }
 
     /**
-     * Delete a file. The caller must be the file owner or have at least manager role.
+     * Delete a file. The uploader may always delete their own file; otherwise the caller needs
+     * files.delete (editor+) IN THE FILE'S OWN PROJECT.
+     *
+     * The old check allowed any manager+ to delete ANY file globally (no project scope) — an IDOR
+     * across projects. We now resolve the file's real project and require files.delete there
+     * (admin/owner still bypass project membership). Owner-restricted/no-project files (private,
+     * user avatar, ...) can only be deleted by their uploader. Denials soft-deny (return false) to
+     * preserve the prior contract and keep handleFileAction's success flag meaningful.
      *
      * @api
      */
@@ -160,18 +200,23 @@ class Files
             return false;
         }
 
-        $currentUserId = session('userdata.id');
-
-        // File owner can delete their own file
-        if ((int) $file['userId'] === (int) $currentUserId) {
+        // The uploader may always delete their own file, regardless of role.
+        if ((int) $file['userId'] === $this->currentUserId()) {
             return $this->fileRepository->deleteFile((int) $fileId);
         }
 
-        // Managers and above can delete any file
-        if (Auth::userIsAtLeast(Roles::$manager)) {
+        $projectId = $this->resolveProjectId($file);
+
+        // Non-owner delete of a project-scoped file requires files.delete in THAT project.
+        if ($projectId !== null) {
+            if (! $this->can(FilesPermissions::DELETE, $projectId)) {
+                return false;
+            }
+
             return $this->fileRepository->deleteFile((int) $fileId);
         }
 
+        // Owner-restricted / no-project file and the caller is not the uploader: deny.
         return false;
     }
 
@@ -247,6 +292,8 @@ class Files
      * targets with no project mapping fall back to that path's (unrestricted) behaviour.
      *
      * Not @api: internal authorization helper for the upload controller, not a JSON-RPC method.
+     * Returns the same verdict the @api upload() enforces in-body, so the controller can render a
+     * clean 403 before invoking it.
      *
      * @param  string  $module  The target module (e.g. project, ticket, wiki)
      * @param  int  $moduleId  The target entity id within that module
@@ -254,29 +301,30 @@ class Files
      */
     public function userCanUploadToModule(string $module, int $moduleId): bool
     {
-        if (Auth::userIsAtLeast(Roles::$admin)) {
-            return true;
-        }
-
         $projectId = $this->resolveProjectId(['module' => $module, 'moduleId' => $moduleId]);
 
         if ($projectId !== null) {
-            return $this->projectRepository->isUserAssignedToProject((int) session('userdata.id'), $projectId);
+            // files.upload is commenter+; admin/owner bypass project membership.
+            return $this->can(FilesPermissions::UPLOAD, $projectId);
         }
 
+        // Non-project modules (user avatar, private, ...) keep prior behavior; their flows pin
+        // moduleId server-side.
         return true;
     }
 
     /**
-     * Resolves a file by its encoded name, authorizes the given user, and returns
+     * Resolves a file by its encoded name, authorizes the CURRENT (session) user, and returns
      * the file response.
      *
-     * Authorization mirrors the previous controller behavior: admins/owners bypass
-     * all checks; project-scoped files require the user to be assigned to the owning
-     * project; owner-restricted modules require the user to be the uploader.
+     * Project-scoped files require files.view in the owning project (readonly+; admin/owner bypass
+     * project membership — equivalent to the prior admin-bypass + isUserAssignedToProject check).
+     * Owner-restricted modules require the caller to be the uploader. Authorization always uses the
+     * session user, never the $userId argument: this @api method previously trusted the passed id,
+     * so a JSON-RPC caller could read any owner-restricted file by claiming to be its uploader.
      *
      * @param  string  $encName  The encoded (hashed) filename without extension.
-     * @param  int  $userId  The id of the requesting user.
+     * @param  int  $userId  Retained for signature/RPC compatibility; not used for authorization.
      * @return Response The file content response, 403 if unauthorized, or 404 if not found.
      *
      * @throws \Exception
@@ -295,31 +343,29 @@ class Files
         $realName = $fileRecord['realName'];
         $ext = $fileRecord['extension'];
 
-        // Check project-level access unless the caller is admin or owner
-        if (! Auth::userIsAtLeast(Roles::$admin)) {
-            $projectId = $this->resolveProjectId($fileRecord);
+        $currentUserId = $this->currentUserId();
+        $projectId = $this->resolveProjectId($fileRecord);
 
-            if ($projectId !== null) {
-                if (! $this->projectRepository->isUserAssignedToProject($userId, $projectId)) {
-                    Log::warning('Unauthorized file access attempt', [
-                        'userId' => $userId,
-                        'fileId' => $fileRecord['id'],
-                        'projectId' => $projectId,
-                    ]);
+        if ($projectId !== null) {
+            if (! $this->can(FilesPermissions::VIEW, $projectId)) {
+                Log::warning('Unauthorized file access attempt', [
+                    'userId' => $currentUserId,
+                    'fileId' => $fileRecord['id'],
+                    'projectId' => $projectId,
+                ]);
 
-                    return new Response('', 403);
-                }
-            } elseif ($this->isOwnerRestrictedModule($fileRecord)) {
-                // For private/user files, only the file owner can access
-                if ((int) ($fileRecord['userId'] ?? 0) !== $userId) {
-                    Log::warning('Unauthorized file access attempt on private file', [
-                        'userId' => $userId,
-                        'fileId' => $fileRecord['id'],
-                        'module' => $fileRecord['module'] ?? '',
-                    ]);
+                return new Response('', 403);
+            }
+        } elseif ($this->isOwnerRestrictedModule($fileRecord)) {
+            // For private/user files, only the file owner can access.
+            if ((int) ($fileRecord['userId'] ?? 0) !== $currentUserId) {
+                Log::warning('Unauthorized file access attempt on private file', [
+                    'userId' => $currentUserId,
+                    'fileId' => $fileRecord['id'],
+                    'module' => $fileRecord['module'] ?? '',
+                ]);
 
-                    return new Response('', 403);
-                }
+                return new Response('', 403);
             }
         }
 
@@ -350,7 +396,9 @@ class Files
      *
      * @throws BindingResolutionException
      *
-     * @api
+     * Not @api: an internal controller helper shaped around $_POST/$_FILES, called in-process by the
+     * Browse/ShowAll controllers. It is deliberately NOT JSON-RPC reachable — its delegates
+     * (deleteFile/upload) self-authorize, but the request-array signature is not an API surface.
      */
     public function handleFileAction(array $post, array $files, string $module, int|string|null $moduleId): array
     {

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -95,6 +95,7 @@ class Install
         30512,
         30513,
         30514,
+        30515,
     ];
 
     /**
@@ -2981,6 +2982,34 @@ class Install
             Log::error('Migration 30514: '.$e->getMessage());
 
             return ['Migration 30514 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Files domain. Adds
+     * files.view/upload/delete (all project-scoped).
+     *
+     * No DefaultRolePermissions matrix edit was needed — these are standard project verbs that
+     * auto-grant through the existing rules (view→readonly+, upload→commenter+, delete→editor+,
+     * manager+ via the project wildcard, admin/owner via scope:any). The re-seed is still required
+     * so the new keys land in zp_role_permissions for the built-in roles.
+     *
+     * Flush the discovered-provider cache FIRST so FilesPermissions is rediscovered.
+     */
+    public function update_sql_30515(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30515: '.$e->getMessage());
+
+            return ['Migration 30515 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -44,6 +44,9 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('goals.create', 'Create', true),
             new Permission('goals.edit', 'Edit', true),
             new Permission('goals.delete', 'Delete', true),
+            new Permission('files.view', 'View', true),
+            new Permission('files.upload', 'Upload', true),
+            new Permission('files.delete', 'Delete', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -78,7 +81,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view', 'files.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -101,6 +104,11 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('blueprints.view', $grants);      // inherited from readonly
         $this->assertNotContains('goals.create', $grants);      // commenter views but cannot create
         $this->assertContains('goals.view', $grants);           // inherited from readonly
+        // Files: a commenter inherits view and gains the standard upload verb (attachments), but
+        // cannot delete (editor+).
+        $this->assertContains('files.view', $grants);           // inherited from readonly
+        $this->assertContains('files.upload', $grants);         // commenter upload verb
+        $this->assertNotContains('files.delete', $grants);      // editor+
         // Timesheets are editor+ (global); a commenter logs no time.
         $this->assertNotContains('timesheets.view', $grants);
         $this->assertNotContains('timesheets.create', $grants);
@@ -133,6 +141,10 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('goals.create', $grants);
         $this->assertContains('goals.edit', $grants);
         $this->assertContains('goals.delete', $grants);
+        // Files uses standard project verbs, so editor auto-gets upload + delete (and view).
+        $this->assertContains('files.view', $grants);
+        $this->assertContains('files.upload', $grants);
+        $this->assertContains('files.delete', $grants);
         // Timesheets are GLOBAL-scoped, so the project verb rule does NOT match them — editor gets
         // its own-time keys explicitly (view/create/edit/delete) but NOT the manager-only `manage`.
         $this->assertContains('timesheets.view', $grants);

--- a/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
+++ b/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
@@ -363,6 +363,26 @@ class FilesServiceTest extends TestCase
         $service->upload(['file' => []], 'project', 5);
     }
 
+    public function test_upload_throws_for_project_scoped_module_with_unresolvable_project(): void
+    {
+        // A project-scoped module (ticket) whose project can't be resolved (invalid/deleted id)
+        // fails closed even with allow-all permissions — no orphan-file upload bypass.
+        $repo = $this->make(FileRepository::class, ['getProjectIdForFile' => fn () => null]);
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        $service->upload(['file' => []], 'ticket', 999);
+    }
+
+    public function test_user_can_upload_to_module_denies_project_scoped_with_unresolvable_project(): void
+    {
+        $repo = $this->make(FileRepository::class, ['getProjectIdForFile' => fn () => null]);
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertFalse($service->userCanUploadToModule('ticket', 999));
+    }
+
     public function test_user_can_upload_to_module_reflects_project_permission(): void
     {
         $this->assertTrue(
@@ -450,5 +470,55 @@ class FilesServiceTest extends TestCase
         $service = $this->makeService($repo, null, $this->allowingPermissions());
 
         $this->assertSame(404, $service->getFileForUser('missing', 1)->getStatusCode());
+    }
+
+    public function test_get_file_for_user_denies_orphaned_project_file(): void
+    {
+        // A ticket file whose ticket was deleted resolves to no project; rather than fall through
+        // to the non-project serve path it must be denied (fail closed), even with allow-all perms.
+        $repo = $this->make(FileRepository::class, [
+            'getFileByEncName' => fn () => [
+                'id' => 14, 'realName' => 'a.pdf', 'extension' => 'pdf',
+                'module' => 'ticket', 'moduleId' => 999, 'userId' => 2,
+            ],
+            'getProjectIdForFile' => fn () => null,
+        ]);
+        $fileManager = $this->make(FileManager::class, [
+            'getFile' => fn () => $this->fail('an orphaned ticket file must not be served'),
+        ]);
+
+        $service = $this->makeService($repo, $fileManager, $this->allowingPermissions());
+
+        $this->assertSame(403, $service->getFileForUser('enc', 1)->getStatusCode());
+    }
+
+    // ---- handleFileAction result reflects upload() outcome ----------------
+
+    public function test_handle_file_action_reports_failure_when_upload_is_denied(): void
+    {
+        /** @var Files $service */
+        $service = $this->make(Files::class, [
+            'upload' => function () {
+                throw new AuthorizationException;
+            },
+        ]);
+
+        $result = $service->handleFileAction(['upload' => '1'], ['file' => ['name' => 'a.png']], 'ticket', 5);
+
+        $this->assertSame('upload', $result['action']);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_handle_file_action_reports_failure_when_upload_returns_error_string(): void
+    {
+        /** @var Files $service */
+        $service = $this->make(Files::class, [
+            'upload' => fn () => 'Error uploading file',
+        ]);
+
+        $result = $service->handleFileAction(['upload' => '1'], ['file' => ['name' => 'a.png']], 'project', 5);
+
+        $this->assertSame('upload', $result['action']);
+        $this->assertFalse($result['success']);
     }
 }

--- a/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
+++ b/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
@@ -2,17 +2,73 @@
 
 namespace Unit\app\Domain\Files\Services;
 
+use Leantime\Core\Auth\Permissions\PermissionService;
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Core\Files\FileManager;
+use Leantime\Core\Language as LanguageCore;
+use Leantime\Domain\Files\Repositories\Files as FileRepository;
 use Leantime\Domain\Files\Services\Files;
-use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
+use Symfony\Component\HttpFoundation\Response;
 use Unit\TestCase;
 
 /**
- * Unit tests for the Files service logic extracted from the Files controllers
- * (Get, Browse, ShowAll) during the thin-controller refactor.
+ * Unit tests for the Files service: the pure helpers extracted during the thin-controller refactor
+ * (getImageExtensions, isOwnerRestrictedModule, handleFileAction) plus the authorization the native
+ * permission engine added. The authz tests prove the four IDOR-prone @api methods fail closed:
+ *  - getFilesByModule resolves the target's project and denies non-members (no enumeration)
+ *  - upload authorizes against the target project (commenter+) on the JSON-RPC path too
+ *  - deleteFile preserves owner-delete but scopes the non-owner path to the file's project (editor+),
+ *    closing the old manager-global cross-project bypass
+ *  - getFileForUser authorizes the SESSION user, never the spoofable $userId argument
  */
 class FilesServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The current (session) user the service authorizes as.
+        session(['userdata.id' => 1]);
+    }
+
+    /** Permission stub that grants everything. */
+    private function allowingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'currentUserCan' => fn () => true,
+            'authorize' => fn () => null,
+        ]);
+    }
+
+    /** Permission stub that denies everything (authorize throws, currentUserCan is false). */
+    private function denyingPermissions(): PermissionService
+    {
+        return $this->make(PermissionService::class, [
+            'currentUserCan' => fn () => false,
+            'authorize' => function (): void {
+                throw new AuthorizationException;
+            },
+        ]);
+    }
+
+    private function makeService(
+        ?FileRepository $repo = null,
+        ?FileManager $fileManager = null,
+        ?PermissionService $perms = null,
+    ): Files {
+        $service = new Files(
+            $repo ?? $this->make(FileRepository::class),
+            $fileManager ?? $this->make(FileManager::class),
+            $this->make(LanguageCore::class),
+        );
+        $service->setPermissionService($perms ?? $this->allowingPermissions());
+
+        return $service;
+    }
+
+    // ---- pure helpers -----------------------------------------------------
 
     public function test_get_image_extensions_returns_the_shared_whitelist(): void
     {
@@ -50,6 +106,8 @@ class FilesServiceTest extends TestCase
         $this->assertFalse($service->isOwnerRestrictedModule(['module' => 'client']));
         $this->assertFalse($service->isOwnerRestrictedModule([]));
     }
+
+    // ---- handleFileAction (controller helper; delegates self-authorize) ---
 
     public function test_handle_file_action_deletes_when_del_file_present(): void
     {
@@ -127,65 +185,244 @@ class FilesServiceTest extends TestCase
         $this->assertFalse($result['success']);
     }
 
-    // ---------------------------------------------------------------------
-    // userCanUploadToModule() — authorizes the /files/upload (legacy /api/files)
-    // endpoint, which previously forwarded any module/moduleId to upload() with
-    // no access control.
-    // ---------------------------------------------------------------------
+    // ---- getFilesByModule -------------------------------------------------
 
-    public function test_user_can_upload_to_module_allows_admin_anywhere(): void
+    public function test_get_files_by_module_denies_non_member(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'admin']]);
-
-        /** @var Files $service */
-        $service = $this->make(Files::class, [
-            // Admins bypass before any project resolution happens.
-            'resolveProjectId' => fn () => $this->fail('admins must short-circuit before resolving a project'),
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => $this->fail('Repository must not be queried when files.view is denied'),
         ]);
 
-        $this->assertTrue($service->userCanUploadToModule('project', 999));
+        $service = $this->makeService($repo, null, $this->denyingPermissions());
+
+        // module=project → projectId resolves to moduleId (5) directly; can(VIEW,5)=false → soft-deny.
+        $this->assertSame([], $service->getFilesByModule('project', 5));
     }
 
-    public function test_user_can_upload_to_module_denies_inaccessible_project(): void
+    public function test_get_files_by_module_allows_member(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
-
-        /** @var Files $service */
-        $service = $this->make(Files::class, [
-            'resolveProjectId' => fn () => 5,
-            'projectRepository' => $this->make(ProjectRepository::class, [
-                'isUserAssignedToProject' => fn () => false,
-            ]),
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => [['id' => 99, 'module' => 'project', 'moduleId' => 5]],
         ]);
 
-        $this->assertFalse($service->userCanUploadToModule('ticket', 42));
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertCount(1, $service->getFilesByModule('project', 5));
     }
 
-    public function test_user_can_upload_to_module_allows_accessible_project(): void
+    public function test_get_files_by_module_empty_module_returns_empty_without_dumping(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
-
-        /** @var Files $service */
-        $service = $this->make(Files::class, [
-            'resolveProjectId' => fn () => 5,
-            'projectRepository' => $this->make(ProjectRepository::class, [
-                'isUserAssignedToProject' => fn () => true,
-            ]),
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => $this->fail('An empty module must never dump the file table'),
         ]);
 
-        $this->assertTrue($service->userCanUploadToModule('project', 5));
+        // Even with allow-all permissions, an empty module has no project context and must refuse.
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertSame([], $service->getFilesByModule(''));
     }
 
-    public function test_user_can_upload_to_module_allows_targets_with_no_project_mapping(): void
+    public function test_get_files_by_module_owner_restricted_denies_other_user(): void
     {
-        session(['userdata' => ['id' => 1, 'role' => 'editor']]);
-
-        /** @var Files $service */
-        $service = $this->make(Files::class, [
-            // e.g. wiki uploads resolve to no project; mirrors the read-path behaviour.
-            'resolveProjectId' => fn () => null,
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => $this->fail('Owner-restricted listing must not return another user\'s files'),
         ]);
 
-        $this->assertTrue($service->userCanUploadToModule('wiki', 12));
+        // module=user, entityId=2 (not the session user 1) → soft-deny regardless of role.
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertSame([], $service->getFilesByModule('user', 2));
+    }
+
+    public function test_get_files_by_module_owner_restricted_allows_owner(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => [['id' => 7, 'module' => 'user', 'moduleId' => 1]],
+        ]);
+
+        // module=user, entityId=1 == session user → allowed.
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertCount(1, $service->getFilesByModule('user', 1));
+    }
+
+    // ---- deleteFile -------------------------------------------------------
+
+    public function test_delete_file_allows_owner_even_without_permission(): void
+    {
+        $deleted = false;
+        $repo = $this->make(FileRepository::class, [
+            'getFile' => fn () => ['id' => 10, 'userId' => 1, 'module' => 'project', 'moduleId' => 5],
+            'deleteFile' => function () use (&$deleted) {
+                $deleted = true;
+
+                return true;
+            },
+        ]);
+
+        // Deny-all permissions: the owner path must still delete (file.userId === session user 1).
+        $service = $this->makeService($repo, null, $this->denyingPermissions());
+
+        $this->assertTrue($service->deleteFile(10));
+        $this->assertTrue($deleted, 'Owner deletion should reach the repository');
+    }
+
+    public function test_delete_file_denies_non_owner_without_permission(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFile' => fn () => ['id' => 10, 'userId' => 2, 'module' => 'project', 'moduleId' => 5],
+            'deleteFile' => fn () => $this->fail('A non-owner without files.delete must not delete'),
+        ]);
+
+        // File owned by user 2; session user is 1 without files.delete in project 5 → soft-deny.
+        $service = $this->makeService($repo, null, $this->denyingPermissions());
+
+        $this->assertFalse($service->deleteFile(10));
+    }
+
+    public function test_delete_file_allows_non_owner_with_project_permission(): void
+    {
+        $deleted = false;
+        $repo = $this->make(FileRepository::class, [
+            'getFile' => fn () => ['id' => 10, 'userId' => 2, 'module' => 'project', 'moduleId' => 5],
+            'deleteFile' => function () use (&$deleted) {
+                $deleted = true;
+
+                return true;
+            },
+        ]);
+
+        // Non-owner, but allow-all grants files.delete in the file's project (editor+).
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertTrue($service->deleteFile(10));
+        $this->assertTrue($deleted);
+    }
+
+    public function test_delete_file_missing_returns_false(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFile' => fn () => false,
+        ]);
+
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertFalse($service->deleteFile(999));
+    }
+
+    public function test_delete_file_owner_restricted_non_owner_denied(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFile' => fn () => ['id' => 11, 'userId' => 2, 'module' => 'user', 'moduleId' => 2],
+            'deleteFile' => fn () => $this->fail('A no-project file may only be deleted by its uploader'),
+        ]);
+
+        // Owner-restricted (module=user → no project); session user 1 is not the owner (2) →
+        // deny even with allow-all (the old manager-global delete of others' files is dropped).
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertFalse($service->deleteFile(11));
+    }
+
+    // ---- upload -----------------------------------------------------------
+
+    public function test_upload_throws_when_project_upload_denied(): void
+    {
+        $service = $this->makeService(null, null, $this->denyingPermissions());
+
+        $this->expectException(AuthorizationException::class);
+
+        // Passes the initial validation (module/moduleId present, file is an array) and reaches the
+        // project authorize() before any file is written → throws on deny.
+        $service->upload(['file' => []], 'project', 5);
+    }
+
+    public function test_user_can_upload_to_module_reflects_project_permission(): void
+    {
+        $this->assertTrue(
+            $this->makeService(null, null, $this->allowingPermissions())->userCanUploadToModule('project', 5)
+        );
+
+        $this->assertFalse(
+            $this->makeService(null, null, $this->denyingPermissions())->userCanUploadToModule('project', 5)
+        );
+    }
+
+    public function test_user_can_upload_to_module_nonproject_preserved(): void
+    {
+        // Non-project modules (user avatar, ...) have no project context; preserved as allowed even
+        // under deny-all (their flows pin moduleId server-side).
+        $service = $this->makeService(null, null, $this->denyingPermissions());
+
+        $this->assertTrue($service->userCanUploadToModule('user', 9));
+    }
+
+    // ---- getFileForUser ---------------------------------------------------
+
+    public function test_get_file_for_user_denies_non_member(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFileByEncName' => fn () => [
+                'id' => 12, 'realName' => 'doc.pdf', 'extension' => 'pdf',
+                'module' => 'project', 'moduleId' => 5, 'userId' => 2,
+            ],
+        ]);
+        $fileManager = $this->make(FileManager::class, [
+            'getFile' => fn () => $this->fail('A non-member must not receive file bytes'),
+        ]);
+
+        $service = $this->makeService($repo, $fileManager, $this->denyingPermissions());
+
+        $response = $service->getFileForUser('abc123', 1);
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_get_file_for_user_allows_member(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFileByEncName' => fn () => [
+                'id' => 12, 'realName' => 'doc.pdf', 'extension' => 'pdf',
+                'module' => 'project', 'moduleId' => 5, 'userId' => 2,
+            ],
+        ]);
+        $fileManager = $this->make(FileManager::class, [
+            'getFile' => fn () => new Response('bytes', 200),
+        ]);
+
+        $service = $this->makeService($repo, $fileManager, $this->allowingPermissions());
+
+        $response = $service->getFileForUser('abc123', 1);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_get_file_for_user_owner_restricted_uses_session_user_not_arg(): void
+    {
+        // Owner-restricted file owned by user 2. Session user is 1. Even though the caller passes
+        // userId=2 (spoofing the owner) the check uses the SESSION user (1) and denies.
+        $repo = $this->make(FileRepository::class, [
+            'getFileByEncName' => fn () => [
+                'id' => 13, 'realName' => 'secret.txt', 'extension' => 'txt',
+                'module' => 'private', 'moduleId' => 2, 'userId' => 2,
+            ],
+        ]);
+        $fileManager = $this->make(FileManager::class, [
+            'getFile' => fn () => $this->fail('Owner-restricted file must not be served to a non-owner'),
+        ]);
+
+        $service = $this->makeService($repo, $fileManager, $this->allowingPermissions());
+
+        $response = $service->getFileForUser('enc', 2);
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_get_file_for_user_missing_returns_404(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFileByEncName' => fn () => false,
+        ]);
+
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertSame(404, $service->getFileForUser('missing', 1)->getStatusCode());
     }
 }

--- a/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
+++ b/tests/Unit/app/Domain/Files/Services/FilesServiceTest.php
@@ -246,6 +246,32 @@ class FilesServiceTest extends TestCase
         $this->assertCount(1, $service->getFilesByModule('user', 1));
     }
 
+    public function test_get_files_by_module_client_without_id_returns_empty(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => $this->fail('client listing with no id must not dump every client\'s files'),
+        ]);
+
+        // module=client has no project mapping; with no specific client id it must refuse rather
+        // than enumerate all client files (the legitimate ShowClient path always passes an id).
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertSame([], $service->getFilesByModule('client'));
+    }
+
+    public function test_get_files_by_module_client_with_id_passes_through(): void
+    {
+        $repo = $this->make(FileRepository::class, [
+            'getFilesByModule' => fn () => [['id' => 8, 'module' => 'client', 'moduleId' => 3]],
+        ]);
+
+        // A specific client id is the legitimate ShowClient call; authz remains a Clients-domain
+        // follow-up, so it passes through.
+        $service = $this->makeService($repo, null, $this->allowingPermissions());
+
+        $this->assertCount(1, $service->getFilesByModule('client', 3));
+    }
+
     // ---- deleteFile -------------------------------------------------------
 
     public function test_delete_file_allows_owner_even_without_permission(): void


### PR DESCRIPTION
## Summary

Brings the **Files** domain onto the native DB-backed permission engine and closes four fail-open `@api` IDORs. Part of the service-layer hardening rollout (after Sprints, Comments, Wiki/Ideas, the canvas family, and Timesheets).

`FilesPermissions`: `files.view` (readonly+) / `files.upload` (commenter+) / `files.delete` (editor+) — all standard project verbs, so they auto-grant through the existing matrix with **no `DefaultRolePermissions` edit**.

## IDORs closed (were reachable by any authenticated JSON-RPC caller)

| Method | Before | After |
|---|---|---|
| `getFilesByModule` | no check — enumerate any project's files by guessing ids; bare call dumps the whole table | resolves the target's real project, requires `files.view` (soft-deny `[]`); owner-restricted → owner-only; empty/unknown module → `[]` |
| `upload` | no service check (only the controller pre-gated) | authorizes `files.upload` against the resolved project in-body — guards the RPC path |
| `deleteFile` | owner **OR manager+ globally** (delete any file in any project) | owner always; else `files.delete` **in the file's own project** (editor+; admin/owner bypass membership) |
| `getFileForUser` | trusted the passed `$userId` for the owner check (spoofable via RPC) | authorizes the **session** user; project files via `can(files.view, project)` |

`handleFileAction` drops `@api` (a `$_POST`/`$_FILES`-shaped controller helper, not an API surface; its delegates self-authorize). `userCanUploadToModule` migrated to the engine; dead `ProjectRepository` dependency removed. `Browse`/`ShowAll` get `#[RequiresPermission(files.view)]` (session project) as defense-in-depth.

## Grant-equivalence

The only intentional behavior changes are the two confirmed with the maintainer:
- **Non-owner delete → editor+** (was owner-OR-manager+). Aligns with the editor-gated delete button (which silently failed for non-owned files before); a non-owner editor in the project gains delete. Closes the manager-global cross-project bypass.
- **Upload → commenter+** (was any project member incl. readonly). Drops a `readonly` member's raw-endpoint upload; the UI never offered it to them.

Owner-delete, view, and admin/owner bypass are **preserved**.

## Notes / documented follow-ups (non-blocking)
- The `client` module has no project mapping; client-file listing/upload authz stays a Clients-domain concern (`ShowClient` is admin/manager-gated) — to be addressed with the Clients rollout.
- An admin replacing **another** user's avatar no longer deletes the old owner-restricted file (orphan, not a security issue).
- `getModules` (a non-`@api` UI dropdown helper) still uses `Auth::userIsAtLeast(admin)` — no clean engine equivalent; left as-is.

## Migration / tests
- `update_sql_30515`: flush registry → `syncDiscoveredPermissions` → `seedBuiltInRoles` (no matrix edit). dbVersion 3.5.14 → **3.5.15**.
- Rewrote `FilesServiceTest` (its old `userCanUploadToModule` tests asserted the pre-engine impl) with fail-closed authz coverage; added `files.*` to `DefaultRolePermissionsTest`.

Reviewed via a 5-lens adversarial pass (grant-equivalence / fail-closed-IDOR / consumer-regression / test-correctness / runtime-correctness): verdict SHIP, 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)