### PR TITLE
feat(components): forms.textarea no-op primitive + migrate 10 plain textareas

### DIFF
--- a/app/Domain/Help/Templates/projectDefinitionStep.blade.php
+++ b/app/Domain/Help/Templates/projectDefinitionStep.blade.php
@@ -7,13 +7,13 @@
                 <p>{!!  __('text.structured_project_thinking') !!}</p>
                 <br />
                 <label><strong>{{ __('label.what_are_you_trying_to_accomplish') }}</strong></label>
-                <textarea id="accomplish" name="accomplish" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></textarea>
+                <x-global::forms.textarea id="accomplish" name="accomplish" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></x-global::forms.textarea>
                 <br />
                 <label><strong>{{ __('label.how_does_the_world_look_like') }}</strong></label>
-                <textarea id="wordlview" name="worldview" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></textarea>
+                <x-global::forms.textarea id="wordlview" name="worldview" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></x-global::forms.textarea>
                 <br />
                 <label><strong>{{ __('label.why_is_this_important') }}</strong></label>
-                <textarea id="whyImportant" name="whyImportant" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></textarea>
+                <x-global::forms.textarea id="whyImportant" name="whyImportant" value="" placeholder="" rows="3" style="width:99%; overflow-x: hidden;"></x-global::forms.textarea>
 
             </div>
             <div class="col-md-4">

--- a/app/Domain/Ideas/Templates/ideaDialog.blade.php
+++ b/app/Domain/Ideas/Templates/ideaDialog.blade.php
@@ -74,7 +74,7 @@
                         </div>
                         <div class="row" id="newMilestone" style="display:none;">
                             <div class="col-md-12">
-                                <textarea name="newMilestone"></textarea><br/>
+                                <x-global::forms.textarea name="newMilestone"></x-global::forms.textarea><br/>
                                 <input type="hidden" name="type" value="milestone"/>
                                 <input type="hidden" name="leancanvasitemid" value="{{ $id }} "/>
                                 <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryCanvasSubmitButton').click()"

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -35,7 +35,7 @@ $currentPay = $userHours * $userInfo['wage'];
                     </span>
                     <label for="description">{!! __('label.description') !!}</label>
                     <span class="field">
-                        <textarea rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</textarea><br />
+                        <x-global::forms.textarea rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</x-global::forms.textarea><br />
                     </span>
                     <input type="hidden" name="saveTimes" value="1" />
                     <input type="submit" value="{{ __('buttons.save') }}" name="saveTimes" class="button" />

--- a/app/Domain/Timesheets/Templates/addTime.blade.php
+++ b/app/Domain/Timesheets/Templates/addTime.blade.php
@@ -105,9 +105,9 @@ $values = $values ?? [];
                             <label for="hours">{!! __('HOURS') !!}</label> <x-global::forms.text-input
                                     id="hours" name="hours"
                                     value="{{ $values['hours'] }}" size="7" /> <br/>
-                            <label for="description">{!! __('DESCRIPTION') !!}</label> <textarea
+                            <label for="description">{!! __('DESCRIPTION') !!}</label> <x-global::forms.textarea
                                     rows="5" cols="50" id="description"
-                                    name="description">{{ $values['description'] }}</textarea><br/>
+                                    name="description">{{ $values['description'] }}</x-global::forms.textarea><br/>
                             <br/>
                             <br/>
                             <label for="invoicedEmpl">{!! __('INVOICED') !!}</label> <input

--- a/app/Domain/Timesheets/Templates/editTime.blade.php
+++ b/app/Domain/Timesheets/Templates/editTime.blade.php
@@ -124,8 +124,8 @@ use Leantime\Core\Support\FromFormat;
 <label for="hours">{!! __('label.hours') !!}</label> <x-global::forms.text-input
     id="hours" name="hours"
     value="{{ $values['hours'] }}" size="7" /> <br />
-<label for="description">{!! __('label.description') !!}</label> <textarea
-    rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</textarea><br />
+<label for="description">{!! __('label.description') !!}</label> <x-global::forms.textarea
+    rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</x-global::forms.textarea><br />
 
 
 

--- a/app/Domain/Widgets/Templates/partials/myToDos.blade.php
+++ b/app/Domain/Widgets/Templates/partials/myToDos.blade.php
@@ -196,8 +196,8 @@
                                            value=""/>
                                     <input type="hidden" name="dateToFinish"
                                            value="{{ date('Y-m-d', strtotime('next friday'))}}"/>
-                                    <textarea name="description" class="description-input" style="display:none;"
-                                              placeholder="{{ __('input.placeholders.description') }}"></textarea>
+                                    <x-global::forms.textarea name="description" class="description-input" style="display:none;"
+                                              placeholder="{{ __('input.placeholders.description') }}"></x-global::forms.textarea>
                                 </div>
                                 <div>
                                     <x-global::forms.button tag="input" inputType="submit" :labelText="__('buttons.save')" name="create"
@@ -281,8 +281,8 @@
                                         @endphp
                                         <input type="hidden" name="dateToFinish"
                                                value="{{ $dueDate }}"/>
-                                        <textarea name="description" class="description-input" style="display:none;"
-                                                  placeholder="{{ __('input.placeholders.description') }}"></textarea>
+                                        <x-global::forms.textarea name="description" class="description-input" style="display:none;"
+                                                  placeholder="{{ __('input.placeholders.description') }}"></x-global::forms.textarea>
                                     </div>
                                     <div>
                                         <x-global::forms.button tag="input" inputType="submit" :labelText="__('buttons.save')" name="create"

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -88,7 +88,7 @@
                             </div>
                             <div class="row" id="newMilestone" style="display:none;">
                                 <div class="col-md-12">
-                                    <textarea name="newMilestone"></textarea><br />
+                                    <x-global::forms.textarea name="newMilestone"></x-global::forms.textarea><br />
                                     <input type="hidden" name="type" value="milestone" />
                                     <input type="hidden" name="leancanvasitemid" value="{{ $id }} " />
                                     <x-global::forms.button tag="input" inputType="button" :labelText="__('buttons.save')" onclick="jQuery('#primaryArticleSubmitButton').click()" contentRole="primary" />

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -86,8 +86,8 @@ Status: ⬜ todo · 🟡 in progress · ✅ no-op done (on master) · 🎨 desig
 | Component | Tag | Cat | Status | Ref | Notes |
 |---|---|---|---|---|---|
 | button | `forms.button` | forms | ✅ | refactor/table-component | merged #3531: no-op migration + 3-tier role model |
-| text-input | `forms.text-input` | forms | 🟡 | refactor/table-component | PR #3558: thin no-op; **146 call-sites / 56 files migrated**; **defer JS-coupled** (datepickers/tags/inline-edit/color/sorter/hourCell) + legacy `<?php echo ?>`-in-attr |
-| textarea | `forms.textarea` | forms | ⬜ | selectsComponentUpdates | |
+| text-input | `forms.text-input` | forms | ✅ | refactor/table-component | merged #3558: no-op; 146 call-sites / 56 files; variants `headline`/`large`/`small` (dropped `form`/`legacy` as CSS-redundant); HTML-native `type` prop; **defer JS-coupled** (datepickers/tags/inline-edit/color/sorter/hourCell) + legacy `<?php echo ?>`-in-attr |
+| textarea | `forms.textarea` | forms | 🟡 | selectsComponentUpdates | PR #3562: thin no-op (attrs + inner-content slot); 10 plain migrated / 6 files; **defer Tiptap editors** (`.tiptapSimple`/`.tiptapComplex`/`.wiki-editor-textarea`) |
 | select (native) | `forms.select` | forms | ⬜ | refactor/table-component | native no-op first; JS-enhanced later |
 | form-field | `forms.field-row` | forms | ⬜ | refactor/table-component | label-row + caption + validation wrapper |
 | card (content-box) | `elements.card` | elements | ⬜ | ui-components | **replaces `.maincontentinner`** (167 sites) |
@@ -304,3 +304,14 @@ Only visually-distinct treatments earn a variant. Verdicts:
   canonical one being .secretInput) but its call-sites are the deferred async-save fields, so it's a planned
   variant; `legacy`(.input) = REDUNDANT (no `.input` CSS rule exists anywhere). **Dropped `variant="legacy"`**
   (1 call-site, TwoFA/edit → bare; removed the arm). Component now exposes only `headline`/`large`/`small`.
+- _textarea_: thin no-op `forms.textarea` (off master, post-#3558 merge; worktree `.claude/worktrees/textarea`).
+  Body is `<textarea {{ $attributes }}>{{ $slot }}</textarea>` — attributes pass through, the field value is
+  the slot (inner content) preserved EXACTLY (textareas are whitespace-sensitive). **10 plain textareas
+  migrated across 6 files** (Help projectDefinitionStep ×3, Ideas/Wiki newMilestone, Timesheets add/edit +
+  Tickets timesheet description, Widgets myToDos description-input ×2). **19 Tiptap editor textareas left
+  RAW** — JS upgrades exactly `textarea.tiptapSimple` / `textarea.tiptapComplex` (core/tiptap/index.js) plus
+  the Wiki `.wiki-editor-textarea`; never route those through the component. No `variant` arm (plain
+  textareas carry no distinct style class; the only textarea classes are editor-coupled). Verified: full diff
+  is pure `<textarea>`↔`<x-global::forms.textarea>` tag swaps (14 ins / 14 del symmetric), view:cache + Pint
+  clean, static audit = 0 plain missed / 19 editors deferred. (No live render: the dev server serves the main
+  checkout, not this worktree branch; the swap is a by-construction no-op like text-input's proven mechanism.)

--- a/app/Views/Templates/components/forms/textarea.blade.php
+++ b/app/Views/Templates/components/forms/textarea.blade.php
@@ -1,0 +1,43 @@
+@props([
+    // NO-OP textarea: renders a plain <textarea> with today's attributes + inner content.
+    // There is NO `variant` arm: the only textarea style-classes in the app (.tiptapSimple /
+    // .tiptapComplex / .wiki-editor-textarea) are JS rich-text EDITOR mounts — never route those
+    // through this component (see do-not-touch below). Plain textareas carry no distinct style
+    // class, so attribute + content passthrough is the whole no-op surface.
+
+    // --- design-system IDL: declared for the durable contract (shared with forms.text-input),
+    //     intentionally NOT rendered in no-op mode (a label/validation wrapper would change
+    //     today's markup). Activated in the design phase's field-row layout. ---
+    'contentRole' => '',      // reserved
+    'state' => '',            // info | warning | danger | success (validation) — reserved
+    'scale' => '',            // xs | s | m | l | xl — reserved
+    'labelPosition' => 'top', // reserved
+    'labelText' => '',        // reserved
+    'caption' => '',          // reserved
+    'validationText' => '',   // reserved
+    'validationState' => '',  // reserved
+])
+
+{{--
+    forms.textarea — NO-OP textarea.
+
+    Renders a plain <textarea> with the SAME attributes the app uses today; every attribute
+    (name, id, rows, cols, placeholder, style, class, data-*, hx-*, required, …) passes through
+    via $attributes, and the field's value is the slot (inner content), preserved EXACTLY.
+
+    ⚠️ DO NOT route rich-text EDITOR textareas through this component — JS upgrades them to Tiptap
+    and they will break. Keep these RAW:
+      • Tiptap: class="tiptapSimple" / class="tiptapComplex"  (JS scans `textarea.tiptapSimple` /
+        `textarea.tiptapComplex` and mounts an editor — public/assets/js/app/core/tiptap/index.js)
+      • Wiki editor: class="wiki-editor-textarea" (id="wikiArticleContent")
+      • any textarea with an inline on* handler or a data-*editor* attribute.
+
+    ⚠️ Whitespace matters: a textarea's value IS its inner content. Keep the slot tight —
+    <x-global::forms.textarea …>{{ $value }}</x-global::forms.textarea> — never add newlines/indent
+    around the value, or you change the field's content.
+
+    Migration:
+      <textarea name="x"></textarea>          -> <x-global::forms.textarea name="x"></x-global::forms.textarea>
+      <textarea name="x">{{ $v }}</textarea>  -> <x-global::forms.textarea name="x">{{ $v }}</x-global::forms.textarea>
+--}}
+<textarea {{ $attributes }}>{{ $slot }}</textarea>

--- a/app/Views/Templates/components/forms/textarea.blade.php
+++ b/app/Views/Templates/components/forms/textarea.blade.php
@@ -21,9 +21,11 @@
 {{--
     forms.textarea — NO-OP textarea.
 
-    Renders a plain <textarea> with the SAME attributes the app uses today; every attribute
-    (name, id, rows, cols, placeholder, style, class, data-*, hx-*, required, …) passes through
-    via $attributes, and the field's value is the slot (inner content), preserved EXACTLY.
+    Renders a plain <textarea> with the SAME attributes the app uses today. Every attribute EXCEPT the
+    declared @props above (name, id, rows, cols, placeholder, style, class, data-*, hx-*, required, …)
+    passes through via $attributes — Blade extracts declared props (state, contentRole, scale, labelText, …)
+    so they are NOT emitted as HTML (they're reserved for the design phase). The field's value is the slot
+    (inner content), preserved EXACTLY.
 
     ⚠️ DO NOT route rich-text EDITOR textareas through this component — JS upgrades them to Tiptap
     and they will break. Keep these RAW:


### PR DESCRIPTION
## What

Third componentization primitive after `forms.button` (#3531) and `forms.text-input` (#3558):
a **no-op** `forms.textarea` component plus migration of the **10 plain `<textarea>` tags** to it.

No-op = zero visual/behaviour change. The component is:

```blade
<textarea {{ $attributes }}>{{ $slot }}</textarea>
```

Attributes pass through; the field's value is the slot (inner content), preserved **exactly** —
textareas are whitespace-sensitive, so every migration keeps the slot tight.

## Deferred (left RAW) — the Tiptap editors ⚠️

Per the do-not-touch rule (same as datepickers for text-input), the **19 rich-text editor textareas
are NOT migrated**. JS upgrades exactly `textarea.tiptapSimple` / `textarea.tiptapComplex`
(`public/assets/js/app/core/tiptap/index.js`) plus the Wiki `.wiki-editor-textarea` — routing those
through a component would break the editors. The component's docblock documents this.

## Migrated (10 plain textareas / 6 files)

- `Help/projectDefinitionStep` ×3 (onboarding prompts)
- `Ideas/ideaDialog` + `Wiki/articleDialog` — `newMilestone`
- `Timesheets/addTime` + `Timesheets/editTime` + `Tickets/.../timesheet` — description
- `Widgets/.../myToDos` ×2 — `description-input` (no JS coupling — verified)

No `variant` arm: plain textareas carry no distinct style class (the only textarea classes are
editor-coupled and deferred).

## Verification

- **Full diff is pure `<textarea>` ↔ `<x-global::forms.textarea>` tag swaps** — every changed line
  only renames the element; all attributes + inner content preserved verbatim (14 ins / 14 del, symmetric).
- `view:cache` (compile gate) + Pint clean.
- Static audit: **0 plain textareas missed, 19 editors correctly deferred, 10 migrated.**
- Editor coupling traced in JS to confirm exactly which selectors TipTap consumes.

## Next
`forms.select` (native), then the `forms.field-row` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
