### PR TITLE
security(calendar): gate the Calendar domain + close cross-user IDORs

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.8.0';
 
-    public string $dbVersion = '3.5.16';
+    public string $dbVersion = '3.5.17';
 }

--- a/app/Domain/Calendar/Controllers/AddEvent.php
+++ b/app/Domain/Calendar/Controllers/AddEvent.php
@@ -6,11 +6,11 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Support\FromFormat;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -24,9 +24,9 @@ class AddEvent extends Controller
     public function init(Calendar $calendarService): void
     {
         $this->calendarService = $calendarService;
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
     }
 
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function get(array $params): Response
     {
         $values = [
@@ -41,6 +41,7 @@ class AddEvent extends Controller
         return $this->tpl->displayPartial('calendar.addEvent');
     }
 
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function post(array $params): Response
     {
 

--- a/app/Domain/Calendar/Controllers/CalendarSettings.php
+++ b/app/Domain/Calendar/Controllers/CalendarSettings.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -41,10 +41,9 @@ class CalendarSettings extends Controller
     /**
      * Display the Calendar Settings modal.
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         // Get external calendars for the current user
         $externalCalendars = $this->calendarService->getMyExternalCalendars((int) session('userdata.id'));
 

--- a/app/Domain/Calendar/Controllers/ConnectCalendar.php
+++ b/app/Domain/Calendar/Controllers/ConnectCalendar.php
@@ -2,10 +2,10 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller as FrontcontrollerCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,10 +40,9 @@ class ConnectCalendar extends Controller
     /**
      * Display the Connect Calendar modal with available providers.
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $providers = self::dispatchFilter('connectOptions.providers', []);
 
         $this->tpl->assign('providers', $providers);
@@ -54,10 +53,9 @@ class ConnectCalendar extends Controller
     /**
      * Handle iCal calendar import submission.
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         if (isset($params['name']) || isset($params['url'])) {
             $values = [
                 'url' => $params['url'] ?? '',

--- a/app/Domain/Calendar/Controllers/DelEvent.php
+++ b/app/Domain/Calendar/Controllers/DelEvent.php
@@ -6,10 +6,10 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,12 +23,12 @@ class DelEvent extends Controller
     public function init(CalendarService $calendarService): void
     {
         $this->calendarService = $calendarService;
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
     }
 
     /**
      * retrieves delete calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function get(array $params): Response
     {
         return $this->tpl->displayPartial('calendar.delEvent');
@@ -37,6 +37,7 @@ class DelEvent extends Controller
     /**
      * sets, creates, and updates edit calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function post(array $params): Response
     {
 

--- a/app/Domain/Calendar/Controllers/DelExternalCalendar.php
+++ b/app/Domain/Calendar/Controllers/DelExternalCalendar.php
@@ -6,10 +6,10 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,12 +23,12 @@ class DelExternalCalendar extends Controller
     public function init(CalendarService $calendarService): void
     {
         $this->calendarService = $calendarService;
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
     }
 
     /**
      * retrieves delete calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function get(array $params): Response
     {
         return $this->tpl->displayPartial('calendar.delExternalCal');
@@ -37,6 +37,7 @@ class DelExternalCalendar extends Controller
     /**
      * sets, creates, and updates edit calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function post(array $params): Response
     {
 

--- a/app/Domain/Calendar/Controllers/EditEvent.php
+++ b/app/Domain/Calendar/Controllers/EditEvent.php
@@ -6,11 +6,11 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Support\FromFormat;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,13 +23,13 @@ class EditEvent extends Controller
      */
     public function init(CalendarService $calendarService): void
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
         $this->calendarService = $calendarService;
     }
 
     /**
      * retrieves edit calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function get(array $params): Response
     {
         $values = $this->calendarService->getEvent($params['id']);
@@ -42,6 +42,7 @@ class EditEvent extends Controller
     /**
      * sets, creates, and updates edit calendar event page data
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function post(array $params): Response
     {
         $params['id'] = $_GET['id'] ?? null;

--- a/app/Domain/Calendar/Controllers/EditExternal.php
+++ b/app/Domain/Calendar/Controllers/EditExternal.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,10 +25,9 @@ class EditExternal extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }
@@ -45,10 +44,9 @@ class EditExternal extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         if (! isset($params['id'])) {
             return $this->tpl->display('errors.error403', responseCode: 403);
         }

--- a/app/Domain/Calendar/Controllers/Export.php
+++ b/app/Domain/Calendar/Controllers/Export.php
@@ -2,7 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Leantime\Domain\Setting\Services\Setting as SettingService;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,6 +31,7 @@ class Export extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function get(array $params): Response
     {
         if (isset($_GET['remove'])) {
@@ -46,6 +49,7 @@ class Export extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function post(array $params): Response
     {
         if (isset($_POST['generateUrl'])) {

--- a/app/Domain/Calendar/Controllers/ExternalCal.php
+++ b/app/Domain/Calendar/Controllers/ExternalCal.php
@@ -2,7 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,6 +25,7 @@ class ExternalCal extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function get(array $params): Response
     {
         $content = $this->calendarService->getCachedExternalCalendarContent(

--- a/app/Domain/Calendar/Controllers/ImportGCal.php
+++ b/app/Domain/Calendar/Controllers/ImportGCal.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,10 +25,9 @@ class ImportGCal extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->tpl->assign('values', [
             'url' => '',
             'name' => '',
@@ -43,10 +42,9 @@ class ImportGCal extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function post(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $values = [
             'url' => $_POST['url'] ?? '',
             'name' => $_POST['name'] ?? 'My Calendar',

--- a/app/Domain/Calendar/Controllers/ShowAllGCals.php
+++ b/app/Domain/Calendar/Controllers/ShowAllGCals.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,10 +25,9 @@ class ShowAllGCals extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->tpl->assign('allCalendars', $this->calendarService->getMyExternalCalendars(session('userdata.id')));
 
         return $this->tpl->display('calendar.showAllGCals');

--- a/app/Domain/Calendar/Controllers/ShowMyCalendar.php
+++ b/app/Domain/Calendar/Controllers/ShowMyCalendar.php
@@ -2,9 +2,9 @@
 
 namespace Leantime\Domain\Calendar\Controllers;
 
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Services\Calendar as CalendarService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,10 +25,9 @@ class ShowMyCalendar extends Controller
      *
      * @param  array  $params  Request parameters
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function get(array $params): Response
     {
-        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager, Roles::$editor]);
-
         $this->tpl->assign('calendar', $this->calendarService->getCalendar(session('userdata.id')));
 
         session(['lastPage' => BASE_URL.'/calendar/showMyCalendar/']);

--- a/app/Domain/Calendar/Permissions/CalendarPermissions.php
+++ b/app/Domain/Calendar/Permissions/CalendarPermissions.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Leantime\Domain\Calendar\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Calendar permission vocabulary.
+ *
+ * Calendar is a PERSONAL feature: events and external-calendar subscriptions belong to a user
+ * (zp_calendar.userId / zp_gcallinks.userId). Two orthogonal axes:
+ *  - CAPABILITY (can you use the calendar at all) — the project-scoped standard verbs below,
+ *    resolved against the current project's role (mirroring the legacy editor+ authOrRedirect on
+ *    the controllers, which used the effective/project role). They auto-grant through the matrix
+ *    with NO DefaultRolePermissions edit: view→readonly+, create/edit/delete→editor+.
+ *  - OWNERSHIP (whose data) — enforced IN-BODY in the service (row.userId === currentUserId), with
+ *    a cross-user override for `manage`.
+ *
+ * `manage` is GLOBAL-scoped (admin+ only — it auto-grants through scope:any and is deliberately NOT
+ * given to managers): it preserves the legacy admin-only cross-user override (patch's
+ * userIsAllowedToUpdate used Auth::userIsAtLeast(admin)).
+ *
+ * Maintainer-approved loosening: VIEW moves from the legacy editor+ page gate to readonly+ — seeing
+ * your OWN calendar is benign (ownership still fences whose events you see).
+ *
+ * The iCal feed methods (getIcalByHash / getIcalByRequestToken) are NOT part of this vocabulary:
+ * they are served by the public, hash-authenticated /calendar/ical route with no session, so they
+ * are de-@api'd rather than permission-gated.
+ */
+final class CalendarPermissions implements ProvidesPermissions
+{
+    /** View your own calendar (events, external subscriptions, feed url). Readonly+. */
+    public const VIEW = 'calendar.view';
+
+    /** Add events / connect external calendars to your own calendar. Editor+. */
+    public const CREATE = 'calendar.create';
+
+    /** Edit your own events / external calendars. Editor+ (cross-user requires MANAGE). */
+    public const EDIT = 'calendar.edit';
+
+    /** Delete your own events / external calendars. Editor+. */
+    public const DELETE = 'calendar.delete';
+
+    /** Cross-user calendar override (act on another user's events). Admin+ (global). */
+    public const MANAGE = 'calendar.manage';
+
+    public function domain(): string
+    {
+        return 'calendar';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::VIEW, 'View your calendar', true),
+            new Permission(self::CREATE, 'Add calendar events', true),
+            new Permission(self::EDIT, 'Edit calendar events', true),
+            new Permission(self::DELETE, 'Delete calendar events', true),
+            new Permission(self::MANAGE, 'Manage any user\'s calendar', false),
+        ];
+    }
+}

--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -68,18 +68,16 @@ class Calendar extends BaseService
     }
 
     /**
-     * Patches calendar event
+     * Patches calendar event.
      *
-     *
-     * @params $id id of event to be updated (only events can be updated. Tickets need to be updated via ticket api
-     * @params $params key value array of columns to be updated
-     *
+     * @param  int  $id  Id of the event to update (only events; tickets are updated via the ticket API).
+     * @param  array  $params  Key/value array of columns to update.
      * @return bool true on success, false on failure
      *
      * @api
      */
     #[RequiresPermission(CalendarPermissions::EDIT)]
-    public function patch(int $id, $params): bool
+    public function patch(int $id, array $params): bool
     {
         // The event's owner can always change it; a cross-user override needs calendar.manage (admin+).
         if ($this->userIsAllowedToUpdate($id)) {

--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -6,12 +6,13 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\Environment;
+use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Events\EventDispatcher;
 use Leantime\Core\Exceptions\MissingParameterException;
 use Leantime\Core\Language as LanguageCore;
-use Leantime\Domain\Auth\Models\Roles;
-use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Repositories\Calendar as CalendarRepository;
 use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Tickets\Services\Tickets;
@@ -20,7 +21,17 @@ use Spatie\IcalendarGenerator\Components\Calendar as IcalCalendar;
 use Spatie\IcalendarGenerator\Components\Event as IcalEvent;
 use Spatie\IcalendarGenerator\Enums\Display;
 
-class Calendar
+/**
+ * Calendar service: personal events, external-calendar subscriptions, and the public iCal feed.
+ *
+ * Authorization: the @api methods carry a dispatch #[RequiresPermission(calendar.*)] capability gate
+ * (project-scoped, session project — readonly+ to view, editor+ to create/edit/delete). OWNERSHIP is
+ * separate and user-based: reads that aren't already userId-scoped by the repository self-authorize
+ * in-body (row.userId === currentUserId() OR can(MANAGE)); the userId PARAMS on the external-calendar
+ * reads are ignored in favor of the session user (closing the RPC param-spoof). The iCal feed methods
+ * are NOT @api — they are served by the public, hash-authenticated /calendar/ical route.
+ */
+class Calendar extends BaseService
 {
     private CalendarRepository $calendarRepo;
 
@@ -50,6 +61,7 @@ class Calendar
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function deleteGCal(int $id): bool
     {
         return $this->calendarRepo->deleteGCal($id);
@@ -66,10 +78,10 @@ class Calendar
      *
      * @api
      */
-    public function patch($id, $params): bool
+    #[RequiresPermission(CalendarPermissions::EDIT)]
+    public function patch(int $id, $params): bool
     {
-        // Admins can always change anything.
-        // Otherwise user has to own the event
+        // The event's owner can always change it; a cross-user override needs calendar.manage (admin+).
         if ($this->userIsAllowedToUpdate($id)) {
             return $this->calendarRepo->patch($id, $params);
         }
@@ -78,28 +90,22 @@ class Calendar
     }
 
     /**
-     * Checks if user is allowed to make changes to event
+     * Whether the current user may change the given event. The event's owner always may; a
+     * cross-user override requires calendar.manage (admin+ — replaces the legacy
+     * Auth::userIsAtLeast(admin) check, preserving the same admin-only override).
      *
-     *
-     * @params int $eventId Id of event to be checked
-     *
-     * @return bool true on success, false on failure
-     *
-     * @api
+     * @param  int  $eventId  Id of event to be checked
+     * @return bool true when allowed, false otherwise
      */
     private function userIsAllowedToUpdate($eventId): bool
     {
-
-        if (Auth::userIsAtLeast(Roles::$admin)) {
+        if ($this->can(CalendarPermissions::MANAGE)) {
             return true;
-        } else {
-            $event = $this->calendarRepo->getEvent($eventId);
-            if ($event && $event['userId'] == session('userdata.id')) {
-                return true;
-            }
         }
 
-        return false;
+        $event = $this->calendarRepo->getEvent($eventId);
+
+        return $event && (int) ($event['userId'] ?? 0) === $this->currentUserId();
     }
 
     /**
@@ -112,6 +118,7 @@ class Calendar
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function addEvent(array $values): int|false
     {
         $values['allDay'] = $values['allDay'] ?? false;
@@ -153,11 +160,26 @@ class Calendar
     }
 
     /**
+     * Returns a single event, fail-closed to its owner. The repository fetches by bare id, so
+     * without this check any user could read any event by id over RPC; calendar.manage (admin+)
+     * is the cross-user override. Soft-denies (returns false) for a foreign event.
+     *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function getEvent(int $eventId): mixed
     {
-        return $this->calendarRepo->getEvent($eventId);
+        $event = $this->calendarRepo->getEvent($eventId);
+
+        if ($event === false || $event === null) {
+            return $event;
+        }
+
+        if ((int) ($event['userId'] ?? 0) !== $this->currentUserId() && ! $this->can(CalendarPermissions::MANAGE)) {
+            return false;
+        }
+
+        return $event;
     }
 
     /**
@@ -171,6 +193,7 @@ class Calendar
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function editEvent(array $values): bool
     {
         if (isset($values['id']) === true) {
@@ -236,6 +259,7 @@ class Calendar
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::DELETE)]
     public function delEvent(int $id): int|false
     {
         // Trigger event for plugins
@@ -245,13 +269,18 @@ class Calendar
     }
 
     /**
+     * Returns one external-calendar subscription, scoped to the SESSION user. The $userId argument
+     * is retained for signature/RPC compatibility but IGNORED for authorization — otherwise an RPC
+     * caller could read another user's subscription by passing a foreign id.
+     *
      * @return array|false
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function getExternalCalendar(int $id, int $userId): bool|array
     {
-        return $this->calendarRepo->getExternalCalendar($id, $userId);
+        return $this->calendarRepo->getExternalCalendar($id, $this->currentUserId() ?? 0);
     }
 
     /**
@@ -266,11 +295,13 @@ class Calendar
      * controller behaviour.
      *
      * @param  int  $calId  The external calendar id.
-     * @param  int  $userId  The id of the user owning the calendar.
+     * @param  int  $userId  Retained for signature compatibility; the underlying read is pinned to
+     *                       the session user via getExternalCalendar().
      * @return string The iCal content, or an empty string when unavailable.
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function getCachedExternalCalendarContent(int $calId, int $userId): string
     {
         $cacheTime = 60 * 30; // 30min
@@ -306,8 +337,12 @@ class Calendar
     }
 
     /**
+     * Edits an external-calendar subscription. The repository scopes the update to the session
+     * user (WHERE userId = session), so a foreign id is a no-op.
+     *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::EDIT)]
     public function editExternalCalendar(array $values, int $id): void
     {
         $this->calendarRepo->editGUrl($values, $id);
@@ -316,14 +351,16 @@ class Calendar
     /**
      * Retrieves all external calendars for a given user.
      *
-     * @param  int  $userId  The user ID
+     * @param  int  $userId  Retained for signature/RPC compatibility but IGNORED — the list is
+     *                       always scoped to the SESSION user, closing the cross-user param spoof.
      * @return array|false The external calendars or false if none found
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::VIEW)]
     public function getMyExternalCalendars(int $userId): array|false
     {
-        return $this->calendarRepo->getMyExternalCalendars($userId);
+        return $this->calendarRepo->getMyExternalCalendars($this->currentUserId() ?? 0);
     }
 
     /**
@@ -333,6 +370,7 @@ class Calendar
      *
      * @api
      */
+    #[RequiresPermission(CalendarPermissions::CREATE)]
     public function addExternalCalendarUrl(array $values): void
     {
         $this->calendarRepo->addGUrl($values);
@@ -347,7 +385,9 @@ class Calendar
      *
      * @throws MissingParameterException If either user hash or calendar hash is empty.
      *
-     * @api
+     * Not @api: served by the PUBLIC, hash-authenticated /calendar/ical route (no session). The
+     * userHash+calHash secrets ARE the credential; exposing it over JSON-RPC would let a caller
+     * brute-force feeds. The Ical controller calls it internally.
      */
     public function getIcalByHash(string $userHash, string $calHash): IcalCalendar
     {
@@ -612,7 +652,9 @@ class Calendar
      * @throws MissingParameterException If the token does not contain both hashes.
      * @throws \Exception If the calendar could not be retrieved.
      *
-     * @api
+     * Not @api: the entry point for the PUBLIC, hash-authenticated /calendar/ical route (no
+     * session) — the Ical controller calls it directly. Not exposed via JSON-RPC (delegates to
+     * getIcalByHash, where the hashes are the credential).
      */
     public function getIcalByRequestToken(string $token, string $act = ''): IcalCalendar
     {
@@ -948,8 +990,6 @@ class Calendar
      *
      * @param  int|null  $dateFrom
      * @param  int|null  $dateTo
-     *
-     * @api
      */
     private function mapEventData(
         string $title,

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -97,6 +97,7 @@ class Install
         30514,
         30515,
         30516,
+        30517,
     ];
 
     /**
@@ -3036,6 +3037,31 @@ class Install
             Log::error('Migration 30516: '.$e->getMessage());
 
             return ['Migration 30516 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync the permission catalog + re-seed built-in role grants for the Calendar domain. Adds
+     * calendar.view/create/edit/delete (project-scoped standard verbs → auto-grant readonly+/editor+)
+     * and calendar.manage (global → admin+ via scope:any). NO DefaultRolePermissions matrix edit:
+     * all verbs auto-grant. The re-seed lands the new keys in zp_role_permissions for the built-ins.
+     *
+     * Flush the discovered-provider cache FIRST so CalendarPermissions is rediscovered.
+     */
+    public function update_sql_30517(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+            $seeder->seedBuiltInRoles();
+        } catch (\Exception $e) {
+            Log::error('Migration 30517: '.$e->getMessage());
+
+            return ['Migration 30517 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/DefaultRolePermissionsTest.php
@@ -48,6 +48,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
             new Permission('files.upload', 'Upload', true),
             new Permission('files.delete', 'Delete', true),
             new Permission('reports.view', 'View', true),
+            // Calendar: project-scoped capability verbs (view→readonly+, create/edit/delete→editor+)
+            // + a GLOBAL manage verb (admin+ cross-user override; managers do NOT get it).
+            new Permission('calendar.view', 'View', true),
+            new Permission('calendar.create', 'Create', true),
+            new Permission('calendar.edit', 'Edit', true),
+            new Permission('calendar.delete', 'Delete', true),
+            new Permission('calendar.manage', 'Manage any calendar', false),
             new Permission('comments.view', 'View', true),
             new Permission('comments.create', 'Create', true),
             new Permission('comments.moderate', 'Moderate', true),
@@ -82,7 +89,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
 
     public function test_readonly_can_only_view_project_content(): void
     {
-        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view', 'files.view', 'reports.view'], $this->grantsFor('readonly'));
+        $this->assertEqualsCanonicalizing(['tickets.view', 'comments.view', 'sprints.view', 'wiki.view', 'ideas.view', 'blueprints.view', 'goals.view', 'files.view', 'reports.view', 'calendar.view'], $this->grantsFor('readonly'));
     }
 
     public function test_commenter_adds_comment_upload_and_can_create_comments(): void
@@ -156,6 +163,13 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('timesheets.edit', $grants);
         $this->assertContains('timesheets.delete', $grants);
         $this->assertNotContains('timesheets.manage', $grants);
+        // Calendar uses standard PROJECT verbs, so editor auto-gets view/create/edit/delete; the
+        // GLOBAL manage verb (cross-user override) stays admin+.
+        $this->assertContains('calendar.view', $grants);
+        $this->assertContains('calendar.create', $grants);
+        $this->assertContains('calendar.edit', $grants);
+        $this->assertContains('calendar.delete', $grants);
+        $this->assertNotContains('calendar.manage', $grants);
         $this->assertContains('comments.create', $grants);    // inherited
         $this->assertNotContains('comments.moderate', $grants); // manager+ only
         $this->assertNotContains('users.view', $grants);        // company-wide, admin+
@@ -178,6 +192,14 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('timesheets.manage', $grants);
         $this->assertContains('timesheets.view', $grants);
         $this->assertContains('timesheets.edit', $grants);
+        // Calendar: manager holds all four project capability verbs (project '*' rule) but NOT the
+        // cross-user override — calendar.manage is GLOBAL-scoped and admin-only (legacy override was
+        // Auth::userIsAtLeast(admin)).
+        $this->assertContains('calendar.view', $grants);
+        $this->assertContains('calendar.create', $grants);
+        $this->assertContains('calendar.edit', $grants);
+        $this->assertContains('calendar.delete', $grants);
+        $this->assertNotContains('calendar.manage', $grants);
         // Managers may INVITE users (within their own client — scoped in the controller), but
         // cannot view the roster, edit, delete, or import accounts (those stay admin+).
         $this->assertContains('users.create', $grants);
@@ -214,6 +236,7 @@ class DefaultRolePermissionsTest extends \Unit\TestCase
         $this->assertContains('projectsettings.labels.manage', $grants);
         $this->assertContains('comments.moderate', $grants);
         $this->assertContains('tickets.delete', $grants);
+        $this->assertContains('calendar.manage', $grants);  // cross-user calendar override (admin+)
         // Per policy (admin views + edits company settings), admins hold both company.settings
         // keys via an explicit grant alongside the wildcard-with-exclude rule.
         $this->assertContains('company.settings.view', $grants);

--- a/tests/Unit/app/Domain/Calendar/Services/CalendarServiceTest.php
+++ b/tests/Unit/app/Domain/Calendar/Services/CalendarServiceTest.php
@@ -182,4 +182,136 @@ class CalendarServiceTest extends TestCase
         $this->assertEquals('actuser', $capturedUserHash, 'user hash should come from the act segment');
         $this->assertEquals('actcal', $capturedCalHash, 'cal hash should come from the act segment');
     }
+
+    // ---- permission-engine authorization ---------------------------------
+
+    /** Builds the service with a stubbed repo + PermissionService, as the session user (id 1). */
+    private function makeServiceWithPermissions(
+        CalendarRepository $repo,
+        \Leantime\Core\Auth\Permissions\PermissionService $perms
+    ): \Leantime\Domain\Calendar\Services\Calendar {
+        session(['userdata.id' => 1]);
+
+        $service = new \Leantime\Domain\Calendar\Services\Calendar(
+            calendarRepo: $repo,
+            language: $this->language,
+            settingsRepo: $this->settingsRepository,
+            config: $this->config
+        );
+        $service->setPermissionService($perms);
+
+        return $service;
+    }
+
+    /** PermissionService stub: currentUserCan returns the given value for every key. */
+    private function permissions(bool $allow): \Leantime\Core\Auth\Permissions\PermissionService
+    {
+        return $this->make(\Leantime\Core\Auth\Permissions\PermissionService::class, [
+            'currentUserCan' => fn () => $allow,
+            'authorize' => fn () => null,
+        ]);
+    }
+
+    public function test_get_event_returns_own_event(): void
+    {
+        $repo = $this->make(CalendarRepository::class, [
+            'getEvent' => fn () => ['id' => 5, 'userId' => 1, 'description' => 'mine'],
+        ]);
+        // can(MANAGE) = false, but the session user (1) owns the event.
+        $service = $this->makeServiceWithPermissions($repo, $this->permissions(false));
+
+        $this->assertSame(1, $service->getEvent(5)['userId']);
+    }
+
+    public function test_get_event_soft_denies_foreign_event_without_manage(): void
+    {
+        $repo = $this->make(CalendarRepository::class, [
+            'getEvent' => fn () => ['id' => 5, 'userId' => 2, 'description' => 'someone else'],
+        ]);
+        // Event owned by user 2; session user 1 lacks calendar.manage → soft-deny.
+        $service = $this->makeServiceWithPermissions($repo, $this->permissions(false));
+
+        $this->assertFalse($service->getEvent(5));
+    }
+
+    public function test_get_event_allows_foreign_event_with_manage(): void
+    {
+        $repo = $this->make(CalendarRepository::class, [
+            'getEvent' => fn () => ['id' => 5, 'userId' => 2, 'description' => 'someone else'],
+        ]);
+        // calendar.manage (admin+) is the cross-user override.
+        $service = $this->makeServiceWithPermissions($repo, $this->permissions(true));
+
+        $this->assertSame(2, $service->getEvent(5)['userId']);
+    }
+
+    public function test_get_external_calendar_ignores_passed_userid_and_uses_session(): void
+    {
+        $capturedUserId = null;
+        $repo = $this->make(CalendarRepository::class, [
+            'getExternalCalendar' => function ($id, $userId) use (&$capturedUserId) {
+                $capturedUserId = $userId;
+
+                return ['id' => $id, 'url' => 'https://example.com/cal.ics'];
+            },
+        ]);
+        $service = $this->makeServiceWithPermissions($repo, $this->permissions(true));
+
+        // Caller passes a FOREIGN userId (99); the service must query as the session user (1).
+        $service->getExternalCalendar(7, 99);
+
+        $this->assertSame(1, $capturedUserId, 'external calendar lookup must use the session user, not the passed id');
+    }
+
+    public function test_get_my_external_calendars_ignores_passed_userid_and_uses_session(): void
+    {
+        $capturedUserId = null;
+        $repo = $this->make(CalendarRepository::class, [
+            'getMyExternalCalendars' => function ($userId) use (&$capturedUserId) {
+                $capturedUserId = $userId;
+
+                return [];
+            },
+        ]);
+        $service = $this->makeServiceWithPermissions($repo, $this->permissions(true));
+
+        $service->getMyExternalCalendars(99);
+
+        $this->assertSame(1, $capturedUserId, 'calendar list must use the session user, not the passed id');
+    }
+
+    public function test_rpc_surface_is_locked(): void
+    {
+        $reflect = fn (string $m) => (new \ReflectionMethod(\Leantime\Domain\Calendar\Services\Calendar::class, $m))->getDocComment();
+        $isApi = fn (string $m) => ($d = $reflect($m)) !== false && preg_match('/^\s*\*\s*@api\b/m', $d) === 1;
+        $gate = function (string $m): ?string {
+            $attrs = (new \ReflectionMethod(\Leantime\Domain\Calendar\Services\Calendar::class, $m))
+                ->getAttributes(\Leantime\Core\Auth\Permissions\RequiresPermission::class);
+
+            return $attrs === [] ? null : $attrs[0]->newInstance()->permission;
+        };
+
+        // The iCal feed methods are served by the public hash-authed route — never RPC-callable.
+        $this->assertFalse($isApi('getIcalByHash'), 'getIcalByHash must not be @api');
+        $this->assertFalse($isApi('getIcalByRequestToken'), 'getIcalByRequestToken must not be @api');
+
+        // Every @api method carries a calendar.* dispatch gate.
+        $expected = [
+            'getEvent' => 'calendar.view',
+            'getExternalCalendar' => 'calendar.view',
+            'getMyExternalCalendars' => 'calendar.view',
+            'getCachedExternalCalendarContent' => 'calendar.view',
+            'addEvent' => 'calendar.create',
+            'addExternalCalendarUrl' => 'calendar.create',
+            'editEvent' => 'calendar.edit',
+            'editExternalCalendar' => 'calendar.edit',
+            'patch' => 'calendar.edit',
+            'delEvent' => 'calendar.delete',
+            'deleteGCal' => 'calendar.delete',
+        ];
+        foreach ($expected as $method => $permission) {
+            $this->assertTrue($isApi($method), "$method should stay @api");
+            $this->assertSame($permission, $gate($method), "$method must carry the $permission gate");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Brings the **Calendar** domain onto the native permission engine — the last domain before Projects. New `CalendarPermissions`: `calendar.view`/`create`/`edit`/`delete` (project-scoped standard verbs → auto-grant readonly+/editor+) + `calendar.manage` (**global**, admin+ via `scope:any`, the cross-user override). **No `DefaultRolePermissions` matrix edit.**

Calendar is **user-scoped** (personal events + external-calendar subscriptions), so capability and ownership are separate axes: the `@api` methods carry a dispatch capability gate, and ownership is enforced independently.

## IDORs / spoofs closed (RPC)

| Method | Issue | Fix |
|---|---|---|
| `getEvent` | repo fetches by **bare id** → any user reads any event | in-body ownership: `event.userId === currentUserId()` OR `can(manage)`; foreign → soft-deny `false` |
| `getExternalCalendar($id, $userId)` | `$userId` param trusted → read another user's subscription | param **ignored**, pinned to the session user |
| `getMyExternalCalendars($userId)` | same param spoof | param **ignored**, pinned to the session user |
| `patch` (`userIsAllowedToUpdate`) | `Auth::userIsAtLeast(admin)` | `can(calendar.manage)` OR owner — **admin-only override preserved** (manager does *not* get it) |

The repo already session-scopes the write paths (`editEvent`/`delPersonalEvent`/`deleteGCal`/`editGUrl` are `WHERE userId = session`; `addEvent`/`addGUrl` pin `userId` on insert), so those aren't cross-user IDORs.

## Pre-auth iCal feed

`getIcalByHash` + `getIcalByRequestToken` are **de-`@api`'d**: the feed is served by the **public, hash-authenticated** `/calendar/ical` route (`AuthCheck` publicActions, no session) — the `Ical` controller calls them directly. Removing `@api` only closes RPC brute-force exposure; the feed is untouched and the `Ical` controller stays ungated. (Verified end-to-end.)

## Controllers

All **12 non-feed controllers** replace the legacy editor+ `Auth::authOrRedirect` with `#[RequiresPermission(calendar.VERB)]` — VIEW for the read pages (`ShowMyCalendar`/`ShowAllGCals`/`CalendarSettings`/`ExternalCal`/`Export`), CREATE/EDIT/DELETE for the rest. `Ical` stays public.

## Grant-equivalence

**One maintainer-approved change**: the calendar VIEW pages loosen from editor+ to **readonly+** (seeing your *own* calendar; ownership still fences whose events). Create/edit/delete stay editor+; cross-user stays admin-only. The `@api` reads are simultaneously **hardened** from no-gate to owner/member. Everything else is grant-equivalent.

## Migration / tests

- `update_sql_30517`: flush registry → sync → re-seed (no matrix edit). dbVersion 3.5.16 → **3.5.17**.
- `CalendarServiceTest` +6 (getEvent ownership ×3, the two `$userId`-spoof pins, a reflection **surface test** locking the `@api`/gate contract — the iCal methods must stay non-`@api`).
- `calendar.*` added to the role-matrix test (readonly view-only, editor full, manager all-but-manage, admin manage).
- Full local Unit suite green (531 / 1274); CalendarServiceTest 10/37; matrix 7/109; PHPStan L1 + Pint + boot clean.

Reviewed via a 4-lens adversarial pass (ownership-IDOR / pre-auth-feed-controllers / grant-equivalence-consumers / test-runtime): verdict **SHIP, 0 blockers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)