### PR TITLE
fix(editor): position @mention dropdown beneath the caret

### DIFF
--- a/public/assets/js/app/core/tiptap/extensions/mention.js
+++ b/public/assets/js/app/core/tiptap/extensions/mention.js
@@ -171,24 +171,24 @@ function positionPopup(popup, clientRect) {
     var popupWidth = popup.offsetWidth || 280;
     var viewportHeight = window.innerHeight;
     var viewportWidth = window.innerWidth;
-    var scrollTop = window.scrollY || document.documentElement.scrollTop;
-    var scrollLeft = window.scrollX || document.documentElement.scrollLeft;
 
-    // Calculate position
-    var top = clientRect.bottom + scrollTop + 4;
-    var left = clientRect.left + scrollLeft;
+    // The popup is position: fixed, so clientRect (viewport-relative) is used directly
+    // without adding scroll offsets.
+    var top = clientRect.bottom + 4;
+    var left = clientRect.left;
 
-    // Adjust if popup would go off-screen
-    if (top + popupHeight > viewportHeight + scrollTop) {
-        top = clientRect.top + scrollTop - popupHeight - 4;
+    // Flip above the caret if it would overflow the bottom of the viewport.
+    if (top + popupHeight > viewportHeight) {
+        top = clientRect.top - popupHeight - 4;
     }
 
-    if (left + popupWidth > viewportWidth + scrollLeft) {
-        left = viewportWidth + scrollLeft - popupWidth - 8;
+    // Keep within horizontal viewport bounds.
+    if (left + popupWidth > viewportWidth) {
+        left = viewportWidth - popupWidth - 8;
     }
 
-    if (left < scrollLeft) {
-        left = scrollLeft + 8;
+    if (left < 0) {
+        left = 8;
     }
 
     popup.style.top = top + 'px';


### PR DESCRIPTION
## Problem

When typing `@` in the rich-text editor, the user-mention suggestion dropdown appears much further **down** the page than the text caret. The offset grows the more the page is scrolled.

## Root cause

The popup is styled `position: fixed` (viewport-relative):

```css
/* public/assets/css/components/tiptap-editor.css */
.tiptap-mention-popup { position: fixed; ... }
```

But `positionPopup()` in `public/assets/js/app/core/tiptap/extensions/mention.js` added the page scroll offset on top of the caret's `getBoundingClientRect()` coordinates — which are *already* viewport-relative. For a `position: fixed` element this double-counts the scroll, pushing the dropdown down by exactly the scrolled amount.

## Fix

Drop the `scrollTop`/`scrollLeft` additions and make the off-screen boundary checks purely viewport-relative, consistent with `position: fixed`. The popup still flips above the caret near the bottom edge and clamps horizontally.

## Verification

1. Rebuild assets: `npx mix` (`mention.js` compiles into `compiled-tiptap-editor.min.js`).
2. Open the editor (ticket description / comment box), type `@` — dropdown now appears directly beneath the caret.
3. Scroll the page down so the editor is partway down the viewport, type `@` again — dropdown stays beneath the caret (the case that was broken).
4. Caret near the bottom/right edge — dropdown flips above / clamps horizontally instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)