### PR TITLE
refactor(install): consolidate the 14 permission-engine migrations into one

### DIFF
--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -85,19 +85,10 @@ class Install
         // 30503 (zp_device_tokens) intentionally skipped — superseded by
         // 30504 which puts push columns on zp_access_tokens instead.
         30504,
-        30505,
-        30506,
-        30507,
-        30508,
-        30509,
-        30510,
-        30511,
-        30512,
-        30513,
-        30514,
-        30515,
-        30516,
-        30517,
+        // 30505–30517 (the native-permission-engine rollout: table creation + the per-domain
+        // re-seeds, added one PR at a time) were consolidated into the single 30518 migration.
+        // Pre-release, so no installed DB ran the intermediate versions; fresh installs are
+        // covered by SchemaBuilder + setupDB().
         30518,
     ];
 
@@ -2676,18 +2667,31 @@ class Install
     }
 
     /**
-     * Migration 30505: Create the native permission engine tables (zp_roles,
-     * zp_permissions, zp_role_permissions — mirrors SchemaBuilder), then sync the
-     * discovered `domain.action` vocabulary and seed the six built-in roles with their
-     * default grants. Idempotent.
+     * Migration 30518 — the single native-permission-engine migration for existing installs.
      *
-     * @return bool|array Returns true on success, array of errors on failure
+     * Creates the three engine tables (zp_roles, zp_permissions, zp_role_permissions — mirroring
+     * {@see \Leantime\Domain\Install\Services\SchemaBuilder}, which covers fresh installs), then
+     * syncs the discovered `domain.action` vocabulary and seeds the six built-in roles with their
+     * default grants.
+     *
+     * This consolidates what was originally rolled out as 30505 (tables + first seed) plus the
+     * per-domain re-seeds 30506–30517 — each an idempotent `flush → sync → seed` that picked up
+     * one more domain's permission provider. syncDiscoveredPermissions() discovers ALL providers
+     * and seedBuiltInRoles() applies the FULL matrix, so one seed reproduces the entire sequence.
+     * Pre-release: no installed DB ran the intermediate versions, so collapsing them is safe and
+     * keeps the migration history honest.
+     *
+     * Idempotent + additive: re-running never drops an admin's customized zp_role_permissions
+     * rows. The registry cache is flushed first so a stale discovered-provider list can't cause a
+     * partial seed.
+     *
+     * @return bool|array True on success, array of error strings on failure.
      */
-    public function update_sql_30505(): bool|array
+    public function update_sql_30518(): bool|array
     {
         try {
-            // The legacy zp_roles rights table was dropped at update_sql_30002. If a stale
-            // copy survives on a very old install it lacks the 'level' column — replace it.
+            // The legacy zp_roles rights table was dropped at update_sql_30002. If a stale copy
+            // survives on a very old install it lacks the 'level' column — replace it.
             if (Schema::hasTable('zp_roles') && ! Schema::hasColumn('zp_roles', 'level')) {
                 Schema::drop('zp_roles');
             }
@@ -2736,352 +2740,8 @@ class Install
                 });
             }
 
-            // Populate the vocabulary, then grant the built-in roles their defaults.
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30505: '.$e->getMessage());
-
-            return ['Migration 30505 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30506: the Users domain joined the native permission engine. Re-sync the
-     * discovered permission catalog (adds users.view/create/edit/delete/import, all
-     * company-wide) and re-seed the built-in role grants. The engine tables already exist
-     * (created in 30505), so this is table-creation-free. Both seeder calls are idempotent and
-     * additive — re-running never removes an admin's customized zp_role_permissions rows.
-     */
-    public function update_sql_30506(): bool|array
-    {
-        try {
-            // The discovered-provider list is cached cross-request (installation store) outside
-            // debug mode. An install that already ran 30505 cached it WITHOUT UsersPermissions
-            // (which didn't exist then) — seeding against that stale list would never create the
-            // users.* permissions, leaving admin/owner/manager with no user-management grants
-            // (and, with enforcement on, 403'd out of user management). Flush it first.
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30506: '.$e->getMessage());
-
-            return ['Migration 30506 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30507: the Clients domain joined the native permission engine. Re-sync the
-     * discovered permission catalog (adds clients.view/create/edit/delete, all company-wide)
-     * and re-seed the built-in role grants (admin/owner auto-grant clients.* via the company
-     * wildcard). Table-creation-free; idempotent + additive. Flush the discovered-provider
-     * cache first — an install that already ran 30505/30506 cached the provider list WITHOUT
-     * ClientsPermissions, so seeding against that stale list would never create clients.*.
-     */
-    public function update_sql_30507(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30507: '.$e->getMessage());
-
-            return ['Migration 30507 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30508: the Setting domain joined the native permission engine. Re-sync the
-     * discovered permission catalog (adds company.settings.view/edit + projectsettings.labels.manage)
-     * and re-seed the built-in role grants. Table-creation-free; idempotent + additive. Flush the
-     * discovered-provider cache first — an install that already ran 30505-30507 cached the provider
-     * list WITHOUT SettingPermissions, so seeding against that stale list would never create the
-     * new keys (admins would lose the company-settings screen, managers the label dialog).
-     */
-    public function update_sql_30508(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30508: '.$e->getMessage());
-
-            return ['Migration 30508 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30509: the Sprints domain joined the native permission engine. Re-sync the
-     * discovered permission catalog (adds sprints.view/create/edit/delete, all project-scoped)
-     * and re-seed the built-in role grants — the standard verbs auto-grant via the existing
-     * project rules (readonly view; editor create/edit/delete; manager+ all). Table-creation-free;
-     * idempotent + additive. Flush the discovered-provider cache first — an install that already
-     * ran 30505-30508 cached the provider list WITHOUT SprintsPermissions, so seeding against that
-     * stale list would never create the sprints.* keys (and lower roles would lose sprint access).
-     */
-    public function update_sql_30509(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30509: '.$e->getMessage());
-
-            return ['Migration 30509 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30510: the Wiki domain joined the native permission engine. Re-sync the discovered
-     * permission catalog (adds wiki.view/create/edit/delete, all project-scoped) and re-seed the
-     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
-     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
-     * Flush the discovered-provider cache first — an install that already ran 30505-30509 cached the
-     * provider list WITHOUT WikiPermissions, so seeding against that stale list would never create
-     * the wiki.* keys (and lower roles would lose wiki access).
-     */
-    public function update_sql_30510(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30510: '.$e->getMessage());
-
-            return ['Migration 30510 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Migration 30511: the Ideas domain joined the native permission engine. Re-sync the discovered
-     * permission catalog (adds ideas.view/create/edit/delete, all project-scoped) and re-seed the
-     * built-in role grants — the standard verbs auto-grant via the existing project rules (readonly
-     * view; editor create/edit/delete; manager+ all). Table-creation-free; idempotent + additive.
-     * Flush the discovered-provider cache first — an install that already ran 30505-30510 cached the
-     * provider list WITHOUT IdeasPermissions, so seeding against that stale list would never create
-     * the ideas.* keys (and lower roles would lose idea access).
-     */
-    public function update_sql_30511(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30511: '.$e->getMessage());
-
-            return ['Migration 30511 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Blueprints (canvas)
-     * domain. Adds blueprints.view/create/edit/delete (all project-scoped); the standard verbs
-     * auto-grant via the existing project rules (readonly view; editor create/edit/delete;
-     * manager+ all). Table-creation-free; idempotent + additive.
-     *
-     * Flush the discovered-provider cache FIRST — an install that already ran the earlier
-     * permission migrations cached the provider list WITHOUT BlueprintsPermissions, so seeding
-     * against that stale list would never create the blueprints.* keys (and every role would
-     * then be denied canvas access, since currentUserCan requires the role to hold the key).
-     */
-    public function update_sql_30512(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30512: '.$e->getMessage());
-
-            return ['Migration 30512 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Goalcanvas (Goals)
-     * domain. Adds goals.view/create/edit/delete (all project-scoped); the standard verbs
-     * auto-grant via the existing project rules (readonly view; editor create/edit/delete;
-     * manager+ all). Table-creation-free; idempotent + additive.
-     *
-     * Flush the discovered-provider cache FIRST — an install that already ran the earlier
-     * permission migrations cached the provider list WITHOUT GoalcanvasPermissions, so seeding
-     * against that stale list would never create the goals.* keys (and every role would then be
-     * denied goal access, since currentUserCan requires the role to hold the key).
-     */
-    public function update_sql_30513(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30513: '.$e->getMessage());
-
-            return ['Migration 30513 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Timesheets domain. Adds
-     * timesheets.view/create/edit/delete/manage (all GLOBAL-scoped — company-wide time logging).
-     *
-     * This migration MUST re-seed because the DefaultRolePermissions matrix changed: editor now
-     * gains the four global timesheets keys (own-time) and manager gains timesheets.manage
-     * (company-wide invoicing/reports/others' time). Without re-seeding, those roles would not
-     * hold the new keys and the timesheet pages/API would deny everyone below admin.
-     *
-     * Flush the discovered-provider cache FIRST so TimesheetsPermissions is rediscovered.
-     */
-    public function update_sql_30514(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30514: '.$e->getMessage());
-
-            return ['Migration 30514 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Files domain. Adds
-     * files.view/upload/delete (all project-scoped).
-     *
-     * No DefaultRolePermissions matrix edit was needed — these are standard project verbs that
-     * auto-grant through the existing rules (view→readonly+, upload→commenter+, delete→editor+,
-     * manager+ via the project wildcard, admin/owner via scope:any). The re-seed is still required
-     * so the new keys land in zp_role_permissions for the built-in roles.
-     *
-     * Flush the discovered-provider cache FIRST so FilesPermissions is rediscovered.
-     */
-    public function update_sql_30515(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30515: '.$e->getMessage());
-
-            return ['Migration 30515 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Reports domain. Adds
-     * reports.view (project-scoped standard verb → auto-grants readonly+; no
-     * DefaultRolePermissions matrix edit). The re-seed lands the new key in zp_role_permissions
-     * for the built-in roles.
-     *
-     * Flush the discovered-provider cache FIRST so ReportsPermissions is rediscovered.
-     */
-    public function update_sql_30516(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30516: '.$e->getMessage());
-
-            return ['Migration 30516 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Calendar domain. Adds
-     * calendar.view/create/edit/delete (project-scoped standard verbs → auto-grant readonly+/editor+)
-     * and calendar.manage (global → admin+ via scope:any). NO DefaultRolePermissions matrix edit:
-     * all verbs auto-grant. The re-seed lands the new keys in zp_role_permissions for the built-ins.
-     *
-     * Flush the discovered-provider cache FIRST so CalendarPermissions is rediscovered.
-     */
-    public function update_sql_30517(): bool|array
-    {
-        try {
-            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
-
-            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
-            $seeder->syncDiscoveredPermissions();
-            $seeder->seedBuiltInRoles();
-        } catch (\Exception $e) {
-            Log::error('Migration 30517: '.$e->getMessage());
-
-            return ['Migration 30517 failed: '.$e->getMessage()];
-        }
-
-        return true;
-    }
-
-    /**
-     * Sync the permission catalog + re-seed built-in role grants for the Projects domain. Adds
-     * projects.view (project-scoped → readonly+) and projects.create/edit/delete (GLOBAL → manager+
-     * via an explicit DefaultRolePermissions rule; admin/owner via scope:any).
-     *
-     * This migration MUST re-seed because the matrix CHANGED (manager gains the three global
-     * projects keys). Without re-seeding, managers would not hold projects.create/edit/delete and
-     * project management would deny everyone below admin.
-     *
-     * Flush the discovered-provider cache FIRST so ProjectsPermissions is rediscovered.
-     */
-    public function update_sql_30518(): bool|array
-    {
-        try {
+            // Populate the vocabulary, then grant the built-in roles their defaults. Flush the
+            // discovered-provider cache first so every domain's permission provider is rediscovered.
             app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
 
             $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);


### PR DESCRIPTION
## What

Collapses the 14 native-permission-engine migrations (`update_sql_30505`–`30518`) into a **single** `update_sql_30518`, and removes `30505`–`30517` from `$dbUpdates`.

**Net: −367 / +27 lines.**

## Why

The permission engine rolled out one domain per PR. Each PR added a migration that ran the same idempotent `flush → syncDiscoveredPermissions() → seedBuiltInRoles()`:

- `30505` — created the 3 engine tables + first seed
- `30506`–`30517` — **pure re-seeds** (verified: zero schema/SQL work) to pick up each newly-added domain's permission provider

Since `syncDiscoveredPermissions()` discovers **all** providers and `seedBuiltInRoles()` applies the **full** matrix, one seed now reproduces the entire 14-step sequence. The intermediate migrations were only ever needed to advance dev DBs incrementally during the rollout.

## Safety

- **Pre-release** — no installed DB ran the intermediate versions, so collapsing them rewrites no production history.
- **`dbVersion` stays `3.5.18`** — the max migration slot is unchanged. `updateDB()` short-circuits when `stored == dbVersion`, so dev DBs already at 30518 do nothing; DBs that predate the permission engine run the one consolidated migration (table creation folded in, `hasTable`-guarded + the legacy-`zp_roles` shape guard preserved). No renumber-down landmine.
- **Fresh installs unchanged** — `SchemaBuilder::createAllTables()` creates the three tables and `setupDB()` seeds them, fully independent of the update path. (This answers the 'is fresh install covered?' question — yes, it always was.)

## Verification

- `php -l`, Pint, and PHPStan (`.phpstan/phpstan.neon`) all green on `Install.php`.
- Table-creation block is byte-identical to the previously-merged-and-tested `30505`; the seed calls are identical to those run in every `30506`–`30518`.
- `DefaultRolePermissionsTest` continues to assert the seeded matrix; CI's `InstallCest` exercises the fresh-install seeding end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)