### PR TITLE
Release v3.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version: 3.9.4
+
+## Bug Fixes
+- **My Work Across Projects** - Fixed an issue that prevented "My Work" from loading tickets across different projects, and exposed and secured the mark-ticket-done action (#3527)
+
+---
+
 # Version: 3.9.3
 
 ## Bug Fixes

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -7,7 +7,7 @@ namespace Leantime\Core\Configuration;
  */
 class AppSettings
 {
-    public string $appVersion = '3.9.3';
+    public string $appVersion = '3.9.4';
 
     public string $dbVersion = '3.5.18';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leantime",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leantime",
-      "version": "3.9.3",
+      "version": "3.9.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leantime",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "description": "Open source innovation management system",
   "dependencies": {
     "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",


### PR DESCRIPTION
Automated release PR. Review and edit the changelog below (it ships as CHANGELOG.md and as the GitHub release notes), wait for CI, then merge - the release publishes automatically.

---

# Version: 3.9.4

## Bug Fixes
- **My Work Across Projects** - Fixed an issue that prevented "My Work" from loading tickets across different projects, and exposed and secured the mark-ticket-done action (#3527)
