### PR TITLE
fix(tickets): unblock cross-project 'my work' reads + expose/secure markTicketDone

### DIFF
--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -1207,12 +1207,19 @@ class Tickets extends BaseService
     }
 
     /**
-     * Retrieves the open tickets assigned to a user for a specific project
-     * that are due this week and later, with optional inclusion of completed
-     * tickets and milestones.
+     * Retrieves the open tickets assigned to a user that are due this week and later, optionally
+     * narrowed to a single project, with optional inclusion of completed tickets and milestones.
+     *
+     * This is a "my work" view (filtered by $userId). $projectId is optional: pass a project id to
+     * narrow to it (the dispatch gate then runs the per-project membership check), or omit it / pass
+     * 0 for the cross-project view mobile's Tasks tab uses. When no concrete project resolves, the
+     * enforcer has no project to scope to (the session project is null on Bearer), so tickets.view
+     * is evaluated against the user's global role — a user can always see their own assigned
+     * tickets. A mandatory $projectId here previously fail-closed (-32001 on 0, -32602 when omitted)
+     * for every role, breaking the mobile Tasks tab.
      *
      * @param  int  $userId  The ID of the user whose tickets are to be retrieved.
-     * @param  int  $projectId  The ID of the project for which tickets are to be retrieved.
+     * @param  int|null  $projectId  Optional project to narrow to; null/0 = across all the user's projects.
      * @param  bool  $includeDoneTickets  Whether to include tickets marked as done. Default is false.
      * @param  bool  $includeMilestones  Whether to include milestones in the results. Default is false.
      * @return array Returns an array of grouped tickets categorized by their due date (e.g.,
@@ -1220,11 +1227,6 @@ class Tickets extends BaseService
      *
      * @api
      */
-    // projectId is OPTIONAL: this is a cross-project "my work" view (filtered by $userId). When a
-    // real project id is supplied the dispatch gate runs the per-project check; when it's omitted
-    // or 0 (mobile's cross-project sentinel) the enforcer falls back to the global tickets.view
-    // role — a user can always see their own assigned tickets. Mandatory-projectId here previously
-    // fail-closed (-32001 on 0, -32602 when omitted) for every role, breaking the mobile Tasks tab.
     #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
     public function getOpenUserTicketsThisWeekAndLater($userId, $projectId = null, bool $includeDoneTickets = false, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -1220,8 +1220,13 @@ class Tickets extends BaseService
      *
      * @api
      */
+    // projectId is OPTIONAL: this is a cross-project "my work" view (filtered by $userId). When a
+    // real project id is supplied the dispatch gate runs the per-project check; when it's omitted
+    // or 0 (mobile's cross-project sentinel) the enforcer falls back to the global tickets.view
+    // role — a user can always see their own assigned tickets. Mandatory-projectId here previously
+    // fail-closed (-32001 on 0, -32602 when omitted) for every role, breaking the mobile Tasks tab.
     #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getOpenUserTicketsThisWeekAndLater($userId, $projectId, bool $includeDoneTickets = false, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
+    public function getOpenUserTicketsThisWeekAndLater($userId, $projectId = null, bool $includeDoneTickets = false, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
         if ($includeDoneTickets === true) {
@@ -1323,7 +1328,7 @@ class Tickets extends BaseService
      * @api
      */
     #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getOpenUserTicketsByProject($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
+    public function getOpenUserTicketsByProject($userId, $projectId = null, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
         $searchCriteria = $this->prepareTicketSearchArray(['currentProject' => $projectId, 'users' => $userId, 'status' => '', 'sprint' => '']);
@@ -1367,7 +1372,7 @@ class Tickets extends BaseService
      * @api
      */
     #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getOpenUserTicketsByPriority($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
+    public function getOpenUserTicketsByPriority($userId, $projectId = null, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
         $searchCriteria = $this->prepareTicketSearchArray(['currentProject' => $projectId, 'users' => $userId, 'status' => '', 'sprint' => '']);
@@ -1426,7 +1431,7 @@ class Tickets extends BaseService
      * @api
      */
     #[RequiresPermission(TicketsPermissions::VIEW, projectIdParam: 'projectId')]
-    public function getOpenUserTicketsBySprint($userId, $projectId, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
+    public function getOpenUserTicketsBySprint($userId, $projectId = null, bool $includeMilestones = false, ?int $limit = null, ?int $offset = null, ?string $group = null): array
     {
 
         $searchCriteria = $this->prepareTicketSearchArray(['currentProject' => $projectId, 'users' => $userId, 'status' => '', 'sprint' => '']);
@@ -2398,12 +2403,25 @@ class Tickets extends BaseService
         return $this->patch($id, ['status' => $newStatusId]);
     }
 
+    /**
+     * Mark a ticket done by resolving the project's first DONE-statusType status and patching to
+     * it. Mobile's swipe-to-complete (the marquee gesture). Companion to {@see markTicketReopen}.
+     *
+     * Was unexposed (-32601) AND unauthorized — unlike its reopen companion it carried no @api,
+     * no #[RequiresPermission], and no in-body authorize (patch()'s dispatch attribute does not
+     * fire on this internal call). Now mirrors markTicketReopen exactly.
+     *
+     * @api
+     */
+    #[RequiresPermission(TicketsPermissions::EDIT, entityScoped: true)]
     public function markTicketDone(int $id): bool
     {
         $ticket = $this->ticketRepository->getTicket($id);
         if (! $ticket || empty($ticket->projectId)) {
             return false;
         }
+
+        $this->authorize(TicketsPermissions::EDIT, (int) $ticket->projectId);
 
         $statusLabels = $this->ticketRepository->getStateLabels((int) $ticket->projectId);
         if (! is_array($statusLabels)) {

--- a/tests/Acceptance/API/BearerApiCest.php
+++ b/tests/Acceptance/API/BearerApiCest.php
@@ -130,6 +130,17 @@ class BearerApiCest
         $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getAllOpenUserTickets', new \stdClass);
         $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProject', ['id' => $ownerProjectId]);
         $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProjectProgress', ['projectId' => $ownerProjectId]);
+
+        // Cross-project "my work" with the projectId=0 sentinel mobile sends — must NOT fail-closed
+        // (it previously -32001'd for every role, owner included). The param is now optional, so a
+        // missing/zero project falls back to the global tickets.view role.
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getOpenUserTicketsThisWeekAndLater', ['userId' => $editorId, 'projectId' => 0]);
+
+        // markTicketDone (mobile swipe-complete) must be exposed AND honor the per-project authorize
+        // for an assigned editor. (Previously -32601 — unexposed. Mirrors markTicketReopen now.)
+        $assignedTicketId = (int) $I->grabFromDatabase('zp_tickets', 'id', ['projectId' => $ownerProjectId]);
+        Assert::assertNotEmpty($assignedTicketId, 'Seed ticket not found in project');
+        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.markTicketDone', ['id' => $assignedTicketId]);
     }
 
     /** POST /api/jsonrpc with the test bearer + method, return the decoded body. */

--- a/tests/Acceptance/API/BearerApiCest.php
+++ b/tests/Acceptance/API/BearerApiCest.php
@@ -131,16 +131,22 @@ class BearerApiCest
         $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProject', ['id' => $ownerProjectId]);
         $this->assertRpcSucceeds($I, 'leantime.rpc.Projects.Projects.getProjectProgress', ['projectId' => $ownerProjectId]);
 
-        // Cross-project "my work" with the projectId=0 sentinel mobile sends — must NOT fail-closed
-        // (it previously -32001'd for every role, owner included). The param is now optional, so a
-        // missing/zero project falls back to the global tickets.view role.
-        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.getOpenUserTicketsThisWeekAndLater', ['userId' => $editorId, 'projectId' => 0]);
+        // Cross-project "my work" with the projectId=0 sentinel mobile sends — must actually
+        // SUCCEED, not just avoid -32001 (it previously -32001'd on 0 / -32602 when omitted, for
+        // every role incl. owner). Assert no error at all + an array result, so a regression to any
+        // error code (not only -32001) fails the test.
+        $body = $this->rpc($I, 'leantime.rpc.Tickets.Tickets.getOpenUserTicketsThisWeekAndLater', ['userId' => $editorId, 'projectId' => 0]);
+        Assert::assertArrayNotHasKey('error', $body, 'projectId=0 cross-project read must not error: '.json_encode($body));
+        Assert::assertIsArray($body['result'] ?? null, 'expected an array result, got: '.json_encode($body));
 
-        // markTicketDone (mobile swipe-complete) must be exposed AND honor the per-project authorize
-        // for an assigned editor. (Previously -32601 — unexposed. Mirrors markTicketReopen now.)
+        // markTicketDone (mobile swipe-complete) must be EXPOSED (was -32601) AND succeed for the
+        // assigned editor. Assert no error + result true, so a regression to -32601/-32602/false is
+        // caught — assertRpcSucceeds (absence of -32001 only) would not catch those.
         $assignedTicketId = (int) $I->grabFromDatabase('zp_tickets', 'id', ['projectId' => $ownerProjectId]);
         Assert::assertNotEmpty($assignedTicketId, 'Seed ticket not found in project');
-        $this->assertRpcSucceeds($I, 'leantime.rpc.Tickets.Tickets.markTicketDone', ['id' => $assignedTicketId]);
+        $done = $this->rpc($I, 'leantime.rpc.Tickets.Tickets.markTicketDone', ['id' => $assignedTicketId]);
+        Assert::assertArrayNotHasKey('error', $done, 'markTicketDone must be exposed + authorized: '.json_encode($done));
+        Assert::assertTrue($done['result'] ?? false, 'markTicketDone should return true: '.json_encode($done));
     }
 
     /** POST /api/jsonrpc with the test bearer + method, return the decoded body. */


### PR DESCRIPTION
## Two backend breakages from the mobile audit (verified on a live non-manager Bearer session, post-3.9.3)

### 1. Cross-project "my work" reads fail-closed
`getOpenUserTicketsThisWeekAndLater` (+ `ByProject`/`ByPriority`/`BySprint`) declared a **mandatory** `projectId` with `projectIdParam: 'projectId'`. The mobile Tasks tab calls them cross-project (projectId omitted, or the `|| 0` sentinel), so the enforcer fail-closed:
- `projectId: 0` → **-32001** (positive-int check rejects 0 → unresolved → mandatory → deny)
- omitted → **-32602** Required Parameter Missing

…for **every** role, **owner included** (admin-masking made it look owner-safe in static analysis — it isn't; I reproduced -32001 as owner too).

These are "this user's own tickets" views (filtered by ``), so **`projectId` is now optional**: a missing/0 project falls back to the global `tickets.view` role (a user can always see their own assigned tickets), while a real project id still runs the per-project membership check.

### 2. markTicketDone unexposed + unsecured
Mobile's swipe-to-complete returned **-32601** (no `@api`). Worse, unlike its `markTicketReopen` companion it also had **no `#[RequiresPermission]` and no in-body authorize** — `patch()`'s dispatch attribute doesn't fire on the internal call, so naively exposing it would have been an *unauthorized* write. Now mirrors `markTicketReopen` exactly: `@api` + `#[RequiresPermission(EDIT, entityScoped: true)]` + `authorize(EDIT, $ticket->projectId)`.

**Verified:** assigned editor → `200 true`; non-assigned user → **-32001** (entityScoped authorize holds).

## Tests
`BearerApiCest` non-manager scenario gains the `projectId=0` sentinel read + a `markTicketDone` assertion. Both scenarios green via the Sanctum-guard path (**52 assertions**). Pint + PHPStan clean.

## Deliberately NOT changed
- The audit's predicted "entityScoped writes break for non-managers" is **disproven empirically** — editor `quickAddTicket`/`getComments`/`markTicketDone` all work.
- `getSetting`/`getCalendar`/`getAllNotifications` stay unexposed — they accept an arbitrary `userId`/key and are **deliberate IDOR guards**. The right fix is session-scoped variants coordinated with mobile, not a blind `@api` (would reintroduce IDOR).

Ships as **3.9.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)