### PR TITLE
fix: resolve recent reported bugs (#3535, #3539, #3536, #3542)

### DIFF
--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -586,9 +586,16 @@ class Calendar extends BaseService
 
                 if (dtHelper()->isValidDateString($ticket['editFrom'])) {
 
-                    // Set ticket to all-day ticket when no time is set
+                    // Set ticket to all-day ticket when no time is set.
+                    // Guard editTo the same way editFrom is guarded: a ticket can
+                    // have a planned start but no (or a sentinel) end date, and
+                    // parseDbDateTime() throws on empty/zero-date values — which
+                    // previously took down the whole calendar feed with a 500.
                     $dateFrom = dtHelper()->parseDbDateTime($ticket['editFrom']);
-                    $dateTo = dtHelper()->parseDbDateTime($ticket['editTo']);
+                    $hasValidEditTo = dtHelper()->isValidDateString($ticket['editTo'] ?? '');
+                    $dateTo = $hasValidEditTo
+                        ? dtHelper()->parseDbDateTime($ticket['editTo'])
+                        : $dateFrom;
 
                     if ($from || $until) {
 
@@ -618,7 +625,7 @@ class Calendar extends BaseService
                         backgroundColor: $backgroundColor,
                         borderColor: $statusColor,
                         dateFrom: $ticket['editFrom'],
-                        dateTo: $ticket['editTo']
+                        dateTo: $hasValidEditTo ? $ticket['editTo'] : $ticket['editFrom']
                     );
                 }
             }

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -118,10 +118,14 @@ class Oidc
     }
 
     /**
+     * Builds the OIDC authorization redirect URL and stores the CSRF state in
+     * the session. Returns false when the provider's auth endpoint cannot be
+     * resolved (callers treat a falsy result as "OIDC unavailable").
+     *
      * @throws GuzzleException
      * @throws \Exception
      */
-    public function buildLoginUrl(): string
+    public function buildLoginUrl(): string|false
     {
 
         if ($this->getAuthUrl()) {
@@ -144,7 +148,7 @@ class Oidc
     /**
      * @throws GuzzleException
      */
-    private function getAuthUrl(): string
+    private function getAuthUrl(): string|false
     {
         if (! empty($this->authUrl || $this->loadEndpoints())) {
             return $this->authUrl;

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -126,12 +126,15 @@ class Oidc
 
         if ($this->getAuthUrl()) {
 
+            $state = $this->generateState();
+            session(['oidc.state' => $state]);
+
             return $this->getAuthUrl().'?'.http_build_query([
                 'client_id' => $this->clientId,
                 'redirect_uri' => $this->buildRedirectUrl(),
                 'response_type' => 'code',
                 'scope' => $this->scopes,
-                'state' => $this->generateState(),
+                'state' => $state,
             ]);
         }
 
@@ -554,10 +557,17 @@ class Oidc
         return bin2hex(random_bytes(16));
     }
 
+    /**
+     * Verifies the state parameter returned by the OIDC provider against the
+     * value stored in the session when the login flow was initiated. The state
+     * is consumed (one-time use) regardless of the outcome to prevent replay.
+     */
     private function verifyState(string $state): bool
     {
-        // TODO
-        return true;
+        $storedState = (string) session('oidc.state');
+        session()->forget('oidc.state');
+
+        return $storedState !== '' && hash_equals($storedState, $state);
     }
 
     private function encodeBase64Url(string $value): string

--- a/app/Domain/Projects/Templates/newProject.blade.php
+++ b/app/Domain/Projects/Templates/newProject.blade.php
@@ -47,7 +47,7 @@
                                         {!! __('label.describe_outcome') !!}
                                         <br /><br />
                                     </p>
-                                    <textarea name="details" id="details" class="tiptapComplex" rows="5" cols="50">{{ htmlentities($project['details']) }}</textarea>
+                                    <textarea name="details" id="details" class="tiptapComplex" rows="5" cols="50">{{ $project['details'] }}</textarea>
 
                                 </div>
                             </div>

--- a/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
@@ -20,7 +20,7 @@
                         {!! __('label.accomplish') !!}
                         <br /><br />
                     </p>
-                    <textarea name="details" id="details" class="tiptapComplex" rows="5" cols="50">{{ htmlentities($project['details']) }}</textarea>
+                    <textarea name="details" id="details" class="tiptapComplex" rows="5" cols="50">{{ $project['details'] }}</textarea>
                 </div>
             </div>
             <div class="row padding-top">

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -162,7 +162,7 @@
             <br />
             <input type="text" value="{{ $tpl->escape($currentArticle->tags) }}" name="tags" id="tags" />
 
-            <textarea class="tiptapComplex" rows="20" cols="80" id="wikiArticleContentEditor" name="description">{{ htmlentities($currentArticle->description ?? '') }}</textarea>
+            <textarea class="tiptapComplex" rows="20" cols="80" id="wikiArticleContentEditor" name="description">{{ $currentArticle->description ?? '' }}</textarea>
 
                 <div class="row">
                     <div class="col-md-10 padding-top-sm">

--- a/public/assets/css/components/print.css
+++ b/public/assets/css/components/print.css
@@ -70,4 +70,33 @@
         padding: 0px !important;
         bottom: 10px;
     }
+
+    /*
+     * When a modal (e.g. a single to-do) is open, print only the modal's
+     * content instead of the underlying page. nyroModal appends .nyroModalBg
+     * (overlay) and .nyroModalCont (content) to the body, so we can hide the
+     * rest of the app and let the modal flow onto the page.
+     */
+    body:has(.nyroModalCont) .mainwrapper,
+    body:has(.nyroModalCont) .nyroModalBg,
+    .nyroModalCont .nyroModalClose,
+    .nyroModalCont .modalCloseButton {
+        display: none !important;
+    }
+
+    body:has(.nyroModalCont) .nyroModalCont {
+        position: static !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        height: auto !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        box-shadow: none !important;
+        overflow: visible !important;
+        page-break-inside: avoid;
+    }
+
+    body:has(.nyroModalCont) .nyroModalCont * {
+        overflow: visible !important;
+    }
 }

--- a/tests/Unit/app/Domain/Calendar/Services/CalendarServiceTest.php
+++ b/tests/Unit/app/Domain/Calendar/Services/CalendarServiceTest.php
@@ -8,6 +8,7 @@ use Leantime\Core\Language;
 use Leantime\Domain\Calendar\Repositories\Calendar as CalendarRepository;
 use Leantime\Domain\Menu\Repositories\Menu;
 use Leantime\Domain\Setting\Repositories\Setting;
+use Leantime\Domain\Tickets\Services\Tickets;
 use Spatie\IcalendarGenerator\Components\Calendar as IcalCalendar;
 use Unit\TestCase;
 
@@ -313,5 +314,59 @@ class CalendarServiceTest extends TestCase
             $this->assertTrue($isApi($method), "$method should stay @api");
             $this->assertSame($permission, $gate($method), "$method must carry the $permission gate");
         }
+    }
+
+    // ---- calendar feed robustness ----------------------------------------
+
+    /**
+     * Regression for #3536: a ticket with a valid planned start (editFrom) but an
+     * empty/sentinel editTo used to throw in parseDbDateTime(), 500-ing the whole
+     * "My Work" calendar feed and leaving the dashboard widget loading forever.
+     * editTo must now be guarded and fall back to editFrom.
+     */
+    public function test_get_calendar_survives_ticket_with_empty_edit_to(): void
+    {
+        $repo = $this->make(CalendarRepository::class, [
+            'getAll' => fn () => [],
+        ]);
+
+        $ticket = [
+            'id' => 10,
+            'headline' => 'Planned task',
+            'description' => '',
+            'projectId' => 3,
+            'status' => 3,
+            'dateToFinish' => '',                 // invalid -> due-date block is skipped
+            'editFrom' => '2026-06-18 09:00:00',  // valid planned start
+            'editTo' => '',                       // empty end date -> previously threw
+        ];
+
+        $tickets = $this->make(Tickets::class, [
+            'getOpenUserTicketsThisWeekAndLater' => fn () => ['thisWeek' => ['tickets' => [$ticket]]],
+            'getStatusLabels' => fn () => [],
+        ]);
+        app()->instance(Tickets::class, $tickets);
+
+        $service = new \Leantime\Domain\Calendar\Services\Calendar(
+            calendarRepo: $repo,
+            language: $this->language,
+            settingsRepo: $this->settingsRepository,
+            config: $this->config
+        );
+
+        $events = $service->getCalendar(1);
+
+        $editEvents = array_values(array_filter(
+            $events,
+            fn ($event) => ($event['dateContext'] ?? null) === 'edit'
+        ));
+
+        $this->assertCount(1, $editEvents, 'the planned-edit event should still be produced (no exception)');
+        $this->assertSame('2026-06-18 09:00:00', $editEvents[0]['dateFrom']);
+        $this->assertSame(
+            '2026-06-18 09:00:00',
+            $editEvents[0]['dateTo'],
+            'editTo should fall back to editFrom when empty'
+        );
     }
 }


### PR DESCRIPTION
Addresses four recently reported issues (June 2026).

## #3535 — OIDC login CSRF (security)
`Oidc::verifyState()` was a stub that unconditionally returned `true`, and the generated `state` was never persisted. The OIDC callback therefore accepted any `state`, so an attacker could deliver a crafted callback URL with their own authorization code and log a victim in as the attacker.
- `buildLoginUrl()` now stores the generated state in the session.
- `verifyState()` compares it constant-time (`hash_equals`), consumes it one-time, and a mismatch throws via `displayError()` **before** any token exchange.

## #3539 — Project/wiki description renders as literal HTML
The Blade migration left `{{ htmlentities($x) }}`, so editor content was HTML-escaped twice and TinyMCE/tiptap rendered the entities as literal text (e.g. `<p>This is a test project</p>`). Dropped the redundant `htmlentities()` (Blade's `{{ }}` already escapes) in `newProject`, `projectDetails`, and the wiki `articleDialog`.

## #3536 — Calendar 500 in My Work + dashboard widget spinning
`getCalendar()` parsed `$ticket['editTo']` with `parseDbDateTime()` without the `isValidDateString()` guard used for every other date there. A ticket with a planned start but an empty/sentinel end date threw and 500'd the whole feed (and left the HTMX widget loading forever). Guarded `editTo` and fall back to `editFrom`.

## #3542 — Printing one to-do printed the whole board
With a to-do modal open, Ctrl+P printed the underlying board too. Added `@media print` rules that, when a nyroModal is present, hide the rest of the app and let the modal content flow onto the page.

## Notes
- Out of scope / handled elsewhere: #3537/#3541 (symfony/yaml) shipped in 3.9.5 (#3543); #3538 is a plugin-repo fix (separate PR); #3533/#3540 await reporter logs; #3534 is a Docker image republish.
- Manual verification recommended (see issues). `dist` CSS is built on deploy, so the print change ships via source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)