### PR TITLE
fix: define $groupId variable before Blade component render in kanban view

### DIFF
--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -85,8 +85,8 @@
                 $swimlaneExpanded = ! in_array($group['id'], session('collapsedSwimlanes', []));
                 $groupBy = $searchCriteria['groupBy'] ?? 'status';
                 $groupId = $group['id'];
-                $groupIdKey = (string) $group['id'];
-                $swimlaneBreakdown = $statusBreakdown[$groupIdKey] ?? $statusBreakdown[$group['id']] ?? [];
+                $groupIdKey = (string) $groupId;
+                $swimlaneBreakdown = $statusBreakdown[$groupIdKey] ?? $statusBreakdown[$groupId] ?? [];
                 $statusCounts = $swimlaneBreakdown['statusCounts'] ?? [];
                 $timeAlert = $swimlaneBreakdown['timeAlert'] ?? null;
                 @endphp

--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -84,6 +84,7 @@
                 @php
                 $swimlaneExpanded = ! in_array($group['id'], session('collapsedSwimlanes', []));
                 $groupBy = $searchCriteria['groupBy'] ?? 'status';
+                $groupId = $group['id'];
                 $groupIdKey = (string) $group['id'];
                 $swimlaneBreakdown = $statusBreakdown[$groupIdKey] ?? $statusBreakdown[$group['id']] ?? [];
                 $statusCounts = $swimlaneBreakdown['statusCounts'] ?? [];


### PR DESCRIPTION
## Summary

Fixes #3553

The 'Group By' feature on the Kanban board throws a 500 error () because the  variable is not defined in scope when the  Blade component is rendered via .

## Root Cause

In , the  block (line 84-91) defines , , , and , but does **not** define . The subsequent  call passes  in its data array, but the Blade compiler resolves  from the enclosing template scope before the data extraction takes effect.

## Fix

Add  to the  block alongside the other variables, ensuring it is available in the outer template scope when the Blade component is compiled.

## Reproduction

1. Open a project
2. Navigate to To-Dos (Kanban view)
3. Select any Group By parameter
4. Observe HTTP 500 error