### PR TITLE
refactor(js): update internal /api/* calls to canonical domain routes

### DIFF
--- a/app/Domain/Blueprints/Js/blueprintsController.js
+++ b/app/Domain/Blueprints/Js/blueprintsController.js
@@ -160,7 +160,7 @@ leantime.blueprintsController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/api/users?profileImage=" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Canvas/Js/canvasController.js
+++ b/app/Domain/Canvas/Js/canvasController.js
@@ -137,7 +137,7 @@ leantime.canvasController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/api/users?profileImage=" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Goalcanvas/Js/goalCanvasController.js
+++ b/app/Domain/Goalcanvas/Js/goalCanvasController.js
@@ -124,7 +124,7 @@ leantime.goalCanvasController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/api/users?profileImage=" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Ideas/Js/ideasController.js
+++ b/app/Domain/Ideas/Js/ideasController.js
@@ -157,7 +157,7 @@ leantime.ideasController = (function () {
                     leantime.rpc('Ideas.Ideas.patchIdeaItem', { id: canvasId, params: { author: userId } })
                         .then(function (success) {
                             if (! success) { return; }
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/api/users?profileImage=" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
 
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated")});
                         })

--- a/app/Domain/Projects/Js/projectsController.js
+++ b/app/Domain/Projects/Js/projectsController.js
@@ -261,7 +261,7 @@ leantime.projectsController = (function () {
                 jQuery.ajax(
                     {
                         type: 'POST',
-                        url: leantime.appUrl + '/api/projects',
+                        url: leantime.appUrl + '/projects/projectImage',
                         data: formData,
                         processData: false,
                         contentType: false,

--- a/app/Domain/Setting/Js/settingRepository.js
+++ b/app/Domain/Setting/Js/settingRepository.js
@@ -17,7 +17,7 @@ leantime.settingRepository = (function () {
         jQuery.ajax(
             {
                 type: 'POST',
-                url: leantime.appUrl + '/api/setting',
+                url: leantime.appUrl + '/setting/logo',
                 data: formData,
                 processData: false,
                 contentType: false,

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -825,7 +825,7 @@ leantime.ticketsController = (function () {
                 leantime.rpc('Tickets.Tickets.patchTicket', { id: ticketId, values: { editorId: userId } })
                     .then(
                     function () {
-                        jQuery("#userDropdownMenuLink" + ticketId + " span.text span#userImage" + ticketId + " img").attr("src", leantime.appUrl + "/api/users?profileImage=" + userId);
+                        jQuery("#userDropdownMenuLink" + ticketId + " span.text span#userImage" + ticketId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
                         jQuery("#userDropdownMenuLink" + ticketId + " span.text span#user" + ticketId).text(dataLabel);
                         jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
 
@@ -1399,7 +1399,7 @@ leantime.ticketsController = (function () {
                                 var $userDropdown = jQuery('#userDropdownMenuLink' + ticketId);
                                 if ($userDropdown.length) {
                                     // Update user image
-                                    $userDropdown.find('span.text span img').attr('src', leantime.appUrl + '/api/users?profileImage=' + newGroupValue);
+                                    $userDropdown.find('span.text span img').attr('src', leantime.appUrl + '/users/profileImage/' + newGroupValue);
 
                                     // Get the new user's name from swimlane header
                                     var $newSwimlaneHeader = jQuery('#swimlane-row-' + newGroupValue + ' .swimlane-header-label');

--- a/app/Domain/Users/Js/usersRepository.js
+++ b/app/Domain/Users/Js/usersRepository.js
@@ -8,7 +8,7 @@ leantime.usersRepository = (function () {
         jQuery.ajax(
             {
                 type: 'POST',
-                url: leantime.appUrl + '/api/users',
+                url: leantime.appUrl + '/users/profileImage',
                 data: formData,
                 processData: false,
                 contentType: false,


### PR DESCRIPTION
## Summary

Closes part of #2936.

This PR updates all first-party JavaScript to use the canonical domain-scoped routes instead of the legacy `/api/*` shims.

### Changes

| Legacy URL | Canonical URL | File |
|---|---|---|
| `/api/setting` (POST) | `/setting/logo` | `Setting/Js/settingRepository.js` |
| `/api/users` (POST upload) | `/users/profileImage` | `Users/Js/usersRepository.js` |
| `/api/users?profileImage=` (GET src) | `/users/profileImage/:id` | `Canvas, Goalcanvas, Tickets, Ideas` |
| `/api/projects` (POST upload) | `/projects/projectImage` | `Projects/Js/projectsController.js` |

### Notes
- The legacy `/api/*` aliases are kept in `routes.php` for backward compatibility (plugins, external integrations).
- Canvas PATCH calls to `/api/*canvas` and `/api/blueprints/*` are already going through proper `Api\Controllers\Canvas` and `Api\Controllers\Goalcanvas` — no change needed there.
- File upload calls remain as `multipart/form-data` jQuery.ajax — they cannot use JSON-RPC due to the binary payload.
- All 7 files linted clean.

### Testing
- Logo upload in company settings
- User profile photo upload
- Project avatar upload
- User avatar display in canvas, goals, tickets, ideas dropdowns