### PR TITLE
Release v3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version: 3.9.1
+
+## Bug Fixes
+- **Bearer API Authentication** - Restored user context for Sanctum Bearer API requests, fixing a 3.9.0 regression (#3514)
+
+## Improvements
+- **API Contract Tests** - Added a Bearer-auth JSON-RPC contract test suite with a CI gate (#3513)
+
+---
+
 # Version: 3.9.0
 
 ## Highlights

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -7,7 +7,7 @@ namespace Leantime\Core\Configuration;
  */
 class AppSettings
 {
-    public string $appVersion = '3.9.0';
+    public string $appVersion = '3.9.1';
 
     public string $dbVersion = '3.5.18';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leantime",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leantime",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leantime",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Open source innovation management system",
   "dependencies": {
     "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",


### PR DESCRIPTION
Automated release PR. Review and edit the changelog below (it ships as CHANGELOG.md and as the GitHub release notes), wait for CI, then merge - the release publishes automatically.

---

# Version: 3.9.1

## Bug Fixes
- **Bearer API Authentication** - Restored user context for Sanctum Bearer API requests, fixing a 3.9.0 regression (#3514)

## Improvements
- **API Contract Tests** - Added a Bearer-auth JSON-RPC contract test suite with a CI gate (#3513)
