### PR TITLE
test(api): Bearer-auth JSON-RPC contract suite + CI gate

### DIFF
--- a/.github/workflows/api-bearer-tests.yml
+++ b/.github/workflows/api-bearer-tests.yml
@@ -1,0 +1,36 @@
+name: API Tests (Bearer auth)
+
+# Sibling to acceptancetests.yml. Exists because the JSON-RPC endpoint
+# accepts three auth modes (session, x-api-key, Bearer) and ApiCest only
+# exercises x-api-key. Bearer is the mode mobile + AdvancedAuth integrators
+# hit, and a 2026-06 permission-engine deploy silently broke it for every
+# gated read with no CI signal. This workflow closes that gap.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master", "*.*-dev" ]
+  pull_request:
+    branches: [ "master", "*.*-dev" ]
+
+jobs:
+  bearer-api:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: redis, gd, ldap, mbstring, pdo_mysql, zip, bcmath, exif, pcntl
+
+      - name: Run Bearer API Tests
+        run: make bearer-api-test-ci
+
+      - name: Store screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: bearer-api-test
+          path: tests/_output

--- a/app/Command/CreateBearerTokenCommand.php
+++ b/app/Command/CreateBearerTokenCommand.php
@@ -12,22 +12,30 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'test:create-token',
-    description: 'Mint a Sanctum-style Bearer token for an existing user. Plugin-independent — does not require AdvancedAuth. Intended for CI + local testing of the JSON-RPC surface under Bearer auth.',
+    name: 'auth:create-bearer-token',
+    description: 'Mint a Sanctum-style Bearer token for an existing user. Plugin-independent — does not require AdvancedAuth. CLI-only.',
 )]
-class CreateTestTokenCommand extends Command
+class CreateBearerTokenCommand extends Command
 {
     protected function configure(): void
     {
         parent::configure();
 
         $this->addOption('email', null, InputOption::VALUE_REQUIRED, 'Email of an existing user to mint a token for')
-            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'Token name (logged on the row, useful for traceability)', 'test-bearer')
-            ->addOption('quiet-output', null, InputOption::VALUE_NONE, 'Print only the token (no decoration). Useful for shell capture in CI.');
+            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'Token name (logged on the row, useful for traceability)', 'cli-issued')
+            ->addOption('quiet-output', null, InputOption::VALUE_NONE, 'Print only the token (no decoration). Useful for shell capture.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // Hard CLI gate. The Laravel console kernel already only runs
+        // commands from CLI in practice, but a future HTTP-served
+        // Artisan::call() (or a misconfigured kernel) must not be able
+        // to mint a bearer through here. Bail before any work happens.
+        if (! app()->runningInConsole()) {
+            return Command::FAILURE;
+        }
+
         ! defined('BASE_URL') && define('BASE_URL', '');
         ! defined('CURRENT_URL') && define('CURRENT_URL', '');
 
@@ -59,7 +67,6 @@ class CreateTestTokenCommand extends Command
         }
 
         if ($input->getOption('quiet-output')) {
-            // Plain token only — pipe-safe.
             $output->write($result['token']);
 
             return Command::SUCCESS;

--- a/app/Command/CreateTestTokenCommand.php
+++ b/app/Command/CreateTestTokenCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Leantime\Command;
+
+use Illuminate\Console\Command;
+use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
+use Leantime\Domain\Users\Repositories\Users;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'test:create-token',
+    description: 'Mint a Sanctum-style Bearer token for an existing user. Plugin-independent — does not require AdvancedAuth. Intended for CI + local testing of the JSON-RPC surface under Bearer auth.',
+)]
+class CreateTestTokenCommand extends Command
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption('email', null, InputOption::VALUE_REQUIRED, 'Email of an existing user to mint a token for')
+            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'Token name (logged on the row, useful for traceability)', 'test-bearer')
+            ->addOption('quiet-output', null, InputOption::VALUE_NONE, 'Print only the token (no decoration). Useful for shell capture in CI.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        ! defined('BASE_URL') && define('BASE_URL', '');
+        ! defined('CURRENT_URL') && define('CURRENT_URL', '');
+
+        $io = new SymfonyStyle($input, $output);
+
+        $email = $input->getOption('email');
+        if ($email === null || ! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $io->error('A valid --email is required');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $usersRepo = app()->make(Users::class);
+            $user = $usersRepo->getUserByEmail($email);
+
+            if (! $user || empty($user['id'])) {
+                $io->error("No user found with email: {$email}");
+
+                return Command::FAILURE;
+            }
+
+            $tokenRepo = app()->make(AccessTokenRepository::class);
+            $result = $tokenRepo->createToken((int) $user['id'], (string) $input->getOption('name'));
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if ($input->getOption('quiet-output')) {
+            // Plain token only — pipe-safe.
+            $output->write($result['token']);
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf(
+            "Bearer token minted for user #%d (%s)\nToken id: %d\nToken:    %s\n\nUse with: Authorization: Bearer %s",
+            $user['id'],
+            $email,
+            $result['id'],
+            $result['token'],
+            $result['token'],
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/makefile
+++ b/makefile
@@ -126,6 +126,11 @@ acceptance-test-ci: build-dev
 	docker compose --file .dev/docker-compose.yaml --file .dev/docker-compose.tests.yaml exec leantime-dev php vendor/bin/codecept build
 	docker compose --file .dev/docker-compose.yaml --file .dev/docker-compose.tests.yaml exec leantime-dev php vendor/bin/codecept run Acceptance --steps
 
+bearer-api-test-ci: build-dev
+	docker compose --file .dev/docker-compose.yaml --file .dev/docker-compose.tests.yaml up --detach --build --remove-orphans
+	docker compose --file .dev/docker-compose.yaml --file .dev/docker-compose.tests.yaml exec leantime-dev php vendor/bin/codecept build
+	docker compose --file .dev/docker-compose.yaml --file .dev/docker-compose.tests.yaml exec leantime-dev php vendor/bin/codecept run Acceptance --group bearer-api --steps
+
 codesniffer:
 	./vendor/squizlabs/php_codesniffer/bin/phpcs app -d memory_limit=1048M
 

--- a/tests/Acceptance/API/BearerApiCest.php
+++ b/tests/Acceptance/API/BearerApiCest.php
@@ -6,6 +6,7 @@ use Codeception\Attribute\Depends;
 use Codeception\Attribute\Group;
 use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
 use Leantime\Domain\Users\Repositories\Users;
+use PHPUnit\Framework\Assert;
 use Tests\Support\AcceptanceTester;
 use Tests\Support\Page\Acceptance\Install;
 
@@ -53,13 +54,13 @@ class BearerApiCest
     {
         $usersRepo = app()->make(Users::class);
         $user = $usersRepo->getUserByEmail('test@leantime.io');
-        $I->assertNotEmpty($user['id'] ?? null, 'Test user not found after install');
+        Assert::assertNotEmpty($user['id'] ?? null, 'Test user not found after install');
 
         $tokenRepo = app()->make(AccessTokenRepository::class);
         $minted = $tokenRepo->createToken((int) $user['id'], 'bearer-api-cest');
 
         $this->bearerToken = $minted['token'];
-        $I->assertNotEmpty($this->bearerToken, 'Token mint returned empty string');
+        Assert::assertNotEmpty($this->bearerToken, 'Token mint returned empty string');
     }
 
     #[Group('bearer-api')]
@@ -97,7 +98,7 @@ class BearerApiCest
             ],
         ]);
         $newId = is_array($created) && isset($created['result']) ? $created['result'] : null;
-        $I->assertIsInt($newId, 'quickAddTicket should return an int id');
+        Assert::assertIsInt($newId, 'quickAddTicket should return an int id');
 
         $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getTicket', ['id' => $newId]);
     }
@@ -173,7 +174,7 @@ class BearerApiCest
         $body = $this->rpc($I, $method, $params);
 
         $code = $body['error']['code'] ?? null;
-        $I->assertNotSame(
+        Assert::assertNotSame(
             -32001,
             $code,
             sprintf(

--- a/tests/Acceptance/API/BearerApiCest.php
+++ b/tests/Acceptance/API/BearerApiCest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Acceptance\API;
+
+use Codeception\Attribute\Depends;
+use Codeception\Attribute\Group;
+use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
+use Leantime\Domain\Users\Repositories\Users;
+use Tests\Support\AcceptanceTester;
+use Tests\Support\Page\Acceptance\Install;
+
+/**
+ * Bearer-token JSON-RPC contract suite.
+ *
+ * Sibling to ApiCest (x-api-key auth). Exists because the JSON-RPC endpoint
+ * accepts three auth modes (session cookie, x-api-key, Bearer token), and only
+ * the first two had test coverage. The Bearer path is what the mobile app +
+ * any AdvancedAuth integrator hits, and a permission-engine deploy in
+ * 2026-06 silently broke it for every -32001 gated read without CI noticing.
+ *
+ * Each primitive asserts the response is 200, JSON, and NOT a `-32001`
+ * permission denial. That last assertion is the regression gate.
+ */
+class BearerApiCest
+{
+    private string $bearerToken;
+
+    private Install $installPage;
+
+    public function _before(AcceptanceTester $I, Install $installPage)
+    {
+        $this->installPage = $installPage;
+
+        // Fresh install — same fixture as ApiCest so this Cest can run
+        // standalone or alongside it.
+        $this->installPage->install(
+            'test@leantime.io',
+            'Test123456!',
+            'John',
+            'Smith',
+            'Smith & Co'
+        );
+    }
+
+    /**
+     * Mint a Bearer token directly via AccessTokenRepository — no UI flow,
+     * no AdvancedAuth plugin needed. This is the entire reason the suite
+     * exists: Bearer auth must be testable without depending on a paid
+     * plugin's web UI.
+     */
+    #[Group('bearer-api')]
+    public function mintBearerToken(AcceptanceTester $I)
+    {
+        $usersRepo = app()->make(Users::class);
+        $user = $usersRepo->getUserByEmail('test@leantime.io');
+        $I->assertNotEmpty($user['id'] ?? null, 'Test user not found after install');
+
+        $tokenRepo = app()->make(AccessTokenRepository::class);
+        $minted = $tokenRepo->createToken((int) $user['id'], 'bearer-api-cest');
+
+        $this->bearerToken = $minted['token'];
+        $I->assertNotEmpty($this->bearerToken, 'Token mint returned empty string');
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function usersGetUserResolvesWhoAmI(AcceptanceTester $I)
+    {
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Users.Users.getUser', new \stdClass);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function projectsListIsReachable(AcceptanceTester $I)
+    {
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProjectsUserHasAccessTo', new \stdClass);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function ticketsGetAllOpenUserTicketsIsReachable(AcceptanceTester $I)
+    {
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getAllOpenUserTickets', new \stdClass);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function ticketsGetTicketHonorsBearerAuth(AcceptanceTester $I)
+    {
+        // Quick-add a ticket so we have a known id, then fetch it via
+        // getTicket. This is the exact pair that broke mobile in 2026-06:
+        // -32001 on getTicket against a project the user clearly owns.
+        $created = $this->rpc($I, 'leantime.rpc.Tickets.Tickets.quickAddTicket', [
+            'params' => [
+                'headline' => 'Bearer-auth contract test',
+                'projectId' => 1,
+            ],
+        ]);
+        $newId = is_array($created) && isset($created['result']) ? $created['result'] : null;
+        $I->assertIsInt($newId, 'quickAddTicket should return an int id');
+
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getTicket', ['id' => $newId]);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function commentsGetCommentsHonorsBearerAuth(AcceptanceTester $I)
+    {
+        // Comments are entity-scoped — they resolve the host entity's
+        // project from (module, moduleId). Project 1 has the seeded
+        // welcome ticket id 1 in a fresh install.
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Comments.Comments.getComments', [
+            'module' => 'ticket',
+            'moduleId' => 1,
+        ]);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function notificationsGetUnreadCountIsReachable(AcceptanceTester $I)
+    {
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Notifications.Notifications.getUnreadCount', new \stdClass);
+    }
+
+    #[Group('bearer-api')]
+    #[Depends('mintBearerToken')]
+    public function missingBearerReturns401(AcceptanceTester $I)
+    {
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPost('/api/jsonrpc', [
+            'jsonrpc' => '2.0',
+            'method' => 'leantime.rpc.Tickets.Tickets.getAllOpenUserTickets',
+            'params' => new \stdClass,
+            'id' => 1,
+        ]);
+
+        $I->seeResponseCodeIs(401);
+    }
+
+    /**
+     * Hit /api/jsonrpc with the test bearer + the given method, return the
+     * decoded body. Caller decides what to assert.
+     */
+    private function rpc(AcceptanceTester $I, string $method, array|\stdClass $params): array
+    {
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->haveHttpHeader('Authorization', 'Bearer '.$this->bearerToken);
+
+        $I->sendPost('/api/jsonrpc', [
+            'jsonrpc' => '2.0',
+            'method' => $method,
+            'params' => $params,
+            'id' => 1,
+        ]);
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+
+        return json_decode($I->grabResponse(), true) ?? [];
+    }
+
+    /**
+     * Hit /api/jsonrpc and assert no `-32001` permission-engine denial.
+     *
+     * Other engine codes (e.g. `-32602` Invalid params, `-32601` Method not
+     * found) are out of scope — we're testing the auth → user-context →
+     * project-role bootstrap on the Bearer path, not method correctness.
+     * Any `-32001` here means the engine refused a request it would have
+     * allowed under x-api-key or session auth — which IS the regression.
+     */
+    private function assertRpcSucceeds(AcceptanceTester $I, string $method, array|\stdClass $params): void
+    {
+        $body = $this->rpc($I, $method, $params);
+
+        $code = $body['error']['code'] ?? null;
+        $I->assertNotSame(
+            -32001,
+            $code,
+            sprintf(
+                'Bearer-auth call to %s was denied by permission engine (-32001). Response: %s',
+                $method,
+                json_encode($body)
+            )
+        );
+    }
+}

--- a/tests/Httprequests/JsonRPC-bearer.http
+++ b/tests/Httprequests/JsonRPC-bearer.http
@@ -5,7 +5,7 @@
 #   1. Copy http-client.sample.env.json -> http-client.env.json
 #   2. Edit http-client.env.json: set base-url and bearer-token
 #   3. To mint a fresh bearer (no AdvancedAuth plugin required):
-#        php bin/leantime test:create-token --email=you@example.com --quiet-output
+#        php bin/leantime auth:create-bearer-token --email=you@example.com --quiet-output
 #      Copy the output into the bearer-token env var.
 #
 # These mirror the BearerApiCest.php contract suite, which is what runs

--- a/tests/Httprequests/JsonRPC-bearer.http
+++ b/tests/Httprequests/JsonRPC-bearer.http
@@ -1,0 +1,132 @@
+# Bearer-auth JSON-RPC requests — for local exploration / debugging the
+# Bearer auth path on /api/jsonrpc.
+#
+# Setup (one-time per environment):
+#   1. Copy http-client.sample.env.json -> http-client.env.json
+#   2. Edit http-client.env.json: set base-url and bearer-token
+#   3. To mint a fresh bearer (no AdvancedAuth plugin required):
+#        php bin/leantime test:create-token --email=you@example.com --quiet-output
+#      Copy the output into the bearer-token env var.
+#
+# These mirror the BearerApiCest.php contract suite, which is what runs
+# in CI on every PR. Use this file when you need to poke at the auth
+# behavior manually (different user, different project, different role)
+# without running the full Codeception harness.
+
+###
+
+# whoami — server-authoritative session resolution from Bearer
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Users.Users.getUser",
+  "params": {},
+  "id": 1
+}
+
+###
+
+# Projects accessible to the bearer's user
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Projects.Projects.getProjectsUserHasAccessTo",
+  "params": {},
+  "id": 1
+}
+
+###
+
+# Open tickets across all accessible projects
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Tickets.Tickets.getAllOpenUserTickets",
+  "params": {},
+  "id": 1
+}
+
+###
+
+# Get a single ticket — projectIdParam-resolved permission check.
+# This is the call that started returning -32001 in the 2026-06 deploy.
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Tickets.Tickets.getTicket",
+  "params": {"id": 1},
+  "id": 1
+}
+
+###
+
+# Quick-add a ticket — RPC mutation under bearer
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Tickets.Tickets.quickAddTicket",
+  "params": {
+    "params": {
+      "headline": "Bearer-auth manual test",
+      "projectId": 1
+    }
+  },
+  "id": 1
+}
+
+###
+
+# Get comments on a ticket — entityScoped permission check.
+# Second of the 2026-06 regression pair.
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Comments.Comments.getComments",
+  "params": {"module": "ticket", "moduleId": 1},
+  "id": 1
+}
+
+###
+
+# Unread notifications count
+POST {{ base-url }}/api/jsonrpc
+Authorization: Bearer {{ bearer-token }}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Notifications.Notifications.getUnreadCount",
+  "params": {},
+  "id": 1
+}
+
+###
+
+# Missing bearer — expect 401
+POST {{ base-url }}/api/jsonrpc
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "leantime.rpc.Tickets.Tickets.getAllOpenUserTickets",
+  "params": {},
+  "id": 1
+}


### PR DESCRIPTION
## Summary

- Adds the missing test coverage for the **Bearer-token** auth path on `/api/jsonrpc` — the only one of the three auth modes (session / x-api-key / Bearer) without a CI gate.
- Mobile and AdvancedAuth integrators hit `/api/jsonrpc` via Bearer. A permission-engine deploy in master silently broke that path with `-32001 "You are not allowed to perform this action"` on every gated read — `ApiCest` stayed green because it tests x-api-key, not Bearer. This PR closes that blind spot.

## What's included

- **`app/Command/CreateTestTokenCommand.php`** — `php bin/leantime test:create-token --email=...` mints a Bearer token via `AccessTokenRepository::createToken()`. Plugin-independent — no AdvancedAuth required. `--quiet-output` for shell capture.
- **`tests/Acceptance/API/BearerApiCest.php`** — sibling to `ApiCest`. Same Codeception harness, same JSON-RPC envelope, Bearer header + the regression-class assertion: every primitive asserts `error.code !== -32001`.
  - whoami (`Users.getUser`)
  - `Projects.getProjectsUserHasAccessTo`
  - `Tickets.getAllOpenUserTickets`
  - `Tickets.quickAddTicket` → `Tickets.getTicket` pair (the projectIdParam-resolved engine check)
  - `Comments.getComments` (the entityScoped engine check)
  - `Notifications.getUnreadCount`
  - missing-bearer → 401
- **`.github/workflows/api-bearer-tests.yml`** — mirrors `acceptancetests.yml`. Runs on PR and master push.
- **`tests/Httprequests/JsonRPC-bearer.http`** — IDE-runnable companion. Same coverage, drives via a `{{ bearer-token }}` env var that `test:create-token` feeds. For local debugging without spinning up Codeception.
- **`makefile`** — adds `bearer-api-test-ci` (same docker-compose pattern as `acceptance-test-ci`, filtered to `--group bearer-api`).

## Why now

The deploy that landed on cloud broke `Tickets.getTicket` and `Comments.getComments` for every Bearer-authed caller — every mobile user, every integrator using AdvancedAuth tokens. CI stayed green because the permission engine resolves user-context correctly under x-api-key (what `ApiCest` tests) and session (what `LoginCest` tests) — only Bearer fails. This suite would have failed the relevant PRs before merge.

## Test plan

- [ ] CI on this PR runs the new `Bearer API tests` workflow and passes (or fails — if it fails, that's the live regression and a sign we need to ship the engine fix before merging this).
- [ ] Locally: `make bearer-api-test-ci` runs the suite end-to-end.
- [ ] Locally: `php bin/leantime test:create-token --email=test@leantime.io --quiet-output` prints a usable token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)