### PR TITLE
Release v3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version: 3.9.2
+
+## Bug Fixes
+- **Route Caching** - Automatically recovers from stale route cache and corrects an invalid exception import to prevent routing errors (#3523)
+- **Bearer/PAT Authentication** - Fixed Bearer and personal access token authentication by validating against the core token store (#3522)
+
+---
+
 # Version: 3.9.1
 
 ## Bug Fixes

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -7,7 +7,7 @@ namespace Leantime\Core\Configuration;
  */
 class AppSettings
 {
-    public string $appVersion = '3.9.1';
+    public string $appVersion = '3.9.2';
 
     public string $dbVersion = '3.5.18';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leantime",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leantime",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leantime",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Open source innovation management system",
   "dependencies": {
     "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",


### PR DESCRIPTION
Automated release PR. Review and edit the changelog below (it ships as CHANGELOG.md and as the GitHub release notes), wait for CI, then merge - the release publishes automatically.

---

# Version: 3.9.2

## Bug Fixes
- **Route Caching** - Automatically recovers from stale route cache and corrects an invalid exception import to prevent routing errors (#3523)
- **Bearer/PAT Authentication** - Fixed Bearer and personal access token authentication by validating against the core token store (#3522)
