### PR TITLE
fix(auth): establish user context for Sanctum Bearer API requests (3.9.0 regression)

### DIFF
--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -125,11 +125,41 @@ class AuthCheck
             if ($this->auth->guard($guard)->check()) {
                 $this->auth->shouldUse($guard);
 
+                $this->establishApiUserSession($request);
+
                 return true;
             }
         }
 
         return new Response(json_encode(['error' => 'Unauthorized']), 401);
+    }
+
+    /**
+     * Establish the Leantime user context (`session('userdata')`) for an authenticated API request.
+     *
+     * Every API guard must leave the SAME context behind: the permission engine — and everything
+     * else — reads the user's id and role from `session('userdata')`. The x-api-key guard populates
+     * it as a side effect of {@see \Leantime\Domain\Api\Services\Api::getAPIKeyUser()}, but the
+     * Sanctum (Bearer) guard resolves the user straight from its token and never does — so the
+     * engine saw no user and denied every gated `@api` method with -32001 on Bearer requests.
+     *
+     * This makes the HTTP API auth path uniform: whichever guard authenticated, the context is
+     * built once, from the canonical user row, through the same `setApiUserSession()` builder the
+     * x-api-key path uses. Idempotent — it skips when a guard already populated `userdata`
+     * (x-api-key, or a stateful web session), so those paths are byte-for-byte untouched. Services
+     * are resolved lazily because this only runs for an authenticated API request.
+     */
+    protected function establishApiUserSession(IncomingRequest $request): void
+    {
+        if (session()->exists('userdata') || ($apiUser = $request->user()) === null) {
+            return;
+        }
+
+        $userData = app(\Leantime\Domain\Users\Services\Users::class)->getUser((int) $apiUser->id);
+
+        if (is_array($userData)) {
+            app(\Leantime\Domain\Api\Services\Api::class)->setApiUserSession($userData, true);
+        }
     }
 
     /**

--- a/tests/Unit/app/Core/Middleware/AuthCheckTest.php
+++ b/tests/Unit/app/Core/Middleware/AuthCheckTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\app\Core\Middleware;
+
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Middleware\AuthCheck;
+use Leantime\Domain\Api\Services\Api;
+use Leantime\Domain\Users\Services\Users;
+
+/**
+ * Guards the Bearer-auth regression (3.9.0): the permission engine reads the user's id + role from
+ * session('userdata'), which the x-api-key guard establishes as a side effect of getAPIKeyUser()
+ * but the Sanctum (Bearer) guard never did — so every gated @api method denied Bearer requests.
+ * establishApiUserSession() makes the API auth path uniform: any guard that resolves a user has the
+ * same userdata built from the canonical user row, through the same setApiUserSession() builder.
+ *
+ * This tests the middleware's responsibility — resolve the user id, fetch the canonical row, and
+ * hand it to the session builder, idempotently. The builder itself is covered by ApiServiceTest.
+ */
+class AuthCheckTest extends \Unit\TestCase
+{
+    use \Codeception\Test\Feature\Stub;
+
+    /**
+     * A request whose user() resolver returns an object with the given id — i.e. a guard (Sanctum
+     * or x-api-key) has authenticated, but userdata has not been established yet.
+     */
+    private function apiRequestForUser(int $userId): IncomingRequest
+    {
+        $request = IncomingRequest::create('/api/jsonrpc', 'POST');
+        $request->setUserResolver(fn () => (object) ['id' => $userId]);
+
+        return $request;
+    }
+
+    /** Invoke the protected establishApiUserSession() on a constructor-less AuthCheck. */
+    private function establish(IncomingRequest $request): void
+    {
+        $authCheck = $this->make(AuthCheck::class);
+        (fn () => $this->establishApiUserSession($request))->call($authCheck);
+    }
+
+    public function test_establishes_userdata_from_the_canonical_row_when_missing(): void
+    {
+        session()->forget('userdata');
+
+        $row = ['id' => 42, 'firstname' => 'Gloria', 'role' => 20];
+
+        app()->instance(Users::class, $this->make(Users::class, [
+            'getUser' => fn ($id = null) => (int) $id === 42 ? $row : false,
+        ]));
+
+        $captured = null;
+        app()->instance(Api::class, $this->make(Api::class, [
+            'setApiUserSession' => function (array $user, bool $isExternalAuth = false) use (&$captured) {
+                $captured = ['user' => $user, 'external' => $isExternalAuth];
+            },
+        ]));
+
+        $this->establish($this->apiRequestForUser(42));
+
+        $this->assertSame($row, $captured['user'] ?? null, 'the canonical row must be handed to the session builder');
+        $this->assertTrue($captured['external'] ?? false, 'API sessions are external auth');
+    }
+
+    public function test_is_idempotent_when_userdata_already_exists(): void
+    {
+        // x-api-key (and stateful web) already populated userdata before this runs — leave it,
+        // and never re-resolve the user.
+        session(['userdata' => ['id' => 7, 'role' => 'admin']]);
+
+        app()->instance(Users::class, $this->make(Users::class, [
+            'getUser' => function ($id = null) {
+                $this->fail('must not re-resolve the user when userdata already exists');
+            },
+        ]));
+
+        $called = false;
+        app()->instance(Api::class, $this->make(Api::class, [
+            'setApiUserSession' => function (array $user, bool $isExternalAuth = false) use (&$called) {
+                $called = true;
+            },
+        ]));
+
+        $this->establish($this->apiRequestForUser(42));
+
+        $this->assertFalse($called, 'must not rebuild an already-established session');
+        $this->assertSame(7, session('userdata.id'), 'existing userdata must be left untouched');
+    }
+}

--- a/tests/Unit/app/Core/Middleware/AuthCheckTest.php
+++ b/tests/Unit/app/Core/Middleware/AuthCheckTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\app\Core\Middleware;
+namespace Unit\app\Core\Middleware;
 
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Middleware\AuthCheck;


### PR DESCRIPTION
## Production regression (3.9.0)

Every gated `@api` method returns **`-32001`** when called via a **Sanctum Bearer token** (AdvancedAuth). Affects the mobile app + all cloud/self-hosted integrators using Bearer tokens (Zapier-style automations, custom scripts, RPC consumers). **x-api-key and the web UI are unaffected.**

## Root cause

The permission engine resolves the user's id + role from `session('userdata')`. That context is established per auth path:

| Path | How `userdata` is set | Status |
|---|---|---|
| Web session | `Auth::setUserSession()` at login | ✅ |
| **x-api-key** (`jsonRpc`/`ApiGuard`) | side effect of `Api::getAPIKeyUser()` | ✅ |
| **Sanctum Bearer** | resolves user from the token — **nothing** | ❌ |

So `getRoleToCheck()` hit `session()->exists('userdata') === false → return false` → `effectiveRole()` = false → `currentUserCan()` = false → deny. Pre-engine these methods weren't gated, so the missing `userdata` didn't matter; the engine made it load-bearing on a path that never populated it.

**Why CI missed it:** `ApiCest` authenticates with **x-api-key** (and resets the session cookie), so it exercises the working provider path and never Sanctum Bearer. That's the test gap this PR closes.

## Fix — unify the API auth path

`AuthCheck::authenticateApi()` now establishes `userdata` for **whichever guard authenticated**, from the canonical user row via the **same `setApiUserSession()` builder** x-api-key already uses. So Bearer and x-api-key end up with identical session data.

- **Idempotent** — skips when a guard already populated `userdata` (x-api-key, stateful web), so the working x-api-key path is **byte-for-byte untouched**.
- **`getAPIKeyUser`'s side effect is kept on purpose** — the **McpServer plugin's CLI command** (`McpStartCommand`) resolves users outside the HTTP middleware and depends on it. Removing it would break MCP; the HTTP path is unified at the `authenticateApi` chokepoint instead.

## Tests

`AuthCheckTest` covers establishment (canonical row → builder) + idempotency. Pint + PHPStan green; existing API unit tests unaffected (x-api-key path confirmed).

**Follow-up (not this PR):** an end-to-end acceptance test under a real Sanctum token (mintable via core `AccessToken::createToken`) once the `personal_access_tokens` table is in the acceptance env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)