### PR TITLE
Fix for "Add Milestone" broken feature

### DIFF
--- a/app/Domain/Tickets/Templates/milestoneDialog.blade.php
+++ b/app/Domain/Tickets/Templates/milestoneDialog.blade.php
@@ -1,5 +1,5 @@
 @php
-    $currentMilestone = $milestone ?? null;
+    $currentMilestone = $currentMilestone ?? $milestone ?? null;
     $milestones = $milestones ?? [];
     $statusLabels = $statusLabels ?? [];
 @endphp


### PR DESCRIPTION
Refactor currentMilestone assignment logic. Make the template work whether the controller passes currentMilestone or milestone. This change fix the Issue of the current broken "Add Milestone" feature.

### Description

In a simple and not destructive way we are going to fix the current broken "Add Milestone" feature, i was happily using this patch for my Leantime implementation and so i decided to share it. Thank you for the awesome project!

### Link to ticket

Links to the GitHub issue being addressed by this change:
https://github.com/Leantime/leantime/issues/3462
https://github.com/Leantime/leantime/issues/3489

### Type

- [X] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

<img width="1439" height="905" alt="image" src="https://github.com/user-attachments/assets/e22d9616-6023-4988-99a9-29aa70b442dc" />

