### PR TITLE
fix(auth): Sanctum-guard session stores role name not raw int (fixes Bearer -32001 on all gated methods)

### DIFF
--- a/.dev/dev-apache-site.conf
+++ b/.dev/dev-apache-site.conf
@@ -2,6 +2,15 @@
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/html/public
 
+	# Pass the Authorization header through to PHP so $request->bearerToken() works.
+	# Without this, Apache strips it (it only lands in HTTP_AUTHORIZATION), Laravel's
+	# Sanctum guard never sees the Bearer token, and the test env silently exercises a
+	# different auth path than production — which is how the 3.9.x Bearer role regression
+	# slipped past CI. With it, BearerApiCest goes through the real Sanctum-guard path.
+	<Directory /var/www/html/public>
+		CGIPassAuth On
+	</Directory>
+
 	ErrorLog /var/www/html/storage/logs/apacheError.log
 	CustomLog /var/www/html/storage/logs/access.log combined
 </VirtualHost>
@@ -15,6 +24,10 @@
     SSLCertificateKeyFile /etc/ssl/private/key.pem
 
     SetEnv HTTPS "on"
+
+	<Directory /var/www/html/public>
+		CGIPassAuth On
+	</Directory>
 
 	ErrorLog /var/www/html/storage/logs/apacheError.log
 	CustomLog /var/www/html/storage/logs/access.log combined

--- a/app/Domain/Auth/Services/AuthUser.php
+++ b/app/Domain/Auth/Services/AuthUser.php
@@ -5,6 +5,7 @@ namespace Leantime\Domain\Auth\Services;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Laravel\Sanctum\HasApiTokens;
+use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth as AuthService;
 
 class AuthUser implements UserProvider
@@ -105,7 +106,12 @@ class AuthUser implements UserProvider
             'profileId' => $user['profileId'],
             'mail' => filter_var($user['username'], FILTER_SANITIZE_EMAIL),
             'clientId' => $user['clientId'],
-            'role' => $user['role'],
+            // Store the role NAME string (e.g. "owner"), not the raw DB int ("50"). The permission
+            // engine's getRoleToCheck() validates the session role against Roles::getRoles() (the
+            // name list), so a raw int resolves to false and denies every #[RequiresPermission]
+            // method. The other two userdata builders (Api::setApiUserSession, Auth::setUserSession)
+            // already convert it; this is the Sanctum-guard path and must match them.
+            'role' => Roles::getRoleString($user['role']),
             'settings' => $user['settings'] ? safe_unserialize($user['settings'], []) : [],
             'twoFAEnabled' => $user['twoFAEnabled'] ?? false,
             'twoFAVerified' => true, // Auto-verify for API tokens

--- a/tests/Unit/app/Domain/Auth/Services/AuthUserSessionRoleTest.php
+++ b/tests/Unit/app/Domain/Auth/Services/AuthUserSessionRoleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Unit\app\Domain\Auth\Services;
+
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Auth\Services\AuthUser;
+
+/**
+ * Regression guard for the 3.9.x Bearer-auth role bug.
+ *
+ * AuthUser is the userdata builder on the Sanctum (Bearer) guard path: AccessToken::findToken ->
+ * AuthUser::setUser -> setUserSession. It stored the RAW DB role int ("50") in session('userdata'),
+ * while the permission engine's Auth::getRoleToCheck() validates the session role against
+ * Roles::getRoles() (the role-NAME list). So "50" resolved to false and the engine denied every
+ * #[RequiresPermission] @api method with -32001 — for every Bearer/Sanctum integrator, on any
+ * server that exposes the Authorization header (production). CI missed it because its Apache hid
+ * the header, routing Bearer through the fallback path (which builds userdata via
+ * Api::setApiUserSession, and that one DOES convert the role).
+ *
+ * The fix: AuthUser::setUserSession must store the role NAME string, matching the other two
+ * userdata builders. This asserts the resulting session role is engine-valid for every built-in
+ * role — it FAILS on the raw-int bug and PASSES on the fix, independent of web server config.
+ */
+class AuthUserSessionRoleTest extends \Unit\TestCase
+{
+    private function userRow(int $role): array
+    {
+        return [
+            'id' => 1,
+            'firstname' => 'Test',
+            'username' => 'test@leantime.io',
+            'profileId' => 0,
+            'clientId' => 0,
+            'role' => $role,
+            'settings' => '',
+            'twoFAEnabled' => false,
+            'twoFASecret' => '',
+            'createdOn' => '2026-01-01 00:00:00',
+            'modified' => '2026-01-01 00:00:00',
+        ];
+    }
+
+    public function test_sanctum_guard_session_role_is_engine_valid_for_every_builtin_role(): void
+    {
+        // setUserSession touches no instance state, so a constructor-less instance avoids the DB.
+        $authUser = (new \ReflectionClass(AuthUser::class))->newInstanceWithoutConstructor();
+        $setUserSession = new \ReflectionMethod(AuthUser::class, 'setUserSession');
+        $setUserSession->setAccessible(true);
+
+        foreach (array_keys(Roles::getRoles()) as $roleInt) {
+            session()->forget('userdata');
+
+            $setUserSession->invoke($authUser, $this->userRow((int) $roleInt));
+
+            $sessionRole = session('userdata.role');
+
+            $this->assertContains(
+                $sessionRole,
+                Roles::getRoles(),
+                "AuthUser stored an engine-invalid role for DB int $roleInt: ".var_export($sessionRole, true)
+            );
+            $this->assertNotFalse(
+                Auth::getRoleToCheck(false),
+                "getRoleToCheck() rejected the Sanctum-guard session role for DB int $roleInt"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Production-down regression (still broken after 3.9.2)

Every `#[RequiresPermission]` JSON-RPC method returns **-32001** for **Sanctum Bearer-token** callers (mobile app + all AdvancedAuth integrators). 3.9.2's #3522 fixed one Bearer auth path but not this one.

## Root cause (reproduced end-to-end)

There are **two non-equivalent Bearer auth paths**, and they build `session('userdata')` differently:

| Path | When | `userdata.role` |
|---|---|---|
| Sanctum **guard** (`AccessToken::findToken` → `AuthUser::setUserSession`) | server exposes `Authorization` header → **production** | `$user['role']` → **`"50"` (raw DB int)** ❌ |
| #3522 **fallback** (`Api::setApiUserSession`) | server hides it → **our CI Apache** | `Roles::getRoleString(...)` → `"owner"` ✅ |
| web login (`Auth::setUserSession`) | — | `Roles::getRoleString(...)` → `"owner"` ✅ |

The engine's `getRoleToCheck()` validates the session role against `Roles::getRoles()` (the **name** list). `"50"` isn't a name → returns **false** → every gated method -32001s. `AuthUser` is the only builder of the three that didn't convert the role.

**Reproduced locally** with `CGIPassAuth` on (= production): a Bearer call to `getAllOpenUserTickets` returns `-32001` and the log shows `Check for invalid role detected: 50`. With the fix it returns 200.

**Why CI passed anyway:** the dev/CI Apache stripped the `Authorization` header, so `bearerToken()` was null, the Sanctum guard never ran, and Bearer fell through to the fallback path (the one that converts the role). The guard path production uses was never exercised.

## Fix

- `AuthUser::setUserSession`: store `Roles::getRoleString($user['role'])`, matching the other two userdata builders. One line + import.
- **Close the test gap:** add `CGIPassAuth On` to `dev-apache-site.conf` so `BearerApiCest` now goes through the real Sanctum-guard path (it previously only tested the fallback).
- **`AuthUserSessionRoleTest`:** a deterministic, server-independent unit guard asserting the Sanctum-guard session role is engine-valid for every built-in role. Fails on the raw-int bug, passes on the fix.

## Verification

Reproduced the bug end-to-end (guard path → -32001 + the exact prod log line) and proved the fix's transformation (`getRoleString(50)='owner'` → `getRoleToCheck()='owner'`). CI here is the assembled end-to-end check: `unit` runs the deterministic guard; `bearer-api`/`acceptance` now exercise the Sanctum-guard path.

Ships as **3.9.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)