### PR TITLE
ci(release): set up PHP before make package (fixes v3.9.0 release build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
 
+      # Same PHP setup as Makefile CI - the runner's stock ext-redis (5.3.7)
+      # conflicts with symfony/cache >= 7.4, which requires ext-redis >= 6.1.
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: redis, gd, ldap, mbstring, pdo_mysql, zip, bcmath, exif, pcntl
+
       - name: version
         run: echo "version=$(make get-version)" >> $GITHUB_OUTPUT
         id: version


### PR DESCRIPTION
## Summary

The first automated release (merge of #3511) failed at `make package` → `composer install`:

```
ext-redis is present at version 5.3.7 and cannot be modified by Composer
symfony/cache v7.4.13 conflicts with ext-redis <6.1
```

The runner's stock PHP 8.3 ships ext-redis 5.3.7. The regular Makefile CI avoids this by using `shivammathur/setup-php@v2` (which installs a current redis extension), but the release workflow never had that step — it predates the symfony/cache 7.4 bump and simply hadn't built since.

This adds the identical Setup PHP step (same version, same extension list as `makefile.yml`) before `make package`.

## After merging

Master already carries v3.9.0 (version bump + changelog from #3511), so just trigger **Create Release** manually via "Run workflow" — that escape hatch releases whatever version `AppSettings.php` declares, which is exactly the recovery path it exists for. It will tag `v3.9.0`, publish the release with the changelog body, and attach the artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)