### PR TITLE
fix(blueprints): canvas add/edit item returns 404 (canvasSlug bound to $id)

### DIFF
--- a/app/Domain/Blueprints/Controllers/BoardDialog.php
+++ b/app/Domain/Blueprints/Controllers/BoardDialog.php
@@ -58,10 +58,11 @@ class BoardDialog
     /**
      * get - display the create/edit board dialog.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Current board id
      */
     #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -88,10 +89,11 @@ class BoardDialog
     /**
      * post - handle create/edit board submissions.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Current board id
      */
     #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');

--- a/app/Domain/Blueprints/Controllers/DelCanvas.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvas.php
@@ -45,10 +45,11 @@ class DelCanvas
     /**
      * get - display the delete confirmation dialog.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Board id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::DELETE)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -62,10 +63,11 @@ class DelCanvas
     /**
      * post - process the board deletion.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Board id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');

--- a/app/Domain/Blueprints/Controllers/DelCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvasItem.php
@@ -41,7 +41,7 @@ class DelCanvasItem
     }
 
     #[RequiresPermission(BlueprintsPermissions::DELETE)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');
@@ -53,7 +53,7 @@ class DelCanvasItem
     }
 
     #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return $this->tpl->displayPartial('errors.error404');

--- a/app/Domain/Blueprints/Controllers/DelCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvasItem.php
@@ -40,6 +40,12 @@ class DelCanvasItem
         $this->template = $templateRegistry->get($this->canvasSlug);
     }
 
+    /**
+     * get - display the delete confirmation dialog for a canvas item.
+     *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
+     * @param  string|null  $id  Canvas item id from the route
+     */
     #[RequiresPermission(BlueprintsPermissions::DELETE)]
     public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
@@ -52,6 +58,12 @@ class DelCanvasItem
         return $this->tpl->displayPartial('blueprints.delCanvasItem');
     }
 
+    /**
+     * post - delete the canvas item identified by the route id.
+     *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
+     * @param  string|null  $id  Canvas item id from the route
+     */
     #[RequiresPermission(BlueprintsPermissions::DELETE, entityScoped: true)]
     public function post(?string $canvasSlug = null, ?string $id = null): Response
     {

--- a/app/Domain/Blueprints/Controllers/EditCanvasComment.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasComment.php
@@ -69,10 +69,11 @@ class EditCanvasComment
     /**
      * get - handle GET requests for the comment editing view.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Canvas item id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {
@@ -153,10 +154,11 @@ class EditCanvasComment
     /**
      * post - handle POST requests for updating canvas items and adding comments.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Canvas item id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {

--- a/app/Domain/Blueprints/Controllers/EditCanvasItem.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasItem.php
@@ -65,10 +65,11 @@ class EditCanvasItem
     /**
      * get - handle GET requests for viewing/editing a canvas item.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Canvas item id
      */
     #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {
@@ -172,10 +173,11 @@ class EditCanvasItem
     /**
      * post - handle POST requests for creating/updating canvas items and comments.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Canvas item id
      */
     #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {

--- a/app/Domain/Blueprints/Controllers/Export.php
+++ b/app/Domain/Blueprints/Controllers/Export.php
@@ -49,10 +49,11 @@ class Export
     /**
      * get - generate and return the XML export file.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Board id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         if ($this->template === null) {
             return new Response('Unknown canvas type', 404);

--- a/app/Domain/Blueprints/Controllers/ShowCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ShowCanvas.php
@@ -63,10 +63,11 @@ class ShowCanvas
     /**
      * get - display the canvas board (and handle the board switcher).
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Active board id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::VIEW, entityScoped: true)]
-    public function get(?string $id = null): Response
+    public function get(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {
@@ -95,10 +96,11 @@ class ShowCanvas
     /**
      * post - handle create / edit / clone / merge / import board actions.
      *
+     * @param  string|null  $canvasSlug  Canvas type slug from the route (resolved in the constructor)
      * @param  string|null  $id  Active board id from the route
      */
     #[RequiresPermission(BlueprintsPermissions::EDIT, entityScoped: true)]
-    public function post(?string $id = null): Response
+    public function post(?string $canvasSlug = null, ?string $id = null): Response
     {
         $data = $this->request->getRequestParams();
         if ($id !== null) {

--- a/tests/Unit/app/Domain/Blueprints/Controllers/CanvasRouteBindingTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Controllers/CanvasRouteBindingTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Unit\app\Domain\Blueprints\Controllers;
+
+use Illuminate\Routing\RouteDependencyResolverTrait;
+use Leantime\Core\Http\IncomingRequest;
+use ReflectionMethod;
+use Unit\TestCase;
+
+/**
+ * Regression coverage for canvas modal actions 404ing (PR #3544).
+ *
+ * The Blueprints controllers are routed under `blueprints/{canvasSlug}/{action}/{id?}`.
+ * Their action methods were declared `get(?string $id = null)` — omitting the
+ * `{canvasSlug}` segment — so Laravel bound the FIRST route param (`canvasSlug`) to
+ * the first method param (`$id`). `$id` then held the slug ("swot"), the real id was
+ * dropped, and EditCanvasItem/EditCanvasComment rendered the `errors.error404` partial
+ * (at HTTP 200) for every add/edit. The fix declares `$canvasSlug` first so `$id`
+ * binds to the real id. These tests assert that binding via the real route table —
+ * no DB/session/browser needed.
+ */
+class CanvasRouteBindingTest extends TestCase
+{
+    /** Routed Blueprints actions that take an {id?} segment, by action name. */
+    public static function canvasActionProvider(): array
+    {
+        return [
+            'showCanvas' => ['showCanvas'],
+            'editCanvasItem' => ['editCanvasItem'],
+            'editCanvasComment' => ['editCanvasComment'],
+            'boardDialog' => ['boardDialog'],
+            'delCanvas' => ['delCanvas'],
+            'delCanvasItem' => ['delCanvasItem'],
+            'export' => ['export'],
+        ];
+    }
+
+    /**
+     * Register the real Blueprints routes into the current app's router. Uses the
+     * actual routes.php (not a hand-rolled copy) so the test tracks the real
+     * definitions. Re-required per test because each test gets a fresh app/router.
+     */
+    private function matchRoute(string $uri): \Illuminate\Routing\Route
+    {
+        require APP_ROOT.'/app/Domain/Blueprints/routes.php';
+
+        $request = IncomingRequest::create($uri, 'GET');
+        $route = $this->app->make('router')->getRoutes()->match($request);
+        $request->setRouteResolver(fn () => $route);
+
+        return $route;
+    }
+
+    /**
+     * Map the arguments the controller action actually RECEIVES for $route, modelling
+     * exactly what Illuminate\Routing\ControllerDispatcher::dispatch() does:
+     *
+     *     $controller->{$method}(...array_values($resolvedParameters));
+     *
+     * The values are spread POSITIONALLY, so what matters is each method parameter's
+     * position, not the route key. This is the layer the bug lived in: with
+     * `get(?string $id)` the slug (first positional value) landed in `$id`. Returns a
+     * [paramName => boundValue] map.
+     */
+    private function actionReceives(\Illuminate\Routing\Route $route): array
+    {
+        $resolver = new class($this->app)
+        {
+            use RouteDependencyResolverTrait;
+
+            public function __construct(public $container) {}
+
+            public function resolve($route): array
+            {
+                return $this->resolveClassMethodDependencies(
+                    $route->parametersWithoutNulls(),
+                    $route->getControllerClass(),
+                    $route->getActionMethod(),
+                );
+            }
+        };
+
+        $positional = array_values($resolver->resolve($route));
+        $params = (new ReflectionMethod($route->getControllerClass(), $route->getActionMethod()))->getParameters();
+
+        $bound = [];
+        foreach ($params as $i => $param) {
+            $bound[$param->getName()] = $positional[$i] ?? null;
+        }
+
+        return $bound;
+    }
+
+    /**
+     * @dataProvider canvasActionProvider
+     */
+    public function test_route_binds_real_id_not_canvas_slug(string $action): void
+    {
+        $received = $this->actionReceives($this->matchRoute("/blueprints/swot/{$action}/42"));
+
+        $this->assertSame('swot', $received['canvasSlug'] ?? null, "{$action}: \$canvasSlug must receive the slug");
+        $this->assertSame('42', $received['id'] ?? null, "{$action}: \$id must receive the route id, not the slug");
+    }
+
+    /**
+     * @dataProvider canvasActionProvider
+     */
+    public function test_missing_id_does_not_leak_slug_into_id(string $action): void
+    {
+        $received = $this->actionReceives($this->matchRoute("/blueprints/swot/{$action}"));
+
+        $this->assertSame('swot', $received['canvasSlug'] ?? null, "{$action}: \$canvasSlug must receive the slug");
+        $this->assertNull($received['id'] ?? null, "{$action}: omitted {id?} must not leak the slug into \$id");
+    }
+
+    /**
+     * The structural invariant behind the fix: any Blueprints action routed under the
+     * {canvasSlug} prefix must declare `canvasSlug` as its first parameter, so route
+     * params line up with method params. Guards against re-introducing the bug on a
+     * new action.
+     *
+     * @dataProvider canvasActionProvider
+     */
+    public function test_action_declares_canvas_slug_as_first_parameter(string $action): void
+    {
+        $route = $this->matchRoute("/blueprints/swot/{$action}");
+
+        $params = (new ReflectionMethod($route->getControllerClass(), $route->getActionMethod()))->getParameters();
+
+        $this->assertNotEmpty($params, "{$action}: action must declare parameters");
+        $this->assertSame('canvasSlug', $params[0]->getName(), "{$action}: first parameter must be \$canvasSlug");
+    }
+}


### PR DESCRIPTION
## Problem

Opening any Blueprints canvas and clicking **"+ Add New"** (or editing an existing item) showed a **"Page not found / 404"** inside the modal — for every canvas type (insights, minempathy, swot, …). The request actually returned **HTTP 200** with the 404 *page* as its body, and nothing was logged (the env runs with `app.debug` off), which made it hard to spot.

## Root cause

The Blueprints controllers are routed under `blueprints/{canvasSlug}/{action}/{id?}` (two path params), but their action methods were declared `get(?string $id = null)` / `post(?string $id = null)` — they omitted the `{canvasSlug}` parameter.

Laravel binds route parameters to method parameters in order, so the **first route param (`canvasSlug`) was bound to the first method param (`$id`)**. `$id` therefore received the slug string (e.g. `"insights"`), and the real id was dropped.

`EditCanvasItem`/`EditCanvasComment` then treated the slug as an item id — `getCanvasItem((int)"insights" = 0, …)` returns `false` — and returned `displayPartial('errors.error404')`.

It was latent in *all* canvas controllers, but only the "edit item" actions failed visibly. `ShowCanvas`/`BoardDialog`/`DelCanvasItem` masked the same misbinding by falling back to the session board on a bad id — which also meant they were **silently ignoring the board id in the URL** (`showCanvas/27` loaded the session board, not 27).

Regression from the dispatch-bridge removal — the old `blueprintsDispatch()` helper synced the path id into `$_GET['id']`.

## Fix

Declare `?string $canvasSlug = null` as the **first parameter** on every action method routed under the `{canvasSlug}` prefix (`ShowCanvas`, `EditCanvasItem`, `EditCanvasComment`, `BoardDialog`, `DelCanvas`, `DelCanvasItem`, `Export`). This realigns `$id` to the real id. The slug is still read in each constructor via `$request->route('canvasSlug')`; the parameter only exists to keep route→method binding aligned. Method bodies are unchanged.

## Verification

- Confirmed the resolved arg for `get()` was `{"canvasSlug":"insights"}` → `$id === "insights"`; after the fix, `editCanvasItem?type=…` → `id=NULL` (add form) and `editCanvasItem/15` → `id="15"` (edit the real item).
- Live server (`leantime-oss.test`): add-item, edit-existing (real 18 KB form), `editCanvasComment`, and `showCanvas` all return 200 with real content; verified for both `insights` and the originally-reported `minempathy`.
- Browser end-to-end at the exact reported URL: the modal renders the item form (Description / Status / Relates to…) instead of the 404.
- `./vendor/bin/pint --test` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)