### PR TITLE
security(permissions): fail closed when a mandatory projectIdParam can't be resolved

### DIFF
--- a/app/Core/Auth/Permissions/PermissionEnforcer.php
+++ b/app/Core/Auth/Permissions/PermissionEnforcer.php
@@ -27,6 +27,9 @@ class PermissionEnforcer
     /** @var array<string, RequiresPermission|null> Memoized attribute lookups per class::method. */
     private array $cache = [];
 
+    /** @var array<string, bool> Memoized "is this param mandatory" lookups per class::method::param. */
+    private array $mandatoryParamCache = [];
+
     public function __construct(private PermissionService $permissions) {}
 
     /**
@@ -52,9 +55,25 @@ class PermissionEnforcer
             return;
         }
 
-        $allowed = $attribute->global
-            ? $this->permissions->currentUserCan($attribute->permission, null, true)
-            : $this->permissions->currentUserCan($attribute->permission, $this->resolveProjectId($attribute, $params));
+        $reason = '';
+
+        if ($attribute->global) {
+            $allowed = $this->permissions->currentUserCan($attribute->permission, null, true);
+        } else {
+            $projectId = $this->resolveProjectId($attribute, $class, $method, $params);
+
+            if ($projectId === false) {
+                // A declared projectIdParam that can't be resolved to a concrete project, on a
+                // method whose signature makes that param mandatory, fails closed: we cannot
+                // identify which project to authorize against, and silently falling back to the
+                // session project would authorize the wrong one. Optional params keep the
+                // session fallback (see resolveProjectId).
+                $allowed = false;
+                $reason = sprintf(' (unresolved mandatory project param "%s")', $attribute->projectIdParam);
+            } else {
+                $allowed = $this->permissions->currentUserCan($attribute->permission, $projectId);
+            }
+        }
 
         if ($allowed) {
             return;
@@ -64,14 +83,14 @@ class PermissionEnforcer
         $user = session('userdata.id') ?? 'guest';
 
         if (! $this->shouldBlock()) {
-            Log::info(sprintf('[permissions:audit] would deny "%s" on %s for user %s', $attribute->permission, $target, $user));
+            Log::info(sprintf('[permissions:audit] would deny "%s" on %s for user %s%s', $attribute->permission, $target, $user, $reason));
 
             return;
         }
 
         // Log the permission key server-side for audit; the thrown exception stays generic
         // so the authorization vocabulary is never exposed to the client.
-        Log::info(sprintf('Authorization denied: "%s" on %s for user %s', $attribute->permission, $target, $user));
+        Log::info(sprintf('Authorization denied: "%s" on %s for user %s%s', $attribute->permission, $target, $user, $reason));
 
         throw new AuthorizationException;
     }
@@ -105,20 +124,83 @@ class PermissionEnforcer
     }
 
     /**
-     * Project id for a project-scoped check: the named parameter if the attribute declares
-     * one, else the current session project. Returns null when neither resolves.
+     * Resolve the project id for a project-scoped check.
+     *
+     * Three outcomes:
+     *  - int   — a concrete project to authorize against (the declared param, or the session
+     *            project for attributes that declare no param);
+     *  - null  — no concrete project and none required (the session project was empty on an
+     *            attribute that allows the fallback): the engine checks capability only;
+     *  - false — DENY. The attribute declares a projectIdParam, the value is absent/null/zero,
+     *            AND the target method's signature makes that param mandatory (no default).
+     *            We can't identify the project and the method can't run without it, so we fail
+     *            closed instead of authorizing against the unrelated session project.
      *
      * @param  array<string, mixed>  $params
      */
-    private function resolveProjectId(RequiresPermission $attribute, array $params): ?int
+    private function resolveProjectId(RequiresPermission $attribute, object|string $class, string $method, array $params): int|false|null
     {
-        if ($attribute->projectIdParam !== null && isset($params[$attribute->projectIdParam])) {
-            return (int) $params[$attribute->projectIdParam];
+        // No declared param: scope to the ambient session project (session-scoped views).
+        if ($attribute->projectIdParam === null) {
+            return $this->sessionProject();
         }
 
+        $name = $attribute->projectIdParam;
+
+        // Declared param present with a concrete, non-zero value: scope to it.
+        if (array_key_exists($name, $params) && $params[$name] !== null && (int) $params[$name] !== 0) {
+            return (int) $params[$name];
+        }
+
+        // Declared but absent/null/zero. Fail closed only when the method proves the project is
+        // mandatory; methods that default the project (e.g. poll/dashboard "current project"
+        // endpoints) legitimately mean "the session project" and keep the fallback.
+        if ($this->paramIsMandatory($class, $method, $name)) {
+            return false;
+        }
+
+        return $this->sessionProject();
+    }
+
+    /** The current session project as an int, or null when none/zero is set. */
+    private function sessionProject(): ?int
+    {
         $current = session('currentProject');
 
         return ($current === null || (int) $current === 0) ? null : (int) $current;
+    }
+
+    /**
+     * Whether $paramName on $class::$method is mandatory — i.e. has no default value, so a
+     * caller cannot legitimately omit it. Mirrors the JSON-RPC dispatcher's own "required"
+     * definition ({@see \Leantime\Domain\Api\Controllers\Jsonrpc::prepareParameters()}:
+     * `! isDefaultValueAvailable()`) so the two stay in lockstep. Memoized; tolerant of a
+     * missing method/param (returns false → keep the session fallback) so it never over-denies
+     * a target it can't reflect (e.g. a controller action taking a single $params array).
+     */
+    private function paramIsMandatory(object|string $class, string $method, string $paramName): bool
+    {
+        $className = is_object($class) ? $class::class : $class;
+        $key = $className.'::'.$method.'::'.$paramName;
+
+        if (array_key_exists($key, $this->mandatoryParamCache)) {
+            return $this->mandatoryParamCache[$key];
+        }
+
+        $mandatory = false;
+
+        try {
+            foreach ((new ReflectionMethod($className, $method))->getParameters() as $param) {
+                if ($param->getName() === $paramName) {
+                    $mandatory = ! $param->isDefaultValueAvailable();
+                    break;
+                }
+            }
+        } catch (ReflectionException) {
+            $mandatory = false;
+        }
+
+        return $this->mandatoryParamCache[$key] = $mandatory;
     }
 
     /** Whether denials block (true) or are only logged (false, the default — audit mode). */

--- a/tests/Unit/app/Core/Auth/Permissions/PermissionEnforcerTest.php
+++ b/tests/Unit/app/Core/Auth/Permissions/PermissionEnforcerTest.php
@@ -89,6 +89,64 @@ class PermissionEnforcerTest extends \Unit\TestCase
 
         $this->assertSame([], $calls);
     }
+
+    public function test_mandatory_project_param_absent_fails_closed(): void
+    {
+        // paramAction declares projectIdParam:'projectId' and types it `int` (no default) — the
+        // project is mandatory. With it absent, the enforcer must NOT fall back to the session
+        // project (which would authorize the wrong project); it denies without consulting the
+        // engine. allow:true proves the denial comes from the unresolved-project path, not a
+        // negative engine answer.
+        config(['permissions.enforce' => true]);
+
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls, allow: true);
+
+        $threw = false;
+        try {
+            $enforcer->enforce(PermissionEnforcerFixture::class, 'paramAction', []);
+        } catch (\Leantime\Core\Exceptions\AuthorizationException) {
+            $threw = true;
+        }
+
+        $this->assertTrue($threw, 'an unresolvable mandatory project param must deny');
+        $this->assertSame([], $calls, 'the engine must not be consulted when the project is unresolvable');
+    }
+
+    public function test_mandatory_project_param_explicit_null_fails_closed(): void
+    {
+        // isset() was the original bug: it is false for an explicit null, so a null projectId
+        // silently fell through to the session project. A mandatory param passed null now denies.
+        config(['permissions.enforce' => true]);
+
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls, allow: true);
+
+        $threw = false;
+        try {
+            $enforcer->enforce(PermissionEnforcerFixture::class, 'paramAction', ['projectId' => null]);
+        } catch (\Leantime\Core\Exceptions\AuthorizationException) {
+            $threw = true;
+        }
+
+        $this->assertTrue($threw, 'an explicit-null mandatory project param must deny');
+        $this->assertSame([], $calls);
+    }
+
+    public function test_optional_project_param_keeps_the_session_fallback(): void
+    {
+        // optionalParamAction defaults projectId to null ("current project"), so an absent value
+        // is legitimate — the enforcer authorizes against the session project, exactly as the
+        // method itself will operate. This is what makes the poll/dashboard endpoints keep working.
+        session(['currentProject' => 7]);
+
+        $calls = [];
+        $enforcer = $this->spyEnforcer($calls);
+
+        $enforcer->enforce(PermissionEnforcerFixture::class, 'optionalParamAction', []);
+
+        $this->assertSame([['key' => 'tickets.view', 'projectId' => 7, 'forceGlobal' => false]], $calls);
+    }
 }
 
 /**
@@ -105,6 +163,11 @@ class PermissionEnforcerFixture
 
     #[RequiresPermission('tickets.view', projectIdParam: 'projectId')]
     public function paramAction(int $projectId): void {}
+
+    // Same attribute, but the project param is OPTIONAL (defaults to null) — "current project"
+    // semantics. An absent/null value must keep the session fallback, not deny.
+    #[RequiresPermission('tickets.view', projectIdParam: 'projectId')]
+    public function optionalParamAction(?int $projectId = null): void {}
 
     #[RequiresPermission('tickets.view')]
     public function sessionAction(): void {}


### PR DESCRIPTION
## Problem

`PermissionEnforcer::resolveProjectId()` used `isset($params[$projectIdParam])`, which is **false for an explicit `null`**. So when a `#[RequiresPermission(..., projectIdParam: 'projectId')]` method received its project param as absent or null, the enforcer silently **fell back to the session project** — authorizing against the *wrong* project instead of denying.

This is the engine-level root cause of the fail-open patched ad-hoc in #3501 (Reports), where the workaround was to type the param `int` so the JSON-RPC dispatcher would reject null before enforcement. This fixes it centrally.

It's **defense-in-depth, not a live hole**: `Jsonrpc::prepareParameters()` already rejects missing-required and typed-non-nullable-null params with `-32602` before `enforce()` runs, and the membership AND-in already closes foreign-project ids. The only reachable gap was an *untyped* required param (e.g. `getProjectProgress($projectId)`) passed explicit null — which fell back to the user's own session project (own-project data, harmless) instead of denying.

## Fix

`resolveProjectId()` now returns one of three outcomes:

- **int** — a concrete project (the declared param, or the session project for attributes that declare no param);
- **null** — no concrete project required (capability-only check);
- **false → DENY** — a declared `projectIdParam` is absent/null/zero **and** the target method's signature makes it mandatory.

"Mandatory" = `! ReflectionParameter::isDefaultValueAvailable()`, mirroring `Jsonrpc::prepareParameters()`'s own `$required` definition so the two stay in lockstep (memoized per class::method::param).

### Why reflection-gated (and what it does NOT break)

Project params split into two intents that share the same attribute:

- **Mandatory** (`int $projectId`, `$projectId` with no default) — a legitimate caller always supplies the project → fail-closed on absent/null.
- **Optional** (`?int $projectId = null`) — the poll/dashboard "current project" endpoints (`pollComments`, `pollForNewIdeas`, `pollGoals`, `getAllSprints`, the Tickets `pollFor*` family, …). `null` is legitimate and *depends on* the session fallback.

A blanket "declared-but-null → deny" would 403 ~15 live HTMX-refresh endpoints. Reflecting `isDefaultValueAvailable()` exempts them. Verified against all ~50 `projectIdParam` call sites across 12 domains: this changes behavior for none of them on legitimate traffic. Any case the enforcer can't reflect (e.g. a controller action taking a single `$params` array) defaults to the session fallback — never over-denies.

## Tests

`PermissionEnforcerTest` gains 3 cases (8 total, all green): mandatory param absent → deny (engine never consulted), mandatory param explicit-null → deny, optional param → session fallback preserved.

Pint + PHPStan (`.phpstan/phpstan.neon`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)