### PR TITLE
feat(core): extract shared AI/MCP support classes and add PAT management

### DIFF
--- a/app/Core/Support/AbstractEntityFormatter.php
+++ b/app/Core/Support/AbstractEntityFormatter.php
@@ -165,7 +165,7 @@ abstract class AbstractEntityFormatter implements EntityFormatterInterface
         }
 
         if (is_array($value)) {
-            return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) ?: '[]';
         }
 
         $stringValue = (string) $value;

--- a/app/Core/Support/AbstractEntityFormatter.php
+++ b/app/Core/Support/AbstractEntityFormatter.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+/**
+ * Abstract base class for entity formatters.
+ *
+ * Provides common functionality for formatting domain entities into markdown,
+ * including sanitization, field filtering, and utility methods.
+ */
+abstract class AbstractEntityFormatter implements EntityFormatterInterface
+{
+    /**
+     * Default fields to exclude from formatting across all entities.
+     */
+    protected array $defaultExcludedFields = [
+        'password',
+        'token',
+        'secret',
+        'key',
+        'hash',
+        'salt',
+    ];
+
+    /**
+     * Fields to exclude from formatting for this specific entity type.
+     */
+    protected array $excludedFields = [];
+
+    /**
+     * Priority order for displaying fields (higher priority = displayed first).
+     */
+    protected array $fieldPriority = [];
+
+    /**
+     * Format the entity using the default formatting logic.
+     */
+    public function format(): string
+    {
+        return $this->formatForContext([]);
+    }
+
+    /**
+     * Format the entity with context-aware formatting.
+     */
+    public function formatForContext(array $context = []): string
+    {
+        $data = $this->prepareEntityData($context);
+        $header = $this->formatHeader($data);
+        $body = $this->formatBody($data, $context);
+
+        return $header."\n".$body;
+    }
+
+    /**
+     * Get a compact summary of the entity.
+     */
+    public function getSummary(): string
+    {
+        $data = $this->prepareEntityData();
+
+        return $this->formatSummary($data);
+    }
+
+    /**
+     * Prepare the entity data for formatting.
+     * This method should be implemented by concrete classes to extract
+     * and organize data from their specific entity types.
+     */
+    abstract protected function prepareEntityData(array $context = []): array;
+
+    /**
+     * Format the header section of the entity.
+     */
+    abstract protected function formatHeader(array $data): string;
+
+    /**
+     * Format the body section of the entity.
+     */
+    protected function formatBody(array $data, array $context = []): string
+    {
+        $filteredData = $this->filterFields($data, $context);
+        $sortedData = $this->sortFields($filteredData);
+
+        return Str::toMarkdown($sortedData);
+    }
+
+    /**
+     * Format a compact summary of the entity.
+     */
+    abstract protected function formatSummary(array $data): string;
+
+    /**
+     * Filter out excluded fields and apply context-specific filtering.
+     */
+    protected function filterFields(array $data, array $context = []): array
+    {
+        $excludedFields = array_merge($this->defaultExcludedFields, $this->excludedFields);
+
+        // Apply context-specific field filtering
+        if (isset($context['includeFields']) && is_array($context['includeFields'])) {
+            $data = array_intersect_key($data, array_flip($context['includeFields']));
+        }
+
+        if (isset($context['excludeFields']) && is_array($context['excludeFields'])) {
+            $excludedFields = array_merge($excludedFields, $context['excludeFields']);
+        }
+
+        // Remove excluded fields
+        foreach ($excludedFields as $field) {
+            unset($data[$field]);
+        }
+
+        // Remove empty values unless specifically requested to keep them
+        if (! isset($context['keepEmpty']) || ! $context['keepEmpty']) {
+            $data = array_filter($data, function ($value) {
+                return $value !== null && $value !== '' && $value !== [];
+            });
+        }
+
+        return $data;
+    }
+
+    /**
+     * Sort fields according to priority and alphabetically.
+     */
+    protected function sortFields(array $data): array
+    {
+        if (empty($this->fieldPriority)) {
+            return $data;
+        }
+
+        $prioritized = [];
+
+        // First add prioritized fields in order
+        foreach ($this->fieldPriority as $field) {
+            if (isset($data[$field])) {
+                $prioritized[$field] = $data[$field];
+                unset($data[$field]);
+            }
+        }
+
+        // Then add remaining fields alphabetically
+        ksort($data);
+
+        return array_merge($prioritized, $data);
+    }
+
+    /**
+     * Sanitize a value for safe LLM consumption.
+     *
+     * @param  mixed  $value
+     */
+    protected function sanitizeValue($value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'Yes' : 'No';
+        }
+
+        if (is_array($value)) {
+            return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        }
+
+        $stringValue = (string) $value;
+
+        return Str::sanitizeForLLM($stringValue);
+    }
+
+    /**
+     * Format a date value in a human-readable format.
+     *
+     * @param  mixed  $date
+     */
+    protected function formatDate($date): string
+    {
+        if (empty($date) || $date === '0000-00-00' || $date === '0000-00-00 00:00:00') {
+            return 'Not set';
+        }
+
+        try {
+            $dateTime = CarbonImmutable::parse($date);
+
+            return $dateTime->toIso8601String();
+        } catch (\Exception $e) {
+            return $this->sanitizeValue($date);
+        }
+    }
+
+    /**
+     * Format a priority value with appropriate visual indicators.
+     *
+     * @param  mixed  $priority
+     */
+    protected function formatPriority($priority): string
+    {
+        return match (strtolower((string) $priority)) {
+            '1', 'low' => '🔵 Low',
+            '2', 'medium', 'normal' => '🟡 Medium',
+            '3', 'high' => '🟠 High',
+            '4', 'urgent', 'critical' => '🔴 Urgent',
+            default => $this->sanitizeValue($priority) ?: 'Not set'
+        };
+    }
+
+    /**
+     * Format a status with appropriate visual indicators.
+     *
+     * @param  mixed  $status
+     * @param  array  $statusLabels  Optional status label mapping
+     */
+    protected function formatStatus($status, array $statusLabels = []): string
+    {
+        if (! empty($statusLabels) && isset($statusLabels[$status])) {
+            $label = $statusLabels[$status];
+            $statusType = $label['statusType'] ?? '';
+
+            $emoji = match (strtolower($statusType)) {
+                'new' => '🆕',
+                'inprogress' => '🔄',
+                'done' => '✅',
+                default => '📝'
+            };
+
+            return $emoji.' '.$label['name'];
+        }
+
+        return $this->sanitizeValue($status) ?: 'Not set';
+    }
+}

--- a/app/Core/Support/EntityFormatterInterface.php
+++ b/app/Core/Support/EntityFormatterInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+/**
+ * Interface for entity formatters that convert domain models into markdown for AI consumption.
+ *
+ * This interface defines the contract for formatting domain entities (tickets, projects, users, etc.)
+ * into structured markdown documents suitable for AI prompts and embeddings.
+ */
+interface EntityFormatterInterface
+{
+    /**
+     * Format the entity into a standard markdown representation.
+     *
+     * @return string Markdown formatted string representing the entity
+     */
+    public function format(): string;
+
+    /**
+     * Format the entity with additional context-aware information.
+     *
+     * @param  array  $context  Additional context that might affect formatting (e.g., user preferences, specific fields to include/exclude)
+     * @return string Context-aware markdown formatted string
+     */
+    public function formatForContext(array $context = []): string;
+
+    /**
+     * Get the type of entity this formatter handles.
+     *
+     * @return string Entity type (e.g., 'ticket', 'project', 'user')
+     */
+    public function getEntityType(): string;
+
+    /**
+     * Get the unique identifier of the entity being formatted.
+     *
+     * @return mixed Entity ID (could be int, string, or other identifier type)
+     */
+    public function getEntityId(): mixed;
+
+    /**
+     * Get a compact, one-line summary of the entity.
+     *
+     * @return string Brief summary suitable for lists or references
+     */
+    public function getSummary(): string;
+}

--- a/app/Core/Support/LLMStringSanitizer.php
+++ b/app/Core/Support/LLMStringSanitizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * Sanitizes strings for safe LLM/AI consumption, prevents prompt injection attacks.
+ *
+ * Delegates to the Str::sanitizeForLLM() macro for the actual sanitization logic.
+ * This class provides a static API for use in entity formatters and other contexts
+ * where the Str macro call pattern is less convenient.
+ */
+class LLMStringSanitizer
+{
+    /**
+     * Sanitize a string for safe use with LLM APIs.
+     *
+     * Removes potential prompt injection patterns and problematic characters
+     * that could interfere with JSON serialization or system prompts.
+     *
+     * @param  mixed  $input  The value to sanitize
+     * @param  bool  $removeNewlines  Whether to strip newlines from the result
+     * @return string The sanitized string
+     */
+    public static function sanitizeForLLM(mixed $input, bool $removeNewlines = false): string
+    {
+        if (! is_string($input)) {
+            return $input ?? '';
+        }
+
+        return Str::sanitizeForLLM($input, $removeNewlines);
+    }
+}

--- a/app/Core/Support/LLMStringSanitizer.php
+++ b/app/Core/Support/LLMStringSanitizer.php
@@ -25,8 +25,12 @@ class LLMStringSanitizer
      */
     public static function sanitizeForLLM(mixed $input, bool $removeNewlines = false): string
     {
+        if ($input === null) {
+            return '';
+        }
+
         if (! is_string($input)) {
-            return $input ?? '';
+            return (string) $input;
         }
 
         return Str::sanitizeForLLM($input, $removeNewlines);

--- a/app/Core/Support/MarkdownHelper.php
+++ b/app/Core/Support/MarkdownHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * Converts PHP arrays into formatted markdown strings for LLM consumption.
+ *
+ * Delegates to the Str::toMarkdown() macro for the actual conversion logic.
+ * This class provides a static API for use in entity formatters and other contexts.
+ */
+class MarkdownHelper
+{
+    /**
+     * Converts a PHP array into a formatted markdown string.
+     *
+     * @param  mixed  $data  The data to convert to markdown
+     * @param  int  $headerLevel  Starting header level (1-6)
+     * @return string Markdown formatted string
+     */
+    public static function encode(mixed $data, int $headerLevel = 2): string
+    {
+        if (! is_array($data)) {
+            return self::sanitizeForMarkdown((string) $data);
+        }
+
+        return Str::toMarkdown($data, $headerLevel);
+    }
+
+    /**
+     * Check if an array is associative (has string keys) or sequential (numeric keys).
+     *
+     * @param  mixed  $array  The array to check
+     * @return bool True if associative, false if sequential
+     */
+    public static function isAssociativeArray(mixed $array): bool
+    {
+        if (! is_array($array) || empty($array)) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
+     * Sanitize a value for safe markdown formatting.
+     *
+     * @param  mixed  $value  The value to sanitize
+     * @return string The sanitized string
+     */
+    public static function sanitizeForMarkdown(mixed $value): string
+    {
+        if ($value === null) {
+            return '*null*';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return LLMStringSanitizer::sanitizeForLLM((string) $value);
+    }
+}

--- a/app/Core/Support/MarkdownHelper.php
+++ b/app/Core/Support/MarkdownHelper.php
@@ -25,7 +25,7 @@ class MarkdownHelper
             return self::sanitizeForMarkdown((string) $data);
         }
 
-        return Str::toMarkdown($data, $headerLevel);
+        return Str::toMarkdown($data);
     }
 
     /**

--- a/app/Core/Support/RoutingFormatter.php
+++ b/app/Core/Support/RoutingFormatter.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+/**
+ * Routing Formatter - Formats conversation history and routing context for AI consumption.
+ */
+class RoutingFormatter extends AbstractEntityFormatter
+{
+    protected array $conversationHistory;
+
+    public function __construct(array $conversationHistory = [])
+    {
+        $this->conversationHistory = $conversationHistory;
+
+        // Set field priority for conversation history formatting
+        $this->fieldPriority = $this->getPriorityFields();
+
+    }
+
+    /**
+     * Prepare the entity data for formatting.
+     */
+    protected function prepareEntityData(array $context = []): array
+    {
+        return [
+            'conversation_history' => $this->conversationHistory,
+            'exchange_count' => count($this->conversationHistory),
+            'latest_date' => $this->getLatestDate(),
+            'has_feedback' => $this->hasFeedback(),
+        ];
+    }
+
+    /**
+     * Format the header section of the entity.
+     */
+    protected function formatHeader(array $data): string
+    {
+        $count = $data['exchange_count'] ?? 0;
+        $latestDate = $data['latest_date'] ?? 'Unknown';
+
+        if ($count === 0) {
+            return "## Recent Conversation History\n\nNo recent conversation history available.";
+        }
+
+        return "## Recent Conversation History\n\n".
+               "**Total Exchanges:** {$count}\n".
+               "**Latest Exchange:** {$latestDate}\n\n".
+               'The following shows recent interactions between the user and assistant:';
+    }
+
+    /**
+     * Format the body section with conversation history.
+     */
+    protected function formatBody(array $data, array $context = []): string
+    {
+        if (empty($data['conversation_history'])) {
+            return '';
+        }
+
+        return $this->formatRecentHistoryAsPrompt($data['conversation_history']);
+    }
+
+    /**
+     * Format a compact summary of the conversation history.
+     */
+    protected function formatSummary(array $data): string
+    {
+        $count = $data['exchange_count'] ?? 0;
+
+        if ($count === 0) {
+            return 'No conversation history';
+        }
+
+        $latestDate = $data['latest_date'] ?? 'Unknown date';
+
+        return "Conversation history with {$count} exchanges, latest from {$latestDate}";
+    }
+
+    /**
+     * Get entity type.
+     */
+    public function getEntityType(): string
+    {
+        return 'routing';
+    }
+
+    /**
+     * Get entity identifier.
+     */
+    public function getEntityId(): string
+    {
+        return 'conversation_history_'.count($this->conversationHistory);
+    }
+
+    /**
+     * Get the date of the latest conversation exchange.
+     */
+    protected function getLatestDate(): string
+    {
+        if (empty($this->conversationHistory)) {
+            return 'No exchanges';
+        }
+
+        $latest = end($this->conversationHistory);
+
+        return $latest['date'] ?? 'Unknown date';
+    }
+
+    /**
+     * Check if any conversation exchange has feedback.
+     */
+    protected function hasFeedback(): bool
+    {
+        foreach ($this->conversationHistory as $exchange) {
+            if (isset($exchange['feedback']) && $exchange['feedback'] !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Format recent conversation history as a prompt.
+     *
+     * @param  array  $recentHistory  An array containing the recent conversation history. Each item should include
+     *                                keys for 'date', 'message', 'response', and 'feedback'.
+     * @return string The formatted conversation history as a string in prompt format.
+     */
+    protected function formatRecentHistoryAsPrompt(array $recentHistory): string
+    {
+        $prompt = '';
+
+        // Add recent conversation history if available
+        if (! empty($recentHistory)) {
+            foreach ($recentHistory as $exchange) {
+                $date = $this->sanitizeValue($exchange['date'] ?? 'Unknown date');
+                $message = $this->sanitizeValue($exchange['message'] ?? '');
+                $response = $this->sanitizeValue($exchange['response'] ?? '');
+
+                $prompt .= "**Date (UTC):** {$date}\n";
+                $prompt .= "**User:** {$message}\n";
+                $prompt .= "**Assistant:** {$response}\n\n";
+
+                $feedback = $this->formatFeedback($exchange['feedback'] ?? null);
+                $prompt .= "**User Rating:** {$feedback}\n\n";
+                $prompt .= "---\n\n";
+            }
+        }
+
+        return $prompt;
+    }
+
+    /**
+     * Format feedback value into human-readable text.
+     */
+    protected function formatFeedback(mixed $feedback): string
+    {
+        switch ($feedback) {
+            case 1:
+                return 'Positive';
+            case -1:
+                return 'Negative';
+            default:
+                return 'Neutral (no feedback)';
+        }
+    }
+
+    /**
+     * Get priority fields for this formatter (conversation history specific).
+     */
+    protected function getPriorityFields(): array
+    {
+        return [
+            'date',
+            'message',
+            'response',
+            'feedback',
+            'id',
+        ];
+    }
+
+    /**
+     * Format optimized conversation history for token efficiency.
+     *
+     * @param  array  $optimizedHistory  History with full_exchanges and key_facts_exchanges
+     * @return array Formatted history ready for AI consumption
+     */
+    public function formatOptimizedHistory(array $optimizedHistory): array
+    {
+        $formattedHistory = [];
+
+        // Add recent full exchanges first
+        if (! empty($optimizedHistory['full_exchanges'])) {
+            $formattedHistory = array_merge($formattedHistory, $optimizedHistory['full_exchanges']);
+        }
+
+        // Add key facts exchanges as compressed entries
+        if (! empty($optimizedHistory['key_facts_exchanges'])) {
+            foreach ($optimizedHistory['key_facts_exchanges'] as $keyFactExchange) {
+                if (! empty($keyFactExchange['key_facts'])) {
+                    $formattedHistory[] = [
+                        'id' => $keyFactExchange['id'],
+                        'date' => $keyFactExchange['date'],
+                        'message' => '[Key Facts]',
+                        'response' => $keyFactExchange['key_facts'],
+                        'feedback' => $keyFactExchange['feedback'],
+                    ];
+                }
+            }
+        }
+
+        return $formattedHistory;
+    }
+
+    /**
+     * Create a routing formatter from optimized history data.
+     */
+    public static function fromOptimizedHistory(array $optimizedHistory): self
+    {
+        $formatter = new self;
+        $formattedHistory = $formatter->formatOptimizedHistory($optimizedHistory);
+        $formatter->conversationHistory = $formattedHistory;
+
+        return $formatter;
+    }
+
+    /**
+     * Update the conversation history.
+     */
+    public function setConversationHistory(array $conversationHistory): self
+    {
+        $this->conversationHistory = $conversationHistory;
+
+        return $this;
+    }
+
+    /**
+     * Get the current conversation history.
+     */
+    public function getConversationHistory(): array
+    {
+        return $this->conversationHistory;
+    }
+}

--- a/app/Domain/Api/Templates/apiKey.blade.php
+++ b/app/Domain/Api/Templates/apiKey.blade.php
@@ -21,8 +21,8 @@
                 lt_{{ substr($values['user'], 0, 5) }}***<br /><br />
 
                 <label for="firstname">{!! __('label.key_name') !!}</label><div class="clearfix"></div>
-                    <input
-                    type="text" name="firstname" id="firstname"
+                    <x-global::forms.text-input
+                    name="firstname" id="firstname"
                     value="{{ $values['firstname'] }}" /><br />
 
 

--- a/app/Domain/Api/Templates/newAPIKey.blade.php
+++ b/app/Domain/Api/Templates/newAPIKey.blade.php
@@ -13,7 +13,7 @@
 {!! $tpl->displayNotification() !!}
     @if ($apiKeyValues !== false && isset($apiKeyValues['id']))
         <p>Your API Key was successfully created. Please copy the key below. This is your only chance to copy it.</p>
-        <input type="text" id="apiKey" value="lt_{{ $apiKeyValues['user'] }}_{{ $apiKeyValues['passwordClean'] }}" style="width:100%;"/>
+        <x-global::forms.text-input id="apiKey" value="lt_{{ $apiKeyValues['user'] }}_{{ $apiKeyValues['passwordClean'] }}" style="width:100%;" />
         <x-global::forms.button contentRole="primary" onclick="leantime.snippets.copyUrl('apiKey');">{!! __('links.copy_key') !!}</x-global::forms.button>
     @else
     <form action="{{ BASE_URL }}/api/newApiKey" method="post" class="stdform formModal" >
@@ -26,8 +26,8 @@
                 <h4 class="widgettitle title-light">{!! __('label.basic_information') !!}</h4>
 
                 <label for="firstname">{!! __('label.key_name') !!}</label><div class="clearfix"></div>
-                    <input
-                    type="text" name="firstname" id="firstname"
+                    <x-global::forms.text-input
+                    name="firstname" id="firstname"
                     value="" /><br />
 
 

--- a/app/Domain/Auth/Hxcontrollers/PersonalTokens.php
+++ b/app/Domain/Auth/Hxcontrollers/PersonalTokens.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Leantime\Domain\Auth\Hxcontrollers;
+
+use Leantime\Core\Controller\HtmxController;
+use Leantime\Domain\Auth\Services\AccessToken;
+
+/**
+ * HxController for Personal Access Token management.
+ *
+ * Provides HTMX endpoints for creating, listing, and revoking
+ * personal access tokens from the user settings page.
+ */
+class PersonalTokens extends HtmxController
+{
+    protected static string $view = 'auth::partials.tokens';
+
+    private AccessToken $tokenService;
+
+    /**
+     * Initialize the controller with dependencies.
+     */
+    public function init(AccessToken $tokenService): void
+    {
+        $this->tokenService = $tokenService;
+    }
+
+    /**
+     * List all tokens for the current user.
+     */
+    public function get(): void
+    {
+        $tokens = $this->tokenService->getUserTokens(session('userdata.id'));
+        $this->tpl->assign('tokens', $tokens);
+    }
+
+    /**
+     * Create a new personal access token.
+     */
+    public function create(): string
+    {
+        $name = $this->incomingRequest->request->get('name');
+
+        if (empty($name)) {
+            $this->tpl->setNotification(__('notifications.token_name_required'), 'error');
+
+            return $this->emptyResponse(400);
+        }
+
+        $token = $this->tokenService->createToken(
+            session('userdata.id'),
+            $name
+        );
+
+        $this->tpl->setNotification(__('notifications.token_created'), 'success');
+
+        // Return the token value in a modal for one-time display
+        $this->tpl->assign('newToken', $token->token);
+
+        return $this->tpl->displayPartial('auth.token-created');
+    }
+
+    /**
+     * Delete a personal access token.
+     */
+    public function delete(): void
+    {
+        $id = $this->incomingRequest->get('id');
+
+        if (! $this->tokenService->deleteToken((int) $id)) {
+            $this->tpl->setNotification(__('notifications.token_not_found'), 'error');
+
+            return;
+        }
+
+        $this->tpl->setNotification(__('notifications.token_deleted'), 'success');
+
+        $this->get();
+    }
+}

--- a/app/Domain/Auth/Hxcontrollers/PersonalTokens.php
+++ b/app/Domain/Auth/Hxcontrollers/PersonalTokens.php
@@ -36,15 +36,17 @@ class PersonalTokens extends HtmxController
 
     /**
      * Create a new personal access token.
+     *
+     * @return mixed
      */
-    public function create(): string
+    public function create()
     {
         $name = $this->incomingRequest->request->get('name');
 
         if (empty($name)) {
             $this->tpl->setNotification(__('notifications.token_name_required'), 'error');
 
-            return $this->emptyResponse(400);
+            return $this->tpl->emptyResponse(400);
         }
 
         $token = $this->tokenService->createToken(

--- a/app/Domain/Auth/Listeners/ShowPersonalTokenContent.php
+++ b/app/Domain/Auth/Listeners/ShowPersonalTokenContent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Leantime\Domain\Auth\Listeners;
+
+/**
+ * Renders the Personal Access Tokens tab content in the user account settings page.
+ *
+ * Loads via HTMX: the tab panel contains an hx-get that fetches the token list
+ * from the Auth HxController on first reveal.
+ */
+class ShowPersonalTokenContent
+{
+    /**
+     * Render the tab content panel with HTMX lazy-loading.
+     */
+    public function handle(mixed $payload): void
+    {
+        echo '<div id="personalTokens"
+            hx-get="'.BASE_URL.'/hx/auth/personalTokens"
+            hx-trigger="load"
+            hx-swap="innerHTML">
+        </div>';
+    }
+}

--- a/app/Domain/Auth/Listeners/ShowPersonalTokenTab.php
+++ b/app/Domain/Auth/Listeners/ShowPersonalTokenTab.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Leantime\Domain\Auth\Listeners;
+
+/**
+ * Injects the Personal Access Tokens tab into the user account settings page.
+ */
+class ShowPersonalTokenTab
+{
+    /**
+     * Render the tab navigation item.
+     */
+    public function handle(mixed $payload): void
+    {
+        echo '<li><a href="#personalTokens"><i class="fa-solid fa-key"></i> '.__('tabs.personal_access_tokens').'</a></li>';
+    }
+}

--- a/app/Domain/Auth/Templates/login.blade.php
+++ b/app/Domain/Auth/Templates/login.blade.php
@@ -23,11 +23,11 @@
 
         <div class="">
             <label for="username">Email</label>
-            <input type="text" name="username" id="username" class="form-control" placeholder="{{ __($inputPlaceholder) }}" value=""/>
+            <x-global::forms.text-input variant="form" name="username" id="username" placeholder="{{ __($inputPlaceholder) }}" value="" />
         </div>
         <div class="">
             <label for="password">Password</label>
-            <input type="password" name="password" id="password" autocomplete="off" class="form-control" placeholder="{{ __('input.placeholders.enter_password') }}" value=""/>
+            <x-global::forms.text-input inputType="password" variant="form" name="password" id="password" autocomplete="off" placeholder="{{ __('input.placeholders.enter_password') }}" value="" />
             <div class="forgotPwContainer">
                 <a href="{{ BASE_URL }}/auth/resetPw" class="forgotPw">{!! __('links.forgot_password') !!}</a>
             </div>

--- a/app/Domain/Auth/Templates/login.blade.php
+++ b/app/Domain/Auth/Templates/login.blade.php
@@ -23,11 +23,11 @@
 
         <div class="">
             <label for="username">Email</label>
-            <x-global::forms.text-input variant="form" name="username" id="username" placeholder="{{ __($inputPlaceholder) }}" value="" />
+            <x-global::forms.text-input name="username" id="username" placeholder="{{ __($inputPlaceholder) }}" value="" />
         </div>
         <div class="">
             <label for="password">Password</label>
-            <x-global::forms.text-input inputType="password" variant="form" name="password" id="password" autocomplete="off" placeholder="{{ __('input.placeholders.enter_password') }}" value="" />
+            <x-global::forms.text-input type="password" name="password" id="password" autocomplete="off" placeholder="{{ __('input.placeholders.enter_password') }}" value="" />
             <div class="forgotPwContainer">
                 <a href="{{ BASE_URL }}/auth/resetPw" class="forgotPw">{!! __('links.forgot_password') !!}</a>
             </div>

--- a/app/Domain/Auth/Templates/partials/tokens.blade.php
+++ b/app/Domain/Auth/Templates/partials/tokens.blade.php
@@ -1,0 +1,46 @@
+@fragment('tokens-table')
+<div class="row">
+    <div class="col-md-12">
+        <div>
+            <h5 class="subtitle">{{ __('headlines.personal_access_tokens') }}</h5>
+            <p>{{ __('text.create_tokens_to_authenticate') }}</p>
+            <br />
+
+            <a class="btn btn-primary"
+                     href="#/auth/tokenNew">
+                {{ __('buttons.create_token') }}
+            </a> <br />
+
+            <div class="clearfix"></div>
+
+            <table class="table table-bordered" id="tokens-table">
+                <thead>
+                    <tr>
+                        <th>{{ __('label.name') }}</th>
+                        <th>{{ __('label.last_used') }}</th>
+                        <th>{{ __('label.created_on') }}</th>
+                        <th>{{ __('label.actions') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach($tokens as $token)
+                    <tr>
+                        <td>{{ $token['name'] }}</td>
+                        <td>{{ $token['last_used_at'] ? format($token['last_used_at'])->date() . ' ' . format($token['last_used_at'])->time(): 'Never' }}</td>
+                        <td>{{ format($token['created_at'])->date(). ' ' . format($token['created_at'])->time() }}</td>
+                        <td>
+                            <button class="btn btn-danger btn-sm"
+                                    hx-delete="{{ BASE_URL }}/hx/auth/personalTokens/delete/{{ $token['id'] }}"
+                                    hx-confirm="{{ __('notifications.confirm_token_delete') }}"
+                                    hx-target="#personalTokens">
+                                <i class="fa fa-trash"></i>
+                            </button>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+@endfragment

--- a/app/Domain/Auth/Templates/requestPwLink.blade.php
+++ b/app/Domain/Auth/Templates/requestPwLink.blade.php
@@ -15,7 +15,7 @@
         {!! $tpl->displayInlineNotification() !!}
         <p>{!! __('text.enter_email_address_to_reset') !!}<br /><br /></p>
         <div class="">
-            <input type="text" name="username" id="username" placeholder="{{ __('input.placeholders.enter_email') }}" />
+            <x-global::forms.text-input name="username" id="username" placeholder="{{ __('input.placeholders.enter_email') }}" />
         </div>
         <div class="">
             <div class="forgotPwContainer">

--- a/app/Domain/Auth/Templates/resetPw.blade.php
+++ b/app/Domain/Auth/Templates/resetPw.blade.php
@@ -20,11 +20,11 @@
         <p>{!! __('text.enter_new_password') !!}<br /><br /></p>
 
         <div class="">
-            <x-global::forms.text-input inputType="password" autocomplete="off" name="password" id="password" placeholder="{{ __('input.placeholders.enter_new_password') }}" />
+            <x-global::forms.text-input type="password" autocomplete="off" name="password" id="password" placeholder="{{ __('input.placeholders.enter_new_password') }}" />
             <span id="pwStrength" style="width:100%;"></span>
         </div>
         <div class=" ">
-            <x-global::forms.text-input inputType="password" autocomplete="off" name="password2" id="password2" placeholder="{{ __('input.placeholders.confirm_password') }}" />
+            <x-global::forms.text-input type="password" autocomplete="off" name="password2" id="password2" placeholder="{{ __('input.placeholders.confirm_password') }}" />
         </div>
         <small>{!! __('label.passwordRequirements') !!}</small><br /><br />
         <div class="">

--- a/app/Domain/Auth/Templates/resetPw.blade.php
+++ b/app/Domain/Auth/Templates/resetPw.blade.php
@@ -20,11 +20,11 @@
         <p>{!! __('text.enter_new_password') !!}<br /><br /></p>
 
         <div class="">
-            <input type="password" autocomplete="off" name="password" id="password" placeholder="{{ __('input.placeholders.enter_new_password') }}" />
+            <x-global::forms.text-input inputType="password" autocomplete="off" name="password" id="password" placeholder="{{ __('input.placeholders.enter_new_password') }}" />
             <span id="pwStrength" style="width:100%;"></span>
         </div>
         <div class=" ">
-            <input type="password" autocomplete="off" name="password2" id="password2" placeholder="{{ __('input.placeholders.confirm_password') }}" />
+            <x-global::forms.text-input inputType="password" autocomplete="off" name="password2" id="password2" placeholder="{{ __('input.placeholders.confirm_password') }}" />
         </div>
         <small>{!! __('label.passwordRequirements') !!}</small><br /><br />
         <div class="">

--- a/app/Domain/Auth/Templates/token-created.blade.php
+++ b/app/Domain/Auth/Templates/token-created.blade.php
@@ -1,0 +1,16 @@
+<h4 class="widgettitle title-light">{{ __('headlines.token_created') }}</h4>
+<p>{{ __('text.copy_token_now') }}</p>
+<div class="form-group">
+    <input type="text" class="form-control" value="{{ $newToken }}" onclick="this.select();" />
+</div>
+
+<div class="align-right">
+    <button type="button" class="btn btn-default"
+            onclick="leantime.modals.closeModal();">
+        {{ __('buttons.close') }}
+    </button>
+    <button type="button" class="btn btn-primary"
+            onclick="leantime.snippets.copyToClipboard('{{ $newToken }}')">
+        {{ __('buttons.copy_to_clipboard') }}
+    </button>
+</div>

--- a/app/Domain/Auth/Templates/tokenNew.blade.php
+++ b/app/Domain/Auth/Templates/tokenNew.blade.php
@@ -1,0 +1,26 @@
+<div id="tokenModal">
+<h4 class="widgettitle title-light">{{ __('headlines.create_access_token') }}</h4>
+
+    <form hx-post="{{ BASE_URL }}/hx/auth/personalTokens/create"
+          hx-target="#tokenModal" id="newToken">
+
+        <div class="form-group">
+            <label for="tokenName">{{ __('label.token_name') }}</label>
+            <input type="text" class="form-control" id="tokenName"
+                   name="name" required>
+            <small class="form-text text-muted">
+                <br/>{{ __('text.token_name_description') }}
+            </small>
+        </div>
+        <br />
+        <div class="align-right">
+            <button type="button" class="btn btn-default"
+                    onclick="jQuery('#modal').modal('hide');">
+                {{ __('buttons.close') }}
+            </button>
+            <button type="submit" class="btn btn-primary">
+                {{ __('buttons.create_token') }}
+            </button>
+        </div>
+    </form>
+</div>

--- a/app/Domain/Auth/register.php
+++ b/app/Domain/Auth/register.php
@@ -1,6 +1,19 @@
 <?php
 
 use Leantime\Core\Events\EventDispatcher;
+use Leantime\Domain\Auth\Listeners\ShowPersonalTokenContent;
+use Leantime\Domain\Auth\Listeners\ShowPersonalTokenTab;
+
+// Register Personal Access Tokens tab in user account settings
+EventDispatcher::add_event_listener(
+    'leantime.domain.users.templates.editOwn.tabs',
+    ShowPersonalTokenTab::class
+);
+
+EventDispatcher::add_event_listener(
+    'leantime.domain.users.templates.editOwn.tabsContent',
+    ShowPersonalTokenContent::class
+);
 
 EventDispatcher::add_filter_listener('leantime.domain.auth.template.userInvite.welcomeText', function ($content, $params) {
     $language = app()->make(\Leantime\Core\Language::class);

--- a/app/Domain/Blueprints/Templates/boardDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/boardDialog.blade.php
@@ -9,8 +9,8 @@
     </div>
     <div class="modal-body">
         <label>{!! __('label.title_new') !!}</label><br />
-        <input type="text" name="canvastitle" value="{{ $canvasTitle }}" placeholder="{{ __('input.placeholders.enter_title_for_board') }}"
-               style="width: 100%"/>
+        <x-global::forms.text-input name="canvastitle" value="{{ $canvasTitle }}" placeholder="{{ __('input.placeholders.enter_title_for_board') }}"
+               style="width: 100%" />
     </div>
     <div class="modal-footer">
         @if(isset($_GET['id']))

--- a/app/Domain/Blueprints/Templates/canvasDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/canvasDialog.blade.php
@@ -63,7 +63,7 @@
         @if($dataLabels[1]['active'])
             <label>{!! __($dataLabels[1]['title']) !!}</label>
             @if(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}"/><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}"/><br />
             @elseif(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%"/><br />
             @else
@@ -76,7 +76,7 @@
         @if($dataLabels[2]['active'])
             <label>{!! __($dataLabels[2]['title']) !!}</label>
             @if(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}"/><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}"/><br />
             @elseif(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%"/><br />
             @else
@@ -89,7 +89,7 @@
         @if($dataLabels[3]['active'])
             <label>{!! __($dataLabels[3]['title']) !!}</label>
             @if(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
             @elseif(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
             @else

--- a/app/Domain/Blueprints/Templates/canvasDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/canvasDialog.blade.php
@@ -42,7 +42,7 @@
         <input type="hidden" value="{{ $id }}" name="itemId" id="itemId"/>
 
         <label>{!! __('label.description') !!}</label>
-        <input type="text" name="description" value="{{ $canvasItem['description'] }}" style="width:100%" /><br />
+        <x-global::forms.text-input name="description" value="{{ $canvasItem['description'] }}" style="width:100%" /><br />
 
         @if(! empty($statusLabels))
             <label>{!! __('label.status') !!}</label>
@@ -63,9 +63,9 @@
         @if($dataLabels[1]['active'])
             <label>{!! __($dataLabels[1]['title']) !!}</label>
             @if(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}"/><br />
             @elseif(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%"/><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[1]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[1]['field']] }}</textarea><br />
             @endif
@@ -76,9 +76,9 @@
         @if($dataLabels[2]['active'])
             <label>{!! __($dataLabels[2]['title']) !!}</label>
             @if(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}"/><br />
             @elseif(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%"/><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[2]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[2]['field']] }}</textarea><br />
             @endif
@@ -89,9 +89,9 @@
         @if($dataLabels[3]['active'])
             <label>{!! __($dataLabels[3]['title']) !!}</label>
             @if(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
             @elseif(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[3]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[3]['field']] }}</textarea><br />
             @endif
@@ -131,7 +131,7 @@
                     </div>
                     <div class="row" id="newMilestone" style="display:none;">
                         <div class="col-md-12">
-                            <input type="text" width="50%" name="newMilestone"><br />
+                            <x-global::forms.text-input width="50%" name="newMilestone" /><br />
                             <input type="hidden" name="type" value="milestone" />
                             <input type="hidden" name="blueprintscanvasitemid" value="{{ $id }} " />
                             <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryCanvasSubmitButton').click()" contentRole="primary" />

--- a/app/Domain/Calendar/Support/CalendarEventFormatter.php
+++ b/app/Domain/Calendar/Support/CalendarEventFormatter.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Leantime\Domain\Calendar\Support;
+
+use Illuminate\Support\Str;
+use Leantime\Core\Support\AbstractEntityFormatter;
+
+/**
+ * Calendar event formatter for AI consumption.
+ *
+ * Formats calendar events into structured markdown suitable for AI prompts,
+ * embeddings, and other LLM operations. Handles all event types: calendar,
+ * ticket, and external events.
+ */
+class CalendarEventFormatter extends AbstractEntityFormatter
+{
+    /**
+     * Fields to exclude from calendar event formatting.
+     */
+    protected array $excludedFields = [
+        'backgroundColor',
+        'borderColor',
+        'url',
+        'className',
+    ];
+
+    /**
+     * Priority order for displaying calendar event fields.
+     */
+    protected array $fieldPriority = [
+        'id',
+        'title',
+        'description',
+        'eventType',
+        'dateContext',
+        'dateFrom',
+        'dateTo',
+        'allDay',
+        'projectId',
+    ];
+
+    public function __construct(
+        protected array $event
+    ) {}
+
+    /**
+     * Get the entity type.
+     */
+    public function getEntityType(): string
+    {
+        return 'calendar_event';
+    }
+
+    /**
+     * Get the entity ID.
+     */
+    public function getEntityId(): mixed
+    {
+        return $this->event['id'] ?? null;
+    }
+
+    /**
+     * Prepare calendar event data for formatting.
+     */
+    protected function prepareEntityData(array $context = []): array
+    {
+        $data = [
+            'id' => $this->event['id'] ?? null,
+            'title' => $this->sanitizeValue($this->event['title'] ?? ''),
+            'description' => $this->sanitizeValue($this->event['description'] ?? ''),
+            'eventType' => $this->sanitizeValue($this->event['eventType'] ?? ''),
+            'dateContext' => $this->sanitizeValue($this->event['dateContext'] ?? ''),
+            'startDate' => $this->formatDate($this->event['dateFrom'] ?? ''),
+            'endDate' => $this->formatDate($this->event['dateTo'] ?? ''),
+            'allDay' => $this->formatAllDay($this->event['allDay'] ?? false),
+            'duration' => $this->calculateDuration(),
+            'projectId' => $this->event['projectId'] ?? null,
+            'projectName' => $this->sanitizeValue($this->event['projectName'] ?? ''),
+            'eventTypeFormatted' => $this->formatEventType(),
+            'dateContextFormatted' => $this->formatDateContext(),
+        ];
+
+        // Add ticket-specific information if this is a ticket event
+        if (($this->event['eventType'] ?? '') === 'ticket') {
+            $data['ticketDetails'] = $this->formatTicketDetails();
+        }
+
+        // Add external calendar information if this is an external event
+        if (($this->event['eventType'] ?? '') === 'external') {
+            $data['externalCalendarInfo'] = $this->formatExternalCalendarInfo();
+        }
+
+        return $data;
+    }
+
+    /**
+     * Format the header section.
+     */
+    protected function formatHeader(array $data): string
+    {
+        $eventTypeEmoji = match ($data['eventType']) {
+            'calendar' => '📅',
+            'ticket' => '🎫',
+            'external' => '🔗',
+            default => '📝'
+        };
+
+        $allDayIndicator = $data['allDay'] === 'Yes' ? ' (All Day)' : '';
+        $projectInfo = ! empty($data['projectName']) ? " - {$data['projectName']}" : '';
+
+        return "## {$eventTypeEmoji} {$data['title']}{$allDayIndicator}{$projectInfo}";
+    }
+
+    /**
+     * Format the body with custom calendar event formatting.
+     */
+    protected function formatBody(array $data, array $context = []): string
+    {
+        $filteredData = $this->filterFields($data, $context);
+
+        // Remove the duplicated header fields from body
+        unset($filteredData['id'], $filteredData['title'], $filteredData['projectName']);
+
+        $sortedData = $this->sortFields($filteredData);
+
+        return "\n".Str::toMarkdown($sortedData);
+    }
+
+    /**
+     * Format a compact summary.
+     */
+    protected function formatSummary(array $data): string
+    {
+        $eventTypeEmoji = match ($data['eventType']) {
+            'calendar' => '📅',
+            'ticket' => '🎫',
+            'external' => '🔗',
+            default => '📝'
+        };
+
+        $timeInfo = $this->formatTimeRange($data['startDate'], $data['endDate'], $data['allDay'] === 'Yes');
+
+        return "{$eventTypeEmoji} {$data['title']} ({$timeInfo})";
+    }
+
+    /**
+     * Format the all-day flag.
+     *
+     * @param  mixed  $allDay
+     */
+    protected function formatAllDay($allDay): string
+    {
+        if (is_bool($allDay)) {
+            return $allDay ? 'Yes' : 'No';
+        }
+
+        if (is_string($allDay)) {
+            return strtolower($allDay) === 'true' ? 'Yes' : 'No';
+        }
+
+        return 'No';
+    }
+
+    /**
+     * Calculate and format event duration.
+     */
+    protected function calculateDuration(): string
+    {
+        $dateFrom = $this->event['dateFrom'] ?? '';
+        $dateTo = $this->event['dateTo'] ?? '';
+
+        if (empty($dateFrom) || empty($dateTo)) {
+            return 'Unknown';
+        }
+
+        try {
+            $start = \DateTime::createFromFormat('Y-m-d H:i:s', $dateFrom);
+            $end = \DateTime::createFromFormat('Y-m-d H:i:s', $dateTo);
+
+            if (! $start || ! $end) {
+                return 'Unknown';
+            }
+
+            $diff = $start->diff($end);
+
+            if ($diff->days > 0) {
+                return $diff->days.' day(s)';
+            } elseif ($diff->h > 0) {
+                $minutes = $diff->i > 0 ? " {$diff->i}min" : '';
+
+                return $diff->h.'h'.$minutes;
+            } elseif ($diff->i > 0) {
+                return $diff->i.' minutes';
+            } else {
+                return 'Less than 1 minute';
+            }
+        } catch (\Exception $e) {
+            return 'Unknown';
+        }
+    }
+
+    /**
+     * Format the event type with description.
+     */
+    protected function formatEventType(): string
+    {
+        return match ($this->event['eventType'] ?? '') {
+            'calendar' => '📅 Calendar Event',
+            'ticket' => '🎫 Task/Ticket Event',
+            'external' => '🔗 External Calendar Import',
+            default => '📝 Other Event'
+        };
+    }
+
+    /**
+     * Format the date context with description.
+     */
+    protected function formatDateContext(): string
+    {
+        return match ($this->event['dateContext'] ?? '') {
+            'plan' => '📋 Planned Event',
+            'due' => '⏰ Due Date',
+            'edit' => '⚙️ Scheduled Work Time',
+            default => '📅 General Event'
+        };
+    }
+
+    /**
+     * Format ticket-specific details.
+     */
+    protected function formatTicketDetails(): array
+    {
+        $details = [];
+
+        if (isset($this->event['ticketId'])) {
+            $details['ticketId'] = $this->event['ticketId'];
+        }
+
+        if (isset($this->event['status'])) {
+            $details['status'] = $this->sanitizeValue($this->event['status']);
+        }
+
+        if (isset($this->event['priority'])) {
+            $details['priority'] = $this->formatPriority($this->event['priority']);
+        }
+
+        if (isset($this->event['assignedTo'])) {
+            $details['assignedTo'] = $this->sanitizeValue($this->event['assignedTo']);
+        }
+
+        return $details;
+    }
+
+    /**
+     * Format external calendar information.
+     */
+    protected function formatExternalCalendarInfo(): array
+    {
+        $details = [];
+
+        if (isset($this->event['calendarId'])) {
+            $details['calendarId'] = $this->sanitizeValue($this->event['calendarId']);
+        }
+
+        if (isset($this->event['externalId'])) {
+            $details['externalId'] = $this->sanitizeValue($this->event['externalId']);
+        }
+
+        if (isset($this->event['lastSync'])) {
+            $details['lastSync'] = $this->formatDate($this->event['lastSync']);
+        }
+
+        return $details;
+    }
+
+    /**
+     * Format time range for summaries.
+     */
+    protected function formatTimeRange(string $startDate, string $endDate, bool $allDay): string
+    {
+        if ($allDay) {
+            try {
+                $start = \DateTime::createFromFormat(\DateTime::ATOM, $startDate);
+                if ($start) {
+                    return $start->format('M j, Y');
+                }
+            } catch (\Exception $e) {
+                // Fall through to default
+            }
+
+            return 'All Day';
+        }
+
+        try {
+            $start = \DateTime::createFromFormat(\DateTime::ATOM, $startDate);
+            $end = \DateTime::createFromFormat(\DateTime::ATOM, $endDate);
+
+            if ($start && $end) {
+                if ($start->format('Y-m-d') === $end->format('Y-m-d')) {
+                    // Same day
+                    return $start->format('M j, Y g:i A').' - '.$end->format('g:i A');
+                } else {
+                    // Multi-day
+                    return $start->format('M j, Y g:i A').' - '.$end->format('M j, Y g:i A');
+                }
+            }
+        } catch (\Exception $e) {
+            // Fall through to default
+        }
+
+        return 'Time not available';
+    }
+}

--- a/app/Domain/Calendar/Support/CalendarEventFormatter.php
+++ b/app/Domain/Calendar/Support/CalendarEventFormatter.php
@@ -33,8 +33,8 @@ class CalendarEventFormatter extends AbstractEntityFormatter
         'description',
         'eventType',
         'dateContext',
-        'dateFrom',
-        'dateTo',
+        'startDate',
+        'endDate',
         'allDay',
         'projectId',
     ];

--- a/app/Domain/Calendar/Templates/addEvent.blade.php
+++ b/app/Domain/Calendar/Templates/addEvent.blade.php
@@ -16,7 +16,7 @@
     @dispatchEvent('afterFormOpen')
 
     <label for="description">{!! __('label.title') !!}</label>
-    <input type="text" id="description" name="description" value="{{ $tpl->escape($values['description']) }}" /><br />
+    <x-global::forms.text-input id="description" name="description" value="{{ $tpl->escape($values['description']) }}" /><br />
 
     <div class="par">
         <label for="dateFrom">{!! __('label.start_date') !!}</label>

--- a/app/Domain/Calendar/Templates/connectCalendar.blade.php
+++ b/app/Domain/Calendar/Templates/connectCalendar.blade.php
@@ -16,10 +16,10 @@
         <form action="{{ BASE_URL }}/calendar/connectCalendar" method="post" class="formModal">
             @csrf
             <label for="ical_name">{{ __('label.calendar_name') }}:</label>
-            <input type="text" id="ical_name" name="name" autocomplete="off" placeholder="{{ __('label.calendar_name') }}" /><br />
+            <x-global::forms.text-input id="ical_name" name="name" autocomplete="off" placeholder="{{ __('label.calendar_name') }}" /><br />
 
             <label for="ical_url">{{ __('label.ical_url') }}:</label>
-            <input type="text" id="ical_url" name="url" autocomplete="off" style="width:100%;" placeholder="https://example.com/calendar.ics" /><br />
+            <x-global::forms.text-input id="ical_url" name="url" autocomplete="off" style="width:100%;" placeholder="https://example.com/calendar.ics" /><br />
 
             <label for="ical_color">{{ __('label.color') }}:</label>
             <input type="text" id="ical_color" name="colorClass" autocomplete="off" value="#082236" class="simpleColorPicker"/>

--- a/app/Domain/Calendar/Templates/editEvent.blade.php
+++ b/app/Domain/Calendar/Templates/editEvent.blade.php
@@ -15,7 +15,7 @@
     @dispatchEvent('afterFormOpen')
 
     <label for="description">{!! __('label.title') !!}</label>
-    <input type="text" id="description" name="description" value="{{ $tpl->escape($values['description']) }}" /><br />
+    <x-global::forms.text-input id="description" name="description" value="{{ $tpl->escape($values['description']) }}" /><br />
 
     <label for="dateFrom">{!! __('label.start_date') !!}</label>
     <input type="text" id="event_date_from" autocomplete="off" name="dateFrom" value="{{ format($values['dateFrom'])->date() }}" />

--- a/app/Domain/Calendar/Templates/editExternalCalendar.blade.php
+++ b/app/Domain/Calendar/Templates/editExternalCalendar.blade.php
@@ -8,10 +8,10 @@
 
     <input type="hidden" name="save" value="1" />
     <label for="name">{{ $tpl->__('label.calendar_name') }}:</label>
-    <input type="text" id="name" name="name" autocomplete="off" value="{{ $values['name'] }}" /><br />
+    <x-global::forms.text-input id="name" name="name" autocomplete="off" value="{{ $values['name'] }}" /><br />
 
     <label for="url">{{ $tpl->__('label.ical_url') }}:</label>
-    <input type="text" id="url" name="url" autocomplete="off" style="width:300px;" value="{{ $values['url'] }}" /><br />
+    <x-global::forms.text-input id="url" name="url" autocomplete="off" style="width:300px;" value="{{ $values['url'] }}" /><br />
 
     <label for="color">{{ $tpl->__('label.color') }}:</label>
     <input type="text" name="colorClass" autocomplete="off" value="{{ $values['colorClass'] }}"  class="simpleColorPicker"/>

--- a/app/Domain/Calendar/Templates/export.blade.php
+++ b/app/Domain/Calendar/Templates/export.blade.php
@@ -19,7 +19,7 @@
 
     @if ($url)
         {!! __('text.you_ical_url') !!}
-        <br /><input type='text' value='{{ $url }}' style='width:100%;'/>
+        <br /><x-global::forms.text-input value='{{ $url }}' style='width:100%;' />
     @else
         {!! __('text.no_url') !!}
     @endif

--- a/app/Domain/Calendar/Templates/importGCal.blade.php
+++ b/app/Domain/Calendar/Templates/importGCal.blade.php
@@ -7,10 +7,10 @@
 <form action="{{ BASE_URL }}/calendar/importGCal" method="post" class="formModal">
 
     <label for="name">{{ $tpl->__('label.calendar_name') }}:</label>
-    <input type="text" id="name" name="name" autocomplete="off" value="{{ $values['name'] }}" /><br />
+    <x-global::forms.text-input id="name" name="name" autocomplete="off" value="{{ $values['name'] }}" /><br />
 
     <label for="url">{{ $tpl->__('label.ical_url') }}:</label>
-    <input type="text" id="url" name="url" autocomplete="off" style="width:300px;" value="{{ $values['url'] }}" /><br />
+    <x-global::forms.text-input id="url" name="url" autocomplete="off" style="width:300px;" value="{{ $values['url'] }}" /><br />
 
     <label for="color">{{ $tpl->__('label.color') }}:</label>
     <input type="text" name="colorClass" autocomplete="off" value="{{ $values['colorClass'] }}"  class="simpleColorPicker"/>

--- a/app/Domain/Calendar/Templates/showAllGCals.blade.php
+++ b/app/Domain/Calendar/Templates/showAllGCals.blade.php
@@ -6,7 +6,7 @@
 <div class="pageheader">
     @dispatchEvent('afterPageHeaderOpen')
     <form action="{{ BASE_URL }}/index.php?act=tickets.showAll" method="post" class="searchbar">
-        <input type="text" name="term" placeholder="To search type and hit enter..." />
+        <x-global::forms.text-input name="term" placeholder="To search type and hit enter..." />
     </form>
 
     <div class="pageicon"><span class="fa {{ $tpl->getModulePicture() }}"></span></div>

--- a/app/Domain/Canvas/Templates/boardDialog.blade.php
+++ b/app/Domain/Canvas/Templates/boardDialog.blade.php
@@ -9,8 +9,8 @@
     </div>
     <div class="modal-body">
         <label>{!! __('label.title_new') !!}</label><br />
-        <input type="text" name="canvastitle" value="{{ $canvasTitle }}" placeholder="{{ __('input.placeholders.enter_title_for_board') }}"
-               style="width: 100%"/>
+        <x-global::forms.text-input name="canvastitle" value="{{ $canvasTitle }}" placeholder="{{ __('input.placeholders.enter_title_for_board') }}"
+               style="width: 100%" />
     </div>
     <div class="modal-footer">
         @if(isset($_GET['id']))

--- a/app/Domain/Canvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Canvas/Templates/canvasDialog.blade.php
@@ -40,7 +40,7 @@
         <input type="hidden" value="{{ $id }}" name="itemId" id="itemId"/>
 
         <label>{!! __('label.description') !!}</label>
-        <input type="text" name="description" value="{{ $canvasItem['description'] }}" style="width:100%" /><br />
+        <x-global::forms.text-input name="description" value="{{ $canvasItem['description'] }}" style="width:100%" /><br />
 
         @if(! empty($statusLabels))
             <label>{!! __('label.status') !!}</label>
@@ -61,9 +61,9 @@
         @if($dataLabels[1]['active'])
             <label>{!! __($dataLabels[1]['title']) !!}</label>
             @if(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" /><br />
             @elseif(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%" /><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[1]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[1]['field']] }}</textarea><br />
             @endif
@@ -74,9 +74,9 @@
         @if($dataLabels[2]['active'])
             <label>{!! __($dataLabels[2]['title']) !!}</label>
             @if(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" /><br />
             @elseif(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%" /><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[2]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[2]['field']] }}</textarea><br />
             @endif
@@ -87,9 +87,9 @@
         @if($dataLabels[3]['active'])
             <label>{!! __($dataLabels[3]['title']) !!}</label>
             @if(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'int')
-                <input type="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
+                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}" /><br />
             @elseif(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'string')
-                <input type="text" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}"/><br />
+                <x-global::forms.text-input name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}" /><br />
             @else
                 <textarea style="width:100%" rows="3" cols="10" name="{{ $dataLabels[3]['field'] }}" class="modalTextArea tiptapSimple">{{ $canvasItem[$dataLabels[3]['field']] }}</textarea><br />
             @endif
@@ -129,7 +129,7 @@
                     </div>
                     <div class="row" id="newMilestone" style="display:none;">
                         <div class="col-md-12">
-                            <input type="text" width="50%" name="newMilestone"><br />
+                            <x-global::forms.text-input width="50%" name="newMilestone" /><br />
                             <input type="hidden" name="type" value="milestone" />
                             <input type="hidden" name="{{ $canvasName }}canvasitemid" value="{{ $id }} " />
                             <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryCanvasSubmitButton').click()" contentRole="primary" />

--- a/app/Domain/Canvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Canvas/Templates/canvasDialog.blade.php
@@ -61,7 +61,7 @@
         @if($dataLabels[1]['active'])
             <label>{!! __($dataLabels[1]['title']) !!}</label>
             @if(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" /><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" /><br />
             @elseif(isset($dataLabels[1]['type']) && $dataLabels[1]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[1]['field'] }}" value="{{ $canvasItem[$dataLabels[1]['field']] }}" style="width:100%" /><br />
             @else
@@ -74,7 +74,7 @@
         @if($dataLabels[2]['active'])
             <label>{!! __($dataLabels[2]['title']) !!}</label>
             @if(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" /><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" /><br />
             @elseif(isset($dataLabels[2]['type']) && $dataLabels[2]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[2]['field'] }}" value="{{ $canvasItem[$dataLabels[2]['field']] }}" style="width:100%" /><br />
             @else
@@ -87,7 +87,7 @@
         @if($dataLabels[3]['active'])
             <label>{!! __($dataLabels[3]['title']) !!}</label>
             @if(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'int')
-                <x-global::forms.text-input inputType="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}" /><br />
+                <x-global::forms.text-input type="number" name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}" /><br />
             @elseif(isset($dataLabels[3]['type']) && $dataLabels[3]['type'] == 'string')
                 <x-global::forms.text-input name="{{ $dataLabels[3]['field'] }}" value="{{ $canvasItem[$dataLabels[3]['field']] }}" /><br />
             @else

--- a/app/Domain/Clients/Templates/editClient.blade.php
+++ b/app/Domain/Clients/Templates/editClient.blade.php
@@ -25,35 +25,35 @@
             <div class="widgetcontent">
 
                 <label for="name">{!! __('NAME') !!}</label>
-                <input type="text" name="name" id="name" value="{{ $values['name'] }}" /><br />
+                <x-global::forms.text-input name="name" id="name" value="{{ $values['name'] }}" /><br />
 
                 <label for="email">{!! __('EMAIL') !!}</label>
-                <input type="text" name="email" id="email" value="{{ $values['email'] }}" /><br />
+                <x-global::forms.text-input name="email" id="email" value="{{ $values['email'] }}" /><br />
 
-                <label for="internet">{!! __('URL') !!}</label> <input
-                    type="text" name="internet" id="internet"
+                <label for="internet">{!! __('URL') !!}</label> <x-global::forms.text-input
+                    name="internet" id="internet"
                     value="{{ $values['internet'] }}" /><br />
 
-                <label for="street">{!! __('STREET') !!}</label> <input
-                    type="text" name="street" id="street"
+                <label for="street">{!! __('STREET') !!}</label> <x-global::forms.text-input
+                    name="street" id="street"
                     value="{{ $values['street'] }}" /><br />
 
-                <label for="zip">{!! __('ZIP') !!}</label> <input type="text"
+                <label for="zip">{!! __('ZIP') !!}</label> <x-global::forms.text-input
                     name="zip" id="zip" value="{{ $values['zip'] }}" /><br />
 
-                <label for="city">{!! __('CITY') !!}</label> <input type="text"
+                <label for="city">{!! __('CITY') !!}</label> <x-global::forms.text-input
                     name="city" id="city" value="{{ $values['city'] }}" /><br />
 
-                <label for="state">{!! __('STATE') !!}</label> <input
-                    type="text" name="state" id="state"
+                <label for="state">{!! __('STATE') !!}</label> <x-global::forms.text-input
+                    name="state" id="state"
                     value="{{ $values['state'] }}" /><br />
 
-                <label for="country">{!! __('COUNTRY') !!}</label> <input
-                    type="text" name="country" id="country"
+                <label for="country">{!! __('COUNTRY') !!}</label> <x-global::forms.text-input
+                    name="country" id="country"
                     value="{{ $values['country'] }}" /><br />
 
-                <label for="phone">{!! __('PHONE') !!}</label> <input
-                    type="text" name="phone" id="phone"
+                <label for="phone">{!! __('PHONE') !!}</label> <x-global::forms.text-input
+                    name="phone" id="phone"
                     value="{{ $values['phone'] }}" /><br />
 
                 <input type="submit" name="save" id="save"

--- a/app/Domain/Clients/Templates/newClient.blade.php
+++ b/app/Domain/Clients/Templates/newClient.blade.php
@@ -31,22 +31,22 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.name') !!}</label>
                                 <div class="span6">
-                                    <input type="text" name="name" id="name" value="{{ $values['name'] }}" />
+                                    <x-global::forms.text-input name="name" id="name" value="{{ $values['name'] }}" />
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.email') !!}</label>
                                 <div class="span6">
-                                    <input type="text" name="email" id="email" value="{{ $values['email'] }}" />
+                                    <x-global::forms.text-input name="email" id="email" value="{{ $values['email'] }}" />
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.url') !!}</label>
                                 <div class="span6">
-                                    <input
-                                            type="text" name="internet" id="internet"
+                                    <x-global::forms.text-input
+                                            name="internet" id="internet"
                                             value="{{ $values['internet'] }}" />
                                 </div>
                             </div>
@@ -54,8 +54,8 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.street') !!}</label>
                                 <div class="span6">
-                                    <input
-                                            type="text" name="street" id="street"
+                                    <x-global::forms.text-input
+                                            name="street" id="street"
                                             value="{{ $values['street'] }}" />
                                 </div>
                             </div>
@@ -63,7 +63,7 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.zip') !!}</label>
                                 <div class="span6">
-                                    <input type="text"
+                                    <x-global::forms.text-input
                                            name="zip" id="zip" value="{{ $values['zip'] }}" />
                                 </div>
                             </div>
@@ -71,7 +71,7 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.city') !!}</label>
                                 <div class="span6">
-                                    <input type="text"
+                                    <x-global::forms.text-input
                                            name="city" id="city" value="{{ $values['city'] }}" />
                                 </div>
                             </div>
@@ -79,8 +79,8 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.state') !!}</label>
                                 <div class="span6">
-                                    <input
-                                            type="text" name="state" id="state"
+                                    <x-global::forms.text-input
+                                            name="state" id="state"
                                             value="{{ $values['state'] }}" />
                                 </div>
                             </div>
@@ -88,8 +88,8 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.country') !!}</label>
                                 <div class="span6">
-                                    <input
-                                            type="text" name="country" id="country"
+                                    <x-global::forms.text-input
+                                            name="country" id="country"
                                             value="{{ $values['country'] }}" />
                                 </div>
                             </div>
@@ -97,8 +97,8 @@
                             <div class="form-group">
                                 <label class="span4 control-label">{!! __('label.phone') !!}</label>
                                 <div class="span6">
-                                    <input
-                                            type="text" name="phone" id="phone"
+                                    <x-global::forms.text-input
+                                            name="phone" id="phone"
                                             value="{{ $values['phone'] }}" />
                                 </div>
                             </div>

--- a/app/Domain/Clients/Templates/showClient.blade.php
+++ b/app/Domain/Clients/Templates/showClient.blade.php
@@ -39,29 +39,29 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.client_id') !!}</label>
                                 <div class="">
-                                    <input type="text" name="id" id="id" value="{{ $values['id'] }}" readonly />
+                                    <x-global::forms.text-input name="id" id="id" value="{{ $values['id'] }}" readonly />
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.name') !!}</label>
                                 <div class="">
-                                    <input type="text" name="name" id="name" value="{{ $values['name'] }}" />
+                                    <x-global::forms.text-input name="name" id="name" value="{{ $values['name'] }}" />
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.email') !!}</label>
                                 <div class="">
-                                    <input type="text" name="email" id="email" value="{{ $values['email'] }}" />
+                                    <x-global::forms.text-input name="email" id="email" value="{{ $values['email'] }}" />
                                 </div>
                             </div>
 
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.url') !!}</label>
                                 <div class="">
-                                    <input
-                                            type="text" name="internet" id="internet"
+                                    <x-global::forms.text-input
+                                             name="internet" id="internet"
                                             value="{{ $values['internet'] }}" />
                                 </div>
                             </div>
@@ -69,8 +69,8 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.street') !!}</label>
                                 <div class="">
-                                    <input
-                                            type="text" name="street" id="street"
+                                    <x-global::forms.text-input
+                                             name="street" id="street"
                                             value="{{ $values['street'] }}" />
                                 </div>
                             </div>
@@ -78,7 +78,7 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.zip') !!}</label>
                                 <div class="">
-                                    <input type="text"
+                                    <x-global::forms.text-input
                                     name="zip" id="zip" value="{{ $values['zip'] }}" />
                                 </div>
                             </div>
@@ -86,7 +86,7 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.city') !!}</label>
                                 <div class="">
-                                    <input type="text"
+                                    <x-global::forms.text-input
                                            name="city" id="city" value="{{ $values['city'] }}" />
                                 </div>
                             </div>
@@ -94,8 +94,8 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.state') !!}</label>
                                 <div class="">
-                                    <input
-                                            type="text" name="state" id="state"
+                                    <x-global::forms.text-input
+                                             name="state" id="state"
                                             value="{{ $values['state'] }}" />
                                 </div>
                             </div>
@@ -103,8 +103,8 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.country') !!}</label>
                                 <div class="">
-                                    <input
-                                            type="text" name="country" id="country"
+                                    <x-global::forms.text-input
+                                             name="country" id="country"
                                             value="{{ $values['country'] }}" />
                                 </div>
                             </div>
@@ -112,8 +112,8 @@
                             <div class="form-group">
                                 <label class=" control-label">{!! __('label.phone') !!}</label>
                                 <div class="">
-                                    <input
-                                            type="text" name="phone" id="phone"
+                                    <x-global::forms.text-input
+                                             name="phone" id="phone"
                                             value="{{ $values['phone'] }}" />
                                 </div>
                             </div>

--- a/app/Domain/Dashboard/Templates/show.blade.php
+++ b/app/Domain/Dashboard/Templates/show.blade.php
@@ -59,7 +59,7 @@
                         href="{{ BASE_URL }}/projects/changeCurrentProject/{{ $project['id'] }}"
                     ><i class="fa fa-link"></i></a>
                     <div class="dropdown-menu padding-md">
-                        <input type="text" id="projectUrl" value="{{ BASE_URL }}/projects/changeCurrentProject/{{ $project['id'] }}" />
+                        <x-global::forms.text-input id="projectUrl" value="{{ BASE_URL }}/projects/changeCurrentProject/{{ $project['id'] }}" />
                         <x-global::forms.button contentRole="primary" onclick="leantime.snippets.copyUrl('projectUrl')">{{ __('links.copy_url') }}</x-global::forms.button>
                     </div>
                 </div>

--- a/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
@@ -8,7 +8,7 @@
 
     <br />
     <label>{{ __('label.goal_description') }}</label>
-    <input type="text" name="title" id="wikiTitle" value="{{ $bigRock['title'] }}" style="width:100%;" /><br />
+    <x-global::forms.text-input name="title" id="wikiTitle" value="{{ $bigRock['title'] }}" style="width:100%;" /><br />
 
     <br />
     <div class="row">

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -28,7 +28,7 @@
             <div class="row">
                 <div class="col-md-8">
                     <label>{{ __('label.what_is_your_goal') }}</label>
-                    <input type="text" name="title" value="{{ $canvasItem['title'] }}" style="width:100%"><br>
+                    <x-global::forms.text-input name="title" value="{{ $canvasItem['title'] }}" style="width:100%" /><br>
 
                     @if (!empty($relatesLabels))
                         <label>{{ __('label.relates') }}</label>
@@ -45,27 +45,27 @@
                     @dispatchEvent('beforeMeasureGoalContainer', $canvasItem)
                     <div id="measureGoalContainer">
                         <label>{{ __('text.what_metric_will_you_be_using') }}</label>
-                        <input type="text" name="description" value="{{ $canvasItem['description'] }}"
-                            style="width:100%"><br>
+                        <x-global::forms.text-input name="description" value="{{ $canvasItem['description'] }}"
+                            style="width:100%" /><br>
                     </div>
 
                     <div class="row">
                         <div class="col-md-3">
                             <label>{{ __('label.starting_value') }}</label>
-                            <input type="number" step="0.01" name="startValue" value="{{ $canvasItem['startValue'] }}"
-                                style="width:105px">
+                            <x-global::forms.text-input inputType="number" step="0.01" name="startValue" value="{{ $canvasItem['startValue'] }}"
+                                style="width:105px" />
                         </div>
                         <div class="col-md-3">
                             <label>{{ __('label.current_value') }}</label>
-                            <input type="number" step="0.01" name="currentValue" id="currentValueField"
+                            <x-global::forms.text-input inputType="number" step="0.01" name="currentValue" id="currentValueField"
                                 value="{{ $canvasItem['currentValue'] }}"
                                 @if ($canvasItem['setting'] == 'linkAndReport') readonly data-tippy-content="Current value calculated from child goals" @endif
-                                style="width:105px">
+                                style="width:105px" />
                         </div>
                         <div class="col-md-3">
                             <label>{{ __('label.goal_value') }}</label>
-                            <input type="number" step="0.01" name="endValue" value="{{ $canvasItem['endValue'] }}"
-                                style="width:105px">
+                            <x-global::forms.text-input inputType="number" step="0.01" name="endValue" value="{{ $canvasItem['endValue'] }}"
+                                style="width:105px" />
                         </div>
                         <div class="col-md-3">
                             <label>{{ __('label.type') }}</label>
@@ -132,7 +132,7 @@
                                 </div>
                                 <div class="row" id="newMilestone" style="display:none;">
                                     <div class="col-md-12">
-                                        <input type="text" width="50%" name="newMilestone"></textarea><br />
+                                        <x-global::forms.text-input width="50%" name="newMilestone" /></textarea><br />
                                         <input type="hidden" name="type" value="milestone" />
                                         <input type="hidden" name="goalcanvasitemid" value="{{ $id }}" />
                                         <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryCanvasSubmitButton').click()" contentRole="primary" />

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -52,19 +52,19 @@
                     <div class="row">
                         <div class="col-md-3">
                             <label>{{ __('label.starting_value') }}</label>
-                            <x-global::forms.text-input inputType="number" step="0.01" name="startValue" value="{{ $canvasItem['startValue'] }}"
+                            <x-global::forms.text-input type="number" step="0.01" name="startValue" value="{{ $canvasItem['startValue'] }}"
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">
                             <label>{{ __('label.current_value') }}</label>
-                            <x-global::forms.text-input inputType="number" step="0.01" name="currentValue" id="currentValueField"
+                            <x-global::forms.text-input type="number" step="0.01" name="currentValue" id="currentValueField"
                                 value="{{ $canvasItem['currentValue'] }}"
                                 @if ($canvasItem['setting'] == 'linkAndReport') readonly data-tippy-content="Current value calculated from child goals" @endif
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">
                             <label>{{ __('label.goal_value') }}</label>
-                            <x-global::forms.text-input inputType="number" step="0.01" name="endValue" value="{{ $canvasItem['endValue'] }}"
+                            <x-global::forms.text-input type="number" step="0.01" name="endValue" value="{{ $canvasItem['endValue'] }}"
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -132,7 +132,7 @@
                                 </div>
                                 <div class="row" id="newMilestone" style="display:none;">
                                     <div class="col-md-12">
-                                        <x-global::forms.text-input width="50%" name="newMilestone" /></textarea><br />
+                                        <x-global::forms.text-input width="50%" name="newMilestone" /><br />
                                         <input type="hidden" name="type" value="milestone" />
                                         <input type="hidden" name="goalcanvasitemid" value="{{ $id }}" />
                                         <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryCanvasSubmitButton').click()" contentRole="primary" />

--- a/app/Domain/Help/Templates/firstTaskStep.blade.php
+++ b/app/Domain/Help/Templates/firstTaskStep.blade.php
@@ -7,7 +7,7 @@
                 <p>{{ __('text.lets_start_with_first_task') }}</p>
                 <br />
                 <label><strong>{{ __('label.whats_one_thing_to_do_today') }}</strong></label>
-                <input type="text" id="firstTask" name="headline" value="" placeholder="{{ __('input.placeholder.finish_slide_deck') }}" style="width:100%;" required />
+                <x-global::forms.text-input id="firstTask" name="headline" value="" placeholder="{{ __('input.placeholder.finish_slide_deck') }}" style="width:100%;" required />
                 <br />
                 <p class="text-muted">{{ __('text.first_task_help') }}</p>
                 <br />

--- a/app/Domain/Help/Templates/inviteTeamStep.blade.php
+++ b/app/Domain/Help/Templates/inviteTeamStep.blade.php
@@ -5,9 +5,9 @@
             <h1>{{ __('headlines.invite_crew') }}</h1>
             <p>{{ __('text.invite_team') }}</p>
             <br />
-            <input type="email" name="email1" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;"/><br />
-            <input type="email" name="email2" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;"/><br />
-            <input type="email" name="email3" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;"/><br />
+            <x-global::forms.text-input inputType="email" name="email1" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
+            <x-global::forms.text-input inputType="email" name="email2" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
+            <x-global::forms.text-input inputType="email" name="email3" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
             <br />
                   </div>
         <div class="col-md-6">

--- a/app/Domain/Help/Templates/inviteTeamStep.blade.php
+++ b/app/Domain/Help/Templates/inviteTeamStep.blade.php
@@ -5,9 +5,9 @@
             <h1>{{ __('headlines.invite_crew') }}</h1>
             <p>{{ __('text.invite_team') }}</p>
             <br />
-            <x-global::forms.text-input inputType="email" name="email1" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
-            <x-global::forms.text-input inputType="email" name="email2" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
-            <x-global::forms.text-input inputType="email" name="email3" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
+            <x-global::forms.text-input type="email" name="email1" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
+            <x-global::forms.text-input type="email" name="email2" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
+            <x-global::forms.text-input type="email" name="email3" value="" placeholder="{{ __('input.placeholder.email_invite') }}" style="width: 100%;" /><br />
             <br />
                   </div>
         <div class="col-md-6">

--- a/app/Domain/Help/Templates/projectIntroStep.blade.php
+++ b/app/Domain/Help/Templates/projectIntroStep.blade.php
@@ -7,7 +7,7 @@
                 <p>{!!  __('text.get_organized_with_projects') !!}</p>
                 <br />
                 <label>{{ __('label.start_with_project_title') }}</label>
-                <input type="text" id="projectName" name="projectname" value="" placeholder="" style="width:100%;"/><br />
+                <x-global::forms.text-input id="projectName" name="projectname" value="" placeholder="" style="width:100%;" /><br />
 
             </div>
             <div class="col-md-4">

--- a/app/Domain/Ideas/Templates/advancedBoards.blade.php
+++ b/app/Domain/Ideas/Templates/advancedBoards.blade.php
@@ -236,9 +236,9 @@
                         </div>
                         <div class="modal-body">
                             <label>{!! __('label.topic_idea_board') !!}</label>
-                            <input type="text" name="canvastitle"
+                            <x-global::forms.text-input name="canvastitle"
                                    placeholder="{{ __('input.placeholders.name_for_idea_board') }}"
-                                   style="width:90%"/>
+                                   style="width:90%" />
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-default"
@@ -261,8 +261,8 @@
                         </div>
                         <div class="modal-body">
                             <label>{!! __('label.title_idea_board') !!}</label>
-                            <input type="text" name="canvastitle" value="{{ $canvasTitle }}"
-                                   style="width:90%"/>
+                            <x-global::forms.text-input name="canvastitle" value="{{ $canvasTitle }}"
+                                   style="width:90%" />
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-default"

--- a/app/Domain/Ideas/Templates/ideaDialog.blade.php
+++ b/app/Domain/Ideas/Templates/ideaDialog.blade.php
@@ -29,8 +29,8 @@
         <input type="hidden" name="milestoneId" value="{{ $canvasItem['milestoneId'] }}"/>
         <input type="hidden" name="changeItem" value="1"/>
 
-        <input type="text" name="description" class="main-title-input" style="width:99%;" value="{{ $tpl->escape($canvasItem['description']) }}"
-               placeholder="{{ __('input.placeholders.short_name') }}"/><br/>
+        <x-global::forms.text-input name="description" variant="headline" style="width:99%;" value="{{ $tpl->escape($canvasItem['description']) }}"
+               placeholder="{{ __('input.placeholders.short_name') }}" /><br/>
 
         <input type="text" value="{{ $tpl->escape($canvasItem['tags']) }}" name="tags" id="tags" />
 

--- a/app/Domain/Ideas/Templates/showBoards.blade.php
+++ b/app/Domain/Ideas/Templates/showBoards.blade.php
@@ -232,8 +232,8 @@
                         </div>
                         <div class="modal-body">
                             <label>{!! __('label.topic_idea_board') !!}</label>
-                            <input type="text" name="canvastitle" placeholder="{{ __('input.placeholders.name_for_idea_board') }}"
-                                   style="width:90%"/>
+                            <x-global::forms.text-input name="canvastitle" placeholder="{{ __('input.placeholders.name_for_idea_board') }}"
+                                   style="width:90%" />
                         </div>
                         <div class="modal-footer">
                             <x-global::forms.button inputType="button" contentRole="tertiary"
@@ -255,8 +255,8 @@
                         </div>
                         <div class="modal-body">
                             <label>{!! __('label.title_idea_board') !!}</label>
-                            <input type="text" name="canvastitle" value="{{ $canvasTitle }}"
-                                   style="width:90%"/>
+                            <x-global::forms.text-input name="canvastitle" value="{{ $canvasTitle }}"
+                                   style="width:90%" />
                         </div>
                         <div class="modal-footer">
                             <x-global::forms.button inputType="button" contentRole="tertiary"

--- a/app/Domain/Install/Templates/new.blade.php
+++ b/app/Domain/Install/Templates/new.blade.php
@@ -15,12 +15,12 @@
 
     <form action="{{ BASE_URL }}/install" method="post" class="registrationForm">
         <h3 class="subtitle">{!! __('subtitles.login_info') !!}</h3>
-        <input type="email" name="email" class="form-control" placeholder="{{ __('label.email') }}" value=""/><br />
+        <x-global::forms.text-input inputType="email" name="email" variant="form" placeholder="{{ __('label.email') }}" value="" /><br />
         <br /><br />
         <h3 class="subtitle">{!! __('subtitles.user_info') !!}</h3>
-        <input type="text" name="firstname" class="form-control" placeholder="{{ __('label.firstname') }}" value=""/><br />
-        <input type="text" name="lastname" class="form-control" placeholder="{{ __('label.lastname') }}" value=""/>
-        <input type="text" name="company" class="form-control" placeholder="{{ __('label.company_name') }}" value=""/>
+        <x-global::forms.text-input name="firstname" variant="form" placeholder="{{ __('label.firstname') }}" value="" /><br />
+        <x-global::forms.text-input name="lastname" variant="form" placeholder="{{ __('label.lastname') }}" value="" />
+        <x-global::forms.text-input name="company" variant="form" placeholder="{{ __('label.company_name') }}" value="" />
         <br /><br />
         <input type="hidden" name="install" value="Install" />
         <p><x-global::forms.button tag="input" inputType="submit" name="installAction" contentRole="primary" :labelText="__('buttons.install')" onClick="this.form.submit(); this.disabled=true; this.value='{{ __('buttons.install') }}'; " /></p>

--- a/app/Domain/Install/Templates/new.blade.php
+++ b/app/Domain/Install/Templates/new.blade.php
@@ -15,12 +15,12 @@
 
     <form action="{{ BASE_URL }}/install" method="post" class="registrationForm">
         <h3 class="subtitle">{!! __('subtitles.login_info') !!}</h3>
-        <x-global::forms.text-input inputType="email" name="email" variant="form" placeholder="{{ __('label.email') }}" value="" /><br />
+        <x-global::forms.text-input type="email" name="email" placeholder="{{ __('label.email') }}" value="" /><br />
         <br /><br />
         <h3 class="subtitle">{!! __('subtitles.user_info') !!}</h3>
-        <x-global::forms.text-input name="firstname" variant="form" placeholder="{{ __('label.firstname') }}" value="" /><br />
-        <x-global::forms.text-input name="lastname" variant="form" placeholder="{{ __('label.lastname') }}" value="" />
-        <x-global::forms.text-input name="company" variant="form" placeholder="{{ __('label.company_name') }}" value="" />
+        <x-global::forms.text-input name="firstname" placeholder="{{ __('label.firstname') }}" value="" /><br />
+        <x-global::forms.text-input name="lastname" placeholder="{{ __('label.lastname') }}" value="" />
+        <x-global::forms.text-input name="company" placeholder="{{ __('label.company_name') }}" value="" />
         <br /><br />
         <input type="hidden" name="install" value="Install" />
         <p><x-global::forms.button tag="input" inputType="submit" name="installAction" contentRole="primary" :labelText="__('buttons.install')" onClick="this.form.submit(); this.disabled=true; this.value='{{ __('buttons.install') }}'; " /></p>

--- a/app/Domain/Logicmodelcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Logicmodelcanvas/Templates/canvasDialog.blade.php
@@ -68,7 +68,7 @@
             <div class="col-md-8">
 
                 {{-- Title --}}
-                <input type="text" name="description" class="main-title-input" style="width:99%;"
+                <x-global::forms.text-input name="description" variant="headline" style="width:99%;"
                     value="{{ $tpl->escape($canvasItem['description']) }}"
                     placeholder="{{ $tpl->__('input.placeholders.short_name') }}" /><br /><br />
 

--- a/app/Domain/Plugins/Templates/plugindetails.blade.php
+++ b/app/Domain/Plugins/Templates/plugindetails.blade.php
@@ -146,7 +146,7 @@
                                         <option value="{{ $compatibility['version_number'] }}">{{ $compatibility['version_number'] }}</option>
                                     @endforeach
                                 </select>
-                                <input class="!tw-mb-none !tw-p-[4px]" type="text" name="plugin[license]" placeholder="License Key" />
+                                <x-global::forms.text-input class="!tw-mb-none !tw-p-[4px]" name="plugin[license]" placeholder="License Key" />
                                 <x-global::button
                                     :tag="'button'"
                                     :type="'secondary'"

--- a/app/Domain/Projects/Templates/duplicateProject.blade.php
+++ b/app/Domain/Projects/Templates/duplicateProject.blade.php
@@ -5,7 +5,7 @@
 <form class="formModal" method="post" action="{{ BASE_URL }}/projects/duplicateProject/{{ $project['id'] }}">
 
     <label>{!! __('label.newProjectName') !!}</label>
-    <input type="text" name="projectName" value="{!! __('label.copy_of') !!} {{ $project['name'] }}" /><br />
+    <x-global::forms.text-input name="projectName" value="{!! __('label.copy_of') !!} {{ $project['name'] }}" /><br />
 
     <label>{!! __('label.planned_start_date') !!}</label>
     <input type="text" name="startDate" class="projectDateFrom" value="{{ format(date('Y-m-d'))->date() }}" placeholder="{{ __('language.dateformat') }}" id="sprintStart" /><br />

--- a/app/Domain/Projects/Templates/newProject.blade.php
+++ b/app/Domain/Projects/Templates/newProject.blade.php
@@ -33,7 +33,7 @@
                                 <div class="col-md-12">
 
                                     <div class="form-group">
-                                        <input type="text" name="name" id="name" class="main-title-input" style="width:99%"  value="{{ $project['name'] }}" placeholder="{{ __('input.placeholders.enter_title_of_project') }}"/>
+                                        <x-global::forms.text-input variant="headline" name="name" id="name" style="width:99%" value="{{ $project['name'] }}" placeholder="{{ __('input.placeholders.enter_title_of_project') }}" />
                                     </div>
                                     <input type="hidden" name="projectState"  id="projectState" value="0" />
 

--- a/app/Domain/Projects/Templates/showProject.blade.php
+++ b/app/Domain/Projects/Templates/showProject.blade.php
@@ -92,7 +92,7 @@
                                             @php
                                             if (($roles::getRoles()[$assignedUser['role']] == $roles::$admin || $roles::getRoles()[$assignedUser['role']] == $roles::$owner)) {
                                             @endphp
-                                                <input type="text" readonly disabled value="{{ __('label.roles.'.$roles::getRoles()[$assignedUser['role']]) }}" />
+                                                <x-global::forms.text-input readonly disabled value="{{ __('label.roles.'.$roles::getRoles()[$assignedUser['role']]) }}" />
                                             @php
                                             } else {
                                             @endphp
@@ -141,7 +141,7 @@
                                                 </div>
                                                 <label for="user-{{ $row['id'] }}" >{!! sprintf(__('text.full_name'), $tpl->escape($row['firstname']), $tpl->escape($row['lastname'])) !!}</label>
                                                 @if ($roles::getRoles()[$row['role']] == $roles::$admin || $roles::getRoles()[$row['role']] == $roles::$owner)
-                                                    <input type="text" readonly disabled value="{{ __('label.roles.'.$roles::getRoles()[$row['role']]) }}" />
+                                                    <x-global::forms.text-input readonly disabled value="{{ __('label.roles.'.$roles::getRoles()[$row['role']]) }}" />
                                                 @else
                                                     @php $assignedUserMatch = collect($project['assignedUsers'])->where('id', $row['id'])->first(); @endphp
                                                     <select name="userProjectRole-{{ $row['id'] }}">
@@ -217,7 +217,7 @@
                     <div class="col-md-4">
                         <strong>{!! __('label.webhook_url') !!}</strong><br />
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
-                            <input type="text" name="mattermostWebhookURL" id="mattermostWebhookURL" value="{{ e($mattermostWebhookURL) }}"/>
+                            <x-global::forms.text-input name="mattermostWebhookURL" id="mattermostWebhookURL" value="{{ e($mattermostWebhookURL) }}" />
                             <br />
                             <input type="submit" value="{{ __('buttons.save') }}" name="mattermostSave" />
                         </form>
@@ -236,7 +236,7 @@
                     <div class="col-md-4">
                         <strong>{!! __('label.webhook_url') !!}</strong><br />
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
-                            <input type="text" name="slackWebhookURL" id="slackWebhookURL" value="{{ e($slackWebhookURL) }}"/>
+                            <x-global::forms.text-input name="slackWebhookURL" id="slackWebhookURL" value="{{ e($slackWebhookURL) }}" />
                             <br />
                             <input type="submit" value="{{ __('buttons.save') }}" name="slackSave" />
                         </form>
@@ -256,19 +256,19 @@
 
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
                             <strong>{!! __('label.base_url') !!}</strong><br />
-                            <input type="text" name="zulipURL" id="zulipURL" placeholder="{{ __('input.placeholders.zulip_url') }}" value="{{ $zulipHook['zulipURL'] }}"/>
+                            <x-global::forms.text-input name="zulipURL" id="zulipURL" placeholder="{{ __('input.placeholders.zulip_url') }}" value="{{ $zulipHook['zulipURL'] }}" />
                             <br />
                             <strong>{!! __('label.bot_email') !!}</strong><br />
-                            <input type="text" name="zulipEmail" id="zulipEmail" placeholder="" value="{{ $tpl->escape($zulipHook['zulipEmail']) }}"/>
+                            <x-global::forms.text-input name="zulipEmail" id="zulipEmail" placeholder="" value="{{ $tpl->escape($zulipHook['zulipEmail']) }}" />
                             <br />
                             <strong>{!! __('label.botkey') !!}</strong><br />
-                            <input type="text" name="zulipBotKey" id="zulipBotKey" placeholder="" value="{{ $tpl->escape($zulipHook['zulipBotKey']) }}"/>
+                            <x-global::forms.text-input name="zulipBotKey" id="zulipBotKey" placeholder="" value="{{ $tpl->escape($zulipHook['zulipBotKey']) }}" />
                             <br />
                             <strong>{!! __('label.stream') !!}</strong><br />
-                            <input type="text" name="zulipStream" id="zulipStream" placeholder="" value="{{ $tpl->escape($zulipHook['zulipStream']) }}"/>
+                            <x-global::forms.text-input name="zulipStream" id="zulipStream" placeholder="" value="{{ $tpl->escape($zulipHook['zulipStream']) }}" />
                             <br />
                             <strong>{!! __('label.topic') !!}</strong><br />
-                            <input type="text" name="zulipTopic" id="zulipTopic" placeholder="" value="{{ $tpl->escape($zulipHook['zulipTopic']) }}"/>
+                            <x-global::forms.text-input name="zulipTopic" id="zulipTopic" placeholder="" value="{{ $tpl->escape($zulipHook['zulipTopic']) }}" />
                             <br />
                             <input type="submit" value="{{ __('buttons.save') }}" name="zulipSave" />
                         </form>

--- a/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
@@ -10,7 +10,7 @@
             <div class="row">
                 <div class="col-md-12">
                     <div class="form-group">
-                        <input type="text" name="name" id="name" class="main-title-input" style="width:99%"  value="{{ $project['name'] }}" placeholder="{{ __('input.placeholders.enter_title_of_project') }}"/>
+                        <x-global::forms.text-input variant="headline" name="name" id="name" style="width:99%"  value="{{ $project['name'] }}" placeholder="{{ __('input.placeholders.enter_title_of_project') }}" />
                     </div>
                 </div>
             </div>
@@ -197,7 +197,7 @@
                     <div class="form-group">
                         <label class="col-md-4 control-label"for="hourBudget">{!! __('label.hourly_budget') !!}</label>
                         <div class="col-md-6">
-                            <input type="text" name="hourBudget" class="input-large" id="hourBudget" value="{{ $project['hourBudget'] }}" />
+                            <x-global::forms.text-input variant="large" name="hourBudget" id="hourBudget" value="{{ $project['hourBudget'] }}" />
 
                         </div>
                     </div>
@@ -205,7 +205,7 @@
                     <div class="form-group">
                         <label class="col-md-4 control-label" for="dollarBudget">{!! __('label.budget_cost') !!}</label>
                         <div class="col-md-6">
-                            <input type="text" name="dollarBudget" class="input-large" id="dollarBudget" value="{{ $project['dollarBudget'] }}" />
+                            <x-global::forms.text-input variant="large" name="dollarBudget" id="dollarBudget" value="{{ $project['dollarBudget'] }}" />
 
                         </div>
                     </div>

--- a/app/Domain/Setting/Templates/editBoxDialog.blade.php
+++ b/app/Domain/Setting/Templates/editBoxDialog.blade.php
@@ -8,7 +8,7 @@
 <form class="formModal" method="post" action="{{ BASE_URL }}/setting/editBoxLabel?{{ http_build_query(['module' => request()->query('module', ''), 'label' => request()->query('label', '')]) }}">
 
     <label>{!! __('label.label') !!}</label>
-    <input type="text" name="newLabel" value="{{ $currentLabel }}" /><br />
+    <x-global::forms.text-input name="newLabel" value="{{ $currentLabel }}" /><br />
 
     <div class="row">
         <div class="col-md-6">

--- a/app/Domain/Setting/Templates/editCompanySettings.blade.php
+++ b/app/Domain/Setting/Templates/editCompanySettings.blade.php
@@ -60,7 +60,7 @@
                                             <label>{!! __('label.company_name') !!}</label>
                                         </div>
                                         <div class="col-md-8">
-                                            <input type="text" name="name" id="companyName"  value="{{ $companySettings['name'] }}" class="pull-left"/>
+                                            <x-global::forms.text-input name="name" id="companyName"  value="{{ $companySettings['name'] }}" class="pull-left" />
                                             <small>{!! __('text.company_name_helper') !!}</small>
                                         </div>
                                     </div>

--- a/app/Domain/Sprints/Templates/sprintdialog.blade.php
+++ b/app/Domain/Sprints/Templates/sprintdialog.blade.php
@@ -18,7 +18,7 @@
 <form class="formModal" method="post" action="{{ BASE_URL }}/sprints/editSprint/{{ $id }}">
 
     <label>{!! __('label.sprint_name') !!}</label>
-    <input type="text" name="name" value="{{ $currentSprint->name }}" placeholder="{{ __('label.sprint_name') }}"/><br />
+    <x-global::forms.text-input name="name" value="{{ $currentSprint->name }}" placeholder="{{ __('label.sprint_name') }}" /><br />
 
     <label>{!! __('label.project') !!}</label>
     <select name="projectId">

--- a/app/Domain/Tickets/Support/TicketFormatter.php
+++ b/app/Domain/Tickets/Support/TicketFormatter.php
@@ -176,7 +176,7 @@ class TicketFormatter extends AbstractEntityFormatter
     {
         $subtaskData = '';
         foreach ($subtasks as $subtask) {
-            $subtaskData .= ' #'.$subtask['id'].' '.$subtask['headline']."\n";
+            $subtaskData .= ' #'.$subtask['id'].' '.$this->sanitizeValue($subtask['headline'])."\n";
         }
 
         return $subtaskData;

--- a/app/Domain/Tickets/Support/TicketFormatter.php
+++ b/app/Domain/Tickets/Support/TicketFormatter.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Support;
+
+use Illuminate\Support\Str;
+use Leantime\Core\Support\AbstractEntityFormatter;
+use Leantime\Domain\Projects\Models\Project;
+use Leantime\Domain\Tickets\Models\Tickets;
+
+/**
+ * Ticket entity formatter for AI consumption.
+ *
+ * Formats ticket/task entities into structured markdown suitable for AI prompts,
+ * embeddings, and other LLM operations.
+ */
+class TicketFormatter extends AbstractEntityFormatter
+{
+    /**
+     * Fields to exclude from ticket formatting.
+     */
+    protected array $excludedFields = [
+        'sortIndex',
+        'timelineDate',
+        'timelineDateToFinish',
+        'timeToFinish',
+        'timeFrom',
+        'timeTo',
+        'url',
+        'doneTickets',
+        'allTickets',
+        'children',
+        'editorProfileId',
+    ];
+
+    /**
+     * Priority order for displaying ticket fields.
+     */
+    protected array $fieldPriority = [
+        'id',
+        'headline',
+        'description',
+        'type',
+        'status',
+        'priority',
+        'projectName',
+        'assignedTo',
+        'dueDate',
+        'storypoints',
+        'planHours',
+    ];
+
+    public function __construct(
+        protected Tickets $ticket,
+        protected Project|array|null $project = null,
+        protected array|false|null $subtasks = null
+    ) {}
+
+    /**
+     * Get the entity type.
+     */
+    public function getEntityType(): string
+    {
+        return 'ticket';
+    }
+
+    /**
+     * Get the entity ID.
+     */
+    public function getEntityId(): mixed
+    {
+        return $this->ticket->id;
+    }
+
+    /**
+     * Prepare ticket data for formatting.
+     */
+    protected function prepareEntityData(array $context = []): array
+    {
+        $data = [
+            'id' => $this->ticket->id,
+            'headline' => $this->sanitizeValue($this->ticket->headline),
+            'type' => $this->sanitizeValue($this->ticket->type),
+            'description' => $this->sanitizeValue($this->ticket->description),
+            'status' => $this->ticket->status,
+            'priority' => $this->ticket->priority,
+            'storypoints' => $this->sanitizeValue($this->ticket->storypoints),
+            'dueDate' => $this->formatDate($this->ticket->dateToFinish),
+            'planHours' => $this->sanitizeValue($this->ticket->planHours),
+            'scheduledFrom' => $this->formatDate($this->ticket->editFrom),
+            'scheduledTo' => $this->formatDate($this->ticket->editTo),
+            'assignedTo' => $this->formatAssignedUser(),
+            'createdBy' => $this->formatCreatedUser(),
+            'projectId' => $this->ticket->projectId,
+            'projectName' => $this->sanitizeValue($this->ticket->projectName),
+            'clientName' => $this->sanitizeValue($this->ticket->clientName),
+            'milestone' => $this->formatMilestone(),
+            'acceptanceCriteria' => $this->sanitizeValue($this->ticket->acceptanceCriteria),
+            'tags' => $this->sanitizeValue($this->ticket->tags),
+            'dependingTicketId' => $this->ticket->dependingTicketId,
+            'parentHeadline' => $this->sanitizeValue($this->ticket->parentHeadline),
+            'lastUpdated' => $this->formatDate($this->ticket->date),
+            'bookedHours' => $this->sanitizeValue($this->ticket->bookedHours),
+            'hourRemaining' => $this->sanitizeValue($this->ticket->hourRemaining),
+            'percentDone' => $this->sanitizeValue($this->ticket->percentDone),
+        ];
+
+        // Add project information if available
+        if ($this->project) {
+            if (is_array($this->project)) {
+                $this->project = new Project($this->project);
+            }
+
+            $data['projectDetails'] = [
+                'name' => $this->sanitizeValue($this->project->name),
+                'type' => $this->sanitizeValue($this->project->type),
+                'state' => $this->sanitizeValue($this->project->state),
+                'progress' => $this->sanitizeValue($this->project->progress),
+                'status' => $this->sanitizeValue($this->project->status),
+            ];
+        }
+
+        if ($this->subtasks) {
+            $data['subtasks'] = $this->formatSubtasks($this->subtasks);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Format the header section.
+     */
+    protected function formatHeader(array $data): string
+    {
+        $type = ! empty($data['type']) ? strtoupper($data['type']) : 'TASK';
+        $projectInfo = ! empty($data['projectName']) ? " ({$data['projectName']})" : '';
+
+        return "## {$type} #{$data['id']} - {$data['headline']}{$projectInfo}";
+    }
+
+    /**
+     * Format the body with custom ticket-specific formatting.
+     */
+    protected function formatBody(array $data, array $context = []): string
+    {
+        $filteredData = $this->filterFields($data, $context);
+
+        // Custom formatting for specific fields
+        if (isset($filteredData['priority'])) {
+            $filteredData['priority'] = $this->formatPriority($filteredData['priority']);
+        }
+
+        // Remove the duplicated header fields from body
+        unset($filteredData['id'], $filteredData['headline'], $filteredData['projectName']);
+
+        $sortedData = $this->sortFields($filteredData);
+
+        return "\n".Str::toMarkdown($sortedData);
+    }
+
+    /**
+     * Format a compact summary.
+     */
+    protected function formatSummary(array $data): string
+    {
+        $type = ! empty($data['type']) ? strtoupper($data['type']) : 'TASK';
+        $status = $this->formatSimpleStatus($data['status'] ?? '');
+        $assignee = ! empty($data['assignedTo']) ? " → {$data['assignedTo']}" : '';
+
+        return "{$type} #{$data['id']}: {$data['headline']}{$status}{$assignee}";
+    }
+
+    /**
+     * Format subtasks into a list string.
+     */
+    protected function formatSubtasks(array $subtasks): string
+    {
+        $subtaskData = '';
+        foreach ($subtasks as $subtask) {
+            $subtaskData .= ' #'.$subtask['id'].' '.$subtask['headline']."\n";
+        }
+
+        return $subtaskData;
+    }
+
+    /**
+     * Format the assigned user information.
+     */
+    protected function formatAssignedUser(): string
+    {
+        $firstName = $this->sanitizeValue($this->ticket->editorFirstname);
+        $lastName = $this->sanitizeValue($this->ticket->editorLastname);
+
+        if (empty($firstName) && empty($lastName)) {
+            return 'Unassigned';
+        }
+
+        $name = trim($firstName.' '.$lastName);
+        $id = $this->ticket->editorId;
+
+        return ! empty($id) ? "{$name} (ID: {$id})" : $name;
+    }
+
+    /**
+     * Format the user who created the ticket.
+     */
+    protected function formatCreatedUser(): string
+    {
+        $firstName = $this->sanitizeValue($this->ticket->userFirstname);
+        $lastName = $this->sanitizeValue($this->ticket->userLastname);
+
+        if (empty($firstName) && empty($lastName)) {
+            return 'Unknown';
+        }
+
+        $name = trim($firstName.' '.$lastName);
+        $id = $this->ticket->userId;
+
+        return ! empty($id) ? "{$name} (ID: {$id})" : $name;
+    }
+
+    /**
+     * Format milestone information.
+     */
+    protected function formatMilestone(): string
+    {
+        if (empty($this->ticket->milestoneHeadline) && empty($this->ticket->milestoneid)) {
+            return 'No milestone';
+        }
+
+        $headline = $this->sanitizeValue($this->ticket->milestoneHeadline) ?: 'Untitled Milestone';
+        $id = $this->ticket->milestoneid;
+
+        return ! empty($id) ? "{$headline} (ID: {$id})" : $headline;
+    }
+
+    /**
+     * Format status for summary (simple version).
+     *
+     * @param  mixed  $status
+     */
+    protected function formatSimpleStatus($status): string
+    {
+        if (empty($status)) {
+            return '';
+        }
+
+        // Simple status indicators for summaries
+        return match ((string) $status) {
+            '1' => ' [NEW]',
+            '2' => ' [IN PROGRESS]',
+            '3' => ' [DONE]',
+            default => " [{$status}]"
+        };
+    }
+}

--- a/app/Domain/Tickets/Templates/milestoneDialog.blade.php
+++ b/app/Domain/Tickets/Templates/milestoneDialog.blade.php
@@ -26,7 +26,7 @@
 <form class="formModal" method="post" action="{{ BASE_URL }}/tickets/editMilestone/{{ $currentMilestone->id }}" style="min-width: 250px;">
 
     <label>{!! __('label.milestone_title') !!}</label>
-    <input type="text" name="headline" value="{{ $currentMilestone->headline }}" placeholder="{{ __('label.milestone_title') }}"/><br />
+    <x-global::forms.text-input name="headline" value="{{ $currentMilestone->headline }}" placeholder="{{ __('label.milestone_title') }}" /><br />
 
     <label class="control-label">{!! __('label.project') !!}</label>
     <select name="projectId" class="tw-w-full">

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -43,7 +43,7 @@
             <div class="col-md-3">
                 <div class="quickAddForm" style="margin-top:15px;">
                     <form action="" method="post">
-                        <input type="text" name="headline" autofocus placeholder="{{ __('input.placeholders.create_task') }}" style="width: 100%;"/>
+                        <x-global::forms.text-input name="headline" autofocus placeholder="{{ __('input.placeholders.create_task') }}" style="width: 100%;" />
                         <input type="hidden" name="sprint" value="{{ $currentSprint }}" />
                         <input type="hidden" name="milestone" value="{{ htmlspecialchars((string) ($searchCriteria['milestone'] ?? ''), ENT_QUOTES, 'UTF-8') }}" />
                         <input type="hidden" name="groupBy" value="{{ htmlspecialchars((string) ($searchCriteria['groupBy'] ?? ''), ENT_QUOTES, 'UTF-8') }}" />

--- a/app/Domain/Tickets/Templates/submodules/additionalFields.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/additionalFields.blade.php
@@ -171,14 +171,14 @@
                     <div class="form-group">
                         <label class=" control-label">{!! __('label.planned_hours') !!}</label>
                         <div class="">
-                            <input type="text" value="{{ $ticket->planHours }}" name="planHours" style="width:90px;"/>
+                            <x-global::forms.text-input value="{{ $ticket->planHours }}" name="planHours" style="width:90px;" />
                         </div>
                     </div>
 
                     <div class="form-group">
                         <label class=" control-label">{!! __('label.estimated_hours_remaining') !!}</label>
                         <div class="">
-                            <input type="text" value="{{ $ticket->hourRemaining }}" name="hourRemaining" style="width:90px;"/>
+                            <x-global::forms.text-input value="{{ $ticket->hourRemaining }}" name="hourRemaining" style="width:90px;" />
                             <a href="javascript:void(0)" class="infoToolTip" data-placement="left" data-toggle="tooltip" data-tippy-content="{{ __('tooltip.how_many_hours_remaining') }}">
                                 &nbsp;<i class="fa fa-question-circle"></i>&nbsp;
                             </a>
@@ -188,15 +188,15 @@
                     <div class="form-group">
                         <label class=" control-label">{!! __('label.booked_hours') !!}</label>
                         <div class="">
-                            <input type="text" disabled="disabled"
-                                   value="{{ $timesheetsAllHours }}" style="width:90px;"/>
+                            <x-global::forms.text-input disabled="disabled"
+                                   value="{{ $timesheetsAllHours }}" style="width:90px;" />
                         </div>
                     </div>
 
                     <div class="form-group">
                         <label class=" control-label">{!! __('label.actual_hours_remaining') !!}</label>
                         <div class="">
-                            <input type="text" disabled="disabled" value="{{ $remainingHours }}" style="width:90px;"/>
+                            <x-global::forms.text-input disabled="disabled" value="{{ $remainingHours }}" style="width:90px;" />
                         </div>
                     </div>
 

--- a/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
@@ -9,7 +9,7 @@
             <form method="post" class="form-group formModal" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}#substasks">
                 <input type="hidden" value="new" name="subtaskId" />
                 <input type="hidden" value="1" name="subtaskSave" />
-                <input name="headline" type="text" title="{{ __('label.headline') }}" style="width:100%" placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
+                <x-global::forms.text-input name="headline" title="{{ __('label.headline') }}" style="width:100%" placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
                 <input type="submit" value="{{ __('buttons.save') }}" name="quickadd"  />
                 <input type="hidden" name="dateToFinish" id="dateToFinish" value="" />
                 <input type="hidden" name="status" value="3" />

--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
@@ -6,7 +6,7 @@
             <div class="col-md-12">
 
                 <div class="form-group">
-                    <input type="text" value="{{ $ticket->headline }}" name="headline" class="main-title-input" autocomplete="off" style="width:99%; margin-bottom:10px;" placeholder="{{ __('input.placeholders.enter_title_of_todo') }}"/>
+                    <x-global::forms.text-input value="{{ $ticket->headline }}" name="headline" variant="headline" autocomplete="off" style="width:99%; margin-bottom:10px;" placeholder="{{ __('input.placeholders.enter_title_of_todo') }}" />
                 </div>
                 <!-- Status -->
                 <div class="form-group tw-flex tw-w-3/5">
@@ -318,8 +318,8 @@
                     <div class="form-group">
                         <label class=" control-label">{!! __('label.planned_hours') !!} / {!! __('label.estimated_hours_remaining') !!}</label>
                         <div class="">
-                            <input type="text" value="{{ $ticket->planHours }}" name="planHours" style="width:45px;"/>&nbsp;/&nbsp;
-                            <input type="text" value="{{ $ticket->hourRemaining }}" name="hourRemaining" style="width:45px;"/>
+                            <x-global::forms.text-input value="{{ $ticket->planHours }}" name="planHours" style="width:45px;" />&nbsp;/&nbsp;
+                            <x-global::forms.text-input value="{{ $ticket->hourRemaining }}" name="hourRemaining" style="width:45px;" />
                             <a href="javascript:void(0)" class="infoToolTip" data-placement="left" data-toggle="tooltip" data-tippy-content="{{ __('tooltip.how_many_hours_remaining') }}">
                                 &nbsp;<i class="fa fa-question-circle"></i>&nbsp;
                             </a>

--- a/app/Domain/Tickets/Templates/submodules/ticketFilter.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketFilter.blade.php
@@ -134,10 +134,10 @@
                 <div class="">
                     <div class="form-group">
                         <label class="inline">{!! __('label.search_term') !!}</label>
-                        <input type="text" name="termInput" id="termInput"
+                        <x-global::forms.text-input name="termInput" id="termInput"
                         style="width: 230px"
                         value="{{ $searchCriteria['term'] }}"
-                        placeholder="{{ __('label.search_term') }}">
+                        placeholder="{{ __('label.search_term') }}" />
                     </div>
                 </div>
 

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -31,7 +31,7 @@ $currentPay = $userHours * $userInfo['wage'];
 
                     <label for="hours">{!! __('label.hours') !!}</label>
                     <span class="field">
-                        <input type="text" id="hours" name="hours" value="{{ $values['hours'] }}" size="7" class="input-small" />
+                        <x-global::forms.text-input id="hours" name="hours" value="{{ $values['hours'] }}" size="7" variant="small" />
                     </span>
                     <label for="description">{!! __('label.description') !!}</label>
                     <span class="field">

--- a/app/Domain/Timesheets/Templates/addTime.blade.php
+++ b/app/Domain/Timesheets/Templates/addTime.blade.php
@@ -7,8 +7,8 @@ $values = $values ?? [];
 
 <div class="pageheader">
     <form action="index.php?act=tickets.showAll" method="post" class="searchbar">
-        <input type="text" name="term"
-               placeholder="{{ __('input.placeholders.search_type_hit_enter') }}"/>
+        <x-global::forms.text-input name="term"
+               placeholder="{{ __('input.placeholders.search_type_hit_enter') }}" />
     </form>
 
     <div class="pageicon"><span class="fa-laptop"></span></div>
@@ -102,9 +102,9 @@ $values = $values ?? [];
                                                                                          value="{{ $values['date'] }}"
                                                                                          size="7"/>
                             <br/>
-                            <label for="hours">{!! __('HOURS') !!}</label> <input
-                                    type="text" id="hours" name="hours"
-                                    value="{{ $values['hours'] }}" size="7"/> <br/>
+                            <label for="hours">{!! __('HOURS') !!}</label> <x-global::forms.text-input
+                                    id="hours" name="hours"
+                                    value="{{ $values['hours'] }}" size="7" /> <br/>
                             <label for="description">{!! __('DESCRIPTION') !!}</label> <textarea
                                     rows="5" cols="50" id="description"
                                     name="description">{{ $values['description'] }}</textarea><br/>

--- a/app/Domain/Timesheets/Templates/editTime.blade.php
+++ b/app/Domain/Timesheets/Templates/editTime.blade.php
@@ -121,8 +121,8 @@ use Leantime\Core\Support\FromFormat;
 <label for="date">{!! __('label.date') !!}</label> <input type="text" autocomplete="off"
     id="datepicker" name="date" value="{{ format(value: $values['date'], fromFormat: FromFormat::DbDate)->date() }}" size="7" />
 <br />
-<label for="hours">{!! __('label.hours') !!}</label> <input
-    type="text" id="hours" name="hours"
+<label for="hours">{!! __('label.hours') !!}</label> <x-global::forms.text-input
+    id="hours" name="hours"
     value="{{ $values['hours'] }}" size="7" /> <br />
 <label for="description">{!! __('label.description') !!}</label> <textarea
     rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</textarea><br />

--- a/app/Domain/TwoFA/Templates/edit.blade.php
+++ b/app/Domain/TwoFA/Templates/edit.blade.php
@@ -30,7 +30,7 @@
                                 <h5>2. {!! __('text.twoFA_verify_code') !!}</h5>
                                 <p>
                                     <span>{!! __('label.twoFACode_short') !!}:</span>
-                                    <x-global::forms.text-input variant="legacy" name="twoFACode" id="twoFACode" /><br/>
+                                    <x-global::forms.text-input name="twoFACode" id="twoFACode" /><br/>
                                 </p>
 
                                 <input type="hidden" name="secret" value="{{ $secret }}" />

--- a/app/Domain/TwoFA/Templates/edit.blade.php
+++ b/app/Domain/TwoFA/Templates/edit.blade.php
@@ -30,7 +30,7 @@
                                 <h5>2. {!! __('text.twoFA_verify_code') !!}</h5>
                                 <p>
                                     <span>{!! __('label.twoFACode_short') !!}:</span>
-                                    <input type="text" class="input" name="twoFACode" id="twoFACode"/><br/>
+                                    <x-global::forms.text-input variant="legacy" name="twoFACode" id="twoFACode" /><br/>
                                 </p>
 
                                 <input type="hidden" name="secret" value="{{ $secret }}" />

--- a/app/Domain/TwoFA/Templates/verify.blade.php
+++ b/app/Domain/TwoFA/Templates/verify.blade.php
@@ -14,9 +14,9 @@
         {!! $tpl->displayInlineNotification() !!}
 
         <div class="">
-            <input type="text" name="twoFA_code" id="twoFA_code" class="form-control"
+            <x-global::forms.text-input variant="form" name="twoFA_code" id="twoFA_code"
                    placeholder="{{ __('label.twoFACode') }}"
-                   value="" autofocus/>
+                   value="" autofocus />
         </div>
         <div class="">
             <div class="forgotPwContainer">

--- a/app/Domain/TwoFA/Templates/verify.blade.php
+++ b/app/Domain/TwoFA/Templates/verify.blade.php
@@ -14,7 +14,7 @@
         {!! $tpl->displayInlineNotification() !!}
 
         <div class="">
-            <x-global::forms.text-input variant="form" name="twoFA_code" id="twoFA_code"
+            <x-global::forms.text-input name="twoFA_code" id="twoFA_code"
                    placeholder="{{ __('label.twoFACode') }}"
                    value="" autofocus />
         </div>

--- a/app/Domain/Users/Templates/editUser.blade.php
+++ b/app/Domain/Users/Templates/editUser.blade.php
@@ -23,12 +23,12 @@
                     <div class="maincontentinner">
                     <h4 class="widgettitle title-light">{!! __('label.profile_information') !!}</h4>
 
-                    <label for="firstname">{!! __('label.firstname') !!}</label> <input
-                        type="text" name="firstname" id="firstname"
+                    <label for="firstname">{!! __('label.firstname') !!}</label> <x-global::forms.text-input
+                        name="firstname" id="firstname"
                         value="{{ $values['firstname'] }}" /><br />
 
-                    <label for="lastname">{!! __('label.lastname') !!}</label> <input
-                        type="text" name="lastname" id="lastname"
+                    <label for="lastname">{!! __('label.lastname') !!}</label> <x-global::forms.text-input
+                        name="lastname" id="lastname"
                         value="{{ $values['lastname'] }}" /><br />
 
 
@@ -77,7 +77,7 @@
                         <div class="pull-left dropdownWrapper" style="padding-left:5px; line-height: 29px;">
                             <a class="dropdown-toggle btn btn-default" data-toggle="dropdown" href="{{ BASE_URL }}/auth/userInvite/{{ $values['pwReset'] }}"><i class="fa fa-link"></i> {!! __('label.copyinviteLink') !!}</a>
                             <div class="dropdown-menu padding-md noClickProp">
-                                <input type="text" id="inviteURL" value="{{ BASE_URL }}/auth/userInvite/{{ $values['pwReset'] }}" />
+                                <x-global::forms.text-input id="inviteURL" value="{{ BASE_URL }}/auth/userInvite/{{ $values['pwReset'] }}" />
                                 <x-global::forms.button contentRole="primary" onclick="leantime.snippets.copyUrl('inviteURL');">{!! __('links.copy_url') !!}</x-global::forms.button>
                             </div>
                             <x-global::forms.button tag="a" link="{{ BASE_URL }}/users/editUser/{{ $values['id'] }}?resendInvite=1" contentRole="default" style="margin-left:5px;"><i class="fa fa-envelope"></i> {!! __('buttons.resend_invite') !!}</x-global::forms.button>
@@ -101,23 +101,23 @@
 
                         <h4 class="widgettitle title-light">{!! __('label.contact_information') !!}</h4>
 
-                        <label for="user">{!! __('label.email') !!}</label> <input
-                            type="text" name="user" id="user" value="{{ $values['user'] }}" /><br />
+                        <label for="user">{!! __('label.email') !!}</label> <x-global::forms.text-input
+                            name="user" id="user" value="{{ $values['user'] }}" /><br />
 
-                        <label for="phone">{!! __('label.phone') !!}</label> <input
-                            type="text" name="phone" id="phone"
+                        <label for="phone">{!! __('label.phone') !!}</label> <x-global::forms.text-input
+                            name="phone" id="phone"
                             value="{{ $values['phone'] }}" /><br /><br />
 
 
                         <h4 class="widgettitle title-light">{!! __('label.employee_information') !!}</h4>
-                        <label for="jobTitle">{!! __('label.jobTitle') !!}</label> <input
-                            type="text" name="jobTitle" id="jobTitle" value="{{ $values['jobTitle'] }}" /><br />
+                        <label for="jobTitle">{!! __('label.jobTitle') !!}</label> <x-global::forms.text-input
+                            name="jobTitle" id="jobTitle" value="{{ $values['jobTitle'] }}" /><br />
 
-                        <label for="jobLevel">{!! __('label.jobLevel') !!}</label> <input
-                            type="text" name="jobLevel" id="jobLevel" value="{{ $values['jobLevel'] }}" /><br />
+                        <label for="jobLevel">{!! __('label.jobLevel') !!}</label> <x-global::forms.text-input
+                            name="jobLevel" id="jobLevel" value="{{ $values['jobLevel'] }}" /><br />
 
-                        <label for="department">{!! __('label.department') !!}</label> <input
-                            type="text" name="department" id="department" value="{{ $values['department'] }}" /><br />
+                        <label for="department">{!! __('label.department') !!}</label> <x-global::forms.text-input
+                            name="department" id="department" value="{{ $values['department'] }}" /><br />
 
 
 

--- a/app/Domain/Users/Templates/importLdapDialog.blade.php
+++ b/app/Domain/Users/Templates/importLdapDialog.blade.php
@@ -23,7 +23,7 @@
     @else
         <form class="importModal userImportModal" method="post" action="{{ BASE_URL }}/users/import">
             <label>{!! __('label.please_enter_password') !!} </label>
-            <input type="password" name="password" />
+            <x-global::forms.text-input inputType="password" name="password" />
             <input type="hidden" name="pwSubmit" value="1"/>
             <input type="submit" value="{{ __('buttons.find_users') }}" />
         </form>

--- a/app/Domain/Users/Templates/importLdapDialog.blade.php
+++ b/app/Domain/Users/Templates/importLdapDialog.blade.php
@@ -23,7 +23,7 @@
     @else
         <form class="importModal userImportModal" method="post" action="{{ BASE_URL }}/users/import">
             <label>{!! __('label.please_enter_password') !!} </label>
-            <x-global::forms.text-input inputType="password" name="password" />
+            <x-global::forms.text-input type="password" name="password" />
             <input type="hidden" name="pwSubmit" value="1"/>
             <input type="submit" value="{{ __('buttons.find_users') }}" />
         </form>

--- a/app/Domain/Users/Templates/newUser.blade.php
+++ b/app/Domain/Users/Templates/newUser.blade.php
@@ -15,12 +15,12 @@
 
                 <h4 class="widgettitle title-light">{!! __('label.profile_information') !!}</h4>
 
-                    <label for="firstname">{!! __('label.firstname') !!}</label> <input
-                        type="text" name="firstname" id="firstname"
+                    <label for="firstname">{!! __('label.firstname') !!}</label> <x-global::forms.text-input
+                        name="firstname" id="firstname"
                         value="{{ $values['firstname'] }}" /><br />
 
-                    <label for="lastname">{!! __('label.lastname') !!}</label> <input
-                        type="text" name="lastname" id="lastname"
+                    <label for="lastname">{!! __('label.lastname') !!}</label> <x-global::forms.text-input
+                        name="lastname" id="lastname"
                         value="{{ $values['lastname'] }}" /><br />
 
             <label for="role">{!! __('label.role') !!}</label>
@@ -57,23 +57,23 @@
                 <h4 class="widgettitle title-light">{!! __('label.contact_information') !!}</h4>
 
 
-                    <label for="user">{!! __('label.email') !!}</label> <input
-                        type="text" name="user" id="user" value="{{ $values['user'] }}" /><br />
+                    <label for="user">{!! __('label.email') !!}</label> <x-global::forms.text-input
+                        name="user" id="user" value="{{ $values['user'] }}" /><br />
 
-                    <label for="phone">{!! __('label.phone') !!}</label> <input
-                        type="text" name="phone" id="phone"
+                    <label for="phone">{!! __('label.phone') !!}</label> <x-global::forms.text-input
+                        name="phone" id="phone"
                         value="{{ $values['phone'] }}" /><br />
             <br/>
 
             <h4 class="widgettitle title-light">{!! __('label.employee_information') !!}</h4>
-                <label for="jobTitle">{!! __('label.jobTitle') !!}</label> <input
-                    type="text" name="jobTitle" id="jobTitle" value="{{ $values['jobTitle'] }}" /><br />
+                <label for="jobTitle">{!! __('label.jobTitle') !!}</label> <x-global::forms.text-input
+                    name="jobTitle" id="jobTitle" value="{{ $values['jobTitle'] }}" /><br />
 
-                <label for="jobLevel">{!! __('label.jobLevel') !!}</label> <input
-                    type="text" name="jobLevel" id="jobLevel" value="{{ $values['jobLevel'] }}" /><br />
+                <label for="jobLevel">{!! __('label.jobLevel') !!}</label> <x-global::forms.text-input
+                    name="jobLevel" id="jobLevel" value="{{ $values['jobLevel'] }}" /><br />
 
-                <label for="department">{!! __('label.department') !!}</label> <input
-                    type="text" name="department" id="department" value="{{ $values['department'] }}" /><br />
+                <label for="department">{!! __('label.department') !!}</label> <x-global::forms.text-input
+                    name="department" id="department" value="{{ $values['department'] }}" /><br />
 
 
                     <p class="stdformbutton">

--- a/app/Domain/Widgets/Templates/partials/myToDos.blade.php
+++ b/app/Domain/Widgets/Templates/partials/myToDos.blade.php
@@ -174,9 +174,9 @@
                               hx-indicator="#todoWidgetLoader">
                             <div class="tw-flex tw-flex-row tw-gap-2">
                                 <div class="tw-flex-grow">
-                                    <input type="text" name="headline" class="main-title-input"
+                                    <x-global::forms.text-input variant="headline" name="headline"
                                            style="font-size:var(--base-font-size)"
-                                           placeholder="{{ __('input.placeholders.what_are_you_working_on') }}"/>
+                                           placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
                                     <input type="hidden" name="quickadd" value="true"/>
                                 </div>
                                 <div>
@@ -250,9 +250,9 @@
                                   hx-indicator="#todoWidgetLoader">
                                 <div class="tw-flex tw-flex-row tw-gap-2">
                                     <div class="tw-flex-grow">
-                                        <input type="text" name="headline" class="main-title-input"
+                                        <x-global::forms.text-input variant="headline" name="headline"
                                                style="font-size:var(--base-font-size)"
-                                               placeholder="{{ __('input.placeholders.what_are_you_working_on') }}"/>
+                                               placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
                                         <input type="hidden" name="quickadd" value="true"/>
                                     </div>
                                     <div>

--- a/app/Domain/Widgets/Templates/partials/todoItem.blade.php
+++ b/app/Domain/Widgets/Templates/partials/todoItem.blade.php
@@ -64,9 +64,9 @@
                 <div class="tw-flex-grow">
                     <div hx-trigger="load"
                          hx-indicator=".htmx-indicator-ticket-{{ $ticket['id'] }}"
-                         hx-get="<?=BASE_URL ?>/hx/tickets/milestones/progress?milestoneId=<?=$ticket['id'] ?>&progressColor={{ trim($ticket['tags'], "#") }}">
+                         hx-get="<?= BASE_URL ?>/hx/tickets/milestones/progress?milestoneId=<?= $ticket['id'] ?>&progressColor={{ trim($ticket['tags'], "#") }}">
                         <div class="htmx-indicator">
-                                <?= $tpl->__("label.loading_milestone") ?>
+                                <?= $tpl->__('label.loading_milestone') ?>
                         </div>
                     </div>
                 </div>
@@ -96,9 +96,9 @@
                         >
                             <input type="hidden" name="id" value="{{ $ticket['id'] }}"/>
                             <div>
-                                <input type="text" class="main-title-input"
+                                <x-global::forms.text-input variant="headline"
                                        style="font-size:var(--base-font-size); margin-bottom:0px"
-                                       value="{{ $ticket['headline'] }}" name="headline"/>
+                                       value="{{ $ticket['headline'] }}" name="headline" />
                             </div>
                             <div>
                                 <x-global::forms.button inputType="submit" name="edit" contentRole="primary">
@@ -230,9 +230,9 @@
             <input type="hidden" value="{{ format($ticket['dateToFinish'])->date() }}" name="dateToFinish"/>
             <div class="tw-flex tw-flex-row tw-gap-2">
                 <div class="tw-flex-grow">
-                    <input name="headline" type="text" class="main-title-input"
+                    <x-global::forms.text-input name="headline" variant="headline"
                            style="font-size:var(--base-font-size)"
-                           placeholder="{{ __('input.placeholders.what_are_you_working_on') }}"/>
+                           placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
                 </div>
                 <div>
                     <input type="hidden" name="status" value="3"/>
@@ -287,9 +287,9 @@
                     />
                     <div class="tw-flex tw-flex-row tw-gap-2">
                         <div class="tw-flex-grow">
-                            <input name="headline" type="text" class="main-title-input"
+                            <x-global::forms.text-input name="headline" variant="headline"
                                    style="font-size:var(--base-font-size)"
-                                   placeholder="{{ __('input.placeholders.what_are_you_working_on') }}"/>
+                                   placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
                         </div>
                         <div>
                             <input type="hidden" name="status" value="3"/>

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -157,7 +157,7 @@
             </div>
             <input type="hidden" class="articleIcon" value="{{ $currentArticle->data }}" name="articleIcon"/>
 
-            <input type="text" name="title" class="main-title-input" value="{{ $tpl->escape($currentArticle->title) }}" placeholder="{{ __('input.placeholders.wiki_title') }}" style="width:80%"/>
+            <x-global::forms.text-input variant="headline" name="title" value="{{ $tpl->escape($currentArticle->title) }}" placeholder="{{ __('input.placeholders.wiki_title') }}" style="width:80%" />
 
             <br />
             <input type="text" value="{{ $tpl->escape($currentArticle->tags) }}" name="tags" id="tags" />

--- a/app/Domain/Wiki/Templates/show.blade.php
+++ b/app/Domain/Wiki/Templates/show.blade.php
@@ -178,9 +178,9 @@
                                             <div class="dropdown-menu"></div>
                                         </div>
                                         <input type="hidden" id="wikiArticleIcon" class="articleIcon" value="{{ e($currentArticle->data) }}" />
-                                        <input type="text"
+                                        <x-global::forms.text-input
                                                id="wikiTitleEditable"
-                                               class="main-title-input"
+                                               variant="headline"
                                                value="{{ e($currentArticle->title) }}"
                                                data-original="{{ e($currentArticle->title) }}"
                                                placeholder="{{ __('input.placeholders.wiki_title') }}"

--- a/app/Domain/Wiki/Templates/wikiDialog.blade.php
+++ b/app/Domain/Wiki/Templates/wikiDialog.blade.php
@@ -20,7 +20,7 @@
 <form class="formModal" method="post" action="{{ BASE_URL }}/wiki/wikiModal/{{ $id }}">
 
     <label>{!! __('label.wiki_title') !!}</label>
-    <input type="text" name="title" id="wikiTitle" value="{{ $tpl->escape($currentWiki->title) }}" placeholder="{{ __('input.placeholders.wiki_title') }}"/><br />
+    <x-global::forms.text-input name="title" id="wikiTitle" value="{{ $tpl->escape($currentWiki->title) }}" placeholder="{{ __('input.placeholders.wiki_title') }}" /><br />
 
     <br />
 

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -85,8 +85,8 @@ Status: ⬜ todo · 🟡 in progress · ✅ no-op done (on master) · 🎨 desig
 ### P0 — primitives & core
 | Component | Tag | Cat | Status | Ref | Notes |
 |---|---|---|---|---|---|
-| button | `forms.button` | forms | 🟡 | refactor/table-component | first pilot; no-op |
-| text-input | `forms.text-input` | forms | ⬜ | refactor/table-component | |
+| button | `forms.button` | forms | ✅ | refactor/table-component | merged #3531: no-op migration + 3-tier role model |
+| text-input | `forms.text-input` | forms | 🟡 | refactor/table-component | this PR; thin no-op; **defer JS-coupled** (datepickers/tags/inline-edit/color) |
 | textarea | `forms.textarea` | forms | ⬜ | selectsComponentUpdates | |
 | select (native) | `forms.select` | forms | ⬜ | refactor/table-component | native no-op first; JS-enhanced later |
 | form-field | `forms.field-row` | forms | ⬜ | refactor/table-component | label-row + caption + validation wrapper |
@@ -191,6 +191,25 @@ class set / behavior. Categories found (to revisit, some need a design decision)
 - ~~`<a onclick>` without `href`~~ — DONE: component emits `href` only when `link` is set; migrate these by omitting the `link` prop.
 - **dropdown-toggle / data-toggle / fileupload / span.btn** — handled in the dropdown / file-upload / later phases.
 
+## Text-input migration — scope & defer rubric
+
+`forms.text-input` is a **thin no-op**: it emits a plain `<input>` with today's class (default = no
+class) and passes all attributes through; the label/validation IDL props are declared but not rendered
+(a wrapper would change markup — that's the design phase). Pass `inputType` (never a raw `type=`).
+
+- ✅ **Migrate (~267):** standard inputs (`form-control` / bare / legacy `input`), headline title inputs
+  (`main-title-input` → `variant="headline"`), search inputs. Map source class → `variant`.
+- ⛔ **Leave RAW — do-not-touch signals** (JS-coupled; breaking these regresses behavior):
+  - **datepickers** (jQuery-UI): `.dates .duedates .quickDueDates .dateFrom .dateTo .editFrom .editTo
+    .startDate .endDate .projectDateFrom .projectDateTo .week-picker .hasDatepicker` + ids `#deadline
+    #sprintStart #sprintEnd #event_date_* #date #startDate #endDate #timesheetdate #invoiced* #paidDate`
+    (many init via inline `<script>` in the template + an a11y pass on `.hasDatepicker`).
+  - **time**: `.timepicker`, `type="time"`, `#dueTime #timeFrom #timeTo`.
+  - **tags**: `#tags` (+ `#tags_tag`/`#tags_tagsinput`), `.tagsinputField`, `data-role="tagsinput"`, `#wikiTagsInput`.
+  - **inline-edit / async-save**: `.secretInput`, `.asyncInputUpdate` (+ `data-label` / `data-id`).
+  - **color**: `.simpleColorPicker`.   **honeypot**: `.ohnohoney`.
+  - **any inline `onchange` / `onblur` / `onkeyup` / `oninput` handler**.
+
 ## Progress log
 
 - _Phase 0_: tracker created; `feature/componentization` branched off master; card-naming resolved.
@@ -223,3 +242,6 @@ class set / behavior. Categories found (to revisit, some need a design decision)
   `<li>` menu-items (incl. menu delete/edit), accordion + inline `|`-separated toggles, add/create
   toggles, nav, timers, and already-`btn` links. Still bare (flagged, not converted): inline per-comment
   `deleteComment` links + per-row table delete actions (would need a smaller-scale/inline treatment).
+- _text-input_: thin no-op `forms.text-input` built on `feature/text-input-component` (off master, post-#3531).
+  Scope + datepicker/tags/inline-edit defer rubric above. Pilot pending (verify no-op render AND that a
+  deferred datepicker still initializes on the same page).

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -204,11 +204,14 @@ class set / behavior. Categories found (to revisit, some need a design decision)
 
 `forms.text-input` is a **thin no-op**: it emits a plain `<input>` with today's class (default = no
 class) and passes all attributes through; the label/validation IDL props are declared but not rendered
-(a wrapper would change markup — that's the design phase). Pass `inputType` (never a raw `type=`).
+(a wrapper would change markup — that's the design phase). Pass the **HTML-native `type=`** (it is a
+declared `@prop`, so Blade extracts it from the attribute bag — emits exactly one `type`, never a duplicate).
 
-- ✅ **Migrate (146 done in PR #3558; more in follow-ups):** standard inputs (`form-control` / bare /
-  legacy `input`), headline title inputs (`main-title-input` → `variant="headline"`), search inputs. Map
-  source class → `variant`; any extra non-variant class (tw-utilities, `pull-left`, …) passes through `class=`.
+- ✅ **Migrate (146 done in PR #3558; more in follow-ups):** standard inputs (bare / legacy `input`),
+  headline title inputs (`main-title-input` → `variant="headline"`), search inputs. Map source class →
+  `variant`; any extra non-variant class (tw-utilities, `pull-left`, …) passes through `class=`.
+  **`.form-control` → bare** (NOT a variant): forms.css element selectors override its look and container
+  rules (`.regpanelinner input{width:100%}`) supply the width, so a bare input renders identically.
 - ⛔ **Leave RAW — do-not-touch signals** (JS-coupled; breaking these regresses behavior):
   - **datepickers** (jQuery-UI): `.dates .duedates .quickDueDates .dateFrom .dateTo .editFrom .editTo
     .startDate .endDate .projectDateFrom .projectDateTo .week-picker .hasDatepicker` + ids `#deadline
@@ -271,3 +274,14 @@ class) and passes all attributes through; the label/validation IDL props are dec
   **Deferred to follow-ups:** `Auth/userInvite` (3 inputs w/ legacy `<?php echo ?>` in attrs — see gotcha),
   `Tickets/partials/ticketCard` + `partials/subtasks` (HTMX inline-edit/date), and everywhere the
   do-not-touch signals (datepickers/tags/inline-edit/color/`sorter`/`hourCell`/dynamic-class).
+- _text-input API refinement (review feedback)_: two API cleanups after review.
+  (1) **`inputType` → `type`**: renamed the prop to the HTML-native `type` (17 call-sites). It's a declared
+  `@prop`, so Blade extracts it from the attribute bag → exactly one `type`, no duplication. (`forms.button`
+  keeps `inputType` because it's polymorphic — `type` is ambiguous across a/button/input.)
+  (2) **dropped `variant="form"`** (the `form`/`bordered`→`.form-control` arm). 3-agent CSS audit proved
+  `.form-control` is cosmetically redundant in Leantime: `forms.css` element selectors (`input[type=text]…`,
+  loaded after Bootstrap) override its bg/border/radius/shadow/padding/height/color, and the only residual
+  effect (desktop `width:100%`) is already supplied by container rules (`.regpanelinner input{width:100%}`)
+  for the sole 7 call-sites (login ×2, twoFA/verify ×1, install ×4 — all entry pages). No JS hooks
+  `.form-control` on inputs. Collapsed those 7 to bare; live render on `/auth/login` = bare inputs, single
+  `type`, no `form-control`. Bare IS the form look now.

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -207,11 +207,23 @@ class) and passes all attributes through; the label/validation IDL props are dec
 (a wrapper would change markup — that's the design phase). Pass the **HTML-native `type=`** (it is a
 declared `@prop`, so Blade extracts it from the attribute bag — emits exactly one `type`, never a duplicate).
 
-- ✅ **Migrate (146 done in PR #3558; more in follow-ups):** standard inputs (bare / legacy `input`),
-  headline title inputs (`main-title-input` → `variant="headline"`), search inputs. Map source class →
-  `variant`; any extra non-variant class (tw-utilities, `pull-left`, …) passes through `class=`.
-  **`.form-control` → bare** (NOT a variant): forms.css element selectors override its look and container
-  rules (`.regpanelinner input{width:100%}`) supply the width, so a bare input renders identically.
+- ✅ **Migrate (146 done in PR #3558; more in follow-ups):** standard inputs (bare), headline title inputs
+  (`main-title-input` → `variant="headline"`), search inputs. Map source class → `variant`; any extra
+  non-variant class (tw-utilities, `pull-left`, …) passes through `class=`.
+  **`.form-control` AND `.input` → bare** (NOT variants): both are pure Bootstrap cruft — forms.css element
+  selectors override `.form-control`, and `.input` has *no backing CSS rule at all*; a bare input renders
+  identically (the entry-page width that `.form-control` gave comes from `.regpanelinner input{width:100%}`).
+
+### Variant taxonomy (evidence-backed — 4-agent CSS audit)
+Only visually-distinct treatments earn a variant. Verdicts:
+| variant | class | real? | what it actually is |
+|---|---|---|---|
+| `headline` | `.main-title-input` | ✅ | large 24/26px (`--font-size-xxxl`) title font + `box-shadow:none`; keeps border/bg |
+| `large` | `.input-large` | ✅ (width-only) | fixed `width:210px` — forms.css never sets width, so it survives |
+| `small` | `.input-small` | ✅ (width-only) | fixed `width:90px` |
+| `ghost` *(planned)* | `.secretInput` | ✅ | inline-edit "looks like text until touched": transparent, no border/shadow, hover/focus reveal box. Pending its async-save JS migration. |
+| ~~`form`~~ | `.form-control` | ❌ removed | overridden by forms.css element selectors |
+| ~~`legacy`~~ | `.input` | ❌ removed | no `.input` CSS rule exists anywhere |
 - ⛔ **Leave RAW — do-not-touch signals** (JS-coupled; breaking these regresses behavior):
   - **datepickers** (jQuery-UI): `.dates .duedates .quickDueDates .dateFrom .dateTo .editFrom .editTo
     .startDate .endDate .projectDateFrom .projectDateTo .week-picker .hasDatepicker` + ids `#deadline
@@ -285,3 +297,10 @@ declared `@prop`, so Blade extracts it from the attribute bag — emits exactly 
   for the sole 7 call-sites (login ×2, twoFA/verify ×1, install ×4 — all entry pages). No JS hooks
   `.form-control` on inputs. Collapsed those 7 to bare; live render on `/auth/login` = bare inputs, single
   `type`, no `form-control`. Bare IS the form look now.
+- _text-input variant taxonomy (review feedback)_: 4-agent CSS audit to keep ONLY evidence-backed variants.
+  Findings: `headline`(.main-title-input) = REAL (large `--font-size-xxxl` font + shadow removed);
+  `large`(.input-large)/`small`(.input-small) = REAL but width-only (210px/90px — the one prop forms.css
+  doesn't set); `ghost`(.secretInput) = REAL inline-edit treatment (4 distinct low-chrome looks found, the
+  canonical one being .secretInput) but its call-sites are the deferred async-save fields, so it's a planned
+  variant; `legacy`(.input) = REDUNDANT (no `.input` CSS rule exists anywhere). **Dropped `variant="legacy"`**
+  (1 call-site, TwoFA/edit → bare; removed the arm). Component now exposes only `headline`/`large`/`small`.

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -86,7 +86,7 @@ Status: ⬜ todo · 🟡 in progress · ✅ no-op done (on master) · 🎨 desig
 | Component | Tag | Cat | Status | Ref | Notes |
 |---|---|---|---|---|---|
 | button | `forms.button` | forms | ✅ | refactor/table-component | merged #3531: no-op migration + 3-tier role model |
-| text-input | `forms.text-input` | forms | 🟡 | refactor/table-component | this PR; thin no-op; **defer JS-coupled** (datepickers/tags/inline-edit/color) |
+| text-input | `forms.text-input` | forms | 🟡 | refactor/table-component | PR #3558: thin no-op; **146 call-sites / 56 files migrated**; **defer JS-coupled** (datepickers/tags/inline-edit/color/sorter/hourCell) + legacy `<?php echo ?>`-in-attr |
 | textarea | `forms.textarea` | forms | ⬜ | selectsComponentUpdates | |
 | select (native) | `forms.select` | forms | ⬜ | refactor/table-component | native no-op first; JS-enhanced later |
 | form-field | `forms.field-row` | forms | ⬜ | refactor/table-component | label-row + caption + validation wrapper |
@@ -169,6 +169,15 @@ even though the same markup works as a raw `<a href="...">`. So when migrating:
 Run the brace/quote-aware scan (forms.button opening tags with a `"` inside any `{{ }}`) after any
 button migration batch — `view:cache` does NOT catch these (they fail at render, not compile).
 
+## ⚠️ Gotcha: no legacy `<?php echo ?>` / `<?= ?>` inside a component attribute value
+
+Raw PHP echo tags work in a plain `<input placeholder="<?php echo … ?>">` (PHP executes at render),
+but Laravel's **component-tag compiler** treats a non-bound attribute value as a *literal string*, so
+`<?php … ?>` inside a `<x-…>` attribute does NOT reliably execute. **Leave such inputs RAW** (or first
+modernize the echo to `{{ … }}` / `{!! $tpl->escape(…) !!}` in a separate step, then migrate). Found in
+`Auth/userInvite` (placeholders use `<?php echo $tpl->language->__('…') ?>`) — deferred. Scan migrated
+tags for `<?php` / `<?=` before committing.
+
 ## Per-component playbook (repeatable)
 
 1. Read what the primitive renders today (classes, JS hooks, every call-site shape).
@@ -197,8 +206,9 @@ class set / behavior. Categories found (to revisit, some need a design decision)
 class) and passes all attributes through; the label/validation IDL props are declared but not rendered
 (a wrapper would change markup — that's the design phase). Pass `inputType` (never a raw `type=`).
 
-- ✅ **Migrate (~267):** standard inputs (`form-control` / bare / legacy `input`), headline title inputs
-  (`main-title-input` → `variant="headline"`), search inputs. Map source class → `variant`.
+- ✅ **Migrate (146 done in PR #3558; more in follow-ups):** standard inputs (`form-control` / bare /
+  legacy `input`), headline title inputs (`main-title-input` → `variant="headline"`), search inputs. Map
+  source class → `variant`; any extra non-variant class (tw-utilities, `pull-left`, …) passes through `class=`.
 - ⛔ **Leave RAW — do-not-touch signals** (JS-coupled; breaking these regresses behavior):
   - **datepickers** (jQuery-UI): `.dates .duedates .quickDueDates .dateFrom .dateTo .editFrom .editTo
     .startDate .endDate .projectDateFrom .projectDateTo .week-picker .hasDatepicker` + ids `#deadline
@@ -208,7 +218,11 @@ class) and passes all attributes through; the label/validation IDL props are dec
   - **tags**: `#tags` (+ `#tags_tag`/`#tags_tagsinput`), `.tagsinputField`, `data-role="tagsinput"`, `#wikiTagsInput`.
   - **inline-edit / async-save**: `.secretInput`, `.asyncInputUpdate` (+ `data-label` / `data-id`).
   - **color**: `.simpleColorPicker`.   **honeypot**: `.ohnohoney`.
-  - **any inline `onchange` / `onblur` / `onkeyup` / `oninput` handler**.
+  - **JS grids / clone-templates**: `.hourCell` (timesheet grid), `.sorter` + `name`/`id` clone markers
+    like `XXNEWKEYXX` or pipe-keyed `name="new|GENERAL_BILLABLE|…"`.
+  - **dynamic `class`/`id`** built with `{{ }}` / `{!! !!}` (can't statically classify → defer).
+  - **legacy `<?php echo ?>` / `<?= ?>` in an attribute value** (see gotcha above).
+  - **any inline `onchange` / `onblur` / `onkeyup` / `oninput` / `onfocus` handler**.
 
 ## Progress log
 
@@ -243,5 +257,17 @@ class) and passes all attributes through; the label/validation IDL props are dec
   toggles, nav, timers, and already-`btn` links. Still bare (flagged, not converted): inline per-comment
   `deleteComment` links + per-row table delete actions (would need a smaller-scale/inline treatment).
 - _text-input_: thin no-op `forms.text-input` built on `feature/text-input-component` (off master, post-#3531).
-  Scope + datepicker/tags/inline-edit defer rubric above. Pilot pending (verify no-op render AND that a
-  deferred datepicker still initializes on the same page).
+  Scope + datepicker/tags/inline-edit defer rubric above. **PR #3558.**
+- _text-input pilot_: `Projects/newProject` headline (`main-title-input` → `variant="headline"`) migrated;
+  Playwright = byte-identical (same class/type/name/id/style/value/placeholder); the two `.dateFrom/.dateTo`
+  datepickers on the same page left RAW (component never applied to JS-coupled inputs → can't regress).
+  (Note: dev instance currently isn't loading `compiled-app`/jQuery, so runtime datepicker init couldn't be
+  exercised — but the datepicker DOM is byte-identical to master since those lines are untouched.)
+- _text-input sweep_: **146 call-sites across 56 files** migrated (63-file 2-phase workflow: per-file migrate
+  + adversarial diff-verify; all 63 verified ok). Diff is perfectly symmetric (202 ins / 202 del = pure
+  in-place swaps). Static audit of all 146: 0 problems (no `type=`/inputType dup, no variant class left in
+  `class=`, no JS-coupled signal swallowed, no nested-quote, no dup attrs). Compile + Pint clean. Live render
+  no-op confirmed on `/setting/editCompanySettings` (`pull-left` passthrough) + `/clients/newClient` (bare).
+  **Deferred to follow-ups:** `Auth/userInvite` (3 inputs w/ legacy `<?php echo ?>` in attrs — see gotcha),
+  `Tickets/partials/ticketCard` + `partials/subtasks` (HTMX inline-edit/date), and everywhere the
+  do-not-touch signals (datepickers/tags/inline-edit/color/`sorter`/`hourCell`/dynamic-class).

--- a/app/Views/Templates/components/forms/text-input.blade.php
+++ b/app/Views/Templates/components/forms/text-input.blade.php
@@ -56,7 +56,7 @@
 @php
     // No-op map: variant -> the exact class the markup uses today.
     $variantClass = match ($variant) {
-        'headline', 'title' => 'main-title-input',
+        'headline' => 'main-title-input',
         'large' => 'input-large',
         'small' => 'input-small',
         default => '',   // bare / search: no class (styled by context / id / name)

--- a/app/Views/Templates/components/forms/text-input.blade.php
+++ b/app/Views/Templates/components/forms/text-input.blade.php
@@ -1,10 +1,14 @@
 @props([
     // NO-OP variant -> the class the app renders TODAY. Default '' = a bare, unclassed input
     // (the common case: ~206 inputs have no class and are styled by their form/context).
-    'variant' => '',          // '' (bare) | headline | large | small | legacy
-                              //   NB: there is no "form" variant — `.form-control` (full-width/bordered)
-                              //   is fully overridden by forms.css's element selectors + container width
-                              //   rules, so a bare input already renders identically. Bare IS the form look.
+    'variant' => '',          // '' (bare) | headline | large | small
+                              //   Only EVIDENCE-BACKED, visually-distinct variants exist here:
+                              //     headline -> .main-title-input  (large 24/26px title font, drop-shadow removed)
+                              //     large    -> .input-large       (fixed 210px width — width only)
+                              //     small    -> .input-small       (fixed 90px width — width only)
+                              //   NO "form" or "legacy" variant: `.form-control` and `.input` are pure Bootstrap
+                              //   cruft — forms.css element selectors override them, so a bare input is identical.
+                              //   (Ghost/inline-edit `.secretInput` is a real future variant, pending its async-save JS.)
     'type' => 'text',         // text | email | password | number | url | tel | search (HTML-native; Blade extracts it from $attributes so it never duplicates)
 
     // --- design-system IDL: declared for the durable contract, but intentionally NOT rendered
@@ -47,7 +51,7 @@
       <input type="email" class="form-control">  -> type="email"   (drop form-control; it's redundant)
       <input class="main-title-input">           -> variant="headline"
       <input class="input-large">                -> variant="large"
-      <input class="input"> (legacy)             -> variant="legacy"
+      <input class="input"> (no CSS / cruft)     -> (bare; .input has no backing rule)
 --}}
 @php
     // No-op map: variant -> the exact class the markup uses today.
@@ -55,7 +59,6 @@
         'headline', 'title' => 'main-title-input',
         'large' => 'input-large',
         'small' => 'input-small',
-        'legacy' => 'input',
         default => '',   // bare / search: no class (styled by context / id / name)
     };
 

--- a/app/Views/Templates/components/forms/text-input.blade.php
+++ b/app/Views/Templates/components/forms/text-input.blade.php
@@ -1,0 +1,64 @@
+@props([
+    // NO-OP variant -> the class the app renders TODAY. Default '' = a bare, unclassed input
+    // (the common case: ~206 inputs have no class and are styled by their form/context).
+    'variant' => '',          // '' (bare) | form | headline | large | small | legacy | search
+    'inputType' => 'text',    // text | email | password | number | url | tel | search
+
+    // --- design-system IDL: declared for the durable contract, but intentionally NOT rendered
+    //     in no-op mode (a label/validation wrapper would change today's markup). They become
+    //     active when the design phase introduces the field-row/label layout. ---
+    'contentRole' => '',      // reserved
+    'state' => '',            // info | warning | danger | success (validation) — reserved
+    'scale' => '',            // xs | s | m | l | xl — reserved
+    'labelPosition' => 'top', // reserved
+    'labelText' => '',        // reserved
+    'caption' => '',          // reserved
+    'validationText' => '',   // reserved
+    'validationState' => '',  // reserved
+    'leadingVisual' => '',    // reserved
+    'trailingVisual' => '',   // reserved
+])
+
+{{--
+    forms.text-input — NO-OP text input.
+
+    Renders a plain <input> with the SAME class the app uses TODAY (default: NO class). Every
+    other attribute (name, id, value, placeholder, style, data-*, hx-*, autocomplete, required,
+    maxlength, autofocus, …) passes straight through via $attributes. Zero visual/behaviour change.
+
+    ⚠️ DO NOT route JS-coupled inputs through this component — they will break. Keep these RAW:
+      • date pickers: .dates .duedates .quickDueDates .dateFrom .dateTo .editFrom .editTo
+        .startDate .endDate .projectDateFrom .projectDateTo .week-picker .hasDatepicker
+        #deadline #sprintStart #sprintEnd #event_date_* #date #startDate #endDate #timesheetdate …
+      • time: .timepicker, type="time"        • tags: #tags .tagsinputField data-role="tagsinput"
+      • inline-edit: .secretInput .asyncInputUpdate (+ data-label / data-id)
+      • color: .simpleColorPicker              • any inline onchange/onblur/onkeyup/oninput handler
+    See COMPONENTS.md for the full do-not-touch list.
+
+    Pass the input type via the `inputType` prop, NOT a `type="…"` attribute (the component emits
+    `type` itself; a `type` attribute would duplicate it).
+
+    Migration cheatsheet (source class -> variant):
+      <input type="text" name=…>                 -> <x-global::forms.text-input name=…>      (bare, no class)
+      <input type="email" class="form-control">  -> inputType="email" variant="form"
+      <input class="main-title-input">           -> variant="headline"
+      <input class="input-large">                -> variant="large"
+      <input class="input"> (legacy)             -> variant="legacy"
+--}}
+@php
+    // No-op map: variant -> the exact class the markup uses today.
+    $variantClass = match ($variant) {
+        'form', 'bordered' => 'form-control',
+        'headline', 'title' => 'main-title-input',
+        'large' => 'input-large',
+        'small' => 'input-small',
+        'legacy' => 'input',
+        default => '',   // bare / search: no class (styled by context / id / name)
+    };
+
+    // Only add a class attribute when there's actually a class — so a bare input stays
+    // class-less (no empty class="") exactly like today.
+    $attrs = $variantClass !== '' ? $attributes->merge(['class' => $variantClass]) : $attributes;
+@endphp
+
+<input type="{{ $inputType }}" {{ $attrs }} />

--- a/app/Views/Templates/components/forms/text-input.blade.php
+++ b/app/Views/Templates/components/forms/text-input.blade.php
@@ -1,8 +1,11 @@
 @props([
     // NO-OP variant -> the class the app renders TODAY. Default '' = a bare, unclassed input
     // (the common case: ~206 inputs have no class and are styled by their form/context).
-    'variant' => '',          // '' (bare) | form | headline | large | small | legacy | search
-    'inputType' => 'text',    // text | email | password | number | url | tel | search
+    'variant' => '',          // '' (bare) | headline | large | small | legacy
+                              //   NB: there is no "form" variant — `.form-control` (full-width/bordered)
+                              //   is fully overridden by forms.css's element selectors + container width
+                              //   rules, so a bare input already renders identically. Bare IS the form look.
+    'type' => 'text',         // text | email | password | number | url | tel | search (HTML-native; Blade extracts it from $attributes so it never duplicates)
 
     // --- design-system IDL: declared for the durable contract, but intentionally NOT rendered
     //     in no-op mode (a label/validation wrapper would change today's markup). They become
@@ -35,12 +38,13 @@
       • color: .simpleColorPicker              • any inline onchange/onblur/onkeyup/oninput handler
     See COMPONENTS.md for the full do-not-touch list.
 
-    Pass the input type via the `inputType` prop, NOT a `type="…"` attribute (the component emits
-    `type` itself; a `type` attribute would duplicate it).
+    Pass the input type via the HTML-native `type="…"` attribute. It is a declared @prop, so Blade
+    extracts it from the attribute bag — the component emits exactly one `type` (never duplicated).
+    Omit it for a plain text input (default "text").
 
     Migration cheatsheet (source class -> variant):
       <input type="text" name=…>                 -> <x-global::forms.text-input name=…>      (bare, no class)
-      <input type="email" class="form-control">  -> inputType="email" variant="form"
+      <input type="email" class="form-control">  -> type="email"   (drop form-control; it's redundant)
       <input class="main-title-input">           -> variant="headline"
       <input class="input-large">                -> variant="large"
       <input class="input"> (legacy)             -> variant="legacy"
@@ -48,7 +52,6 @@
 @php
     // No-op map: variant -> the exact class the markup uses today.
     $variantClass = match ($variant) {
-        'form', 'bordered' => 'form-control',
         'headline', 'title' => 'main-title-input',
         'large' => 'input-large',
         'small' => 'input-small',
@@ -61,4 +64,4 @@
     $attrs = $variantClass !== '' ? $attributes->merge(['class' => $variantClass]) : $attributes;
 @endphp
 
-<input type="{{ $inputType }}" {{ $attrs }} />
+<input type="{{ $type }}" {{ $attrs }} />

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -24,6 +24,7 @@ class LoginCest
     public function loginDeniedForWrongCredentials(AcceptanceTester $I): void
     {
         $I->amOnPage('/auth/login');
+        $I->waitForElementVisible('#login', 10);
         $I->fillField(['name' => 'username'], 'test@leantime.io');
         $I->fillField(['name' => 'password'], 'WrongPassword');
         $I->click('Login');


### PR DESCRIPTION
## Summary

- Extract shared AI support classes (entity formatters, LLM string sanitizer, markdown helper) from McpServer and Copilot plugins into Core and domain modules
- Move Personal Access Token management UI from AdvancedAuth plugin into Core Auth domain so MCP works without AdvancedAuth

### New Core files
- `app/Core/Support/LLMStringSanitizer.php` -- static API wrapping `Str::sanitizeForLLM()` macro
- `app/Core/Support/MarkdownHelper.php` -- static API wrapping `Str::toMarkdown()` macro
- `app/Core/Support/EntityFormatterInterface.php` -- contract for AI entity formatters
- `app/Core/Support/AbstractEntityFormatter.php` -- base class with sanitization, filtering, sorting
- `app/Core/Support/RoutingFormatter.php` -- conversation history formatter

### New Domain files
- `app/Domain/Tickets/Support/TicketFormatter.php` -- ticket entity formatter for AI consumption
- `app/Domain/Calendar/Support/CalendarEventFormatter.php` -- calendar event formatter

### PAT Management in Core
- `app/Domain/Auth/Hxcontrollers/PersonalTokens.php` -- token CRUD HxController
- `app/Domain/Auth/Listeners/ShowPersonalTokenTab.php` + `ShowPersonalTokenContent.php`
- `app/Domain/Auth/Templates/` -- token management Blade templates
- `app/Domain/Auth/register.php` -- registers PAT tab in user settings

## Test plan
- [ ] Verify app loads without errors
- [ ] Verify Personal Access Tokens tab appears in user settings (`/users/editOwn`)
- [ ] Create a token, verify one-time display works
- [ ] Delete a token, verify list refreshes
- [ ] Verify Copilot plugin still works (imports updated in separate plugins PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)