### PR TITLE
fix(deps): promote symfony/yaml to a production dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "socialiteproviders/saml2": "^4.7",
         "php-http/guzzle7-adapter": "^1.1",
         "symfony/cache": "^7.2",
+        "symfony/yaml": "^7.2",
         "prism-php/prism": "^0.57.0",
         "inspector-apm/neuron-ai": "1.12.8",
         "johngrogg/ics-parser": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f66fdeca864541fc68030d6c6946a45",
+    "content-hash": "059448d55d1acb3dfe9c4da8e606b53b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -11821,6 +11821,82 @@
             "time": "2026-04-18T13:18:21+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T06:06:12+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -17081,82 +17157,6 @@
                 }
             ],
             "time": "2026-05-19T20:33:22+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.4.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
## Problem

`symfony/yaml` was never declared in `composer.json` — neither in `require` nor `require-dev`. It only existed in the environment as a **transitive dev dependency** of `codeception/codeception` (a `require-dev` package).

`composer why symfony/yaml` on `master` shows only Codeception *requires* it; everything else (`symfony/routing`, `symfony/translation`, `roave/security-advisories`) merely *conflicts* with old versions, which installs nothing. In `composer.lock` the package sat in the **`packages-dev`** array.

The result: a production `composer install --no-dev` ships **without** `symfony/yaml`, yet it is used at runtime in:

- `app/Domain/Blueprints/Services/TemplateRegistry.php` — `Yaml::parseFile()` on every blueprint/canvas template load
- `app/Core/Configuration/Environment.php` — YAML config file in the boot config priority chain

So production throws `Class "Symfony\Component\Yaml\Yaml" not found` the moment a canvas is opened (and potentially at boot if a YAML config is present).

## Fix

- Add `"symfony/yaml": "^7.2"` to `require` (matching the other symfony 7 components, e.g. `symfony/cache: ^7.2`).
- Regenerate `composer.lock` so the package (resolved at `v7.4.13`) moves from `packages-dev` into the production `packages` array.

No code changes needed — the usages were correct, only the dependency declaration was missing.

## Verification

- `composer why symfony/yaml` now lists `leantime/leantime ... requires symfony/yaml (^7.2)` as a direct requirer.
- In `composer.lock`, the `symfony/yaml` entry is now before the `packages-dev` boundary (production `packages`).
- `composer install --no-dev --dry-run` no longer lists `symfony/yaml` for removal — it stays installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)