### PR TITLE
fix: resolve recent reported bugs (#3488, #3480, #3467, #3463)

### DIFF
--- a/app/Domain/Blueprints/Controllers/EditCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasItem.php
@@ -128,6 +128,12 @@ class EditCanvasItem
                 $type = array_key_first($canvasTypes);
             }
 
+            // Fall back to a known box when the requested type isn't part of this
+            // canvas, otherwise the dialog renders $canvasTypes[$type] on null (500).
+            if (! isset($canvasTypes[$type])) {
+                $type = array_key_first($canvasTypes);
+            }
+
             $canvasItem = [
                 'id' => '',
                 'box' => $type,

--- a/app/Domain/Blueprints/Templates/canvasDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/canvasDialog.blade.php
@@ -16,6 +16,8 @@
     if (isset($canvasItem['id']) && $canvasItem['id'] != '') {
         $id = $canvasItem['id'];
     }
+
+    $boxMeta = $canvasTypes[$canvasItem['box']] ?? ['icon' => '', 'title' => ''];
 @endphp
 
 <script type="text/javascript">
@@ -29,7 +31,7 @@
 
 <div class="" style="width:900px;">
 
-    <h4 class="widgettitle title-light" style="padding-bottom: 0"><i class="fas {{ $canvasTypes[$canvasItem['box']]['icon'] }}"></i> {{ $canvasTypes[$canvasItem['box']]['title'] }}</h4>
+    <h4 class="widgettitle title-light" style="padding-bottom: 0"><i class="fas {{ $boxMeta['icon'] }}"></i> {{ $boxMeta['title'] }}</h4>
     <hr style="margin-top: 5px; margin-bottom: 15px;">
     {!! $tpl->displayNotification() !!}
 

--- a/app/Domain/Connector/Services/Connector.php
+++ b/app/Domain/Connector/Services/Connector.php
@@ -237,7 +237,10 @@ class Connector
         }
 
         if ($matchingStorypointsField) {
-            $validStorypoints = array_keys($this->ticketService->getEffortLabels());
+            // Cast keys to strings: PHP coerces numeric-string array keys (e.g. '1')
+            // to ints, which would break the strict comparison below against the
+            // string CSV value.
+            $validStorypoints = array_map('strval', array_keys($this->ticketService->getEffortLabels()));
             foreach ($values as &$row) {
                 $storypoints = trim((string) ($row[$matchingStorypointsField] ?? ''));
                 if ($storypoints !== '' && ! in_array($storypoints, $validStorypoints, true)) {

--- a/app/Domain/Connector/Services/Connector.php
+++ b/app/Domain/Connector/Services/Connector.php
@@ -225,6 +225,27 @@ class Connector
             }
         }
 
+        // Storypoints/Effort Field Validation
+        // Only a fixed set of values is renderable (see Tickets repository efforts).
+        // An out-of-range value (e.g. "4") imports fine but later crashes ticket/dashboard views.
+        $matchingStorypointsField = '';
+        foreach ($fields as $item) {
+            if ($item['leantimeField'] === 'storypoints') {
+                $matchingStorypointsField = $item['sourceField'];
+                break;
+            }
+        }
+
+        if ($matchingStorypointsField) {
+            $validStorypoints = array_keys($this->ticketService->getEffortLabels());
+            foreach ($values as &$row) {
+                $storypoints = trim((string) ($row[$matchingStorypointsField] ?? ''));
+                if ($storypoints !== '' && ! in_array($storypoints, $validStorypoints, true)) {
+                    $flags[] = $matchingStorypointsField.': '.$storypoints.' '.'is not a valid story point value. Use one of: '.implode(', ', $validStorypoints);
+                }
+            }
+        }
+
         $this->cacheSerializedFieldValues($fields, $values);
 
         return $flags;

--- a/app/Domain/CsvImport/Templates/upload.blade.php
+++ b/app/Domain/CsvImport/Templates/upload.blade.php
@@ -34,6 +34,7 @@
 
 </div>
 
+@once
 <script>
 
     if (typeof uppy === 'undefined') {
@@ -102,5 +103,6 @@
     }
 
 </script>
+@endonce
 
 @endsection

--- a/app/Domain/CsvImport/Templates/upload.blade.php
+++ b/app/Domain/CsvImport/Templates/upload.blade.php
@@ -34,8 +34,6 @@
 
 </div>
 
-@once
-@push('scripts')
 <script>
 
     if (typeof uppy === 'undefined') {
@@ -104,7 +102,5 @@
     }
 
 </script>
-@endpush
-@endonce
 
 @endsection

--- a/app/Domain/Dashboard/Templates/show.blade.php
+++ b/app/Domain/Dashboard/Templates/show.blade.php
@@ -158,7 +158,7 @@
                                                     aria-expanded="false"
                                                 ><span class="text">
                                                      {{ $row['storypoints'] != '' && $row['storypoints'] > 0
-                                                            ? $efforts[''.$row['storypoints'].'']
+                                                            ? ($efforts[''.$row['storypoints'].''] ?? $row['storypoints'])
                                                             : __('label.story_points_unkown')
                                                         }}
                                                 </span>&nbsp;<i class="fa fa-caret-down" aria-hidden="true"></i></a>

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -1,5 +1,8 @@
 @extends($layout)
 @section('content')
+    @php
+        $hiddenRelatesLabels = $relatesLabels ?? [];
+    @endphp
     <script type="text/javascript">
         window.onload = function() {
             if (!window.jQuery) {


### PR DESCRIPTION
Fixes four recently reported bugs. Each is a small, defensive change; Pint passes.

## Fixes

### #3488 — `Undefined variable $hiddenRelatesLabels` (Goalcanvas)
`Goalcanvas/Templates/canvasDialog.blade.php` referenced `$hiddenRelatesLabels` without defining it (its Blueprints/Canvas siblings define it at the top). Added `$hiddenRelatesLabels = $relatesLabels ?? [];` so opening a goal item with no relates labels no longer throws.

### #3480 — CSV import upload button never appears
`CsvImport/Templates/upload.blade.php` is rendered via `displayPartial()`, which uses the `blank` layout — the only layout with **no** `@stack('scripts')`. The Uppy init lived in `@push('scripts')`, so it was silently dropped and the upload widget never initialized. The init script is now inline.

### #3467 — Importer accepts unsupported story-point value → dashboard 500
Two-part fix:
- **Defense:** `Dashboard/Templates/show.blade.php` did a bare `$efforts[storypoints]` lookup that 500s on a value outside the supported set (e.g. `4` from a CSV import). Added the same `?? raw value` fallback the ticket list views already use.
- **Prevention:** `Connector::parseTickets()` now validates story points against the supported set (`0.5, 1, 2, 3, 5, 8, 13`) and flags invalid values at import time.

### #3463 — Blueprints "Server Error" adding a new canvas item
An unknown/stale `type` param made the new-item dialog render `$canvasTypes[$box]` on null → `{"message":"Server Error"}`. `EditCanvasItem` now falls back to a valid box when the type isn't part of the canvas, and the template guards the header lookup via `$boxMeta`.

## Testing
- `vendor/bin/pint --test` passes on the changed PHP files.
- Verified by code inspection. Not yet exercised in a live browser; changes are minimal/defensive.

Closes #3488
Closes #3480
Closes #3467
Closes #3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)