### PR TITLE
feat(events): class-based domain events + filters with legacy-string plugin bridge (Tickets pilot)

### DIFF
--- a/app/Core/Events/Concerns/InteractsWithEvents.php
+++ b/app/Core/Events/Concerns/InteractsWithEvents.php
@@ -20,7 +20,9 @@ trait InteractsWithEvents
 {
     /**
      * Default: no legacy string names. Override during the migration window with the
-     * exact historical leantime.* names this event used to fire under.
+     * exact historical leantime.* name of the CURRENT emit site — rebuilt from a
+     * `legacyHook: __FUNCTION__` constructor discriminator when several methods
+     * historically fired the same raw hook (see the LeantimeEvent docblock).
      *
      * @return array<int, string>
      */

--- a/app/Core/Events/Concerns/InteractsWithEvents.php
+++ b/app/Core/Events/Concerns/InteractsWithEvents.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Leantime\Core\Events\Concerns;
+
+use Leantime\Core\Events\EventDispatcher;
+
+/**
+ * Shared behavior for class-based domain events.
+ *
+ * Provides the static dispatch() ergonomic and a default empty legacyHooks() so events
+ * introduced after the class-based system don't need to declare one:
+ *
+ *     TicketUpdated::dispatch(ticketId: $id);
+ *
+ * Do NOT combine with Laravel's Dispatchable trait — both define dispatch(), and the
+ * Dispatchable version routes through the generic object path instead of the
+ * LeantimeEvent fast path.
+ */
+trait InteractsWithEvents
+{
+    /**
+     * Default: no legacy string names. Override during the migration window with the
+     * exact historical leantime.* names this event used to fire under.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        return [];
+    }
+
+    /**
+     * Construct and dispatch this event through the Leantime event dispatcher.
+     * Arguments (named arguments included) are forwarded to the constructor.
+     */
+    public static function dispatch(mixed ...$args): void
+    {
+        EventDispatcher::dispatch_event(new static(...$args));
+    }
+}

--- a/app/Core/Events/Concerns/InteractsWithFilters.php
+++ b/app/Core/Events/Concerns/InteractsWithFilters.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Leantime\Core\Events\Concerns;
+
+use Leantime\Core\Events\EventDispatcher;
+
+/**
+ * Shared behavior for class-based filters.
+ *
+ * Provides the static dispatch() / instance apply() ergonomics and sensible defaults
+ * for the LeantimeFilter contract:
+ *
+ *     $tickets = TodoWidgetTasksFilter::dispatch(tickets: $tickets, userId: $userId);
+ *
+ * The default payload() returns the $payload property; filter classes that name their
+ * payload something more meaningful (e.g. public array $tickets) override payload().
+ */
+trait InteractsWithFilters
+{
+    /**
+     * Default: no legacy string names. Override during the migration window with the
+     * exact historical leantime.* names this filter used to run under.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        return [];
+    }
+
+    /**
+     * Default payload accessor. Override when the payload property has a domain name.
+     */
+    public function payload(): mixed
+    {
+        return $this->payload;
+    }
+
+    /**
+     * Construct the filter and run the pipeline, returning the filtered payload.
+     * Arguments (named arguments included) are forwarded to the constructor.
+     */
+    public static function dispatch(mixed ...$args): mixed
+    {
+        return EventDispatcher::dispatch_class_filter(new static(...$args));
+    }
+
+    /**
+     * Run the pipeline for an already-constructed filter, returning the filtered payload.
+     */
+    public function apply(): mixed
+    {
+        return EventDispatcher::dispatch_class_filter($this);
+    }
+}

--- a/app/Core/Events/Concerns/InteractsWithFilters.php
+++ b/app/Core/Events/Concerns/InteractsWithFilters.php
@@ -19,7 +19,9 @@ trait InteractsWithFilters
 {
     /**
      * Default: no legacy string names. Override during the migration window with the
-     * exact historical leantime.* names this filter used to run under.
+     * exact historical leantime.* name of the CURRENT emit site — rebuilt from a
+     * `legacyHook: __FUNCTION__` constructor discriminator when several methods
+     * historically ran the same raw hook (see the LeantimeFilter docblock).
      *
      * @return array<int, string>
      */

--- a/app/Core/Events/Contracts/LeantimeEvent.php
+++ b/app/Core/Events/Contracts/LeantimeEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Leantime\Core\Events\Contracts;
+
+/**
+ * Contract for class-based domain events.
+ *
+ * Event classes live in app/Domain/{Domain}/Events/ (or app/Core/{Module}/Events/ for
+ * core modules), are named {Entity}{Verb} with the verb taken from the central
+ * {@see \Leantime\Core\Events\EventVerb} vocabulary, and carry their typed payload as
+ * public (constructor-promoted) properties.
+ *
+ * Listeners subscribe to the class itself:
+ *
+ *     EventDispatcher::add_event_listener(TicketUpdated::class, MyListener::class);
+ *
+ * and receive the bare event object — `MyListener::handle(TicketUpdated $event)`.
+ *
+ * MIGRATION WINDOW: legacyHooks() returns the exact historical string names that the
+ * same logical event used to fire under (the auto-generated
+ * leantime.domain.{...}.{method}.{rawHook} strings). The dispatcher dual-emits to those
+ * names so existing string/wildcard listeners — plugins in particular — keep firing
+ * with today's array payload, without coordinated releases. Remove the entries (and
+ * eventually the mechanism) once all consumers have migrated to the FQCN. Mirrors the
+ * client-side {@see \Leantime\Core\Events\Htmx\HtmxEvents} LEGACY_ALIASES window.
+ *
+ * Use the {@see \Leantime\Core\Events\Concerns\InteractsWithEvents} trait for the
+ * static dispatch() ergonomic and the default empty legacyHooks().
+ */
+interface LeantimeEvent
+{
+    /**
+     * The exact historical dotted string names this event used to fire under.
+     * One entry per emitting method when the same raw hook fired from several methods.
+     * Empty for events introduced after the class-based system.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array;
+}

--- a/app/Core/Events/Contracts/LeantimeEvent.php
+++ b/app/Core/Events/Contracts/LeantimeEvent.php
@@ -16,13 +16,23 @@ namespace Leantime\Core\Events\Contracts;
  *
  * and receive the bare event object — `MyListener::handle(TicketUpdated $event)`.
  *
- * MIGRATION WINDOW: legacyHooks() returns the exact historical string names that the
- * same logical event used to fire under (the auto-generated
+ * MIGRATION WINDOW: legacyHooks() returns the exact historical string name(s) the
+ * CURRENT emit site fired under (the auto-generated
  * leantime.domain.{...}.{method}.{rawHook} strings). The dispatcher dual-emits to those
  * names so existing string/wildcard listeners — plugins in particular — keep firing
- * with today's array payload, without coordinated releases. Remove the entries (and
- * eventually the mechanism) once all consumers have migrated to the FQCN. Mirrors the
- * client-side {@see \Leantime\Core\Events\Htmx\HtmxEvents} LEGACY_ALIASES window.
+ * with today's array payload, without coordinated releases.
+ *
+ * IMPORTANT: never statically list ALL historical emit sites — that would fire every
+ * site's name on every dispatch (exact subscribers fire under the wrong conditions,
+ * wildcard subscribers fire once per name instead of once per event). When the same
+ * raw hook historically fired from several methods, take a constructor discriminator
+ * and have each call site pass its own method name — `legacyHook: __FUNCTION__` — so
+ * each dispatch rebuilds the single name that site produced (see the Tickets pilot
+ * events for the pattern).
+ *
+ * Remove the entries (and eventually the mechanism) once all consumers have migrated
+ * to the FQCN. Mirrors the client-side
+ * {@see \Leantime\Core\Events\Htmx\HtmxEvents} LEGACY_ALIASES window.
  *
  * Use the {@see \Leantime\Core\Events\Concerns\InteractsWithEvents} trait for the
  * static dispatch() ergonomic and the default empty legacyHooks().
@@ -30,9 +40,12 @@ namespace Leantime\Core\Events\Contracts;
 interface LeantimeEvent
 {
     /**
-     * The exact historical dotted string names this event used to fire under.
-     * One entry per emitting method when the same raw hook fired from several methods.
-     * Empty for events introduced after the class-based system.
+     * The exact historical dotted string name(s) the CURRENT emit site fired under —
+     * at most one name per dispatch in practice. When several methods historically
+     * emitted the same raw hook, rebuild the right name from a
+     * `legacyHook: __FUNCTION__` constructor discriminator; never statically list all
+     * sites (see class docblock). Empty for events introduced after the class-based
+     * system.
      *
      * @return array<int, string>
      */

--- a/app/Core/Events/Contracts/LeantimeFilter.php
+++ b/app/Core/Events/Contracts/LeantimeFilter.php
@@ -16,10 +16,13 @@ namespace Leantime\Core\Events\Contracts;
  *     EventDispatcher::add_filter_listener(TodoWidgetTasksFilter::class,
  *         fn ($tickets, TodoWidgetTasksFilter $filter) => $tickets);
  *
- * MIGRATION WINDOW: legacyHooks() returns the exact historical string names; the
- * dispatcher threads the payload through listeners on the FQCN first, then through
- * each legacy name where listeners receive today's ($payload, $availableParams) array
- * signature unchanged. See {@see LeantimeEvent} for the full rationale.
+ * MIGRATION WINDOW: legacyHooks() returns the exact historical string name(s) of the
+ * CURRENT emit site; the dispatcher threads the payload through listeners on the FQCN
+ * first, then through each legacy name where listeners receive today's
+ * ($payload, $availableParams) array signature unchanged. When several methods
+ * historically ran the same raw hook, rebuild the right name from a
+ * `legacyHook: __FUNCTION__` constructor discriminator — never statically list all
+ * sites. See {@see LeantimeEvent} for the full rationale.
  *
  * Use the {@see \Leantime\Core\Events\Concerns\InteractsWithFilters} trait for the
  * payload()/apply() plumbing and the default empty legacyHooks().
@@ -32,7 +35,9 @@ interface LeantimeFilter
     public function payload(): mixed;
 
     /**
-     * The exact historical dotted string names this filter used to run under.
+     * The exact historical dotted string name(s) the CURRENT emit site ran under.
+     * Use a `legacyHook: __FUNCTION__` constructor discriminator when several methods
+     * historically ran the same raw hook (see class docblock).
      *
      * @return array<int, string>
      */

--- a/app/Core/Events/Contracts/LeantimeFilter.php
+++ b/app/Core/Events/Contracts/LeantimeFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Leantime\Core\Events\Contracts;
+
+/**
+ * Contract for class-based filters (the return-value pipeline counterpart of events).
+ *
+ * Filter classes live next to events in Events/, are named {Thing}Filter
+ * (TodoWidgetTasksFilter), hold the initial payload plus typed context as public
+ * (constructor-promoted) properties, and return the filtered payload from apply().
+ *
+ * Listeners subscribe to the class itself and keep the familiar filter signature —
+ * they receive the current payload and the filter object as context, and must return
+ * the (possibly modified) payload:
+ *
+ *     EventDispatcher::add_filter_listener(TodoWidgetTasksFilter::class,
+ *         fn ($tickets, TodoWidgetTasksFilter $filter) => $tickets);
+ *
+ * MIGRATION WINDOW: legacyHooks() returns the exact historical string names; the
+ * dispatcher threads the payload through listeners on the FQCN first, then through
+ * each legacy name where listeners receive today's ($payload, $availableParams) array
+ * signature unchanged. See {@see LeantimeEvent} for the full rationale.
+ *
+ * Use the {@see \Leantime\Core\Events\Concerns\InteractsWithFilters} trait for the
+ * payload()/apply() plumbing and the default empty legacyHooks().
+ */
+interface LeantimeFilter
+{
+    /**
+     * The initial payload to thread through the filter pipeline.
+     */
+    public function payload(): mixed;
+
+    /**
+     * The exact historical dotted string names this filter used to run under.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array;
+}

--- a/app/Core/Events/EventDispatcher.php
+++ b/app/Core/Events/EventDispatcher.php
@@ -322,6 +322,10 @@ class EventDispatcher implements Dispatcher
         if (is_array($listener) && isset($listener[0]) && is_string($listener[0])) {
             [$class, $method] = [$listener[0], $listener[1] ?? 'handle'];
 
+            if (! method_exists($class, $method)) {
+                $method = '__invoke';
+            }
+
             return [app()->make($class), $method];
         }
 

--- a/app/Core/Events/EventDispatcher.php
+++ b/app/Core/Events/EventDispatcher.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+use Leantime\Core\Events\Contracts\LeantimeFilter;
 use Leantime\Core\Routing\RouteLoader;
 
 /**
@@ -158,6 +160,15 @@ class EventDispatcher implements Dispatcher
         string $context = ''
     ): void {
 
+        // Class-based events bypass the string machinery (context building, payload
+        // wrapping) entirely: listeners on the FQCN receive the typed object, listeners
+        // on the declared legacy string names receive today's array payload.
+        if ($event instanceof LeantimeEvent) {
+            self::executeClassEventHandlers($event);
+
+            return;
+        }
+
         // Laravel events can be objects. Let's get those into the right format
         // Event comes out as string, either as class string or regular old string
         // No-op for leantime events
@@ -183,6 +194,138 @@ class EventDispatcher implements Dispatcher
 
         self::executeHandlers($matchedEvents, 'events', $event, $payload);
 
+    }
+
+    /**
+     * Executes listeners for a class-based event.
+     *
+     * Listeners registered on the event's FQCN run first (priority-sorted) and receive
+     * the bare typed event object. Then, for each declared legacy hook name, listeners
+     * registered on (or wildcard-matching) that string run through the exact same code
+     * path as string events, receiving today's array payload built from the event's
+     * public properties — existing string/wildcard listeners (plugins) keep working
+     * unchanged during the migration window.
+     */
+    private static function executeClassEventHandlers(LeantimeEvent $event): void
+    {
+        $fqcn = get_class($event);
+        $legacyHooks = $event->legacyHooks();
+
+        foreach ([$fqcn, ...$legacyHooks] as $name) {
+            if (! in_array($name, self::$available_hooks['events'])) {
+                self::$available_hooks['events'][] = $name;
+            }
+        }
+
+        $matched = self::findEventListeners($fqcn, self::$eventRegistry);
+        if (count($matched) > 0) {
+            usort($matched, fn ($a, $b) => $a['priority'] <=> $b['priority']);
+
+            try {
+                foreach ($matched as $listener) {
+                    $callable = self::resolveClassHookCallable($listener['listener']);
+                    $callable($event);
+                }
+            } catch (\TypeError $e) {
+                Log::error($e);
+            }
+        }
+
+        if (empty($legacyHooks)) {
+            return;
+        }
+
+        $legacyPayload = get_object_vars($event);
+
+        foreach ($legacyHooks as $legacyName) {
+            $matched = self::findEventListeners($legacyName, self::$eventRegistry);
+            if (count($matched) == 0) {
+                continue;
+            }
+
+            $payload = $legacyPayload;
+            $payload['leantime'] = self::defineParams($legacyPayload, $legacyName);
+            $payload['laravel'] = $payload;
+
+            self::executeHandlers($matched, 'events', $legacyName, $payload);
+        }
+    }
+
+    /**
+     * Dispatches a class-based filter, threading the payload through listeners on the
+     * FQCN first (signature: fn ($payload, LeantimeFilter $filter)), then through each
+     * declared legacy hook name where listeners keep today's
+     * fn ($payload, $availableParams) signature. Returns the final payload.
+     *
+     * Filter listeners are deliberately NOT deduplicated across name groups: threading
+     * order is semantic, and a listener registered on both the FQCN and a legacy name
+     * is a registration error that should surface, not be silently absorbed.
+     */
+    public static function dispatch_class_filter(LeantimeFilter $filter): mixed
+    {
+        $fqcn = get_class($filter);
+        $legacyHooks = $filter->legacyHooks();
+
+        foreach ([$fqcn, ...$legacyHooks] as $name) {
+            if (! in_array($name, self::$available_hooks['filters'])) {
+                self::$available_hooks['filters'][] = $name;
+            }
+        }
+
+        $payload = $filter->payload();
+
+        $matched = self::findEventListeners($fqcn, self::$filterRegistry);
+        if (count($matched) > 0) {
+            usort($matched, fn ($a, $b) => $a['priority'] <=> $b['priority']);
+
+            try {
+                foreach ($matched as $listener) {
+                    $callable = self::resolveClassHookCallable($listener['listener']);
+                    $payload = $callable($payload, $filter);
+                }
+            } catch (\TypeError $e) {
+                Log::error($e);
+            }
+        }
+
+        foreach ($legacyHooks as $legacyName) {
+            $matched = self::findEventListeners($legacyName, self::$filterRegistry);
+            if (count($matched) == 0) {
+                continue;
+            }
+
+            $availableParams = self::defineParams(get_object_vars($filter), $legacyName);
+            $payload = self::executeHandlers($matched, 'filters', $legacyName, $payload, $availableParams);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Resolves a listener registration (closure, callable, "Class", "Class@method",
+     * [Class::class, 'method']) into a callable for class-based hooks. Class listeners
+     * are instantiated through the container so constructor DI works; the method
+     * defaults to handle(), falling back to __invoke().
+     */
+    private static function resolveClassHookCallable(mixed $listener): callable
+    {
+        if (is_string($listener) && ! function_exists($listener)) {
+            [$class, $method] = self::parseClassCallable($listener);
+
+            if (! method_exists($class, $method)) {
+                $method = '__invoke';
+            }
+
+            return [app()->make($class), $method];
+        }
+
+        if (is_array($listener) && isset($listener[0]) && is_string($listener[0])) {
+            [$class, $method] = [$listener[0], $listener[1] ?? 'handle'];
+
+            return [app()->make($class), $method];
+        }
+
+        return $listener;
     }
 
     /**

--- a/app/Core/Events/EventVerb.php
+++ b/app/Core/Events/EventVerb.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Leantime\Core\Events;
+
+/**
+ * The central verb vocabulary for class-based domain events.
+ *
+ * Event classes are named {Entity}{Verb} (TicketCreated, MilestoneDeleted) and the verb
+ * MUST be a case of this enum — one vocabulary across all domains, mirroring the client
+ * (HTMX) convention lt:{domain}:{entity}.{verb} and the permission vocabulary
+ * {domain}.{action}. Synonyms are deliberately rejected: it is always Updated, never
+ * Changed/Edited/Saved/Modified. Add a case here only when no existing verb fits.
+ *
+ * All verbs are past tense: events report state changes that already happened.
+ */
+enum EventVerb: string
+{
+    case Created = 'created';
+    case Updated = 'updated';
+    case Deleted = 'deleted';
+    case Added = 'added';
+    case Removed = 'removed';
+    case Moved = 'moved';
+    case Completed = 'completed';
+    case Started = 'started';
+    case Succeeded = 'succeeded';
+    case Failed = 'failed';
+    case Archived = 'archived';
+    case Restored = 'restored';
+    case Duplicated = 'duplicated';
+    case Uploaded = 'uploaded';
+    case Sent = 'sent';
+    case Notified = 'notified';
+    case Registered = 'registered';
+    case Initialized = 'initialized';
+}

--- a/app/Domain/Tickets/Events/MilestoneCreated.php
+++ b/app/Domain/Tickets/Events/MilestoneCreated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired when a milestone is created.
+ */
+final class MilestoneCreated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int|null  $milestoneId  The created milestone id; null when the emit site doesn't capture it.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly ?int $milestoneId = null,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.milestone_created'];
+    }
+}

--- a/app/Domain/Tickets/Events/MilestoneDeleted.php
+++ b/app/Domain/Tickets/Events/MilestoneDeleted.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a milestone was deleted.
+ */
+final class MilestoneDeleted implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int  $milestoneId  The deleted milestone id.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly int $milestoneId,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.milestone_deleted'];
+    }
+}

--- a/app/Domain/Tickets/Events/MilestoneUpdated.php
+++ b/app/Domain/Tickets/Events/MilestoneUpdated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a milestone was updated.
+ */
+final class MilestoneUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int  $milestoneId  The updated milestone id.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly int $milestoneId,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.milestone_updated'];
+    }
+}

--- a/app/Domain/Tickets/Events/StatusLabelsUpdated.php
+++ b/app/Domain/Tickets/Events/StatusLabelsUpdated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a project's ticket status labels were saved.
+ */
+final class StatusLabelsUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int|null  $projectId  The project whose status labels changed.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly ?int $projectId = null,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.statusLabels_updated'];
+    }
+}

--- a/app/Domain/Tickets/Events/TicketCreated.php
+++ b/app/Domain/Tickets/Events/TicketCreated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a ticket (including subtasks) was created.
+ */
+final class TicketCreated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int|null  $ticketId  The created ticket id; null when the emit site doesn't capture it.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly ?int $ticketId = null,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.ticket_created'];
+    }
+}

--- a/app/Domain/Tickets/Events/TicketDeleted.php
+++ b/app/Domain/Tickets/Events/TicketDeleted.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a ticket was deleted.
+ */
+final class TicketDeleted implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int  $ticketId  The deleted ticket id.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly int $ticketId,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.ticket_deleted'];
+    }
+}

--- a/app/Domain/Tickets/Events/TicketListFilter.php
+++ b/app/Domain/Tickets/Events/TicketListFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithFilters;
+use Leantime\Core\Events\Contracts\LeantimeFilter;
+
+/**
+ * Filters the grouped ticket list before it is handed to the list/table templates.
+ * Listeners receive the grouped tickets array and must return it (possibly modified).
+ */
+final class TicketListFilter implements LeantimeFilter
+{
+    use InteractsWithFilters;
+
+    /**
+     * @param  array  $tickets  The grouped tickets to filter.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site ran under for plugin listeners.
+     */
+    public function __construct(
+        public array $tickets,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The grouped tickets array threaded through the pipeline.
+     */
+    public function payload(): mixed
+    {
+        return $this->tickets;
+    }
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.filterTickets'];
+    }
+}

--- a/app/Domain/Tickets/Events/TicketStatusUpdated.php
+++ b/app/Domain/Tickets/Events/TicketStatusUpdated.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired from the repository when a ticket's status column changes (kanban moves,
+ * inline patches). Carries the legacy payload keys (ticketId/status/action/handler)
+ * that existing plugin listeners read.
+ */
+final class TicketStatusUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * Legacy payload discriminator kept for plugin listeners that switch on it.
+     */
+    public string $action = 'ticketStatusUpdate';
+
+    /**
+     * @param  int  $ticketId  The ticket whose status changed.
+     * @param  mixed  $status  The new status value.
+     * @param  mixed  $handler  Optional handler context passed by kanban updates.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly int $ticketId,
+        public readonly mixed $status,
+        public readonly mixed $handler = null,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.repositories.tickets.'.$this->legacyHook.'.ticketStatusUpdate'];
+    }
+}

--- a/app/Domain/Tickets/Events/TicketStatusUpdated.php
+++ b/app/Domain/Tickets/Events/TicketStatusUpdated.php
@@ -9,6 +9,12 @@ use Leantime\Core\Events\Contracts\LeantimeEvent;
  * Fired from the repository when a ticket's status column changes (kanban moves,
  * inline patches). Carries the legacy payload keys (ticketId/status/action/handler)
  * that existing plugin listeners read.
+ *
+ * The legacy bridge emits a SUPERSET of each historical payload: the patchTicket site
+ * historically passed no `handler` key, so its bridged payload now also carries
+ * `handler => null`. This is additive and safe — consumers read keys by name
+ * (`$payload['handler'] ?? …`), never by exact key-set/count — and the kanban
+ * (updateTicketStatus) site, the only live consumer, always carried `handler`.
  */
 final class TicketStatusUpdated implements LeantimeEvent
 {

--- a/app/Domain/Tickets/Events/TicketUpdated.php
+++ b/app/Domain/Tickets/Events/TicketUpdated.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a ticket (including subtasks) was updated.
+ */
+final class TicketUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int|null  $ticketId  The updated ticket id; null for bulk updates (sorting,
+     *                              kanban status+sorting) where no single id applies.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site fired under for plugin listeners.
+     */
+    public function __construct(
+        public readonly ?int $ticketId = null,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.ticket_updated'];
+    }
+}

--- a/app/Domain/Tickets/Events/TodoWidgetTasksFilter.php
+++ b/app/Domain/Tickets/Events/TodoWidgetTasksFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithFilters;
+use Leantime\Core\Events\Contracts\LeantimeFilter;
+
+/**
+ * Filters the current user's tasks before the My-ToDos widget renders them.
+ * Listeners receive the grouped tickets array and must return it (possibly modified).
+ */
+final class TodoWidgetTasksFilter implements LeantimeFilter
+{
+    use InteractsWithFilters;
+
+    /**
+     * @param  array  $tickets  The grouped widget tickets to filter.
+     * @param  bool  $hierarchical  True when tickets are grouped hierarchically
+     *                              (milestone/parent nesting) instead of flat groups.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the exact historical
+     *                                   string name this site ran under for plugin listeners.
+     */
+    public function __construct(
+        public array $tickets,
+        public readonly bool $hierarchical = false,
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The grouped tickets array threaded through the pipeline.
+     */
+    public function payload(): mixed
+    {
+        return $this->tickets;
+    }
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.tickets.services.tickets.'.$this->legacyHook.'.myTodoWidgetTasks'];
+    }
+}

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -11,6 +11,7 @@ use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Events\DispatchesEvents as EventhelperCore;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\EntityRelationshipEnum;
+use Leantime\Domain\Tickets\Events\TicketStatusUpdated;
 use Leantime\Domain\Users\Services\Users;
 
 class Tickets
@@ -1650,7 +1651,7 @@ class Tickets
             $updates[$sanitizedKey] = $value;
 
             if ($key == 'status') {
-                static::dispatch_event('ticketStatusUpdate', ['ticketId' => $id, 'status' => $value, 'action' => 'ticketStatusUpdate']);
+                TicketStatusUpdated::dispatch(ticketId: (int) $id, status: $value, legacyHook: __FUNCTION__);
             }
         }
 
@@ -1722,7 +1723,7 @@ class Tickets
             $updates['kanbanSortIndex'] = $ticketSorting;
         }
 
-        static::dispatch_event('ticketStatusUpdate', ['ticketId' => $ticketId, 'status' => $status, 'action' => 'ticketStatusUpdate', 'handler' => $handler]);
+        TicketStatusUpdated::dispatch(ticketId: (int) $ticketId, status: $status, handler: $handler, legacyHook: __FUNCTION__);
 
         return $this->connection->table('zp_tickets')
             ->where('id', $ticketId)

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -30,6 +30,15 @@ use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
+use Leantime\Domain\Tickets\Events\MilestoneCreated;
+use Leantime\Domain\Tickets\Events\MilestoneDeleted;
+use Leantime\Domain\Tickets\Events\MilestoneUpdated;
+use Leantime\Domain\Tickets\Events\StatusLabelsUpdated;
+use Leantime\Domain\Tickets\Events\TicketCreated;
+use Leantime\Domain\Tickets\Events\TicketDeleted;
+use Leantime\Domain\Tickets\Events\TicketListFilter;
+use Leantime\Domain\Tickets\Events\TicketUpdated;
+use Leantime\Domain\Tickets\Events\TodoWidgetTasksFilter;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
 use Leantime\Domain\Tickets\Permissions\TicketsPermissions;
 use Leantime\Domain\Tickets\Repositories\TicketHistory;
@@ -174,7 +183,10 @@ class Tickets extends BaseService
                 ];
             }
 
-            self::dispatchEvent('statusLabels_updated');
+            StatusLabelsUpdated::dispatch(
+                projectId: session('currentProject') ? (int) session('currentProject') : null,
+                legacyHook: __FUNCTION__
+            );
 
             Cache::forget('projectsettings.'.session('currentProject').'.ticketlabels');
 
@@ -1951,7 +1963,10 @@ class Tickets extends BaseService
 
         $result = $this->ticketRepository->addTicket($values);
 
-        self::dispatchEvent('ticket_created');
+        TicketCreated::dispatch(
+            ticketId: is_int($result) && $result > 0 ? $result : null,
+            legacyHook: __FUNCTION__
+        );
 
         if ($result > 0) {
             $values['id'] = $result;
@@ -2034,7 +2049,7 @@ class Tickets extends BaseService
             return $error;
         }
 
-        self::dispatchEvent('milestone_created');
+        MilestoneCreated::dispatch(legacyHook: __FUNCTION__);
 
         // $params is an array of field names. Exclude id
         return $this->ticketRepository->addTicket($values);
@@ -2118,7 +2133,10 @@ class Tickets extends BaseService
             // Update Ticket
             $addTicketResponse = $this->ticketRepository->addTicket($values);
 
-            self::dispatchEvent('ticket_created');
+            TicketCreated::dispatch(
+                ticketId: is_int($addTicketResponse) && $addTicketResponse > 0 ? $addTicketResponse : null,
+                legacyHook: __FUNCTION__
+            );
 
             if ($addTicketResponse !== false) {
                 $values['id'] = $addTicketResponse;
@@ -2266,7 +2284,7 @@ class Tickets extends BaseService
 
             $this->projectService->notifyProjectUsers($notification);
 
-            self::dispatchEvent('ticket_updated');
+            TicketUpdated::dispatch(ticketId: (int) $values['id'], legacyHook: __FUNCTION__);
 
             return true;
         }
@@ -2497,7 +2515,7 @@ class Tickets extends BaseService
             return false;
         }
 
-        self::dispatchEvent('ticket_updated');
+        TicketUpdated::dispatch(ticketId: (int) $id, legacyHook: __FUNCTION__);
 
         // Todo: create events and move notification logic to notification module
         if (isset($params['status'])) {
@@ -2642,7 +2660,7 @@ class Tickets extends BaseService
 
         $values = $this->prepareTicketDates($values);
 
-        self::dispatchEvent('milestone_updated');
+        MilestoneUpdated::dispatch(milestoneId: $milestoneId, legacyHook: __FUNCTION__);
 
         // $params is an array of field names. Exclude id
         return $this->ticketRepository->updateTicket($values, $milestoneId);
@@ -3021,7 +3039,7 @@ class Tickets extends BaseService
                 return false;
             }
 
-            self::dispatchEvent('ticket_created');
+            TicketCreated::dispatch(legacyHook: __FUNCTION__);
 
         } else {
             // Update Ticket
@@ -3030,7 +3048,7 @@ class Tickets extends BaseService
                 return false;
             }
 
-            self::dispatchEvent('ticket_updated');
+            TicketUpdated::dispatch(ticketId: (int) $subtaskId, legacyHook: __FUNCTION__);
         }
 
         return true;
@@ -3165,7 +3183,7 @@ class Tickets extends BaseService
         $result = $this->ticketRepository->bulkUpdateSortIndex($allUpdates);
 
         if ($result) {
-            self::dispatchEvent('ticket_updated');
+            TicketUpdated::dispatch(legacyHook: __FUNCTION__);
         }
 
         return $result;
@@ -3271,7 +3289,7 @@ class Tickets extends BaseService
             }
         }
 
-        self::dispatchEvent('ticket_updated');
+        TicketUpdated::dispatch(legacyHook: __FUNCTION__);
 
         return true;
     }
@@ -3300,7 +3318,7 @@ class Tickets extends BaseService
         // Collaborator relationship rows are cleaned up inside the repository's delticket().
         if ($this->ticketRepository->delticket($id)) {
 
-            self::dispatchEvent('ticket_deleted');
+            TicketDeleted::dispatch(ticketId: (int) $id, legacyHook: __FUNCTION__);
 
             return true;
         }
@@ -3348,7 +3366,7 @@ class Tickets extends BaseService
         $this->authorize(TicketsPermissions::DELETE, (int) $ticket->projectId);
 
         if ($this->ticketRepository->delMilestone($id)) {
-            self::dispatchEvent('milestone_deleted');
+            MilestoneDeleted::dispatch(milestoneId: (int) $id, legacyHook: __FUNCTION__);
 
             return true;
         }
@@ -3625,7 +3643,7 @@ class Tickets extends BaseService
         }
 
         $allTickets = $this->enrichGroupedTicketsWithCollaborators($allTickets);
-        $allTickets = self::dispatchFilter('filterTickets', $allTickets);
+        $allTickets = TicketListFilter::dispatch(tickets: $allTickets, legacyHook: __FUNCTION__);
 
         return [
             'currentSprint' => session('currentSprint'),
@@ -3785,7 +3803,7 @@ class Tickets extends BaseService
         }
 
         $tickets = $this->enrichGroupedTicketsWithCollaborators($tickets);
-        $tickets = self::dispatch_filter('myTodoWidgetTasks', $tickets);
+        $tickets = TodoWidgetTasksFilter::dispatch(tickets: $tickets, legacyHook: __FUNCTION__);
 
         return [
             'tickets' => $tickets,
@@ -3950,7 +3968,7 @@ class Tickets extends BaseService
         unset($ticketGroup);
 
         // Collaborators were enriched above, before the hierarchy was built.
-        $tickets = self::dispatch_filter('myTodoWidgetTasks', $tickets);
+        $tickets = TodoWidgetTasksFilter::dispatch(tickets: $tickets, hierarchical: true, legacyHook: __FUNCTION__);
 
         return [
             'tickets' => $tickets,

--- a/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
+++ b/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
@@ -58,6 +58,20 @@ class FixtureThingListener
 }
 
 /**
+ * Fixture invokable listener (no handle() method) to cover the __invoke fallback for
+ * array-form registrations like [FixtureInvokableListener::class].
+ */
+class FixtureInvokableListener
+{
+    public static ?object $received = null;
+
+    public function __invoke(FixtureThingCreated $event): void
+    {
+        self::$received = $event;
+    }
+}
+
+/**
  * Fixture filter mirroring a migrated domain filter: payload plus typed context.
  */
 class FixtureThingsFilter implements LeantimeFilter
@@ -146,6 +160,21 @@ class ClassEventDispatchTest extends TestCase
 
         $this->assertCount(1, FixtureThingListener::$received);
         $this->assertSame(7, FixtureThingListener::$received[0]->thingId);
+    }
+
+    /**
+     * An invokable listener registered in array form ([Class::class], no handle()
+     * method) falls back to __invoke() — same as the string registration form.
+     */
+    public function test_array_form_invokable_listener_falls_back_to_invoke(): void
+    {
+        FixtureInvokableListener::$received = null;
+        EventDispatcher::add_event_listener(FixtureThingCreated::class, [FixtureInvokableListener::class]);
+
+        FixtureThingCreated::dispatch(thingId: 11);
+
+        $this->assertInstanceOf(FixtureThingCreated::class, FixtureInvokableListener::$received);
+        $this->assertSame(11, FixtureInvokableListener::$received->thingId);
     }
 
     /**

--- a/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
+++ b/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Unit\app\Core\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Concerns\InteractsWithFilters;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+use Leantime\Core\Events\Contracts\LeantimeFilter;
+use Leantime\Core\Events\EventDispatcher;
+use Unit\TestCase;
+
+/**
+ * Fixture event mirroring a migrated domain event: typed payload, legacy hooks
+ * matching the historical auto-generated string names.
+ */
+class FixtureThingUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    public function __construct(public readonly int $thingId) {}
+
+    public function legacyHooks(): array
+    {
+        return [
+            'leantime.domain.things.services.things.updateThing.thing_updated',
+            'leantime.domain.things.services.things.patchThing.thing_updated',
+        ];
+    }
+}
+
+/**
+ * Fixture event without legacy hooks (an event introduced after the class-based system).
+ */
+class FixtureThingCreated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    public function __construct(public readonly int $thingId) {}
+}
+
+/**
+ * Fixture class-based listener (resolved through the container, handle() receives the
+ * typed event object).
+ */
+class FixtureThingListener
+{
+    public static array $received = [];
+
+    public function handle(FixtureThingUpdated $event): void
+    {
+        self::$received[] = $event;
+    }
+}
+
+/**
+ * Fixture filter mirroring a migrated domain filter: payload plus typed context.
+ */
+class FixtureThingsFilter implements LeantimeFilter
+{
+    use InteractsWithFilters;
+
+    public function __construct(public array $things, public readonly int $userId) {}
+
+    public function payload(): mixed
+    {
+        return $this->things;
+    }
+
+    public function legacyHooks(): array
+    {
+        return [
+            'leantime.domain.things.services.things.getThings.filterThings',
+        ];
+    }
+}
+
+class ClassEventDispatchTest extends TestCase
+{
+    private array $staticSnapshot = [];
+
+    private const STATIC_PROPS = [
+        'eventRegistry',
+        'filterRegistry',
+        'available_hooks',
+        'patternMatchCache',
+        'compiledPatternCache',
+        'eventRegistryVersion',
+        'filterRegistryVersion',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $reflection = new \ReflectionClass(EventDispatcher::class);
+        foreach (self::STATIC_PROPS as $prop) {
+            $property = $reflection->getProperty($prop);
+            $this->staticSnapshot[$prop] = $property->getValue();
+        }
+
+        FixtureThingListener::$received = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(EventDispatcher::class);
+        foreach ($this->staticSnapshot as $prop => $value) {
+            $property = $reflection->getProperty($prop);
+            $property->setValue(null, $value);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A closure listener registered on the FQCN receives the bare typed event object.
+     */
+    public function test_fqcn_closure_listener_receives_typed_event_object(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(FixtureThingUpdated::class, function ($event) use (&$received) {
+            $received = $event;
+        });
+
+        FixtureThingUpdated::dispatch(thingId: 42);
+
+        $this->assertInstanceOf(FixtureThingUpdated::class, $received);
+        $this->assertSame(42, $received->thingId);
+    }
+
+    /**
+     * A class-string listener registered on the FQCN is container-resolved and its
+     * handle() method receives the typed event object. This is the cacheable
+     * registration style new code should use (no closures).
+     */
+    public function test_fqcn_class_listener_handle_receives_typed_event_object(): void
+    {
+        EventDispatcher::add_event_listener(FixtureThingUpdated::class, FixtureThingListener::class);
+
+        FixtureThingUpdated::dispatch(thingId: 7);
+
+        $this->assertCount(1, FixtureThingListener::$received);
+        $this->assertSame(7, FixtureThingListener::$received[0]->thingId);
+    }
+
+    /**
+     * BACKWARDS COMPATIBILITY: a listener registered on the exact historical string name
+     * fires and receives today's array payload (event properties + current_route +
+     * currentEvent) — NOT the event object. Existing plugins keep working unchanged.
+     */
+    public function test_legacy_string_listener_receives_legacy_array_payload(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(
+            'leantime.domain.things.services.things.updateThing.thing_updated',
+            function ($params) use (&$received) {
+                $received = $params;
+            }
+        );
+
+        FixtureThingUpdated::dispatch(thingId: 42);
+
+        $this->assertIsArray($received);
+        $this->assertSame(42, $received['thingId']);
+        $this->assertSame(
+            'leantime.domain.things.services.things.updateThing.thing_updated',
+            $received['currentEvent']
+        );
+        $this->assertArrayHasKey('current_route', $received);
+    }
+
+    /**
+     * BACKWARDS COMPATIBILITY: plugin wildcard subscriptions (leantime.domain.*.services.*)
+     * match the declared legacy names of a class-based event.
+     */
+    public function test_wildcard_listener_matches_legacy_hooks_of_class_event(): void
+    {
+        $called = 0;
+        EventDispatcher::add_event_listener('leantime.domain.*.services.*', function () use (&$called) {
+            $called++;
+        });
+
+        FixtureThingUpdated::dispatch(thingId: 1);
+
+        // The event declares two legacy hooks; the wildcard matches both.
+        $this->assertSame(2, $called);
+    }
+
+    /**
+     * Wildcard string listeners do NOT accidentally match the FQCN (backslashes and
+     * case don't fit the dotted lowercase patterns).
+     */
+    public function test_wildcard_listener_does_not_match_fqcn(): void
+    {
+        $called = 0;
+        EventDispatcher::add_event_listener('leantime.*', function () use (&$called) {
+            $called++;
+        });
+
+        FixtureThingCreated::dispatch(thingId: 1);
+
+        $this->assertSame(0, $called);
+    }
+
+    /**
+     * An event with no legacy hooks only reaches FQCN listeners.
+     */
+    public function test_event_without_legacy_hooks_fires_fqcn_listener_only(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(FixtureThingCreated::class, function ($event) use (&$received) {
+            $received = $event;
+        });
+
+        FixtureThingCreated::dispatch(thingId: 9);
+
+        $this->assertInstanceOf(FixtureThingCreated::class, $received);
+        $this->assertContains(FixtureThingCreated::class, EventDispatcher::get_available_hooks()['events']);
+    }
+
+    /**
+     * FQCN listeners run in priority order, lower number first.
+     */
+    public function test_fqcn_listeners_run_in_priority_order(): void
+    {
+        $order = [];
+        EventDispatcher::add_event_listener(FixtureThingCreated::class, function () use (&$order) {
+            $order[] = 30;
+        }, 30);
+        EventDispatcher::add_event_listener(FixtureThingCreated::class, function () use (&$order) {
+            $order[] = 10;
+        }, 10);
+
+        FixtureThingCreated::dispatch(thingId: 1);
+
+        $this->assertSame([10, 30], $order);
+    }
+
+    /**
+     * Class filter: FQCN listeners thread the payload and receive the filter object as
+     * typed context; the final payload is returned.
+     */
+    public function test_class_filter_threads_payload_through_fqcn_listeners(): void
+    {
+        $receivedFilter = null;
+        EventDispatcher::add_filter_listener(FixtureThingsFilter::class, function ($things, $filter) use (&$receivedFilter) {
+            $receivedFilter = $filter;
+            $things[] = 'added-by-listener';
+
+            return $things;
+        });
+
+        $result = FixtureThingsFilter::dispatch(things: ['original'], userId: 5);
+
+        $this->assertSame(['original', 'added-by-listener'], $result);
+        $this->assertInstanceOf(FixtureThingsFilter::class, $receivedFilter);
+        $this->assertSame(5, $receivedFilter->userId);
+    }
+
+    /**
+     * BACKWARDS COMPATIBILITY: a filter listener on the historical string name receives
+     * today's ($payload, $availableParams) signature — params include the filter's
+     * public properties plus current_route/currentEvent — and its return value threads
+     * into the final result, after FQCN listeners.
+     */
+    public function test_class_filter_threads_payload_through_legacy_listeners(): void
+    {
+        $receivedParams = null;
+
+        EventDispatcher::add_filter_listener(FixtureThingsFilter::class, function ($things, $filter) {
+            $things[] = 'fqcn';
+
+            return $things;
+        });
+
+        EventDispatcher::add_filter_listener(
+            'leantime.domain.things.services.things.getThings.filterThings',
+            function ($things, $params) use (&$receivedParams) {
+                $receivedParams = $params;
+                $things[] = 'legacy';
+
+                return $things;
+            }
+        );
+
+        $result = FixtureThingsFilter::dispatch(things: ['original'], userId: 5);
+
+        // FQCN group runs first, then the legacy group threads its output.
+        $this->assertSame(['original', 'fqcn', 'legacy'], $result);
+        $this->assertSame(5, $receivedParams['userId']);
+        $this->assertArrayHasKey('current_route', $receivedParams);
+    }
+
+    /**
+     * A filter with no listeners at all returns the payload unchanged.
+     */
+    public function test_class_filter_without_listeners_returns_payload_unchanged(): void
+    {
+        $result = FixtureThingsFilter::dispatch(things: ['untouched'], userId: 1);
+
+        $this->assertSame(['untouched'], $result);
+    }
+
+    /**
+     * The instance apply() ergonomic returns the filtered payload too.
+     */
+    public function test_class_filter_apply_instance_method(): void
+    {
+        EventDispatcher::add_filter_listener(FixtureThingsFilter::class, function ($things) {
+            $things[] = 'applied';
+
+            return $things;
+        });
+
+        $filter = new FixtureThingsFilter(things: ['a'], userId: 2);
+
+        $this->assertSame(['a', 'applied'], $filter->apply());
+    }
+
+    /**
+     * Class events route correctly through Laravel's event() helper / the instance
+     * dispatch() of the Dispatcher interface as well.
+     */
+    public function test_class_event_routes_through_laravel_event_helper(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(FixtureThingCreated::class, function ($event) use (&$received) {
+            $received = $event;
+        });
+
+        event(new FixtureThingCreated(thingId: 3));
+
+        $this->assertInstanceOf(FixtureThingCreated::class, $received);
+        $this->assertSame(3, $received->thingId);
+    }
+}

--- a/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
+++ b/tests/Unit/app/Core/Events/ClassEventDispatchTest.php
@@ -10,21 +10,26 @@ use Leantime\Core\Events\EventDispatcher;
 use Unit\TestCase;
 
 /**
- * Fixture event mirroring a migrated domain event: typed payload, legacy hooks
- * matching the historical auto-generated string names.
+ * Fixture event mirroring a migrated domain event: typed payload plus the
+ * `legacyHook: __FUNCTION__` discriminator pattern — each dispatch rebuilds the single
+ * historical name of its emit site (never a static list of all sites).
  */
 class FixtureThingUpdated implements LeantimeEvent
 {
     use InteractsWithEvents;
 
-    public function __construct(public readonly int $thingId) {}
+    public function __construct(
+        public readonly int $thingId,
+        private readonly ?string $legacyHook = null,
+    ) {}
 
     public function legacyHooks(): array
     {
-        return [
-            'leantime.domain.things.services.things.updateThing.thing_updated',
-            'leantime.domain.things.services.things.patchThing.thing_updated',
-        ];
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.things.services.things.'.$this->legacyHook.'.thing_updated'];
     }
 }
 
@@ -158,7 +163,7 @@ class ClassEventDispatchTest extends TestCase
             }
         );
 
-        FixtureThingUpdated::dispatch(thingId: 42);
+        FixtureThingUpdated::dispatch(thingId: 42, legacyHook: 'updateThing');
 
         $this->assertIsArray($received);
         $this->assertSame(42, $received['thingId']);
@@ -171,19 +176,44 @@ class ClassEventDispatchTest extends TestCase
 
     /**
      * BACKWARDS COMPATIBILITY: plugin wildcard subscriptions (leantime.domain.*.services.*)
-     * match the declared legacy names of a class-based event.
+     * match the legacy name of a class-based event — exactly ONCE per dispatch, because
+     * each emit site contributes only its own historical name via the legacyHook
+     * discriminator. Both historical names stay reachable from their respective sites.
      */
-    public function test_wildcard_listener_matches_legacy_hooks_of_class_event(): void
+    public function test_wildcard_listener_fires_once_per_dispatch_for_legacy_hook(): void
     {
         $called = 0;
         EventDispatcher::add_event_listener('leantime.domain.*.services.*', function () use (&$called) {
             $called++;
         });
 
-        FixtureThingUpdated::dispatch(thingId: 1);
+        FixtureThingUpdated::dispatch(thingId: 1, legacyHook: 'updateThing');
+        $this->assertSame(1, $called);
 
-        // The event declares two legacy hooks; the wildcard matches both.
+        FixtureThingUpdated::dispatch(thingId: 1, legacyHook: 'patchThing');
         $this->assertSame(2, $called);
+    }
+
+    /**
+     * BACKWARDS COMPATIBILITY: an exact subscriber to one historical site's name does
+     * NOT fire when a different site emits the same logical event — per-site semantics
+     * are preserved through the migration window.
+     */
+    public function test_exact_legacy_listener_keeps_per_site_semantics(): void
+    {
+        $called = 0;
+        EventDispatcher::add_event_listener(
+            'leantime.domain.things.services.things.patchThing.thing_updated',
+            function () use (&$called) {
+                $called++;
+            }
+        );
+
+        FixtureThingUpdated::dispatch(thingId: 1, legacyHook: 'updateThing');
+        $this->assertSame(0, $called);
+
+        FixtureThingUpdated::dispatch(thingId: 1, legacyHook: 'patchThing');
+        $this->assertSame(1, $called);
     }
 
     /**

--- a/tests/Unit/app/Core/Events/EventDispatcherCharacterizationTest.php
+++ b/tests/Unit/app/Core/Events/EventDispatcherCharacterizationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Unit\app\Core\Events;
+
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Events\EventDispatcher;
+use Leantime\Core\WorkStructure\Events\StructureRegistered;
+use Unit\TestCase;
+
+/**
+ * Fixture emitter that dispatches through the DispatchesEvents trait exactly like a
+ * domain service does, so the auto-generated event names (lowercased FQCN + method +
+ * raw hook) match the real runtime format.
+ */
+class CharacterizationEmitter
+{
+    use DispatchesEvents;
+
+    public function updateThing(): void
+    {
+        self::dispatchEvent('thing_updated', ['thingId' => 7]);
+    }
+
+    public function filterThing(int $payload): mixed
+    {
+        return self::dispatchFilter('thing_filter', $payload, ['mode' => 'strict']);
+    }
+}
+
+/**
+ * Characterization tests locking the CURRENT EventDispatcher behavior before the
+ * class-based event bridge is added. These tests document the string-event contract
+ * that existing plugins rely on; they must keep passing unchanged.
+ */
+class EventDispatcherCharacterizationTest extends TestCase
+{
+    private array $staticSnapshot = [];
+
+    private const STATIC_PROPS = [
+        'eventRegistry',
+        'filterRegistry',
+        'available_hooks',
+        'patternMatchCache',
+        'compiledPatternCache',
+        'eventRegistryVersion',
+        'filterRegistryVersion',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $reflection = new \ReflectionClass(EventDispatcher::class);
+        foreach (self::STATIC_PROPS as $prop) {
+            $property = $reflection->getProperty($prop);
+            $this->staticSnapshot[$prop] = $property->getValue();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(EventDispatcher::class);
+        foreach ($this->staticSnapshot as $prop => $value) {
+            $property = $reflection->getProperty($prop);
+            $property->setValue(null, $value);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * The DispatchesEvents trait builds the full event name as
+     * strtolower(FQCN with \ -> .) + '.' + emitting method + '.' + raw hook.
+     * Plugins subscribe to exactly these strings — the format must not drift.
+     */
+    public function test_trait_builds_full_event_name_from_class_and_method(): void
+    {
+        (new CharacterizationEmitter)->updateThing();
+
+        $this->assertContains(
+            'unit.app.core.events.characterizationemitter.updateThing.thing_updated',
+            EventDispatcher::get_available_hooks()['events']
+        );
+    }
+
+    /**
+     * A listener registered on the full string name receives a SINGLE array argument:
+     * the dispatched payload merged with current_route and currentEvent.
+     */
+    public function test_string_event_listener_receives_define_params_array(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(
+            'unit.app.core.events.characterizationemitter.updateThing.thing_updated',
+            function ($params) use (&$received) {
+                $received = $params;
+            }
+        );
+
+        (new CharacterizationEmitter)->updateThing();
+
+        $this->assertIsArray($received);
+        $this->assertSame(7, $received['thingId']);
+        $this->assertSame(
+            'unit.app.core.events.characterizationemitter.updateThing.thing_updated',
+            $received['currentEvent']
+        );
+        $this->assertArrayHasKey('current_route', $received);
+    }
+
+    /**
+     * Filter listeners receive ($payload, $availableParams) where availableParams is the
+     * emitter-provided context merged with current_route/currentEvent, and the payload is
+     * threaded through listeners in priority order (lower priority number runs first).
+     */
+    public function test_filter_threads_payload_in_priority_order_and_passes_params(): void
+    {
+        $fullName = 'unit.app.core.events.characterizationemitter.filterThing.thing_filter';
+        $receivedParams = null;
+
+        EventDispatcher::add_filter_listener($fullName, function ($payload, $params) use (&$receivedParams) {
+            $receivedParams = $params;
+
+            return $payload + 1;
+        }, 20);
+
+        EventDispatcher::add_filter_listener($fullName, function ($payload, $params) {
+            return $payload * 2;
+        }, 10);
+
+        $result = (new CharacterizationEmitter)->filterThing(5);
+
+        // priority 10 runs first: 5 * 2 = 10, then priority 20: 10 + 1 = 11
+        $this->assertSame(11, $result);
+        $this->assertSame('strict', $receivedParams['mode']);
+        $this->assertSame($fullName, $receivedParams['currentEvent']);
+        $this->assertArrayHasKey('current_route', $receivedParams);
+    }
+
+    /**
+     * Plugins rely on wildcard subscriptions (e.g. leantime.domain.*.services.*) matching
+     * the auto-generated full names. The * wildcard must keep matching.
+     */
+    public function test_wildcard_listener_matches_full_event_name(): void
+    {
+        $called = 0;
+        EventDispatcher::add_event_listener('leantime.domain.*.services.*', function () use (&$called) {
+            $called++;
+        });
+
+        EventDispatcher::dispatch_event('leantime.domain.faux.services.faux.doIt.did_it', ['x' => 1], '');
+
+        $this->assertSame(1, $called);
+    }
+
+    /**
+     * Event listeners for one hook run in priority order, lower number first.
+     */
+    public function test_event_listeners_run_in_priority_order(): void
+    {
+        $order = [];
+        EventDispatcher::add_event_listener('char.priority.event', function () use (&$order) {
+            $order[] = 30;
+        }, 30);
+        EventDispatcher::add_event_listener('char.priority.event', function () use (&$order) {
+            $order[] = 10;
+        }, 10);
+        EventDispatcher::add_event_listener('char.priority.event', function () use (&$order) {
+            $order[] = 20;
+        }, 20);
+
+        EventDispatcher::dispatch_event('char.priority.event', [], '');
+
+        $this->assertSame([10, 20, 30], $order);
+    }
+
+    /**
+     * Current behavior for plain object events (Laravel Dispatchable path, e.g. the
+     * WorkStructure events): the object resolves to its FQCN as the listener name and a
+     * 'leantime' source listener receives the defineParams array with the object at [0].
+     */
+    public function test_plain_object_event_fires_fqcn_string_listener(): void
+    {
+        $received = null;
+        EventDispatcher::add_event_listener(StructureRegistered::class, function ($params) use (&$received) {
+            $received = $params;
+        });
+
+        StructureRegistered::dispatch(1, 'My Structure', 'system');
+
+        $this->assertIsArray($received);
+        $this->assertInstanceOf(StructureRegistered::class, $received[0]);
+        $this->assertSame(1, $received[0]->structureId);
+    }
+
+    /**
+     * The pattern-match cache is invalidated when a listener is added (version counter),
+     * so listeners registered after a first dispatch still fire on later dispatches.
+     */
+    public function test_pattern_cache_busts_when_listener_added_after_dispatch(): void
+    {
+        $first = 0;
+        $second = 0;
+
+        EventDispatcher::add_event_listener('char.cache.*', function () use (&$first) {
+            $first++;
+        });
+        EventDispatcher::dispatch_event('char.cache.bust', [], '');
+
+        EventDispatcher::add_event_listener('char.cache.*', function () use (&$second) {
+            $second++;
+        });
+        EventDispatcher::dispatch_event('char.cache.bust', [], '');
+
+        $this->assertSame(2, $first);
+        $this->assertSame(1, $second);
+    }
+}

--- a/tests/Unit/app/Core/Events/EventVocabularyTest.php
+++ b/tests/Unit/app/Core/Events/EventVocabularyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Unit\app\Core\Events;
+
+use Codeception\Test\Unit;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+use Leantime\Core\Events\Contracts\LeantimeFilter;
+use Leantime\Core\Events\EventVerb;
+
+/**
+ * Enforces the shared event vocabulary across all domains:
+ *
+ *   - event classes are named {Entity}{Verb} with the verb from the central EventVerb
+ *     enum (TicketCreated, MilestoneDeleted — never TicketChanged/TicketEdited)
+ *   - filter classes are named {Thing}Filter (TodoWidgetTasksFilter)
+ *
+ * Scans every class in app/Domain/* /Events and app/Core/* /Events that implements
+ * LeantimeEvent or LeantimeFilter. Failing this test means a synonym crept in — use an
+ * existing verb or (rarely) add one to EventVerb.
+ */
+class EventVocabularyTest extends Unit
+{
+    public function test_event_class_names_end_with_central_vocabulary_verb(): void
+    {
+        $violations = [];
+
+        foreach ($this->discoverEventClasses() as $class) {
+            $implements = class_implements($class);
+            $shortName = substr($class, strrpos($class, '\\') + 1);
+
+            if (in_array(LeantimeFilter::class, $implements, true)) {
+                if (! str_ends_with($shortName, 'Filter')) {
+                    $violations[] = "$class — filter classes must be named {Thing}Filter";
+                }
+
+                continue;
+            }
+
+            if (in_array(LeantimeEvent::class, $implements, true)) {
+                $endsWithVerb = false;
+                foreach (EventVerb::cases() as $verb) {
+                    if (str_ends_with($shortName, $verb->name)) {
+                        $endsWithVerb = true;
+                        break;
+                    }
+                }
+
+                if (! $endsWithVerb) {
+                    $violations[] = "$class — event classes must be named {Entity}{Verb} with a verb from EventVerb";
+                }
+            }
+        }
+
+        $this->assertSame([], $violations, "Event vocabulary violations:\n".implode("\n", $violations));
+    }
+
+    /**
+     * Finds all classes in Domain and Core Events/ folders that implement one of the
+     * class-based hook contracts.
+     *
+     * @return array<int, class-string>
+     */
+    private function discoverEventClasses(): array
+    {
+        $appRoot = dirname(__DIR__, 5);
+
+        $files = array_merge(
+            glob($appRoot.'/app/Domain/*/Events/*.php') ?: [],
+            glob($appRoot.'/app/Core/*/Events/*.php') ?: [],
+        );
+
+        $classes = [];
+
+        foreach ($files as $file) {
+            $relative = str_replace([$appRoot.'/app/', '/', '.php'], ['', '\\', ''], $file);
+            $class = 'Leantime\\'.$relative;
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
+            $implements = class_implements($class) ?: [];
+            if (in_array(LeantimeEvent::class, $implements, true)
+                || in_array(LeantimeFilter::class, $implements, true)) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/tests/Unit/app/Core/Events/EventVocabularyTest.php
+++ b/tests/Unit/app/Core/Events/EventVocabularyTest.php
@@ -22,9 +22,20 @@ class EventVocabularyTest extends Unit
 {
     public function test_event_class_names_end_with_central_vocabulary_verb(): void
     {
+        $discovered = $this->discoverEventClasses();
+
+        // Guard against a vacuous pass: if discovery silently finds nothing (e.g. a
+        // broken base path), the loop below would assert nothing. The pilot ships ten
+        // contract classes in Tickets, so discovery must find them.
+        $this->assertContains(
+            \Leantime\Domain\Tickets\Events\TicketUpdated::class,
+            $discovered,
+            'Event class discovery found nothing — the vocabulary check would pass vacuously.'
+        );
+
         $violations = [];
 
-        foreach ($this->discoverEventClasses() as $class) {
+        foreach ($discovered as $class) {
             $implements = class_implements($class);
             $shortName = substr($class, strrpos($class, '\\') + 1);
 
@@ -62,7 +73,9 @@ class EventVocabularyTest extends Unit
      */
     private function discoverEventClasses(): array
     {
-        $appRoot = dirname(__DIR__, 5);
+        // Anchor on the canonical app-root constant rather than a brittle relative
+        // dirname() hop, so the scan can't silently miss the Events folders.
+        $appRoot = defined('APP_ROOT') ? APP_ROOT : dirname(__DIR__, 5);
 
         $files = array_merge(
             glob($appRoot.'/app/Domain/*/Events/*.php') ?: [],

--- a/tests/Unit/app/Domain/Tickets/Events/TicketsEventsBcTest.php
+++ b/tests/Unit/app/Domain/Tickets/Events/TicketsEventsBcTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Unit\app\Domain\Tickets\Events;
+
+use Codeception\Test\Unit;
+use Leantime\Domain\Tickets\Events\MilestoneCreated;
+use Leantime\Domain\Tickets\Events\MilestoneDeleted;
+use Leantime\Domain\Tickets\Events\MilestoneUpdated;
+use Leantime\Domain\Tickets\Events\StatusLabelsUpdated;
+use Leantime\Domain\Tickets\Events\TicketCreated;
+use Leantime\Domain\Tickets\Events\TicketDeleted;
+use Leantime\Domain\Tickets\Events\TicketListFilter;
+use Leantime\Domain\Tickets\Events\TicketStatusUpdated;
+use Leantime\Domain\Tickets\Events\TicketUpdated;
+use Leantime\Domain\Tickets\Events\TodoWidgetTasksFilter;
+
+/**
+ * Backwards-compatibility contract for the Tickets pilot: every migrated emit site must
+ * keep producing the EXACT historical string name it fired under before the class-based
+ * migration (audited 2026-06). Plugins (Copilot, Llamadorian, Reactions, RecurringTasks,
+ * observability wildcards) subscribe to these strings — a mismatch silently orphans them.
+ *
+ * The expected names are frozen from the pre-migration audit. If this test fails, fix the
+ * event class or call site — do NOT update the expected name unless the corresponding
+ * legacy hook is being intentionally retired at the end of the migration window.
+ */
+class TicketsEventsBcTest extends Unit
+{
+    public function test_every_migrated_emit_site_produces_its_audited_historical_name(): void
+    {
+        $prefix = 'leantime.domain.tickets.services.tickets.';
+        $repoPrefix = 'leantime.domain.tickets.repositories.tickets.';
+
+        $expectations = [
+            // events — services
+            [new TicketCreated(ticketId: 1, legacyHook: 'quickAddTicket'), $prefix.'quickAddTicket.ticket_created'],
+            [new TicketCreated(ticketId: 1, legacyHook: 'addTicket'), $prefix.'addTicket.ticket_created'],
+            [new TicketCreated(legacyHook: 'upsertSubtask'), $prefix.'upsertSubtask.ticket_created'],
+            [new TicketUpdated(ticketId: 1, legacyHook: 'updateTicket'), $prefix.'updateTicket.ticket_updated'],
+            [new TicketUpdated(ticketId: 1, legacyHook: 'patch'), $prefix.'patch.ticket_updated'],
+            [new TicketUpdated(ticketId: 1, legacyHook: 'upsertSubtask'), $prefix.'upsertSubtask.ticket_updated'],
+            [new TicketUpdated(legacyHook: 'updateTicketSorting'), $prefix.'updateTicketSorting.ticket_updated'],
+            [new TicketUpdated(legacyHook: 'updateTicketStatusAndSorting'), $prefix.'updateTicketStatusAndSorting.ticket_updated'],
+            [new TicketDeleted(ticketId: 1, legacyHook: 'delete'), $prefix.'delete.ticket_deleted'],
+            [new MilestoneCreated(legacyHook: 'quickAddMilestone'), $prefix.'quickAddMilestone.milestone_created'],
+            [new MilestoneUpdated(milestoneId: 1, legacyHook: 'quickUpdateMilestone'), $prefix.'quickUpdateMilestone.milestone_updated'],
+            [new MilestoneDeleted(milestoneId: 1, legacyHook: 'deleteMilestone'), $prefix.'deleteMilestone.milestone_deleted'],
+            [new StatusLabelsUpdated(projectId: 1, legacyHook: 'saveStatusLabels'), $prefix.'saveStatusLabels.statusLabels_updated'],
+            // events — repository
+            [new TicketStatusUpdated(ticketId: 1, status: 3, legacyHook: 'patchTicket'), $repoPrefix.'patchTicket.ticketStatusUpdate'],
+            [new TicketStatusUpdated(ticketId: 1, status: 3, legacyHook: 'updateTicketStatus'), $repoPrefix.'updateTicketStatus.ticketStatusUpdate'],
+            // filters
+            [new TicketListFilter(tickets: [], legacyHook: 'getTicketTemplateAssignments'), $prefix.'getTicketTemplateAssignments.filterTickets'],
+            [new TodoWidgetTasksFilter(tickets: [], legacyHook: 'getToDoWidgetAssignments'), $prefix.'getToDoWidgetAssignments.myTodoWidgetTasks'],
+            [new TodoWidgetTasksFilter(tickets: [], hierarchical: true, legacyHook: 'getToDoWidgetHierarchicalAssignments'), $prefix.'getToDoWidgetHierarchicalAssignments.myTodoWidgetTasks'],
+        ];
+
+        foreach ($expectations as [$event, $expectedName]) {
+            $this->assertSame(
+                [$expectedName],
+                $event->legacyHooks(),
+                get_class($event).' must keep firing its audited historical name'
+            );
+        }
+    }
+
+    /**
+     * Each emit site passes __FUNCTION__ as the legacy hook, so the method names baked
+     * into the expectations above must actually exist on the emitting classes — guards
+     * against renames silently orphaning the legacy names.
+     */
+    public function test_legacy_hook_method_names_still_exist_on_emitters(): void
+    {
+        $serviceMethods = [
+            'saveStatusLabels', 'quickAddTicket', 'quickAddMilestone', 'addTicket',
+            'updateTicket', 'patch', 'quickUpdateMilestone', 'upsertSubtask',
+            'updateTicketSorting', 'updateTicketStatusAndSorting', 'delete', 'deleteMilestone',
+            'getTicketTemplateAssignments', 'getToDoWidgetAssignments', 'getToDoWidgetHierarchicalAssignments',
+        ];
+
+        foreach ($serviceMethods as $method) {
+            $this->assertTrue(
+                method_exists(\Leantime\Domain\Tickets\Services\Tickets::class, $method),
+                "Tickets service method {$method} was renamed — its legacy event name is now orphaned"
+            );
+        }
+
+        foreach (['patchTicket', 'updateTicketStatus'] as $method) {
+            $this->assertTrue(
+                method_exists(\Leantime\Domain\Tickets\Repositories\Tickets::class, $method),
+                "Tickets repository method {$method} was renamed — its legacy event name is now orphaned"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Context

Our events and filters are 100% string-based, with names auto-generated from class namespace + emitting method (`leantime.domain.tickets.services.tickets.updateTicket.ticket_updated`). Two problems: nobody can find the right event name (no IDE autocomplete, names silently break on renames), and the string+closure registry can't be cached effectively. This PR introduces class-based events the way Laravel intended — one class per event in the domain's `Events/` folder — with a **temporary bridge** so every existing string/wildcard listener (plugins above all) keeps working without coordinated releases.

## The contract (`app/Core/Events/`)

- **`Contracts/LeantimeEvent` / `Contracts/LeantimeFilter`** — the FQCN is the subscribe handle. Listeners get the typed event object; filter listeners keep the familiar `($payload, $context)` threading signature with the filter object as typed context.
- **`Concerns/InteractsWithEvents` / `InteractsWithFilters`** — `TicketUpdated::dispatch(ticketId: $id)` / `$tickets = TodoWidgetTasksFilter::dispatch(tickets: $tickets)` ergonomics.
- **`EventVerb` enum** — the central past-tense verb vocabulary. Event classes are named `{Entity}{Verb}`, filters `{Thing}Filter`, enforced suite-wide by `EventVocabularyTest` (no `Changed`/`Edited`/`Saved` synonyms — always `Updated`). Consistent with the HTMX `lt:{domain}:{entity}.{verb}` convention and the permission `domain.action` vocabulary.

```php
// listen (register.php) — class-string listeners, cacheable, no closures
EventDispatcher::add_event_listener(TicketUpdated::class, MyListener::class);

// emit (service)
TicketUpdated::dispatch(ticketId: (int) $values['id'], legacyHook: __FUNCTION__);
```

## The backwards-compatibility bridge (temporary)

`legacyHooks()` returns the **exact historical string name of the current emit site**, rebuilt from a `legacyHook: __FUNCTION__` discriminator. The dispatcher dual-emits: FQCN listeners receive the typed object; legacy listeners run through the **unchanged** string code path and receive today's array payload byte-for-byte. Per-site names mean exact subscribers keep their precise firing conditions and broad wildcards (`leantime.domain.*.services.*`) fire once per dispatch — no amplification. Mirrors the client-side `HtmxEvents::LEGACY_ALIASES` migration window; delete per-event once consumers migrate.

The string event path itself is untouched — the class branch is purely additive at the top of `dispatch_event()` plus a new `dispatch_class_filter()` entry point.

## Tickets pilot

8 events (`TicketCreated/Updated/Deleted`, `MilestoneCreated/Updated/Deleted`, `StatusLabelsUpdated`, `TicketStatusUpdated`) + 2 filters (`TicketListFilter`, `TodoWidgetTasksFilter`) replace all 18 string emit sites in the Tickets service/repository. Events carry typed ids where the sites have them.

## Verification

- **Characterization tests written and green before touching the dispatcher** — lock the string contract (payload shapes, filter threading, wildcards, priority order, the Laravel object path).
- **Class-path tests** — typed delivery, legacy array payloads, per-site wildcard/exact semantics, filter threading across name groups, `event()` helper routing.
- **`TicketsEventsBcTest`** — freezes the audited historical name per emit site and fails if an emitting method is renamed (which would silently orphan plugin listeners).
- **Adversarial review (multi-agent)** replayed the committed code against the real plugin listeners (Llamadorian, Copilot, Reactions, RecurringTasks, Crisp, GoogleAnalytics wildcards): identical fire counts and payload key-sets. Its one confirmed finding (contract docs described a static-union `legacyHooks` shape that would break per-site semantics) is fixed in the second commit.
- Full unit suite green (548 tests), Pint clean, PHPStan level 1 with zero new errors.

## Found along the way

Llamadorian subscribes to `leantime.domain.tickets.repositories.tickets.patch.ticketStatusUpdate` — already orphaned before this PR (the repo method was renamed to `patchTicket` at some point). Left dead intentionally; the plugin needs a one-line fix. This silent breakage is exactly what the class-based migration retires.

## Follow-ups (separate PRs)

- Fan out domain-by-domain (Projects, Auth/Users, Calendar, Menu/Widgets, system domains) using the audited emit-site inventory
- Move `Core/WorkStructure/Events/*` and `Files/Events/FileUploaded` onto the contract
- Registry caching (unblocked once listeners are class-strings)
- Template render hooks and core lifecycle hooks intentionally stay string-based (imperative extension points, plugin wildcard injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)