### PR TITLE
fix(routing): self-heal stale route cache + correct BadMethodCallException import

### DIFF
--- a/app/Core/Controller/Controller.php
+++ b/app/Core/Controller/Controller.php
@@ -2,7 +2,7 @@
 
 namespace Leantime\Core\Controller;
 
-use http\Exception\BadMethodCallException;
+use BadMethodCallException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Http\IncomingRequest;

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -242,8 +242,21 @@ class Frontcontroller
         $actionPath = $moduleName.'\\'.$controllerType.'\\'.$actionName;
 
         if ($this->config->debug == false) {
-            if (Cache::store('installation')->has('routes.'.$routepath.'.'.$methodNameLower)) {
-                return Cache::store('installation')->get('routes.'.$routepath.'.'.$methodNameLower);
+            $cachedRoute = Cache::store('installation')->get('routes.'.$routepath.'.'.$methodNameLower);
+
+            // Cached routes can outlive a deploy (e.g. a controller's run() replaced by get()/post()).
+            // Only trust the cache if the class and method still exist; otherwise drop it and re-resolve.
+            if (
+                is_array($cachedRoute)
+                && isset($cachedRoute['class'], $cachedRoute['method'])
+                && class_exists($cachedRoute['class'])
+                && method_exists($cachedRoute['class'], $cachedRoute['method'])
+            ) {
+                return $cachedRoute;
+            }
+
+            if ($cachedRoute !== null) {
+                Cache::store('installation')->forget('routes.'.$routepath.'.'.$methodNameLower);
             }
         }
 

--- a/app/Core/Controller/HtmxController.php
+++ b/app/Core/Controller/HtmxController.php
@@ -2,7 +2,7 @@
 
 namespace Leantime\Core\Controller;
 
-use http\Exception\BadMethodCallException;
+use BadMethodCallException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Events\Htmx\HtmxEvent;

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -330,6 +330,11 @@ class Install
             return true;
         }
 
+        // The version changed: cached routes, plugin lists etc. may reference classes or
+        // methods that no longer exist in the new codebase. Everything in the installation
+        // store is re-derivable, so drop it wholesale before running the updates.
+        Cache::store('installation')->flush();
+
         // Find all update functions that need to be executed
         foreach ($this->dbUpdates as $updateVersion) {
             if ($currentDBVersion < $updateVersion) {

--- a/tests/Unit/app/Core/Controller/FrontcontrollerRouteCacheTest.php
+++ b/tests/Unit/app/Core/Controller/FrontcontrollerRouteCacheTest.php
@@ -23,7 +23,8 @@ class FrontcontrollerRouteCacheTest extends TestCase
     {
         parent::setUp();
 
-        // Route caching is skipped entirely when debug is on.
+        // The cached-route read path is only taken when debug is off (writes happen
+        // regardless), so the validation under test requires debug to be disabled.
         config(['debug' => false]);
     }
 

--- a/tests/Unit/app/Core/Controller/FrontcontrollerRouteCacheTest.php
+++ b/tests/Unit/app/Core/Controller/FrontcontrollerRouteCacheTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Unit\app\Core\Controller;
+
+use Illuminate\Support\Facades\Cache;
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
+use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Unit\TestCase;
+
+/**
+ * Regression coverage for stale route-cache entries. Routes resolved by the
+ * Frontcontroller are cached across requests in the installation store and can
+ * outlive a deploy: a controller whose run() was replaced by get()/post() left
+ * a cached ['method' => 'run'] entry behind, and callAction('run') then hit
+ * __call() and produced a 500 (seen in production on /calendar/showMyCalendar
+ * and /timesheets/showMy). A cached entry must only be trusted if its class and
+ * method still exist; otherwise it gets dropped and the route re-resolved.
+ */
+class FrontcontrollerRouteCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Route caching is skipped entirely when debug is on.
+        config(['debug' => false]);
+    }
+
+    private function frontcontroller(): Frontcontroller
+    {
+        // Built by hand: container resolution would pull in the real
+        // PermissionEnforcer, which needs a database connection.
+        return new Frontcontroller(
+            IncomingRequest::create('/calendar/showMyCalendar', 'GET'),
+            $this->createMock(PermissionEnforcer::class),
+        );
+    }
+
+    private function cacheKey(string $module, string $action, string $method): string
+    {
+        return 'routes.'.$module.'.Controllers.'.$action.'.'.$method;
+    }
+
+    public function test_stale_cached_method_is_dropped_and_route_reresolved(): void
+    {
+        // Simulate a pre-deploy cache entry pointing at the removed run() method.
+        $key = $this->cacheKey('Calendar', 'ShowMyCalendar', 'get');
+        Cache::store('installation')->set($key, [
+            'class' => \Leantime\Domain\Calendar\Controllers\ShowMyCalendar::class,
+            'method' => 'run',
+        ]);
+
+        $result = $this->frontcontroller()->getValidControllerCall('calendar', 'showMyCalendar', 'get', 'Controllers');
+
+        $this->assertSame('get', $result['method']);
+        $this->assertSame(\Leantime\Domain\Calendar\Controllers\ShowMyCalendar::class, $result['class']);
+
+        // The stale entry must have been replaced with the fresh resolution.
+        $this->assertSame($result, Cache::store('installation')->get($key));
+    }
+
+    public function test_cached_entry_with_missing_class_is_dropped(): void
+    {
+        $key = $this->cacheKey('Calendar', 'ShowMyCalendar', 'get');
+        Cache::store('installation')->set($key, [
+            'class' => 'Leantime\\Domain\\Calendar\\Controllers\\NoLongerExists',
+            'method' => 'get',
+        ]);
+
+        $result = $this->frontcontroller()->getValidControllerCall('calendar', 'showMyCalendar', 'get', 'Controllers');
+
+        $this->assertSame(\Leantime\Domain\Calendar\Controllers\ShowMyCalendar::class, $result['class']);
+        $this->assertSame('get', $result['method']);
+    }
+
+    public function test_valid_cached_entry_is_returned_as_is(): void
+    {
+        $key = $this->cacheKey('Calendar', 'ShowMyCalendar', 'get');
+        $cached = [
+            'class' => \Leantime\Domain\Calendar\Controllers\ShowMyCalendar::class,
+            'method' => 'get',
+        ];
+        Cache::store('installation')->set($key, $cached);
+
+        $result = $this->frontcontroller()->getValidControllerCall('calendar', 'showMyCalendar', 'get', 'Controllers');
+
+        $this->assertSame($cached, $result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the production 500s seen on `/calendar/showMyCalendar` and `/timesheets/showMy` (`Class "http\Exception\BadMethodCallException" not found` at `Controller.php:87`). Two stacked bugs:

1. **Stale route cache.** `Frontcontroller::getValidControllerCall()` caches resolved `['class', 'method']` pairs in the installation store with no validation on read and no busting on deploy. Entries cached before a controller's `run()` was replaced by `get()`/`post()` still pointed at `run()`, so `callAction('run')` hit `__call()` on every request. The cache read now verifies the class and method still exist; stale entries are dropped and re-resolved (self-healing).

2. **Broken exception import.** `Controller` and `HtmxController` imported `BadMethodCallException` from the nonexistent pecl_http namespace (`http\Exception\...`), so the intended "method does not exist" exception itself fataled with "Class not found", turning a handleable error into a hard 500.

Additionally, `Install::updateDB()` now flushes the installation cache store when a version change is detected, so cached routes / plugin lists / language files can't reference classes from the previous release.

## Test plan
- New unit tests in `tests/Unit/app/Core/Controller/FrontcontrollerRouteCacheTest.php`: stale method re-resolves, missing class re-resolves, valid cache returned as-is (passing locally).
- phpstan (CI config) clean for changed files; Pint passing.
- Prod immediate mitigation (independent of this PR): clear the installation cache store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)