### PR TITLE
security(reports): gate the Reports domain + de-expose system/telemetry RPC surface

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.15';
+    public string $dbVersion = '3.5.16';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -96,6 +96,7 @@ class Install
         30513,
         30514,
         30515,
+        30516,
     ];
 
     /**
@@ -3010,6 +3011,31 @@ class Install
             Log::error('Migration 30515: '.$e->getMessage());
 
             return ['Migration 30515 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Reports domain. Adds
+     * reports.view (project-scoped standard verb → auto-grants readonly+; no
+     * DefaultRolePermissions matrix edit). The re-seed lands the new key in zp_role_permissions
+     * for the built-in roles.
+     *
+     * Flush the discovered-provider cache FIRST so ReportsPermissions is rediscovered.
+     */
+    public function update_sql_30516(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30516: '.$e->getMessage());
+
+            return ['Migration 30516 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Reports/Controllers/Show.php
+++ b/app/Domain/Reports/Controllers/Show.php
@@ -3,11 +3,11 @@
 namespace Leantime\Domain\Reports\Controllers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Reports\Permissions\ReportsPermissions;
 use Leantime\Domain\Reports\Services\Reports as ReportService;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
@@ -32,8 +32,11 @@ class Show extends Controller
         TicketService $ticketService,
         ReportService $reportService
     ): void {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
+        // Authorization lives on the action attributes (reports.view, session project) — the
+        // Frontcontroller enforces them BEFORE the controller is instantiated, so init() (and the
+        // dailyIngestion() it triggers) never runs for a denied user. Replaces the legacy
+        // editor+ authOrRedirect (maintainer-approved readonly+ loosening: the page only
+        // aggregates data readonly members already see item-by-item).
         $this->projectService = $projectService;
         $this->sprintService = $sprintService;
         $this->ticketService = $ticketService;
@@ -47,6 +50,7 @@ class Show extends Controller
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(ReportsPermissions::VIEW)]
     public function get(array $params): Response
     {
         $currentProject = (int) session('currentProject');
@@ -82,6 +86,7 @@ class Show extends Controller
         return $this->tpl->display('reports.show');
     }
 
+    #[RequiresPermission(ReportsPermissions::VIEW)]
     public function post($params): Response
     {
         return Frontcontroller::redirect(BASE_URL.'/dashboard/show');

--- a/app/Domain/Reports/Permissions/ReportsPermissions.php
+++ b/app/Domain/Reports/Permissions/ReportsPermissions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Leantime\Domain\Reports\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Reports permission vocabulary — a single project-scoped standard verb.
+ *
+ * Project reports (burndown charts, cumulative flow, ticket-status history) only aggregate data
+ * a project member can already read item-by-item (tickets, sprints, milestones are all
+ * readonly-visible), so the standard `view` verb is the sole capability and auto-grants to
+ * readonly+ through the matrix in {@see \Leantime\Core\Auth\Permissions\DefaultRolePermissions}
+ * with NO matrix edit. (Maintainer-approved loosening: the legacy /reports/show page gate was
+ * editor+, which guarded nothing the lower roles couldn't already see.)
+ *
+ * The domain's system-level methods (cron ingestion and telemetry) are deliberately NOT part of
+ * this vocabulary: they run with no session user and are not RPC-exposed (de-@api'd), so there is
+ * nothing to grant.
+ */
+final class ReportsPermissions implements ProvidesPermissions
+{
+    /** View a project's reports (burndown, cumulative flow, status history). Readonly+. */
+    public const VIEW = 'reports.view';
+
+    public function domain(): string
+    {
+        return 'reports';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View project reports', true),
+        ];
+    }
+}

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -208,10 +208,14 @@ class Reports extends BaseService
     /**
      * Returns a project's stored report history, authorized against the requested project.
      *
+     * $projectId is typed int so the param is REQUIRED and non-null: a JSON-RPC caller cannot
+     * pass null to make PermissionEnforcer::resolveProjectId() fall back to the session project
+     * (its isset() check treats explicit null as absent), which would dodge the per-target gate.
+     *
      * @api
      */
     #[RequiresPermission(ReportsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getFullReport($projectId): false|array
+    public function getFullReport(int $projectId): false|array
     {
         return $this->reportRepository->getFullReport($projectId);
     }
@@ -220,12 +224,16 @@ class Reports extends BaseService
      * Computes a project's current ticket report, authorized against the requested project.
      * The repository scopes by BOTH projectId and sprint, so a foreign sprint id yields no rows.
      *
+     * $projectId is typed int for the same reason as getFullReport() — it keeps the dispatch gate
+     * bound to the requested project (no null → session fallback). $sprintId stays mixed because
+     * the empty string is the meaningful "backlog" selector.
+     *
      * @throws BindingResolutionException
      *
      * @api
      */
     #[RequiresPermission(ReportsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getRealtimeReport($projectId, $sprintId): array|bool
+    public function getRealtimeReport(int $projectId, $sprintId): array|bool
     {
         return $this->reportRepository->runTicketReport($projectId, $sprintId);
     }

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -10,9 +10,10 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\AppSettings as AppSettingCore;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
-use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\UI\Template as TemplateCore;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Clients\Repositories\Clients as ClientRepository;
@@ -20,6 +21,7 @@ use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Reactions\Repositories\Reactions;
+use Leantime\Domain\Reports\Permissions\ReportsPermissions;
 use Leantime\Domain\Reports\Repositories\Reports as ReportRepository;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Setting\Services\Setting as SettingsService;
@@ -30,12 +32,19 @@ use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
 /**
+ * Reports service: per-project report aggregation (burndown, ticket-status history) plus the
+ * system-level daily-ingestion and telemetry tasks.
+ *
+ * Authorization model: the three by-projectId @api reads carry a dispatch
+ * #[RequiresPermission(reports.view, projectIdParam: 'projectId')] gate, authorized against the
+ * REQUESTED project (closes the cross-project RPC IDOR). The system/cron methods (ingestion,
+ * telemetry) are NOT @api — they run from the scheduler with no session user and must never be
+ * RPC-reachable.
+ *
  * @api
  */
-class Reports
+class Reports extends BaseService
 {
-    use DispatchesEvents;
-
     private TemplateCore $tpl;
 
     private AppSettingCore $appSettings;
@@ -99,6 +108,7 @@ class Reports
      *
      * @api
      */
+    #[RequiresPermission(ReportsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getSprintBurndownForReport(int $projectId, ?int $requestedSprintId): array
     {
         $allSprints = $this->sprintService->getAllSprints($projectId);
@@ -137,9 +147,13 @@ class Reports
     }
 
     /**
-     * @throws BindingResolutionException
+     * Runs the daily report ingestion for the session's current project.
      *
-     * @api
+     * Not @api: an internal web-path helper (called by the gated Reports\Controllers\Show after
+     * dispatch enforcement). It reads session('currentProject'), so an RPC caller would have no
+     * meaningful project binding — and it was needlessly RPC-exposed before.
+     *
+     * @throws BindingResolutionException
      */
     public function dailyIngestion(): void
     {
@@ -192,25 +206,36 @@ class Reports
     }
 
     /**
+     * Returns a project's stored report history, authorized against the requested project.
+     *
      * @api
      */
+    #[RequiresPermission(ReportsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getFullReport($projectId): false|array
     {
         return $this->reportRepository->getFullReport($projectId);
     }
 
     /**
+     * Computes a project's current ticket report, authorized against the requested project.
+     * The repository scopes by BOTH projectId and sprint, so a foreign sprint id yields no rows.
+     *
      * @throws BindingResolutionException
      *
      * @api
      */
+    #[RequiresPermission(ReportsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getRealtimeReport($projectId, $sprintId): array|bool
     {
         return $this->reportRepository->runTicketReport($projectId, $sprintId);
     }
 
     /**
-     * @api
+     * Builds the anonymous telemetry payload (instance-wide usage counts + company GUID).
+     *
+     * Not @api: system-level data source for sendAnonymousTelemetry() only. Exposing it over
+     * JSON-RPC let any authenticated user read instance-wide aggregates (user/project/feature
+     * counts) — reconnaissance, not a user capability.
      */
     public function getAnonymousTelemetry(
         IdeaRepository $ideaRepository,
@@ -322,9 +347,13 @@ class Reports
     }
 
     /**
-     * @throws BindingResolutionException
+     * Sends the daily anonymous telemetry ping (throttled to once a day, opt-out respected).
      *
-     * @api
+     * Not @api: a system task invoked by the scheduler (register.php cron, no session user) and
+     * the dashboard's lazy trigger — never a user-invokable RPC method (it makes an outbound
+     * HTTP request).
+     *
+     * @throws BindingResolutionException
      */
     public function sendAnonymousTelemetry(): bool|PromiseInterface
     {
@@ -378,11 +407,15 @@ class Reports
     }
 
     /**
+     * Opts the whole instance out of telemetry (writes companysettings.telemetry.active=false).
+     *
+     * Not @api: an instance-wide settings MUTATION. It is invoked internally by the admin-gated
+     * company-settings save (Setting::saveCompanySettings) — over JSON-RPC it previously let ANY
+     * authenticated user flip the company-wide telemetry setting.
+     *
      * @return false|void
      *
      * @throws Exception
-     *
-     * @api
      */
     public function optOutTelemetry()
     {
@@ -481,11 +514,14 @@ class Reports
     }
 
     /**
+     * Counts ALL projects in the instance by status color — a telemetry data source.
+     *
+     * Not @api: instance-wide aggregation with no project scope; over JSON-RPC it disclosed the
+     * whole company's project-health summary to any authenticated user.
+     *
      * @return array
      *
      * @throws Exception
-     *
-     * @api
      */
     public function getProjectStatusReport()
     {

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -47,6 +47,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('files.view', 'View', true),
             new Permission('files.upload', 'Upload', true),
             new Permission('files.delete', 'Delete', true),
+            new Permission('reports.view', 'View', true),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -81,7 +82,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view', 'files.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view', 'files.view', 'reports.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -109,6 +110,9 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('files.view', $grants);           // inherited from readonly
         $this->assertContains('files.upload', $grants);         // commenter upload verb
         $this->assertNotContains('files.delete', $grants);      // editor+
+        // Reports: view-only feature, inherited from readonly (maintainer-approved loosening of
+        // the legacy editor+ page gate — it only aggregates readonly-visible data).
+        $this->assertContains('reports.view', $grants);
         // Timesheets are editor+ (global); a commenter logs no time.
         $this->assertNotContains('timesheets.view', $grants);
         $this->assertNotContains('timesheets.create', $grants);

--- a/tests/Unit/app/Domain/Reports/Services/ReportsServiceTest.php
+++ b/tests/Unit/app/Domain/Reports/Services/ReportsServiceTest.php
@@ -17,11 +17,61 @@ use Unit\TestCase;
 
 /**
  * Unit tests for the sprint-burndown selection logic extracted from the
- * Reports\Controllers\Show controller into the Reports service.
+ * Reports\Controllers\Show controller into the Reports service, plus the permission-engine
+ * security surface: the three by-projectId @api reads must stay gated against the REQUESTED
+ * project, and the system/telemetry methods must never become RPC-reachable again.
  */
 class ReportsServiceTest extends TestCase
 {
     use \Codeception\Test\Feature\Stub;
+
+    /** Matches Jsonrpc::isApiMethod(): @api only at the start of a docblock line. */
+    private function isApiExposed(string $method): bool
+    {
+        $doc = (new \ReflectionMethod(Reports::class, $method))->getDocComment();
+
+        return $doc !== false && preg_match('/^\s*\*\s*@api\b/m', $doc) === 1;
+    }
+
+    /** The #[RequiresPermission] attribute instance on a method, or null. */
+    private function permissionAttribute(string $method): ?\Leantime\Core\Auth\Permissions\RequiresPermission
+    {
+        $attributes = (new \ReflectionMethod(Reports::class, $method))
+            ->getAttributes(\Leantime\Core\Auth\Permissions\RequiresPermission::class);
+
+        return $attributes === [] ? null : $attributes[0]->newInstance();
+    }
+
+    public function test_by_project_reads_are_rpc_exposed_and_gated_against_the_requested_project(): void
+    {
+        foreach (['getSprintBurndownForReport', 'getFullReport', 'getRealtimeReport'] as $method) {
+            $this->assertTrue($this->isApiExposed($method), "$method should stay RPC-callable");
+
+            $attribute = $this->permissionAttribute($method);
+            $this->assertNotNull($attribute, "$method must carry a #[RequiresPermission] dispatch gate");
+            $this->assertSame('reports.view', $attribute->permission, $method);
+            // projectIdParam binds the gate to the REQUESTED project — without it the enforcer
+            // falls back to the session project and the cross-project RPC IDOR reopens.
+            $this->assertSame('projectId', $attribute->projectIdParam, $method);
+        }
+    }
+
+    public function test_system_and_telemetry_methods_are_not_rpc_reachable(): void
+    {
+        // dailyIngestion binds to session state; the others leak instance-wide aggregates or
+        // mutate company-wide settings. None may carry a line-starting @api tag.
+        foreach ([
+            'dailyIngestion',
+            'cronDailyIngestion',
+            'getAnonymousTelemetry',
+            'sendAnonymousTelemetry',
+            'optOutTelemetry',
+            'getProjectStatusReport',
+            'generateTicketReactionsReport',
+        ] as $method) {
+            $this->assertFalse($this->isApiExposed($method), "$method must NOT be RPC-callable");
+        }
+    }
 
     /**
      * Builds the Reports service with every constructor dependency stubbed,


### PR DESCRIPTION
## Summary

Brings the **Reports** domain onto the native permission engine. Part of the service-layer hardening rollout (after Sprints, Comments, Wiki/Ideas, the canvas family, Timesheets, and Files).

`ReportsPermissions`: a single `reports.view` — project-scoped standard verb, auto-grants readonly+ through the existing matrix, **no `DefaultRolePermissions` edit**.

## RPC IDORs closed

| Method | Before | After |
|---|---|---|
| `getSprintBurndownForReport` | any authed RPC caller could pull **any** project's burndown by id | `#[RequiresPermission(reports.view, projectIdParam: 'projectId')]` — authorized against the **requested** project at dispatch |
| `getFullReport` | same — any project's stored report history | same gate |
| `getRealtimeReport` | same — any project's live ticket report | same gate (repo additionally scopes by both `projectId` AND `sprint`; the inner `getSprint` is already entityScoped-hardened — foreign sprint ids yield nothing) |

`projectId` is a **required** param on all three, so the gate can't be dodged by omission (no session fallback possible).

## System/telemetry surface de-exposed (de-`@api`'d, kept working internally)

- **`optOutTelemetry`** — company-wide settings **mutation**: any authenticated user could opt the whole instance out of telemetry over RPC. Still invoked internally by the admin-gated company-settings save.
- **`getAnonymousTelemetry`** — instance-wide usage aggregates + company GUID (reconnaissance over RPC).
- **`getProjectStatusReport`** — ALL projects' status counts, no project scope.
- **`sendAnonymousTelemetry`** — outbound-HTTP system task (scheduler + dashboard trigger only).
- **`dailyIngestion`** — session-bound web helper (only the gated `Reports\Show` calls it).

The scheduler paths (`register.php` → `cronDailyIngestion` / `sendAnonymousTelemetry`) are direct internal calls with **no session user** and are unaffected — verified end-to-end.

## Grant-equivalence

**One maintainer-approved change** (confirmed via explicit question): the `/reports/show` page loosens from editor+ to **readonly+** — it only aggregates data readonly project members can already read item-by-item (tickets, sprints, milestones are all readonly-visible). Simultaneously the three RPC reads **harden** from no-gate to member-of-target-project. The legacy `authOrRedirect` in `init()` is replaced by action attributes, which the Frontcontroller enforces **before instantiation** — so `init()`'s `dailyIngestion()` never runs for a denied user.

## Migration / tests

- `update_sql_30516`: flush registry → sync → re-seed (no matrix edit). dbVersion 3.5.15 → **3.5.16**.
- Two reflection surface tests lock the exposure contract: the 3 reads must stay `@api` **and** carry the `projectIdParam` gate; the 7 system/internal methods must never regain a line-starting `@api`.
- `reports.view` added to the role-matrix tests (readonly exact list + commenter).
- Full local Unit suite green (532 tests / 1252 assertions); boot verified; PHPStan L1 + Pint clean.

Reviewed via a 4-lens adversarial pass (grant-equivalence / fail-open-IDOR / consumer-cron / test-runtime): verdict **SHIP, 0 blockers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)