### PR TITLE
Release v3.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Version: 3.9.3
 
 ## Bug Fixes
-- **Bearer Authentication** - Resolved a Bearer token error (-32001) by storing the role name instead of a raw integer in the Sanctum-guard session (#3525)
+- **Bearer Authentication** - Resolved a Bearer token error (-32001) that denied every permission-gated API method for mobile and token-based integrations. The Sanctum-guard session stored the raw role integer instead of the role name the permission engine expects (#3525)
+
+## Improvements
+- **Unified Session Handling** - All authentication paths (web login, API key, and Bearer token) now build the user session through a single factory, so the role and two-factor state can no longer diverge between them. This also makes two-factor handling consistent for token-based authentication and adds clearer diagnostics when an unresolvable role is encountered (#3526)
+- **API Auth Test Coverage** - The Bearer JSON-RPC contract tests now run through the real server auth path and cover non-manager roles, catching authorization regressions for non-admin users that owner-only testing missed (#3526)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version: 3.9.3
+
+## Bug Fixes
+- **Bearer Authentication** - Resolved a Bearer token error (-32001) by storing the role name instead of a raw integer in the Sanctum-guard session (#3525)
+
+---
+
 # Version: 3.9.2
 
 ## Bug Fixes

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -7,7 +7,7 @@ namespace Leantime\Core\Configuration;
  */
 class AppSettings
 {
-    public string $appVersion = '3.9.2';
+    public string $appVersion = '3.9.3';
 
     public string $dbVersion = '3.5.18';
 }

--- a/app/Domain/Api/Services/Api.php
+++ b/app/Domain/Api/Services/Api.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Api\Contracts\StaticAssetType;
 use Leantime\Domain\Api\Repositories\Api as ApiRepository;
-use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\UserSessionBuilder;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
@@ -94,28 +94,16 @@ class Api
      */
     public function setApiUserSession(array $user, bool $isExternalAuth = false)
     {
-
-        $currentUser = [
-            'id' => (int) $user['id'],
-            'name' => strip_tags($user['firstname']),
-            'profileId' => $user['profileId'],
-            'mail' => filter_var($user['username'], FILTER_SANITIZE_EMAIL),
-            'clientId' => $user['clientId'],
-            'role' => Roles::getRoleString($user['role']),
-            'settings' => $user['settings'] ? safe_unserialize($user['settings'], []) : [],
-            'twoFAEnabled' => $user['twoFAEnabled'] ?? false,
-            'twoFAVerified' => false,
-            'twoFASecret' => $user['twoFASecret'] ?? '',
-            'isExternalAuth' => $isExternalAuth,
-            'createdOn' => ! empty($user['createdOn']) ? dtHelper()->parseDbDateTime($user['createdOn']) : dtHelper()->userNow(),
-            'modified' => ! empty($user['modified']) ? dtHelper()->parseDbDateTime($user['modified']) : dtHelper()->userNow(),
-        ];
+        // x-api-key (and Bearer fallback) session. twoFAVerified: true — like the Sanctum-token
+        // path, an API token is the strong credential and no interactive 2FA is possible (this
+        // was previously false, diverging from the AuthUser/Bearer builder). Built via the shared
+        // factory so role + every field stay identical across all auth paths.
+        $currentUser = UserSessionBuilder::build($user, isExternalAuth: $isExternalAuth, twoFAVerified: true);
 
         $currentUser = self::dispatch_filter('user_session_vars', $currentUser);
 
         // Session handler for api is array
         session(['userdata' => $currentUser]);
-
     }
 
     /**

--- a/app/Domain/Auth/Services/Auth.php
+++ b/app/Domain/Auth/Services/Auth.php
@@ -157,10 +157,13 @@ class Auth implements Authenticatable
             $roleToCheck = session('userdata.projectRole');
         }
 
-        // Ensure the role is a valid role
+        // Ensure the role is a valid role. An unresolvable role here makes the permission engine
+        // deny EVERYTHING (every #[RequiresPermission] check fails) — so log it loudly with
+        // context. This exact breadcrumb ("invalid role detected: 50") is what surfaced the 3.9.x
+        // Bearer regression where a session stored the raw role int instead of its name string.
         if (in_array($roleToCheck, Roles::getRoles()) === false) {
 
-            Log::info('Check for invalid role detected: '.$roleToCheck);
+            Log::warning('Invalid role in session — authorization will deny everything. Resolved role: '.var_export($roleToCheck, true).' (user '.(session('userdata.id') ?? 'guest').'). Expected one of: '.implode(', ', Roles::getRoles()));
 
             return false;
         }
@@ -302,22 +305,11 @@ class Auth implements Authenticatable
             return false;
         }
 
-        $currentUser = [
-            'id' => (int) $user['id'],
-            'globalUserId' => Uuid::uuid5(Uuid::NAMESPACE_DNS, strtolower($user['username'])),
-            'name' => strip_tags($user['firstname']),
-            'profileId' => $user['profileId'],
-            'mail' => filter_var($user['username'], FILTER_SANITIZE_EMAIL),
-            'clientId' => $user['clientId'],
-            'role' => Roles::getRoleString($user['role']),
-            'settings' => $user['settings'] ? safe_unserialize($user['settings'], []) : [],
-            'twoFAEnabled' => $user['twoFAEnabled'] ?? false,
-            'twoFAVerified' => false,
-            'twoFASecret' => $user['twoFASecret'] ?? '',
-            'isExternalAuth' => $isExternalAuth,
-            'createdOn' => ! empty($user['createdOn']) ? dtHelper()->parseDbDateTime($user['createdOn']) : dtHelper()->userNow(),
-            'modified' => ! empty($user['modified']) ? dtHelper()->parseDbDateTime($user['modified']) : dtHelper()->userNow(),
-        ];
+        // Web-login session. twoFAVerified: false — the web flow enforces interactive 2FA via the
+        // AuthCheck gate. Built via the shared factory (role NAME string + consistent fields), with
+        // the web-only globalUserId added on top.
+        $currentUser = UserSessionBuilder::build($user, isExternalAuth: $isExternalAuth, twoFAVerified: false);
+        $currentUser['globalUserId'] = Uuid::uuid5(Uuid::NAMESPACE_DNS, strtolower($user['username']));
 
         $currentUser = self::dispatch_filter('user_session_vars', $currentUser);
 

--- a/app/Domain/Auth/Services/AuthUser.php
+++ b/app/Domain/Auth/Services/AuthUser.php
@@ -5,7 +5,6 @@ namespace Leantime\Domain\Auth\Services;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Laravel\Sanctum\HasApiTokens;
-use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth as AuthService;
 
 class AuthUser implements UserProvider
@@ -100,27 +99,9 @@ class AuthUser implements UserProvider
 
     protected function setUserSession($user)
     {
-        $currentUser = [
-            'id' => (int) $user['id'],
-            'name' => strip_tags($user['firstname']),
-            'profileId' => $user['profileId'],
-            'mail' => filter_var($user['username'], FILTER_SANITIZE_EMAIL),
-            'clientId' => $user['clientId'],
-            // Store the role NAME string (e.g. "owner"), not the raw DB int ("50"). The permission
-            // engine's getRoleToCheck() validates the session role against Roles::getRoles() (the
-            // name list), so a raw int resolves to false and denies every #[RequiresPermission]
-            // method. The other two userdata builders (Api::setApiUserSession, Auth::setUserSession)
-            // already convert it; this is the Sanctum-guard path and must match them.
-            'role' => Roles::getRoleString($user['role']),
-            'settings' => $user['settings'] ? safe_unserialize($user['settings'], []) : [],
-            'twoFAEnabled' => $user['twoFAEnabled'] ?? false,
-            'twoFAVerified' => true, // Auto-verify for API tokens
-            'twoFASecret' => $user['twoFASecret'] ?? '',
-            'isExternalAuth' => false,
-            'createdOn' => ! empty($user['createdOn']) ? dtHelper()->parseDbDateTime($user['createdOn']) : dtHelper()->userNow(),
-            'modified' => ! empty($user['modified']) ? dtHelper()->parseDbDateTime($user['modified']) : dtHelper()->userNow(),
-        ];
-
-        session(['userdata' => $currentUser]);
+        // Sanctum/Bearer-token session. twoFAVerified: true — the token is the strong credential
+        // and no interactive 2FA is possible. Built via the shared factory so role (NAME string,
+        // not raw int) and every other field stay identical to the web + x-api-key paths.
+        session(['userdata' => UserSessionBuilder::build($user, isExternalAuth: false, twoFAVerified: true)]);
     }
 }

--- a/app/Domain/Auth/Services/UserSessionBuilder.php
+++ b/app/Domain/Auth/Services/UserSessionBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Leantime\Domain\Auth\Services;
+
+use Leantime\Domain\Auth\Models\Roles;
+
+/**
+ * Single source of truth for the `session('userdata')` array.
+ *
+ * Every authentication path — web login ({@see Auth::setUserSession}), x-api-key
+ * ({@see \Leantime\Domain\Api\Services\Api::setApiUserSession}) and Sanctum/Bearer tokens
+ * ({@see AuthUser::setUserSession}) — builds this same structure. They used to each build it
+ * inline, which let fields drift silently between paths:
+ *  - `role` was stored as the raw DB int on the Bearer path but as the role-NAME string on the
+ *    others; the permission engine validates against the name list, so Bearer auth denied every
+ *    gated method with -32001 (the 3.9.x regression).
+ *  - `twoFAVerified` likewise diverged between the two token paths.
+ *
+ * Routing all three through this factory makes those bugs structurally impossible: `role` is
+ * ALWAYS converted via {@see Roles::getRoleString()}, and every field is produced identically.
+ * The two genuinely per-path values — whether the session is external-auth and whether 2FA is
+ * already satisfied — are explicit parameters.
+ */
+class UserSessionBuilder
+{
+    /**
+     * Build the canonical userdata array from a `zp_user` row.
+     *
+     * @param  array  $user  A zp_user row (id, firstname, username, profileId, clientId, role, …).
+     * @param  bool  $isExternalAuth  True when the user authenticated via an external provider.
+     * @param  bool  $twoFAVerified  True when 2FA is considered satisfied (token auth — the token
+     *                               is the strong credential and no interactive 2FA is possible).
+     * @return array<string, mixed> The userdata array to store in `session('userdata')`.
+     */
+    public static function build(array $user, bool $isExternalAuth = false, bool $twoFAVerified = false): array
+    {
+        return [
+            'id' => (int) $user['id'],
+            'name' => strip_tags($user['firstname'] ?? ''),
+            'profileId' => $user['profileId'] ?? '',
+            'mail' => filter_var($user['username'] ?? '', FILTER_SANITIZE_EMAIL),
+            'clientId' => $user['clientId'] ?? '',
+            // ALWAYS the role-NAME string the permission engine validates against — never the raw
+            // DB int. This is the field whose drift caused the Bearer -32001 regression.
+            'role' => Roles::getRoleString($user['role']),
+            'settings' => ! empty($user['settings']) ? safe_unserialize($user['settings'], []) : [],
+            'twoFAEnabled' => $user['twoFAEnabled'] ?? false,
+            'twoFAVerified' => $twoFAVerified,
+            'twoFASecret' => $user['twoFASecret'] ?? '',
+            'isExternalAuth' => $isExternalAuth,
+            'createdOn' => ! empty($user['createdOn']) ? dtHelper()->parseDbDateTime($user['createdOn']) : dtHelper()->userNow(),
+            'modified' => ! empty($user['modified']) ? dtHelper()->parseDbDateTime($user['modified']) : dtHelper()->userNow(),
+        ];
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leantime",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leantime",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leantime",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Open source innovation management system",
   "dependencies": {
     "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/tests/Acceptance/API/BearerApiCest.php
+++ b/tests/Acceptance/API/BearerApiCest.php
@@ -15,11 +15,18 @@ use Tests\Support\Page\Acceptance\Install;
  * path is what the mobile app + any AdvancedAuth integrator hits, and a permission-engine deploy in
  * 2026-06 silently broke it (every gated read 401'd) without CI noticing.
  *
- * It is ONE test method on purpose: the minted token lives in zp_access_tokens, and the Db module
- * deletes haveInDatabase() rows after each test — so a multi-method #[Depends] chain would lose the
- * token between the mint and the assertions. Keeping everything in one test keeps the token alive
- * for every call. Each authed call asserts 200, JSON, and NOT a -32001 permission denial — that
- * last assertion is the regression gate.
+ * Each test is self-contained: the minted token lives in zp_access_tokens and the Db module deletes
+ * haveInDatabase() rows after each test, so a method keeps everything it needs alive within itself
+ * (a multi-method #[Depends] chain would lose the token between the mint and the assertions). Each
+ * authed call asserts 200, JSON, and NOT a -32001 permission denial — that last assertion is the
+ * regression gate.
+ *
+ * Two scenarios:
+ *  - bearerAuthHonorsGatedReads — the OWNER (role 50). Owner short-circuits project-role resolution.
+ *  - nonManagerBearerHonorsProjectScopedReads — an EDITOR (role 20). Sub-manager roles run a wholly
+ *    different authorization path (getProjectRole + isUserAssignedToProject + a resolved projectId),
+ *    which owner-only testing never exercises. This is the path that would silently break for real
+ *    non-admin mobile users.
  */
 class BearerApiCest
 {
@@ -80,6 +87,49 @@ class BearerApiCest
 
         // 5) Entity-scoped comments resolve the project from (module, moduleId).
         $this->assertRpcSucceeds($I, 'leantime.rpc.Comments.Comments.getComments', ['module' => 'ticket', 'moduleId' => 1]);
+    }
+
+    #[Group('bearer-api')]
+    public function nonManagerBearerHonorsProjectScopedReads(AcceptanceTester $I)
+    {
+        // A non-manager (editor, role 20) assigned to a project. Unlike the owner, this role does
+        // NOT short-circuit effectiveRoleForProject() — it exercises getProjectRole() +
+        // isUserAssignedToProject() + a resolved project role over Bearer. That path only works
+        // when the session role context is correctly established (the regression), so this is the
+        // guard for "works for the owner but -32001s for real non-admin users."
+        $ownerProjectId = (int) $I->grabFromDatabase('zp_projects', 'id', ['name' => 'My Project']);
+        Assert::assertNotEmpty($ownerProjectId, 'Seed project not found after install');
+
+        $editorId = (int) $I->haveInDatabase('zp_user', [
+            'firstname' => 'Ed',
+            'lastname' => 'Itor',
+            'username' => 'editor@leantime.io',
+            'password' => 'x',
+            'role' => '20',
+            'status' => 'A',
+            'createdOn' => date('Y-m-d H:i:s'),
+        ]);
+        $I->haveInDatabase('zp_relationuserproject', [
+            'userId' => $editorId,
+            'projectId' => $ownerProjectId,
+            'projectRole' => '',
+        ]);
+
+        $this->bearerToken = bin2hex(random_bytes(20));
+        $I->haveInDatabase('zp_access_tokens', [
+            'tokenable_type' => 'Leantime\\Domain\\Auth\\Services\\Auth',
+            'tokenable_id' => $editorId,
+            'name' => 'bearer-api-cest-editor',
+            'token' => hash('sha256', $this->bearerToken),
+            'abilities' => json_encode(['*']),
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        // Cross-project "my work" read (no projectId) + a project-scoped read by id, both as the
+        // editor over Bearer. Must resolve (200, no -32001).
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getAllOpenUserTickets', new \stdClass);
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProject', ['id' => $ownerProjectId]);
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProjectProgress', ['projectId' => $ownerProjectId]);
     }
 
     /** POST /api/jsonrpc with the test bearer + method, return the decoded body. */

--- a/tests/Unit/app/Domain/Auth/Services/UserSessionBuilderTest.php
+++ b/tests/Unit/app/Domain/Auth/Services/UserSessionBuilderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Unit\app\Domain\Auth\Services;
+
+use Leantime\Domain\Api\Services\Api;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\AuthUser;
+use Leantime\Domain\Auth\Services\UserSessionBuilder;
+
+/**
+ * Guards the userdata-builder bug family (3.9.x Bearer regression + the twoFAVerified twin).
+ *
+ * Every auth path now builds session('userdata') through UserSessionBuilder, so a field can't
+ * silently drift between paths. These tests pin the two invariants that historically broke:
+ *  - role is ALWAYS the engine-valid NAME string (never the raw DB int), for every built-in role;
+ *  - the two token paths (Sanctum/Bearer via AuthUser, x-api-key via Api) agree on role +
+ *    twoFAVerified.
+ */
+class UserSessionBuilderTest extends \Unit\TestCase
+{
+    private function userRow(int $role): array
+    {
+        return [
+            'id' => 1,
+            'firstname' => 'Test',
+            'username' => 'test@leantime.io',
+            'profileId' => 0,
+            'clientId' => 0,
+            'role' => $role,
+            'settings' => '',
+            'twoFAEnabled' => false,
+            'twoFASecret' => '',
+            'createdOn' => '2026-01-01 00:00:00',
+            'modified' => '2026-01-01 00:00:00',
+        ];
+    }
+
+    public function test_role_is_engine_valid_name_string_for_every_builtin_role(): void
+    {
+        foreach (array_keys(Roles::getRoles()) as $roleInt) {
+            $userdata = UserSessionBuilder::build($this->userRow((int) $roleInt));
+
+            $this->assertSame(Roles::getRoleString((int) $roleInt), $userdata['role']);
+            $this->assertContains(
+                $userdata['role'],
+                Roles::getRoles(),
+                "Factory produced an engine-invalid role for DB int $roleInt: ".var_export($userdata['role'], true)
+            );
+        }
+    }
+
+    public function test_flags_are_honored(): void
+    {
+        $tokenSession = UserSessionBuilder::build($this->userRow(50), isExternalAuth: true, twoFAVerified: true);
+        $this->assertTrue($tokenSession['isExternalAuth']);
+        $this->assertTrue($tokenSession['twoFAVerified']);
+
+        $default = UserSessionBuilder::build($this->userRow(50));
+        $this->assertFalse($default['isExternalAuth']);
+        $this->assertFalse($default['twoFAVerified']);
+    }
+
+    public function test_both_token_paths_build_consistent_role_and_twofa(): void
+    {
+        // The Sanctum/Bearer path (AuthUser) and the x-api-key path (Api) are both token auth and
+        // must produce the same role + twoFAVerified — these are the exact two fields that drifted.
+        // setUserSession/setApiUserSession touch no instance state, so construct without the DB.
+        $row = $this->userRow(50);
+
+        session()->forget('userdata');
+        $authUser = (new \ReflectionClass(AuthUser::class))->newInstanceWithoutConstructor();
+        $m = new \ReflectionMethod(AuthUser::class, 'setUserSession');
+        $m->setAccessible(true);
+        $m->invoke($authUser, $row);
+        $guardSession = session('userdata');
+
+        session()->forget('userdata');
+        $api = (new \ReflectionClass(Api::class))->newInstanceWithoutConstructor();
+        $api->setApiUserSession($row, false);
+        $apiKeySession = session('userdata');
+
+        $this->assertSame($guardSession['role'], $apiKeySession['role'], 'token paths disagree on role');
+        $this->assertSame($guardSession['twoFAVerified'], $apiKeySession['twoFAVerified'], 'token paths disagree on twoFAVerified');
+        $this->assertContains($guardSession['role'], Roles::getRoles());
+        $this->assertTrue($guardSession['twoFAVerified'], 'token sessions should be 2FA-verified');
+    }
+}


### PR DESCRIPTION
Automated release PR. Review and edit the changelog below (it ships as CHANGELOG.md and as the GitHub release notes), wait for CI, then merge - the release publishes automatically.

---

# Version: 3.9.3

## Bug Fixes
- **Bearer Authentication** - Resolved a Bearer token error (-32001) by storing the role name instead of a raw integer in the Sanctum-guard session (#3525)
