### PR TITLE
chore(phpstan): raise static analysis to level 2 (429→0, fix-forward)

### DIFF
--- a/.phpstan/Rules/FacadeRule.php
+++ b/.phpstan/Rules/FacadeRule.php
@@ -29,8 +29,9 @@ class FacadeRule implements Rule
         $className = $node->class->toString();
 
         // Check if it's likely a facade
-        if (strpos($className, 'Illuminate\\Support\\Facades\\') === 0 || count($node->class->parts) === 1) {
-            $facadeName = count($node->class->parts) === 1 ? $node->class->parts[0] : end($node->class->parts);
+        $parts = $node->class->getParts();
+        if (strpos($className, 'Illuminate\\Support\\Facades\\') === 0 || count($parts) === 1) {
+            $facadeName = count($parts) === 1 ? $parts[0] : end($parts);
 
             if (!in_array($facadeName, self::ALLOWED_FACADES)) {
                 return [

--- a/.phpstan/bootstrap.php
+++ b/.phpstan/bootstrap.php
@@ -12,3 +12,9 @@ require __DIR__.'/../vendor/autoload.php';
 $app = require_once APP_ROOT . '/bootstrap/app.php';
 
 $app->make(\Leantime\Core\Console\ConsoleKernel::class)->bootstrap();
+
+// Register Leantime's CarbonImmutable date/time macros into Carbon's macro registry so
+// Carbon's official PHPStan MacroExtension (vendor/nesbot/carbon/extension.neon) can resolve
+// them (formatDateForUser, setToDbTimezone, ...). At runtime these are registered by the
+// Localization middleware; PHPStan never runs that middleware, so register them here.
+\Carbon\CarbonImmutable::mixin(new \Leantime\Core\Support\CarbonMacros);

--- a/.phpstan/phpstan.neon
+++ b/.phpstan/phpstan.neon
@@ -6,7 +6,7 @@ includes:
 parameters:
     bootstrapFiles:
         - bootstrap.php
-    level: 1
+    level: 2
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - ../public

--- a/.phpstan/phpstan.neon
+++ b/.phpstan/phpstan.neon
@@ -1,3 +1,8 @@
+includes:
+    # Carbon's official PHPStan extension: resolves macros registered via mixin()/macro()
+    # (including Leantime's date/time macros, registered in bootstrap.php) on all Carbon types.
+    - ../vendor/nesbot/carbon/extension.neon
+
 parameters:
     bootstrapFiles:
         - bootstrap.php
@@ -14,9 +19,11 @@ parameters:
         - ../vendor
         - ../config
     stubFiles:
-        # Declares Leantime's runtime-registered methods (Str macros, Collection::countNested,
+        # Declares Leantime's runtime-registered methods (Str/Carbon macros, Collection::countNested,
         # Event::discoverListeners) so vanilla PHPStan stops reporting them as undefined.
         - stubs/leantime-macros.stub
+        # Declares concrete Laravel methods our code calls through looser contracts (no Larastan).
+        - stubs/laravel-gaps.stub
     ignoreErrors:
             # Legacy templates receive their variables from the view layer ($tpl->assign / extract)
             # and blade files via compiled-in view data. PHPStan analyses them as plain PHP and so

--- a/.phpstan/stubs/laravel-gaps.stub
+++ b/.phpstan/stubs/laravel-gaps.stub
@@ -24,6 +24,16 @@ namespace Illuminate\Database;
  */
 interface ConnectionInterface {}
 
+namespace Illuminate\Cache;
+
+/**
+ * Repository forwards lock() via __call to its underlying store when that store is a
+ * LockProvider (Redis/File/Database/...). StartSession uses it for session locking.
+ *
+ * @method \Illuminate\Cache\Lock lock(string $name, int $seconds = 0, ?string $owner = null)
+ */
+class Repository {}
+
 namespace Illuminate\Contracts\Filesystem;
 
 /**

--- a/.phpstan/stubs/laravel-gaps.stub
+++ b/.phpstan/stubs/laravel-gaps.stub
@@ -77,6 +77,16 @@ interface Factory {}
  */
 interface Guard {}
 
+namespace Illuminate\Support;
+
+/**
+ * addRealMinutes() is a Carbon magic method (Carbon 3 dropped its @method annotation but the
+ * __call magic still resolves it). Used by StartSession exactly as upstream Laravel does.
+ *
+ * @method \Illuminate\Support\Carbon addRealMinutes(int $value = 1)
+ */
+class Carbon {}
+
 namespace Laravel\Socialite\Contracts;
 
 /**

--- a/.phpstan/stubs/laravel-gaps.stub
+++ b/.phpstan/stubs/laravel-gaps.stub
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * PHPStan stub: methods that exist on the CONCRETE Laravel classes our code uses at
+ * runtime, but are not declared on the looser contracts/interfaces we type-hint against.
+ *
+ * Leantime intentionally does NOT use Larastan, so vanilla PHPStan only sees the contract
+ * (e.g. ConnectionInterface) and reports the concrete method (e.g. getDriverName()) as
+ * undefined — even though the runtime object (Illuminate\Database\Connection) always has it.
+ *
+ * These @method tags merge onto the real interfaces/classes; native members are unaffected.
+ * Each entry is documented with the concrete class that actually provides the method.
+ */
+
+namespace Illuminate\Database;
+
+/**
+ * Provided at runtime by the abstract Illuminate\Database\Connection that
+ * DatabaseManager::connection() always returns.
+ *
+ * @method string getDriverName()
+ * @method \PDO getPdo()
+ * @method \Illuminate\Database\Query\Grammars\Grammar getQueryGrammar()
+ */
+interface ConnectionInterface {}
+
+namespace Illuminate\Contracts\Filesystem;
+
+/**
+ * Provided by the concrete Illuminate\Filesystem\FilesystemAdapter (and the Cloud contract
+ * for url()/temporaryUrl()). Storage::disk() returns that adapter.
+ *
+ * @method string url(string $path)
+ * @method string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
+ * @method string|false mimeType(string $path)
+ */
+interface Filesystem {}
+
+namespace Illuminate\Contracts\Foundation;
+
+/**
+ * Provided by Illuminate\Foundation\Application (which Leantime\Core\Application extends).
+ *
+ * @method void rebinding(string $abstract, \Closure $callback)
+ * @method string getCachedConfigPath()
+ * @method string detectEnvironment(\Closure $callback)
+ */
+interface Application {}
+
+namespace Illuminate\Container;
+
+/**
+ * terminating() lives on Illuminate\Foundation\Application; the container instance Leantime
+ * passes around is that application.
+ *
+ * @method void terminating(\Closure|string $callback)
+ */
+class Container {}
+
+namespace Illuminate\Contracts\Auth;
+
+/**
+ * Provided by the concrete Illuminate\Auth\AuthManager bound to 'auth'.
+ *
+ * @method string getDefaultDriver()
+ * @method \Illuminate\Contracts\Auth\Authenticatable|null user()
+ */
+interface Factory {}
+
+/**
+ * viaRemember()/getRecallerName()/logoutCurrentDevice() are provided by the concrete
+ * session guard (Illuminate\Auth\SessionGuard) that AuthManager::guard() returns.
+ *
+ * @method bool viaRemember()
+ * @method string getRecallerName()
+ * @method void logoutCurrentDevice()
+ */
+interface Guard {}
+
+namespace Laravel\Socialite\Contracts;
+
+/**
+ * setScopes() is provided by the concrete Laravel\Socialite\Two\AbstractProvider.
+ *
+ * @method \Laravel\Socialite\Contracts\Provider setScopes(array|string $scopes)
+ */
+interface Provider {}

--- a/.phpstan/stubs/leantime-macros.stub
+++ b/.phpstan/stubs/leantime-macros.stub
@@ -14,6 +14,11 @@
  *   bound to the 'events' container singleton (app/Core/Events/EventsServiceProvider.php).
  *
  * The @method tags merge onto the real classes; native methods are unaffected.
+ *
+ * NOTE: Leantime's CarbonImmutable macros (formatDateForUser, setToDbTimezone, ...) are NOT
+ * stubbed here — stubbing Carbon\CarbonInterface would clobber Carbon's own @method API.
+ * They are resolved by Carbon's official PHPStan MacroExtension instead (vendor extension.neon
+ * included from phpstan.neon), fed by the mixin registration in .phpstan/bootstrap.php.
  */
 
 namespace Illuminate\Support;

--- a/app/Core/Auth/Permissions/CheckPermissions.php
+++ b/app/Core/Auth/Permissions/CheckPermissions.php
@@ -24,7 +24,7 @@ class CheckPermissions
     {
         $route = $request->route();
 
-        if ($route !== null) {
+        if ($route instanceof \Illuminate\Routing\Route) {
             $controller = $route->getControllerClass();
             $method = $route->getActionMethod();
 

--- a/app/Core/Bootloader.php
+++ b/app/Core/Bootloader.php
@@ -26,8 +26,6 @@ class Bootloader
 
     /**
      * Get the Bootloader instance
-     *
-     * @param  Application  $app
      */
     public static function getInstance(): self
     {

--- a/app/Core/Bootstrap/LoadConfig.php
+++ b/app/Core/Bootstrap/LoadConfig.php
@@ -119,7 +119,8 @@ class LoadConfig extends LoadConfiguration
      *
      * If the CURRENT_URL constant is not defined, it will be set by appending the getRequestUri method result to the BASE_URL.
      *
-     * @param  string  $appUrl  The URL to be used as BASE_URL and APP_URL. Defaults to an empty string.
+     * @param  mixed  $config  The configuration object providing the appUrl value.
+     * @param  mixed  $app  The application instance used to resolve the request.
      * @return void
      */
     public function setBaseConstants($config, $app)
@@ -168,8 +169,8 @@ class LoadConfig extends LoadConfiguration
     /**
      * Maps Leantime configuration options to Laravel configuration options.
      *
-     * @param  $config  The Laravel configuration object to map to.
-     * @return $config The updated Leantime configuration object with mapped values.
+     * @param  mixed  $config  The Laravel configuration object to map to.
+     * @return mixed The updated Leantime configuration object with mapped values.
      */
     protected function mapLeantime2LaravelConfig($config)
     {

--- a/app/Core/Configuration/DefaultConfig.php
+++ b/app/Core/Configuration/DefaultConfig.php
@@ -45,7 +45,7 @@ class DefaultConfig
 
     /**
      * @var bool Send anonymous data <a href='https://docs.leantime.io/#/using-leantime/company-settings?id=telemetry' target='_blank'>More Info</a>.
-     *           No personal identifieble data will be sent and it will be impossible for us to track individual users.
+     *           No personally identifiable data will be sent and it will be impossible for us to track individual users.
      */
     public bool $allowTelemetry = true;
 

--- a/app/Core/Configuration/DefaultConfig.php
+++ b/app/Core/Configuration/DefaultConfig.php
@@ -44,8 +44,8 @@ class DefaultConfig
     public string $appDir = '';
 
     /**
-     * @var string Send anonymous data <a href='https://docs.leantime.io/#/using-leantime/company-settings?id=telemetry' target='_blank'>More Info</a>.
-     *             No personal identifieble data will be sent and it will be impossible for us to track individual users.
+     * @var bool Send anonymous data <a href='https://docs.leantime.io/#/using-leantime/company-settings?id=telemetry' target='_blank'>More Info</a>.
+     *           No personal identifieble data will be sent and it will be impossible for us to track individual users.
      */
     public bool $allowTelemetry = true;
 
@@ -97,7 +97,7 @@ class DefaultConfig
     public string $editor = 'phpstorm';
 
     /**
-     * @var environment
+     * @var string Application environment
      */
     #[LaravelConfig('app.env')]
     public string $env = 'production';
@@ -453,7 +453,7 @@ class DefaultConfig
     public bool $oidcCreateUser = false;
 
     /**
-     * @var string OIDC
+     * @var int OIDC
      *
      * Default Role for new users
      */

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -47,7 +47,6 @@ class Frontcontroller
     /**
      * __construct - Set the rootpath of the server
      *
-     * @param  IncomingRequest  $request
      * @return void
      */
     public function __construct(IncomingRequest $request, private PermissionEnforcer $permissionEnforcer)
@@ -59,7 +58,6 @@ class Frontcontroller
     /**
      * run - executes the action depending on Request or firstAction
      *
-     * @param  IncomingRequest  $request
      *
      * @throws BindingResolutionException
      */
@@ -173,7 +171,6 @@ class Frontcontroller
      * executeAction - includes the class in includes/modules by the Request
      *
      * @param  string  $controller  actionname.filename
-     * @param  string  $method
      *
      * @throws BindingResolutionException
      */
@@ -441,9 +438,7 @@ class Frontcontroller
     /**
      * redirect - redirects an htmx page.
      *
-     * @param  string  $url
      * @param  array  $headers
-     * @return Response
      */
     public static function redirectHtmx(string $url, $headers = []): Response
     {

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -47,7 +47,7 @@ class Frontcontroller
     /**
      * __construct - Set the rootpath of the server
      *
-     * @param  IncomingRequest  $incomingRequest
+     * @param  IncomingRequest  $request
      * @return void
      */
     public function __construct(IncomingRequest $request, private PermissionEnforcer $permissionEnforcer)
@@ -59,8 +59,7 @@ class Frontcontroller
     /**
      * run - executes the action depending on Request or firstAction
      *
-     * @param  string  $action
-     * @param  int  $httpResponseCode
+     * @param  IncomingRequest  $request
      *
      * @throws BindingResolutionException
      */
@@ -173,8 +172,8 @@ class Frontcontroller
     /**
      * executeAction - includes the class in includes/modules by the Request
      *
-     * @param  string  $completeName  actionname.filename
-     * @param  array  $params
+     * @param  string  $controller  actionname.filename
+     * @param  string  $method
      *
      * @throws BindingResolutionException
      */
@@ -442,8 +441,9 @@ class Frontcontroller
     /**
      * redirect - redirects an htmx page.
      *
-     * @param  int  $http_response_code
-     * @return RedirectResponse
+     * @param  string  $url
+     * @param  array  $headers
+     * @return Response
      */
     public static function redirectHtmx(string $url, $headers = []): Response
     {

--- a/app/Core/Events/DispatchesEvents.php
+++ b/app/Core/Events/DispatchesEvents.php
@@ -67,7 +67,7 @@ trait DispatchesEvents
      * Gets the class Context based on path, this uses the same method as the autoloader
      * Helps create unique strings for events/filters
      */
-    private static function set_class_context(): string
+    protected static function set_class_context(): string
     {
         return str_replace('\\', '.', strtolower(static::class));
     }
@@ -79,7 +79,7 @@ trait DispatchesEvents
      * Exception::getTrace() to avoid the overhead of creating a full
      * exception object on every event dispatch (~60 times per request).
      */
-    private static function get_function_context(?int $functionInt = null): string
+    protected static function get_function_context(?int $functionInt = null): string
     {
         $tracePointer = is_int($functionInt) ? $functionInt : 3;
 

--- a/app/Core/Events/EventDispatcher.php
+++ b/app/Core/Events/EventDispatcher.php
@@ -130,6 +130,8 @@ class EventDispatcher implements Dispatcher
     ) {
 
         $this->dispatch_event($event, $payload, '');
+
+        return null;
     }
 
     public static function dispatch_filter(

--- a/app/Core/Exceptions/ExceptionHandler.php
+++ b/app/Core/Exceptions/ExceptionHandler.php
@@ -97,7 +97,6 @@ class ExceptionHandler implements ExceptionHandlerContract
     /**
      * Create a new exception handler instance.
      *
-     * @param  Application  $container
      * @return void
      */
     public function __construct(Application $container)

--- a/app/Core/Exceptions/ExceptionHandler.php
+++ b/app/Core/Exceptions/ExceptionHandler.php
@@ -582,6 +582,8 @@ class ExceptionHandler implements ExceptionHandlerContract
     /**
      * Determine if the given exception is an HTTP exception.
      *
+     * @phpstan-assert-if-true \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface $e
+     *
      * @return bool
      */
     protected function isHttpException(Throwable $e)

--- a/app/Core/Exceptions/ExceptionHandler.php
+++ b/app/Core/Exceptions/ExceptionHandler.php
@@ -97,7 +97,7 @@ class ExceptionHandler implements ExceptionHandlerContract
     /**
      * Create a new exception handler instance.
      *
-     * @param  Application
+     * @param  Application  $container
      * @return void
      */
     public function __construct(Application $container)

--- a/app/Core/Exceptions/HandleExceptions.php
+++ b/app/Core/Exceptions/HandleExceptions.php
@@ -25,7 +25,7 @@ class HandleExceptions
     /**
      * The application instance.
      *
-     * @var \Leantime\Core\Bootstrap\Application
+     * @var \Leantime\Core\Application
      */
     protected static $app;
 

--- a/app/Core/Files/Contracts/FileManagerInterface.php
+++ b/app/Core/Files/Contracts/FileManagerInterface.php
@@ -31,6 +31,16 @@ interface FileManagerInterface
     public function getFile(string $fileName, string $realName, string $disk = 'default'): Response|false;
 
     /**
+     * Get a public/temporary URL for a file
+     *
+     * @param  string  $fileName  The file name (with extension)
+     * @param  string  $disk  The disk the file lives on
+     * @param  int  $expires  Minutes until a temporary URL expires (0 = permanent/public URL)
+     * @return string|false The URL or false on failure
+     */
+    public function getFileUrl(string $fileName, string $disk = 'default', int $expires = 0): string|false;
+
+    /**
      * Delete a file
      *
      * @param  string  $fileName  The file name (with extension)

--- a/app/Core/Files/Contracts/FileManagerInterface.php
+++ b/app/Core/Files/Contracts/FileManagerInterface.php
@@ -14,7 +14,6 @@ interface FileManagerInterface
      * Upload a file
      *
      * @param  UploadedFile  $file  The file to upload
-     * @param  string  $newName  The new name for the file (without extension)
      * @param  string  $disk  Where to push the file to
      * @return array|false Array with file info or false on failure
      */
@@ -25,7 +24,7 @@ interface FileManagerInterface
      *
      * @param  string  $fileName  The file name (with extension)
      * @param  string  $realName  The original file name (for Content-Disposition)
-     * @param  bool  $public  Whether the file is publicly accessible
+     * @param  string  $disk  The disk the file lives on
      * @return Response|false Response object or false on failure
      */
     public function getFile(string $fileName, string $realName, string $disk = 'default'): Response|false;
@@ -44,7 +43,7 @@ interface FileManagerInterface
      * Delete a file
      *
      * @param  string  $fileName  The file name (with extension)
-     * @param  bool  $public  Whether the file is publicly accessible
+     * @param  string  $disk  The disk the file lives on
      * @return bool True on success, false on failure
      */
     public function deleteFile(string $fileName, string $disk = 'default'): bool;

--- a/app/Core/Files/FileManager.php
+++ b/app/Core/Files/FileManager.php
@@ -430,7 +430,7 @@ class FileManager implements FileManagerInterface
         if (! in_array($sSuffix, ['P', 'T', 'G', 'M', 'K'])) {
             return (int) $sSize;
         }
-        $iValue = substr($sSize, 0, -1);
+        $iValue = (int) substr($sSize, 0, -1);
         switch ($sSuffix) {
             case 'P':
                 $iValue *= 1024;

--- a/app/Core/Http/HtmxRequest.php
+++ b/app/Core/Http/HtmxRequest.php
@@ -9,7 +9,7 @@ class HtmxRequest extends IncomingRequest
     /**
      * Get HTMX request information
      *
-     * @return array[string|bool]
+     * @return array<string, string|bool|null>
      */
     public function getHtmxRequestVars(): array
     {

--- a/app/Core/Language.php
+++ b/app/Core/Language.php
@@ -87,9 +87,6 @@ class Language
 
     /**
      * Constructor method for initializing an instance of the class.
-     *
-     * @param  Environment  $config  The configuration environment.
-     * @param  ApiRequest  $request  The API request object.
      */
     public function __construct()
     {

--- a/app/Core/Language.php
+++ b/app/Core/Language.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Str;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Events\EventDispatcher;
-use Leantime\Core\Http\ApiRequest;
 use Leantime\Core\Http\IncomingRequest;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;

--- a/app/Core/Language.php
+++ b/app/Core/Language.php
@@ -212,22 +212,22 @@ class Language
         }
 
         // Default to english US
-        if (! file_exists(static::DEFAULT_LANG_FOLDER.'/en-US.ini')) {
+        if (! file_exists(self::DEFAULT_LANG_FOLDER.'/en-US.ini')) {
             throw new Exception('Cannot find default english language file en-US.ini');
         }
 
-        $mainLanguageArray = parse_ini_file(static::DEFAULT_LANG_FOLDER.'en-US.ini', false, INI_SCANNER_RAW);
+        $mainLanguageArray = parse_ini_file(self::DEFAULT_LANG_FOLDER.'en-US.ini', false, INI_SCANNER_RAW);
 
         foreach (
             $languageFiles = self::dispatchFilter('language_files', [
                 // Complement english with english customization
-                static::CUSTOM_LANG_FOLDER.'en-US.ini' => false,
+                self::CUSTOM_LANG_FOLDER.'en-US.ini' => false,
 
                 // Overwrite english language by non-english language
-                static::DEFAULT_LANG_FOLDER.$this->language.'.ini' => true,
+                self::DEFAULT_LANG_FOLDER.$this->language.'.ini' => true,
 
                 // Overwrite with non-engish customizations
-                static::CUSTOM_LANG_FOLDER.$this->language.'.ini' => true,
+                self::CUSTOM_LANG_FOLDER.$this->language.'.ini' => true,
             ], ['language' => $this->language]) as $language_file => $isForeign
         ) {
             $mainLanguageArray = $this->includeOverrides($mainLanguageArray, $language_file, $isForeign);
@@ -295,17 +295,17 @@ class Language
         }
 
         $langlist = false;
-        if (file_exists(static::DEFAULT_LANG_FOLDER.'/languagelist.ini')) {
+        if (file_exists(self::DEFAULT_LANG_FOLDER.'/languagelist.ini')) {
             $langlist = parse_ini_file(
-                static::DEFAULT_LANG_FOLDER.'/languagelist.ini',
+                self::DEFAULT_LANG_FOLDER.'/languagelist.ini',
                 false,
                 INI_SCANNER_RAW
             );
         }
 
-        if (file_exists(static::CUSTOM_LANG_FOLDER.'/languagelist.ini')) {
+        if (file_exists(self::CUSTOM_LANG_FOLDER.'/languagelist.ini')) {
             $langlist = parse_ini_file(
-                static::CUSTOM_LANG_FOLDER.'/languagelist.ini',
+                self::CUSTOM_LANG_FOLDER.'/languagelist.ini',
                 false,
                 INI_SCANNER_RAW
             );

--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -204,9 +204,9 @@ class AuthCheck
      * Redirect with origin
      * Returns false if the current route is already the redirection route.
      *
-     * @return Response|RedirectResponse
+     * @return RedirectResponse|false
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function redirectWithOrigin(string $route, string $origin, IncomingRequest $request): false|RedirectResponse
     {

--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -204,7 +204,6 @@ class AuthCheck
      * Redirect with origin
      * Returns false if the current route is already the redirection route.
      *
-     * @return RedirectResponse|false
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/app/Core/Middleware/AuthenticateSession.php
+++ b/app/Core/Middleware/AuthenticateSession.php
@@ -115,7 +115,7 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     protected function redirectTo(Request $request)
     {
-        //
+        return null;
     }
 
     public function setLeantimeSession(IncomingRequest $request, Closure $next): Response

--- a/app/Core/Middleware/AuthenticateSession.php
+++ b/app/Core/Middleware/AuthenticateSession.php
@@ -101,11 +101,11 @@ class AuthenticateSession implements AuthenticatesSessions
     /**
      * Get the guard instance that should be used by the middleware.
      *
-     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard
+     * @return \Illuminate\Contracts\Auth\Guard
      */
     protected function guard()
     {
-        return $this->auth;
+        return $this->auth->guard();
     }
 
     /**

--- a/app/Core/Middleware/InitialHeaders.php
+++ b/app/Core/Middleware/InitialHeaders.php
@@ -16,7 +16,7 @@ class InitialHeaders
      *
      * @param  \Closure(IncomingRequest): Response  $next
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      **/
     public function handle($request, Closure $next): Response
     {

--- a/app/Core/Middleware/Installed.php
+++ b/app/Core/Middleware/Installed.php
@@ -18,7 +18,7 @@ class Installed
      *
      * @param  \Closure(IncomingRequest): Response  $next
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      **/
     public function handle(IncomingRequest $request, Closure $next): Response
     {
@@ -90,7 +90,7 @@ class Installed
     /**
      * Redirect to install
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     private function redirectToInstall(IncomingRequest $request): Response|false
     {

--- a/app/Core/Middleware/LoadPlugins.php
+++ b/app/Core/Middleware/LoadPlugins.php
@@ -18,7 +18,7 @@ class LoadPlugins
      *
      * @param  \Closure(IncomingRequest): Response  $next
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      **/
     public function handle($request, Closure $next): Response
     {

--- a/app/Core/Middleware/StartSession.php
+++ b/app/Core/Middleware/StartSession.php
@@ -467,7 +467,7 @@ class StartSession
      * Resolve the given cache driver.
      *
      * @param  string  $driver
-     * @return \Illuminate\Cache\Store
+     * @return \Illuminate\Cache\Repository
      */
     protected function cache($driver)
     {

--- a/app/Core/Middleware/Updated.php
+++ b/app/Core/Middleware/Updated.php
@@ -19,7 +19,7 @@ class Updated
      *
      * @param  \Closure(IncomingRequest): Response  $next
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      **/
     public function handle(IncomingRequest $request, Closure $next): Response
     {
@@ -56,7 +56,7 @@ class Updated
     /**
      * Redirect to update
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     private function redirectToUpdate(): Response|false
     {

--- a/app/Core/Sessions/PathManifestRepository.php
+++ b/app/Core/Sessions/PathManifestRepository.php
@@ -77,7 +77,6 @@ class PathManifestRepository
      * Create a fresh service manifest data structure.
      *
      * @param  string  $manifestName
-     * @param  array  $paths
      * @return array
      */
     protected function freshManifest($manifestName, array $paths)
@@ -88,8 +87,6 @@ class PathManifestRepository
     /**
      * Write the service manifest file to disk.
      *
-     * @param  string  $manifestName
-     * @param  array  $paths
      * @return array
      *
      * @throws \Exception

--- a/app/Core/Sessions/PathManifestRepository.php
+++ b/app/Core/Sessions/PathManifestRepository.php
@@ -76,7 +76,8 @@ class PathManifestRepository
     /**
      * Create a fresh service manifest data structure.
      *
-     * @param  array  return [$this->manifestKey => $paths];
+     * @param  string  $manifestName
+     * @param  array  $paths
      * @return array
      */
     protected function freshManifest($manifestName, array $paths)
@@ -87,7 +88,8 @@ class PathManifestRepository
     /**
      * Write the service manifest file to disk.
      *
-     * @param  array  $manifest
+     * @param  string  $manifestName
+     * @param  array  $paths
      * @return array
      *
      * @throws \Exception

--- a/app/Core/Support/CarbonMacros.php
+++ b/app/Core/Support/CarbonMacros.php
@@ -149,7 +149,7 @@ class CarbonMacros
     {
         $mixin = $this;
 
-        return function () use ($mixin): CarbonInterface {
+        return function () use ($mixin): CarbonImmutable {
             return self::this()
                 ->setTimezone($mixin->userTimezone)
                 ->locale($mixin->userLanguage);
@@ -167,7 +167,7 @@ class CarbonMacros
     {
         $mixin = $this;
 
-        return function () use ($mixin): CarbonInterface {
+        return function () use ($mixin): CarbonImmutable {
             return self::this()
                 ->setTimezone($mixin->dbTimezone)
                 ->locale($mixin->userLanguage);

--- a/app/Core/Support/CarbonMacros.php
+++ b/app/Core/Support/CarbonMacros.php
@@ -3,7 +3,6 @@
 namespace Leantime\Core\Support;
 
 use Carbon\CarbonImmutable;
-use Carbon\CarbonInterface;
 use Leantime\Core\Language;
 
 /**

--- a/app/Core/Support/Cast.php
+++ b/app/Core/Support/Cast.php
@@ -161,9 +161,6 @@ class Cast
         throw new \InvalidArgumentException('Value cannot be casted datetime');
     }
 
-    /**
-     * @param  iterable  $iterator
-     **/
     protected function handleIterator(iterable $iterator, array $mappings = []): array|object
     {
         $result = is_object($iterator) ? new \stdClass : [];

--- a/app/Core/Support/Cast.php
+++ b/app/Core/Support/Cast.php
@@ -162,7 +162,7 @@ class Cast
     }
 
     /**
-     * @param  array|object  $iterator
+     * @param  iterable  $iterator
      **/
     protected function handleIterator(iterable $iterator, array $mappings = []): array|object
     {

--- a/app/Core/Support/Cast.php
+++ b/app/Core/Support/Cast.php
@@ -74,7 +74,7 @@ class Cast
             try {
                 $type = collect($mappings)->firstOrFail(fn ($mapping, $key) => in_array($key, [$name, '*']));
             } catch (\Illuminate\Support\ItemNotFoundException) {
-                $type = ($reflectionType = $property->getType()) ? $reflectionType->getName() : null;
+                $type = ($reflectionType = $property->getType()) instanceof \ReflectionNamedType ? $reflectionType->getName() : null;
             }
 
             $returnObj->set($name, match (true) {

--- a/app/Core/Support/DateTimeHelper.php
+++ b/app/Core/Support/DateTimeHelper.php
@@ -248,6 +248,19 @@ class DateTimeHelper extends CarbonImmutable
     }
 
     /**
+     * Parses a database 24-hour time string and returns a CarbonImmutable instance.
+     *
+     * @param  string  $db24Time  The 24-hour time string to parse.
+     * @return CarbonImmutable The parsed CarbonImmutable instance in the database timezone (UTC)
+     */
+    public function parseDb24hTime(string $db24Time): CarbonImmutable
+    {
+        $this->datetime = CarbonImmutable::createFromFormat('!H:i', $db24Time, $this->dbTimezone);
+
+        return $this->datetime;
+    }
+
+    /**
      * Returns the current date and time based on the user's timezone and language.
      *
      * @return CarbonImmutable The current date and time in the user's timezone and language.

--- a/app/Core/Support/Format.php
+++ b/app/Core/Support/Format.php
@@ -319,8 +319,6 @@ class Format
     /**
      * Format bytes to human readable format
      *
-     * @param  int  $bytes  The number of bytes
-     * @param  int  $precision  The number of decimal places
      * @return string The formatted size
      */
     public function formatBytes(): string

--- a/app/Core/UI/Composer.php
+++ b/app/Core/UI/Composer.php
@@ -28,7 +28,7 @@ abstract class Composer
     /**
      * Compose the view before rendering.
      *
-     * @param  View  $view
+     * @param  View|array  $parameters
      *
      * @throws BindingResolutionException
      */

--- a/app/Core/UI/Template.php
+++ b/app/Core/UI/Template.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
-use Illuminate\View\Compilers\Compiler;
 use Illuminate\View\View;
 use Illuminate\View\ViewException;
 use Leantime\Core\Configuration\AppSettings;

--- a/app/Core/UI/Template.php
+++ b/app/Core/UI/Template.php
@@ -68,8 +68,6 @@ class Template
     /**
      * __construct - get instance of frontcontroller
      *
-     * @param  Compiler|null  $bladeCompiler
-     *
      * @throws BindingResolutionException
      * @throws \ReflectionException
      */
@@ -263,8 +261,6 @@ class Template
 
     /**
      * Refreshes (main url page in the background)
-     *
-     * @param  string  $eventName
      **/
     public function htmxRefresh(): void
     {
@@ -277,8 +273,6 @@ class Template
 
     /**
      * Sets the response header to trigger an htmx event
-     *
-     * @param  string  $eventName
      **/
     public function closeModal(): void
     {
@@ -405,7 +399,7 @@ class Template
     /**
      * Display JSON content with an optional response code.
      *
-     * @param  array|object|string  $jsonContent  The JSON content to be displayed.
+     * @param  string  $content  The content to be displayed.
      * @param  int  $statusCode  The HTTP response code to be returned (default: 200).
      * @return Response The response object after displaying the JSON content.
      *

--- a/app/Core/UI/Theme.php
+++ b/app/Core/UI/Theme.php
@@ -106,9 +106,6 @@ class Theme
 
     private Language $language;
 
-    /**
-     * @var language
-     */
     private AppSettings $appSettings;
 
     private FileManager $fileManager;

--- a/app/Domain/Auth/Guards/ApiGuard.php
+++ b/app/Domain/Auth/Guards/ApiGuard.php
@@ -13,7 +13,7 @@ class ApiGuard implements Guard
 {
     protected $user;
 
-    private string $apiKey;
+    private string $apiKey = '';
 
     public function __construct(
         protected UserProvider $provider,
@@ -71,11 +71,13 @@ class ApiGuard implements Guard
 
     public function id()
     {
-        if ($this->user()) {
-            return $this->user()->getAuthIdentifier();
-        }
+        // user() currently returns a stdClass of API-key user data (not yet a real
+        // Authenticatable — that conversion is tracked for the level-3 auth pass), so read
+        // the id off the object rather than calling getAuthIdentifier().
+        /** @var \stdClass|null $user */
+        $user = $this->user();
 
-        return null;
+        return $user?->id;
     }
 
     public function validate(array $credentials = [])

--- a/app/Domain/Auth/Guards/ApiGuard.php
+++ b/app/Domain/Auth/Guards/ApiGuard.php
@@ -72,7 +72,7 @@ class ApiGuard implements Guard
     public function id()
     {
         if ($this->user()) {
-            return $this->user()->id;
+            return $this->user()->getAuthIdentifier();
         }
 
         return null;

--- a/app/Domain/Auth/Guards/ApiGuard.php
+++ b/app/Domain/Auth/Guards/ApiGuard.php
@@ -5,6 +5,7 @@ namespace Leantime\Domain\Auth\Guards;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
+use Leantime\Core\Http\ApiRequest;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Domain\Api\Services\Api;
 
@@ -19,7 +20,7 @@ class ApiGuard implements Guard
         protected Api $apiService,
         protected IncomingRequest $request)
     {
-        if ($this->request->isApiRequest()) {
+        if ($this->request instanceof ApiRequest && $this->request->isApiRequest()) {
             $this->apiKey = $this->request->getAPIKey();
         }
     }

--- a/app/Domain/Auth/Guards/ApiGuard.php
+++ b/app/Domain/Auth/Guards/ApiGuard.php
@@ -74,6 +74,8 @@ class ApiGuard implements Guard
         if ($this->user()) {
             return $this->user()->id;
         }
+
+        return null;
     }
 
     public function validate(array $credentials = [])

--- a/app/Domain/Auth/Guards/WebGuard.php
+++ b/app/Domain/Auth/Guards/WebGuard.php
@@ -52,7 +52,7 @@ class WebGuard implements Guard
     public function id()
     {
         if ($this->user()) {
-            return $this->user()->id;
+            return $this->user()->getAuthIdentifier();
         }
 
         return null;

--- a/app/Domain/Auth/Guards/WebGuard.php
+++ b/app/Domain/Auth/Guards/WebGuard.php
@@ -51,11 +51,13 @@ class WebGuard implements Guard
 
     public function id()
     {
-        if ($this->user()) {
-            return $this->user()->getAuthIdentifier();
-        }
+        // user() currently returns a stdClass (AuthUser::retrieveById casts to object; the real
+        // Authenticatable conversion is tracked for the level-3 auth pass), so read the id off
+        // the object rather than calling getAuthIdentifier().
+        /** @var \stdClass|null $user */
+        $user = $this->user();
 
-        return null;
+        return $user?->id;
     }
 
     public function validate(array $credentials = [])

--- a/app/Domain/Auth/Guards/WebGuard.php
+++ b/app/Domain/Auth/Guards/WebGuard.php
@@ -54,6 +54,8 @@ class WebGuard implements Guard
         if ($this->user()) {
             return $this->user()->id;
         }
+
+        return null;
     }
 
     public function validate(array $credentials = [])

--- a/app/Domain/Auth/Services/Auth.php
+++ b/app/Domain/Auth/Services/Auth.php
@@ -68,9 +68,6 @@ class Auth implements Authenticatable
 
     private string $twoFASecret;
 
-    /**
-     * @var string|null
-     */
     private ?SessionManager $session = null;
 
     /**

--- a/app/Domain/Calendar/Repositories/Calendar.php
+++ b/app/Domain/Calendar/Repositories/Calendar.php
@@ -59,10 +59,6 @@ class Calendar extends RepositoryCore
         $this->db = $dbCore->getConnection();
     }
 
-    /**
-     * @param  string  $dateFrom
-     * @param  string  $dateTo
-     */
     public function getAllDates(?CarbonImmutable $dateFrom, ?CarbonImmutable $dateTo): false|array
     {
         $query = $this->db->table('zp_calendar')
@@ -88,7 +84,7 @@ class Calendar extends RepositoryCore
      * @param  int|null  $userId  The user ID to filter the results by.
      * @param  CarbonImmutable|null  $dateFrom  The minimum date and time of the events.
      * @param  CarbonImmutable|null  $dateTo  The maximum date and time of the events.
-     * @return bool|array Returns an array of calendar events if successful, otherwise false.
+     * @return false|array Returns an array of calendar events if successful, otherwise false.
      */
     public function getAll(?int $userId, ?CarbonImmutable $dateFrom, ?CarbonImmutable $dateTo): false|array
     {
@@ -242,9 +238,6 @@ class Calendar extends RepositoryCore
 
     /**
      * Generates an event array for fullcalendar.io frontend.
-     *
-     * @param  int|null  $dateFrom
-     * @param  int|null  $dateTo
      */
     private function mapEventData(
         string $title,

--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -1044,8 +1044,8 @@ class Calendar extends BaseService
     /**
      * Generates an event array for fullcalendar.io frontend.
      *
-     * @param  int|null  $dateFrom
-     * @param  int|null  $dateTo
+     * @param  string|null  $dateFrom
+     * @param  string|null  $dateTo
      */
     private function mapEventData(
         string $title,

--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -1043,9 +1043,6 @@ class Calendar extends BaseService
 
     /**
      * Generates an event array for fullcalendar.io frontend.
-     *
-     * @param  string|null  $dateFrom
-     * @param  string|null  $dateTo
      */
     private function mapEventData(
         string $title,

--- a/app/Domain/Canvas/Services/Canvas.php
+++ b/app/Domain/Canvas/Services/Canvas.php
@@ -64,7 +64,7 @@ class Canvas
     /**
      * getLastUpdatedCanvas - canvas boards ordered by last updated item (delegates to Blueprints).
      *
-     * @param  string  $projectId  projectId (optional)
+     * @param  int|null  $projectId  projectId (optional)
      * @param  array  $boards  Array of project board types
      * @return array List of boards
      *

--- a/app/Domain/Connector/Controllers/Integration.php
+++ b/app/Domain/Connector/Controllers/Integration.php
@@ -77,7 +77,9 @@ class Integration extends Controller
 
         if (isset($params['integrationId'])) {
             $currentIntegration = $this->integrationService->get($params['integrationId']);
-            $this->tpl->assign('integrationId', $currentIntegration->id);
+            if (is_object($currentIntegration)) {
+                $this->tpl->assign('integrationId', $currentIntegration->id);
+            }
         }
 
         if (! isset($params['step'])) {

--- a/app/Domain/Connector/Services/Providers.php
+++ b/app/Domain/Connector/Services/Providers.php
@@ -35,7 +35,7 @@ class Providers
     /**
      * @throws \Exception
      */
-    public function getProvider($providerId): provider
+    public function getProvider($providerId): object
     {
         if (isset($this->providers[$providerId])) {
             return $this->providers[$providerId];

--- a/app/Domain/Entityrelations/Services/Entityrelations.php
+++ b/app/Domain/Entityrelations/Services/Entityrelations.php
@@ -21,11 +21,19 @@ class Entityrelations
 
     public function saveRelationship($entityA, $entityAType, $relationship, $entityB, $entityBType, string $meta = ''): mixed
     {
-        return $this->settingsRepo->saveSetting($entityA, $entityAType, $relationship, $entityB, $entityBType, $meta = '');
+        // FIXME(phpstan-l2): this method is broken. Setting::saveSetting() is (string $type,
+        // mixed $value) — only the first two args were ever persisted; $relationship/$entityB/
+        // $entityBType/$meta were silently dropped by PHP. The injected EntityrelationRepository
+        // ($entityRelationshipsRepo) also has no matching 6-arg method. Trimmed to preserve
+        // current runtime behavior; the relationship-storage design needs to be rebuilt.
+        return $this->settingsRepo->saveSetting($entityA, $entityAType);
     }
 
     public function getRelationshipByEntity(string $entitySide, int $entity, string $entityType, string $relationship): mixed
     {
-        return $this->settingsRepo->getSetting($entitySide, $entity, $entityType, $relationship);
+        // FIXME(phpstan-l2): broken counterpart of saveRelationship() — Setting::getSetting() is
+        // (string $type, mixed $default = false); the extra args were silently dropped. Trimmed
+        // to preserve current runtime behavior. Needs a real entity-relationship store.
+        return $this->settingsRepo->getSetting($entitySide, $entity);
     }
 }

--- a/app/Domain/Files/Repositories/Files.php
+++ b/app/Domain/Files/Repositories/Files.php
@@ -280,8 +280,13 @@ class Files
                 true
             );
 
-            // Use FileManager to upload the file
-            $result = $this->fileManager->upload($symfonyFile, $newname, false);
+            // Use FileManager to upload the file.
+            // FIXME(phpstan-l2): the old call passed ($symfonyFile, $newname, false) but
+            // upload() is (UploadedFile $file, $disk = 'default') — so $newname was being used
+            // as the DISK name (would fail disk lookup) and `false` was ignored. upload() now
+            // computes the stored name itself; the $values below still use the caller's own
+            // $newname/$realName/$ext, which may not match the actually-stored file. Review.
+            $result = $this->fileManager->upload($symfonyFile);
 
             if ($result !== false) {
                 $values = [

--- a/app/Domain/Help/Hxcontrollers/HelperModal.php
+++ b/app/Domain/Help/Hxcontrollers/HelperModal.php
@@ -17,7 +17,8 @@ class HelperModal extends HtmxController
     /**
      * Controller constructor
      *
-     * @param  \Leantime\Domain\Projects\Services\Projects  $projectService  The projects domain service.
+     * @param  Helper       $helperService  The help domain service.
+     * @param  UserService  $userService    The users domain service.
      * @return void
      */
     public function init(

--- a/app/Domain/Help/Hxcontrollers/HelperModal.php
+++ b/app/Domain/Help/Hxcontrollers/HelperModal.php
@@ -17,8 +17,8 @@ class HelperModal extends HtmxController
     /**
      * Controller constructor
      *
-     * @param  Helper       $helperService  The help domain service.
-     * @param  UserService  $userService    The users domain service.
+     * @param  Helper  $helperService  The help domain service.
+     * @param  UserService  $userService  The users domain service.
      * @return void
      */
     public function init(

--- a/app/Domain/Help/Services/FirstTaskStep.php
+++ b/app/Domain/Help/Services/FirstTaskStep.php
@@ -59,7 +59,7 @@ class FirstTaskStep implements OnboardingSteps
     {
 
         if (isset($params['headline'])) {
-            $this->ticketService->quickAddTicket(['headline' => $params['headline']], session('currentProject'));
+            $this->ticketService->quickAddTicket(['headline' => $params['headline']]);
         }
 
         $this->settingsRepo->saveSetting('user.'.session()?->get('userdata.id', -1).'.firstLoginCompleted', true);

--- a/app/Domain/Help/Services/Helper.php
+++ b/app/Domain/Help/Services/Helper.php
@@ -113,7 +113,6 @@ class Helper
      * Constructor for the class.
      * Initializes the availableModals property by dispatching the "addHelperModal" event.
      *
-     * @param  \Leantime\Domain\Setting\Repositories\Setting  $settingsRepo
      * @return void
      */
     public function __construct(private Setting $settingsRepo)

--- a/app/Domain/Help/Services/Helper.php
+++ b/app/Domain/Help/Services/Helper.php
@@ -113,7 +113,7 @@ class Helper
      * Constructor for the class.
      * Initializes the availableModals property by dispatching the "addHelperModal" event.
      *
-     * @param  \Leantime\Domain\Users\Repositories\Users  $userRepository
+     * @param  \Leantime\Domain\Setting\Repositories\Setting  $settingsRepo
      * @return void
      */
     public function __construct(private Setting $settingsRepo)
@@ -136,7 +136,7 @@ class Helper
      * Retrieves the corresponding helper modal for a given route.
      *
      * @param  string  $route  The route for which to retrieve the helper modal.
-     * @return array|string The helper modal associated with the given route. If not found, 'notfound' is returned.
+     * @return array The helper modal associated with the given route. If not found, a 'notfound' template array is returned.
      */
     public function getHelperModalByRoute(string $route): array
     {

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -333,7 +333,7 @@ class Install
         // The version changed: cached routes, plugin lists etc. may reference classes or
         // methods that no longer exist in the new codebase. Everything in the installation
         // store is re-derivable, so drop it wholesale before running the updates.
-        Cache::store('installation')->flush();
+        Cache::store('installation')->clear();
 
         // Find all update functions that need to be executed
         foreach ($this->dbUpdates as $updateVersion) {

--- a/app/Domain/Menu/Composers/Menu.php
+++ b/app/Domain/Menu/Composers/Menu.php
@@ -34,8 +34,6 @@ class Menu extends Composer
     }
 
     /**
-     * @param  array  $data
-     *
      * @throws BindingResolutionException
      */
     public function with(): array

--- a/app/Domain/Menu/Repositories/Menu.php
+++ b/app/Domain/Menu/Repositories/Menu.php
@@ -122,9 +122,6 @@ class Menu
         ],
     ];
 
-    /**
-     * @param  AuthService  $authService
-     */
     public function __construct(
         /** @var SettingRepository */
         private SettingRepository $settingsRepo,

--- a/app/Domain/Menu/Services/Menu.php
+++ b/app/Domain/Menu/Services/Menu.php
@@ -69,7 +69,7 @@ class Menu
         $allAvailableProjects = $projects['allAvailableProjects'];
         $allAvailableProjectsHierarchy = $projects['allAvailableProjectsHierarchy'];
 
-        $clients = $this->projectService->getAllClientsAvailableToUser($userId, 'open', $client);
+        $clients = $this->projectService->getAllClientsAvailableToUser($userId, 'open');
 
         $recent = $this->settingSvc->getSetting('usersettings.'.$userId.'.recentProjects');
         $recentArr = safe_unserialize($recent, []);

--- a/app/Domain/Menu/Services/Menu.php
+++ b/app/Domain/Menu/Services/Menu.php
@@ -28,10 +28,6 @@ class Menu
 
     private MenuRepository $menuRepo;
 
-    /**
-     * @param  TimesheetRepository  $timesheetsRepo
-     * @param  SettingRepository  $settingsRepo
-     */
     public function __construct(
         ProjectService $projectService,
         TimesheetService $timesheetService,

--- a/app/Domain/Menu/Services/Menu.php
+++ b/app/Domain/Menu/Services/Menu.php
@@ -5,10 +5,8 @@ namespace Leantime\Domain\Menu\Services;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Setting\Services\Setting;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users;
 

--- a/app/Domain/Notifications/Hxcontrollers/News.php
+++ b/app/Domain/Notifications/Hxcontrollers/News.php
@@ -5,8 +5,6 @@ namespace Leantime\Domain\Notifications\Hxcontrollers;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
 use Leantime\Core\Controller\HtmxController;
-use Leantime\Domain\Menu\Services\Menu;
-use Leantime\Domain\Timesheets\Services\Timesheets;
 
 class News extends HtmxController
 {
@@ -16,8 +14,6 @@ class News extends HtmxController
 
     /**
      * Controller constructor
-     *
-     * @param  \Leantime\Domain\Notifications\Services\News  $newsService
      */
     public function init(\Leantime\Domain\Notifications\Services\News $newsService): void
     {

--- a/app/Domain/Notifications/Hxcontrollers/News.php
+++ b/app/Domain/Notifications/Hxcontrollers/News.php
@@ -17,9 +17,7 @@ class News extends HtmxController
     /**
      * Controller constructor
      *
-     * @param  Timesheets  $timesheetService
-     * @param  Menu  $menuService
-     * @param  \Leantime\Domain\Menu\Repositories\Menu  $menuRepo
+     * @param  \Leantime\Domain\Notifications\Services\News  $newsService
      */
     public function init(\Leantime\Domain\Notifications\Services\News $newsService): void
     {

--- a/app/Domain/Notifications/Hxcontrollers/NewsBadge.php
+++ b/app/Domain/Notifications/Hxcontrollers/NewsBadge.php
@@ -16,9 +16,7 @@ class NewsBadge extends HtmxController
     /**
      * Controller constructor
      *
-     * @param  Timesheets  $timesheetService
-     * @param  Menu  $menuService
-     * @param  \Leantime\Domain\Menu\Repositories\Menu  $menuRepo
+     * @param  \Leantime\Domain\Notifications\Services\News  $newsService
      */
     public function init(\Leantime\Domain\Notifications\Services\News $newsService): void
     {

--- a/app/Domain/Notifications/Hxcontrollers/NewsBadge.php
+++ b/app/Domain/Notifications/Hxcontrollers/NewsBadge.php
@@ -4,8 +4,6 @@ namespace Leantime\Domain\Notifications\Hxcontrollers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller\HtmxController;
-use Leantime\Domain\Menu\Services\Menu;
-use Leantime\Domain\Timesheets\Services\Timesheets;
 
 class NewsBadge extends HtmxController
 {
@@ -15,8 +13,6 @@ class NewsBadge extends HtmxController
 
     /**
      * Controller constructor
-     *
-     * @param  \Leantime\Domain\Notifications\Services\News  $newsService
      */
     public function init(\Leantime\Domain\Notifications\Services\News $newsService): void
     {

--- a/app/Domain/Oidc/Controllers/Callback.php
+++ b/app/Domain/Oidc/Controllers/Callback.php
@@ -3,7 +3,7 @@
 namespace Leantime\Domain\Oidc\Controllers;
 
 use GuzzleHttp\Exception\GuzzleException;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Oidc\Services\Oidc as OidcService;

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -158,8 +158,6 @@ class Oidc
     }
 
     /**
-     * @return void
-     *
      * @throws GuzzleException
      */
     public function callback(string $code, string $state): Response
@@ -201,9 +199,6 @@ class Oidc
         return $this->getMultiUrl($this->userInfoUrl, $token);
     }
 
-    /**
-     * @return void
-     */
     private function login(array $userInfo): Response
     {
 

--- a/app/Domain/Plugins/Services/Plugins.php
+++ b/app/Domain/Plugins/Services/Plugins.php
@@ -192,8 +192,6 @@ class Plugins
 
         /**
          * Filters session array of enabled plugins before returning
-         *
-         * @var array $enabledPlugins
          */
         return self::dispatch_filter(
             hook: 'beforeReturnCachedPlugins',
@@ -349,7 +347,7 @@ class Plugins
     {
         $this->clearCache();
 
-        /** @var PluginModel|false $plugin */
+        /** @var InstalledPlugin|false $plugin */
         $plugin = $this->pluginRepository->getPlugin($id);
 
         if (! $plugin) {

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -13,7 +13,6 @@ use Leantime\Core\Events\DispatchesEvents as EventhelperCore;
 use Leantime\Core\Support\Avatarcreator;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
-use SVG\SVG;
 
 class Projects
 {
@@ -1037,8 +1036,6 @@ class Projects
     }
 
     /**
-     * @return array|false
-     *
      * @throws BindingResolutionException
      */
     public function getProjectAvatar($id): array|false

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -1037,12 +1037,7 @@ class Projects
     }
 
     /**
-     * @return string[]|SVG
-     *
-     * @throws BindingResolutionException
-     */
-    /**
-     * @return array|SVG
+     * @return array|false
      *
      * @throws BindingResolutionException
      */

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -1873,7 +1873,7 @@ class Projects extends BaseService implements ChecksProjectAccess
      * Sets the avatar for a project.
      *
      * @param  mixed  $file  The file containing the avatar.
-     * @param  mixed  $project  The project object.
+     * @param  mixed  $projectId  The id of the project.
      * @return bool Indicates whether the avatar was successfully set.
      *
      * @throws BindingResolutionException

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -280,7 +280,8 @@ class Projects extends BaseService implements ChecksProjectAccess
     public function notifyProjectUsers(Notification $notification): void
     {
 
-        // Filter notifications
+        // Filter notifications (dispatch_filter returns mixed; the filter preserves the entity)
+        /** @var Notification $notification */
         $notification = EventCore::dispatch_filter('notificationFilter', $notification);
 
         // Email

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -780,6 +780,8 @@ class Projects extends BaseService implements ChecksProjectAccess
         if ($project) {
             return $project['name'];
         }
+
+        return null;
     }
 
     /**

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -147,7 +147,7 @@ class Projects extends BaseService implements ChecksProjectAccess
 
         $dateOfFirstTicket = new DateTime($firstTicket->date);
         $today = new DateTime;
-        $totalprojectDays = $today->diff($dateOfFirstTicket)->format('%a');
+        $totalprojectDays = (int) $today->diff($dateOfFirstTicket)->format('%a');
 
         // Calculate percent
 

--- a/app/Domain/Queue/Services/Queue.php
+++ b/app/Domain/Queue/Services/Queue.php
@@ -89,7 +89,7 @@ class Queue
     public function addToQueue(Workers $channel, string $subject, string $message, $projectId)
     {
 
-        return $this->queue->addMessageToQueue(
+        $this->queue->addMessageToQueue(
             channel: $channel,
             subject: $subject,
             message: $message,
@@ -103,7 +103,7 @@ class Queue
 
         $queue = app()->make(QueueRepository::class);
 
-        return $queue->addMessageToQueue(
+        $queue->addMessageToQueue(
             channel: $channel,
             subject: $subject,
             message: serialize($message),

--- a/app/Domain/Queue/register.php
+++ b/app/Domain/Queue/register.php
@@ -8,7 +8,6 @@ use Leantime\Domain\Queue\Workers\Workers;
 
 EventDispatcher::add_event_listener('leantime.core.console.consolekernel.schedule.cron', function ($params) {
 
-    /** @var Schedule $scheduler */
     if (get_class($scheduler = $params['schedule']) !== Schedule::class) {
         return;
     }

--- a/app/Domain/Reactions/Repositories/Reactions.php
+++ b/app/Domain/Reactions/Repositories/Reactions.php
@@ -38,7 +38,7 @@ class Reactions
     /**
      * getGroupedEntityReactions - gets all reactions for a given entity grouped and counted by reactions
      *
-     * @return array|bool returns the array on success or false on failure
+     * @return array|false returns the array on success or false on failure
      */
     public function getGroupedEntityReactions(string $module, int $moduleId): array|false
     {

--- a/app/Domain/Reactions/Services/Reactions.php
+++ b/app/Domain/Reactions/Services/Reactions.php
@@ -106,7 +106,7 @@ class Reactions
      * getGroupedEntityReactions - gets all reactions for a given entity grouped and counted by reactions
      *
      *
-     * @return array|bool returns the array on success or false on failure
+     * @return array|false returns the array on success or false on failure
      *
      * @api
      */

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -23,7 +23,6 @@ use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Reactions\Repositories\Reactions;
 use Leantime\Domain\Reports\Permissions\ReportsPermissions;
 use Leantime\Domain\Reports\Repositories\Reports as ReportRepository;
-use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Setting\Services\Setting as SettingsService;
 use Leantime\Domain\Sprints\Repositories\Sprints as SprintRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
@@ -63,9 +62,6 @@ class Reports extends BaseService
 
     private SprintService $sprintService;
 
-    /**
-     * @param  SettingsService  $settings
-     */
     public function __construct(
         TemplateCore $tpl,
         AppSettingCore $appSettings,

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -64,7 +64,7 @@ class Reports extends BaseService
     private SprintService $sprintService;
 
     /**
-     * @param  SettingRepository  $settings
+     * @param  SettingsService  $settings
      */
     public function __construct(
         TemplateCore $tpl,

--- a/app/Domain/Reports/register.php
+++ b/app/Domain/Reports/register.php
@@ -8,7 +8,6 @@ use Leantime\Core\Events\EventDispatcher;
 
 EventDispatcher::add_event_listener('leantime.core.console.consolekernel.schedule.cron', function ($params) {
 
-    /** @var Schedule $scheduler */
     if (get_class($scheduler = $params['schedule']) !== Schedule::class) {
         return;
     }

--- a/app/Domain/Tickets/Controllers/NewTicket.php
+++ b/app/Domain/Tickets/Controllers/NewTicket.php
@@ -95,7 +95,7 @@ class NewTicket extends Controller
         $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
         $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
 
-        $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'), 'open');
+        $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
         $this->tpl->assign('allAssignedprojects', $allAssignedprojects);
 
         return $this->tpl->displayPartial('tickets.newTicketModal');
@@ -147,7 +147,7 @@ class NewTicket extends Controller
                 $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
                 $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
 
-                $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'), 'open');
+                $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
                 $this->tpl->assign('allAssignedprojects', $allAssignedprojects);
 
                 return $this->tpl->displayPartial('tickets.newTicketModal');

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -157,7 +157,7 @@ class ShowTicket extends Controller
         // TODO: Refactor thumbnail generation in file manager
         $this->tpl->assign('imgExtensions', ['jpg', 'jpeg', 'png', 'gif', 'psd', 'bmp', 'tif', 'thm', 'yuv']);
 
-        $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'), 'open');
+        $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
         $this->tpl->assign('allAssignedprojects', $allAssignedprojects);
 
         $response = $this->tpl->displayPartial('tickets.showTicketModal');

--- a/app/Domain/Tickets/Hxcontrollers/Milestones.php
+++ b/app/Domain/Tickets/Hxcontrollers/Milestones.php
@@ -4,7 +4,6 @@ namespace Leantime\Domain\Tickets\Hxcontrollers;
 
 use Leantime\Core\Controller\HtmxController;
 use Leantime\Domain\Tickets\Services\Tickets;
-use Leantime\Domain\Timesheets\Services\Timesheets;
 
 class Milestones extends HtmxController
 {
@@ -14,8 +13,6 @@ class Milestones extends HtmxController
 
     /**
      * Controller constructor
-     *
-     * @param  Tickets  $ticketService
      */
     public function init(Tickets $ticketService): void
     {

--- a/app/Domain/Tickets/Hxcontrollers/Milestones.php
+++ b/app/Domain/Tickets/Hxcontrollers/Milestones.php
@@ -15,7 +15,7 @@ class Milestones extends HtmxController
     /**
      * Controller constructor
      *
-     * @param  Timesheets  $timesheetService
+     * @param  Tickets  $ticketService
      */
     public function init(Tickets $ticketService): void
     {

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -4374,7 +4374,6 @@ class Tickets extends BaseService
                         $values['editFrom'] = dtHelper()->parseUserDateTime(
                             $values['editFrom'],
                             $values['timeFrom'],
-                            FromFormat::UserDateTime
                         )->formatDateTimeForDb();
                         unset($values['timeFrom']);
                     } else {

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -18,7 +18,6 @@ use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Exceptions\NotFoundException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\DateTimeHelper;
-use Leantime\Core\Support\FromFormat;
 use Leantime\Core\UI\Template as TemplateCore;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
@@ -431,10 +430,10 @@ class Tickets extends BaseService
      * Retrieves all tickets based on the provided search criteria.
      *
      * @param  array|null  $searchCriteria  An associative array containing search parameters such as
-     *                                    'currentProject', 'currentUser', 'users', 'status', 'term',
-     *                                    'effort', 'excludeType', 'type', 'milestone', 'groupBy',
-     *                                    'orderBy', 'orderDirection', 'priority', 'clients', and 'sprint'.
-     *                                    These values are used to filter the search results.
+     *                                      'currentProject', 'currentUser', 'users', 'status', 'term',
+     *                                      'effort', 'excludeType', 'type', 'milestone', 'groupBy',
+     *                                      'orderBy', 'orderDirection', 'priority', 'clients', and 'sprint'.
+     *                                      These values are used to filter the search results.
      * @return array|false An array of tickets matching the search criteria, or false on failure.
      *
      * @api

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -430,7 +430,7 @@ class Tickets extends BaseService
     /**
      * Retrieves all tickets based on the provided search criteria.
      *
-     * @param  array|null  $searchParams  An associative array containing search parameters such as
+     * @param  array|null  $searchCriteria  An associative array containing search parameters such as
      *                                    'currentProject', 'currentUser', 'users', 'status', 'term',
      *                                    'effort', 'excludeType', 'type', 'milestone', 'groupBy',
      *                                    'orderBy', 'orderDirection', 'priority', 'clients', and 'sprint'.

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -717,6 +717,7 @@ class Timesheets extends Repository
                 return 0;
             }
 
+            /** @var \Carbon\CarbonImmutable $userStartOfDay */
             $userStartOfDay = dtHelper()::createFromTimestamp($inTimestamp, 'UTC')->setToUserTimezone()->startOfDay();
 
             // Use raw query for ON DUPLICATE KEY UPDATE (MySQL specific)

--- a/app/Domain/Users/Controllers/Import.php
+++ b/app/Domain/Users/Controllers/Import.php
@@ -39,7 +39,7 @@ class Import extends Controller
         $this->tpl->assign('admin', true);
         $this->tpl->assign('roles', Roles::getRoles());
 
-        if (session()->exist('tmp.ldapUsers') && count(session('tmp.ldapUsers')) > 0) {
+        if (session()->exists('tmp.ldapUsers') && count(session('tmp.ldapUsers')) > 0) {
             $this->tpl->assign('allLdapUsers', session('tmp.ldapUsers'));
             $this->tpl->assign('confirmUsers', true);
         }

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -8,7 +8,6 @@ use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Db\DatabaseHelper;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Domain\Files\Repositories\Files;
-use SVG\SVG;
 
 class Users
 {
@@ -74,8 +73,6 @@ class Users
 
     /**
      * getUser - get on user from db
-     *
-     * @return array|false
      */
     public function getUserBySha($hash): array|false
     {
@@ -424,8 +421,6 @@ class Users
     }
 
     /**
-     * @return array|false
-     *
      * @throws BindingResolutionException
      */
     public function getProfilePicture($id): array|false

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -410,14 +410,12 @@ class Users
      */
     public function setPicture($fileId, $id): bool
     {
-        $this->connection->table('zp_user')
+        return $this->connection->table('zp_user')
             ->where('id', $id)
             ->update([
                 'profileId' => $fileId,
                 'modified' => dtHelper()->dbNow()->formatDateTimeForDb(),
-            ]);
-
-        return true;
+            ]) > 0;
     }
 
     /**

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -75,7 +75,7 @@ class Users
     /**
      * getUser - get on user from db
      *
-     * @return mixed
+     * @return array|false
      */
     public function getUserBySha($hash): array|false
     {
@@ -424,7 +424,7 @@ class Users
     }
 
     /**
-     * @return string[]|SVG
+     * @return array|false
      *
      * @throws BindingResolutionException
      */

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -411,7 +411,7 @@ class Users
      *
      * @throws BindingResolutionException
      */
-    public function setPicture($fileId, $id): void
+    public function setPicture($fileId, $id): bool
     {
         $this->connection->table('zp_user')
             ->where('id', $id)
@@ -419,6 +419,8 @@ class Users
                 'profileId' => $fileId,
                 'modified' => dtHelper()->dbNow()->formatDateTimeForDb(),
             ]);
+
+        return true;
     }
 
     /**

--- a/app/Domain/Widgets/Controllers/WidgetManager.php
+++ b/app/Domain/Widgets/Controllers/WidgetManager.php
@@ -15,9 +15,6 @@ use Symfony\Component\HttpFoundation;
  */
 class WidgetManager extends Controller
 {
-    /**
-     * @var WidgetService
-     */
     private Widgets $widgetService;
 
     /**

--- a/app/Domain/Widgets/Models/Widget.php
+++ b/app/Domain/Widgets/Models/Widget.php
@@ -4,6 +4,9 @@ namespace Leantime\Domain\Widgets\Models;
 
 class Widget
 {
+    /** Set transiently by the Widgets service to flag freshly-available widgets in the UI. */
+    public bool $isNew = false;
+
     /**
      * Constructor for creating a new instance of the class.
      *

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -105,9 +105,9 @@ if (! function_exists('cast')) {
     /**
      * Casts a variable to a different type if possible.
      *
-     * @param  mixed  $obj  The object to be cast.
-     * @param  string  $to_class  The class to which the object should be cast.
-     * @param  array  $construct_params  Optional parameters to pass to the constructor.
+     * @param  mixed  $source  The object to be cast.
+     * @param  string  $classOrType  The class to which the object should be cast.
+     * @param  array  $constructParams  Optional parameters to pass to the constructor.
      * @param  array  $mappings  Make sure certain sub properties are casted to specific types.
      * @return mixed The casted object, or throws an exception on failure.
      *
@@ -154,7 +154,7 @@ if (! function_exists('redirect')) {
      * Get an instance of the redirector.
      *
      * @param  string|null  $url
-     * @param  int  $status
+     * @param  int  $http_response_code
      * @param  array  $headers
      * @param  bool|null  $secure
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
@@ -171,11 +171,6 @@ if (! function_exists('redirect')) {
 if (! function_exists('currentRoute')) {
     /**
      * Get an instance of the redirector.
-     *
-     * @param  string|null  $to
-     * @param  int  $status
-     * @param  array  $headers
-     * @param  bool|null  $secure
      */
     function currentRoute()
     {
@@ -217,7 +212,7 @@ if (! function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file. Customized for Leantime.
      *
-     * @return Mix|string
+     * @return \Leantime\Core\Support\Mix|string
      *
      * @throws BindingResolutionException
      */
@@ -255,7 +250,7 @@ if (! function_exists('redirect')) {
      * Get an instance of the redirector.
      *
      * @param  string|null  $url
-     * @param  int  $status
+     * @param  int  $http_response_code
      * @param  array  $headers
      * @param  bool|null  $secure
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
@@ -272,11 +267,6 @@ if (! function_exists('redirect')) {
 if (! function_exists('currentRoute')) {
     /**
      * Get an instance of the redirector.
-     *
-     * @param  string|null  $to
-     * @param  int  $status
-     * @param  array  $headers
-     * @param  bool|null  $secure
      */
     function currentRoute()
     {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -212,7 +212,6 @@ if (! function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file. Customized for Leantime.
      *
-     * @return \Leantime\Core\Support\Mix|string
      *
      * @throws BindingResolutionException
      */


### PR DESCRIPTION
## Raise PHPStan from level 1 → 2

Climbs static analysis one level (config `level: 1` → `2`), fix-forward with **no baseline** — matching the level 0→1 precedent. `make phpstan` is green at level 2 (838 files, **0 errors**).

The headline number was misleading: clean master had **429** level-2 findings, but they collapsed to a handful of patterns rather than 429 independent problems.

### How the 429 were resolved

**Systemic (~58% of all findings, ~3 changes):**
- **`DispatchesEvents` trait**: `set_class_context()`/`get_function_context()` `private static` → `protected static`. The trait is mixed into ~60 classes, so `static::` calls to a private method were reported once *per using class* (~112 reports, one defect).
- **Carbon date/time macros**: resolved via Carbon's **official PHPStan `MacroExtension`** (`vendor/nesbot/carbon/extension.neon`, now `include`d), fed by a `CarbonImmutable::mixin(new CarbonMacros)` registration in `.phpstan/bootstrap.php`. Deliberately **not** stubbed — stubbing `Carbon\CarbonInterface` clobbers Carbon's own `@method` API.
- **`.phpstan/stubs/laravel-gaps.stub`** (new): declares concrete Laravel methods our code reaches through looser contracts (no Larastan) — `ConnectionInterface::getDriverName/getPdo`, `Filesystem::url/mimeType`, Auth `Factory`/`Guard`, `Foundation\Application`, `Cache\Repository::lock`, `Socialite\Provider`, `Carbon::addRealMinutes`.

**Mechanical sweep (~100 findings, 47 files):** stale `@param` names, `@return`/`@param`/`@var` vs native-type mismatches, malformed docblocks, and namespace typos — most notably `\Leantime\Core\Bootstrap\Application` → `\Leantime\Core\Application` (that namespace never existed) and the correct `BindingResolutionException` / `HttpResponseException` FQCNs.

### 🐛 Real bugs surfaced by level 2 (fixed here, not just type noise)

- **`session()->exist(...)` → `exists()`** — the typo'd method doesn't exist (would fatal on the LDAP-import path).
- **Missing `DateTimeHelper::parseDb24hTime()`** — `Format`'s `FromFormat::Db24hTime` case called a method that never existed; added it.
- **Profile pictures were never deleted** — `setPicture()` is `void` but was used in `... && $this->userRepo->setPicture(...) && $oldPicture`, so the branch was always falsy. Now returns `bool`.
- **`ApiGuard::id`/`WebGuard::id`** use the `Authenticatable` contract's `getAuthIdentifier()` instead of `->id`.
- A handful of call sites passed **extra arguments PHP was silently dropping** (a lost `'open'` project-status filter, a dropped client filter, etc.) — removed to match the real signatures.

### ⚠️ Flagged for review (`FIXME(phpstan-l2)` in the diff)

- **`Files\Repositories\Files::upload()`** was calling `upload($file, $newname, false)` but the method is `(UploadedFile $file, $disk = 'default')` — the filename was being passed as the **disk name**. Changed to `upload($file)`; the surrounding `$values` still use the caller's own `$newname`/`$realName`, which may not match the actually-stored file. **Please confirm the intended disk + name handling.**
- **`Entityrelations::saveRelationship/getRelationshipByEntity`** call `Setting::saveSetting/getSetting` with 6/4 args against 2/1-2-arg signatures — the methods are broken (relationship data was silently dropped) and the injected `EntityrelationRepository` has no matching method. Trimmed to preserve current runtime behavior; **the relationship-storage design needs rebuilding.**

### Notes
- `app/Plugins/*` is a private submodule not checked out in CI, so this only covers core/domain (matches CI exactly).
- **Runtime-affecting changes** (file upload, `setPicture`, `guard()`, `session()->exists`) should be validated with `make unit-test` / `make acceptance-test` before merge.
- **Level 3** (+46 findings, incl. an auth `stdClass` → `Authenticatable` change that touches the bearer/sanctum-sensitive `UserProvider`) is planned as a separate stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
