### PR TITLE
Fix for List view on To-Dos

### DIFF
--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3642,6 +3642,7 @@ class Tickets extends BaseService
             'futureSprints' => $futureSprints,
             'users' => $users,
             'milestones' => $milestones,
+            'groupBy' => $searchCriteria['groupBy'] ?? '',
             'groupByOptions' => $groupByOptions,
             'newField' => $newField,
             'sortOptions' => $sortOptions,


### PR DESCRIPTION
Fix undefined $groupBy in showList view. Restore the missing groupBy template variable to prevent errors when opening the To-Do List View. After this fix a user is able to press on `List` view on To-Dos.

### Description

**Suggested change**

Add the missing `groupBy` value to the template assignments:

```php
'groupBy' => $searchCriteria['groupBy'] ?? '',
```

**Reasoning**

The `showList` view expects a `$groupBy` variable, but `getTicketTemplateAssignments()` does not provide it. Passing the current `groupBy` value restores the expected contract between the service and the view, preventing the "Undefined variable $groupBy" error while preserving the user's selected grouping state.


### Link to ticket

https://github.com/Leantime/leantime/issues/3470
https://github.com/Leantime/leantime/issues/3495
https://github.com/Leantime/leantime/issues/3466

### Type

- [X] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

<img width="1292" height="746" alt="image" src="https://github.com/user-attachments/assets/932644fe-4064-4bde-8208-ba341b9a897e" />
