### PR TITLE
feat(components): migrate 44 class=button submit inputs to forms.button

### DIFF
--- a/app/Domain/Api/Templates/apiKey.blade.php
+++ b/app/Domain/Api/Templates/apiKey.blade.php
@@ -64,7 +64,7 @@
                     <div class="clearfix"></div>
 
                 <p class="stdformbutton">
-                    <input type="submit" name="save" id="save" value="{{ __('buttons.save') }}" class="button" />
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                 </p>
 
             </div>

--- a/app/Domain/Api/Templates/delKey.blade.php
+++ b/app/Domain/Api/Templates/delKey.blade.php
@@ -20,7 +20,7 @@
             <form method="post">
                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                 <p>{!! __('text.confirm_key_deletion') !!}</p><br />
-                <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" link="{{ BASE_URL }}/setting/editCompanySettings/#apiKeys" contentRole="tertiary">{!! __('buttons.back') !!}</x-global::forms.button>
             </form>
 

--- a/app/Domain/Api/Templates/newAPIKey.blade.php
+++ b/app/Domain/Api/Templates/newAPIKey.blade.php
@@ -69,7 +69,7 @@
                     <div class="clearfix"></div>
 
                 <p class="stdformbutton">
-                    <input type="submit" name="save" id="save" value="{{ __('buttons.save') }}" class="button" />
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                 </p>
 
             </div>

--- a/app/Domain/Blueprints/Templates/delCanvas.blade.php
+++ b/app/Domain/Blueprints/Templates/delCanvas.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/delCanvas/{{ $id }}">
     <p>{!! __('text.confirm_board_deletion') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary"
        link="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>

--- a/app/Domain/Blueprints/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Blueprints/Templates/delCanvasItem.blade.php
@@ -7,6 +7,6 @@
 
 <form method="post" action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/delCanvasItem/{{ $id }}">
     <p>{!! __('text.confirm_board_item_deletion') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>

--- a/app/Domain/Calendar/Templates/addEvent.blade.php
+++ b/app/Domain/Calendar/Templates/addEvent.blade.php
@@ -50,7 +50,7 @@
 
     <p class="stdformbutton">
         <input type="hidden" value="1" name="save" />
-        <input type="submit" name="saveEvent" id="saveEvent" value="{{ __('buttons.save') }}" class="button" />
+        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveEvent" id="saveEvent" />
     </p>
 
     @dispatchEvent('beforeFormClose')

--- a/app/Domain/Calendar/Templates/editEvent.blade.php
+++ b/app/Domain/Calendar/Templates/editEvent.blade.php
@@ -50,7 +50,7 @@
     <br />
     <x-global::forms.button tag="a" link="{{ BASE_URL }}/calendar/delEvent/{{ (int) $_GET['id'] }}" class="formModal delete right" state="danger" variant="outline"><i class="fa fa-trash"></i> {!! __('links.delete') !!}</x-global::forms.button>
     <input type="hidden" value="1" name="save" />
-    <input type="submit" name="saveEvent" id="save" value="{{ __('buttons.save') }}" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveEvent" id="save" />
 
     <div class="clear"></div>
 

--- a/app/Domain/Canvas/Templates/delCanvas.blade.php
+++ b/app/Domain/Canvas/Templates/delCanvas.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/delCanvas/{{ $id }}">
     <p>{!! __('text.confirm_board_deletion') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary"
        link="{{ BASE_URL }}/{{ $canvasName }}canvas/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>

--- a/app/Domain/Canvas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Canvas/Templates/delCanvasItem.blade.php
@@ -7,6 +7,6 @@
 
 <form method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/delCanvasItem/{{ $id }}">
     <p>{!! __('text.confirm_board_item_deletion') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/{{ $canvasName }}canvas/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>

--- a/app/Domain/Clients/Templates/delClient.blade.php
+++ b/app/Domain/Clients/Templates/delClient.blade.php
@@ -26,7 +26,7 @@
                 @dispatchEvent('afterFormOpen')
 
                 <p>{!! __('text.confirm_client_deletion') !!}<br /></p>
-                <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" link="/clients/showClient/{{ $client['id'] }}" contentRole="tertiary">{!! __('buttons.back') !!}</x-global::forms.button>
 
                 @dispatchEvent('beforeFormClose')

--- a/app/Domain/Clients/Templates/editClient.blade.php
+++ b/app/Domain/Clients/Templates/editClient.blade.php
@@ -56,8 +56,7 @@
                     name="phone" id="phone"
                     value="{{ $values['phone'] }}" /><br />
 
-                <input type="submit" name="save" id="save"
-                    value="{{ __('SAVE') }}" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('SAVE')" name="save" id="save" />
 
                 </div>
             </div>

--- a/app/Domain/Clients/Templates/showClient.blade.php
+++ b/app/Domain/Clients/Templates/showClient.blade.php
@@ -218,7 +218,7 @@
                             </div>
                         </div>
 
-                        <input type="submit" name="upload" class="button" value="{{ __('buttons.upload') }}" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.upload')" name="upload" />
 
                     </form>
                 </div>

--- a/app/Domain/Files/Templates/showAll.blade.php
+++ b/app/Domain/Files/Templates/showAll.blade.php
@@ -30,7 +30,7 @@
                             </div>
                         </div>
 
-                        <input type="submit" name="upload" class="button" value="{{ __('UPLOAD') }}" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('UPLOAD')" name="upload" />
 
                     </form>
 

--- a/app/Domain/Goalcanvas/Templates/delCanvas.blade.php
+++ b/app/Domain/Goalcanvas/Templates/delCanvas.blade.php
@@ -8,7 +8,7 @@
         <input type="hidden" name="csrf_token" value="{{ $csrf_token }}">
     @endif
     <p>{{ __('text.confirm_board_deletion') }}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/goalcanvas/showCanvas">{{ __('buttons.back') }}</x-global::forms.button>
 </form>
 

--- a/app/Domain/Goalcanvas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Goalcanvas/Templates/delCanvasItem.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/goalcanvas/delCanvasItem/{{ $id }}">
     <p>{{ __('text.confirm_board_item_deletion') }}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/goalcanvas/showCanvas">{{ __('buttons.back') }}</x-global::forms.button>
 </form>
 @endsection

--- a/app/Domain/Ideas/Templates/delCanvas.blade.php
+++ b/app/Domain/Ideas/Templates/delCanvas.blade.php
@@ -16,7 +16,7 @@
         <div class="widgetcontent">
             <form method="post" action="{{ BASE_URL }}/ideas/delCanvas/{{ $tpl->escape($_GET['id']) }}">
                 <p>{!! __('text.are_you_sure_delete_idea_board') !!}</p>
-                <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/ideas/showBoards">{!! __('buttons.back') !!}</x-global::forms.button>
             </form>
         </div>

--- a/app/Domain/Ideas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Ideas/Templates/delCanvasItem.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/ideas/delCanvasItem/{{ (int) $_GET['id'] }}">
     <p>{!! __('text.are_you_sure_delete_idea') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/ideas/showBoards/">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>
 

--- a/app/Domain/Projects/Templates/delProject.blade.php
+++ b/app/Domain/Projects/Templates/delProject.blade.php
@@ -21,7 +21,7 @@
 
             <form method="post">
                 <p>{!! __('text.confirm_project_deletion') !!}</p><br />
-                <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" link="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}" contentRole="tertiary">{!! __('buttons.back') !!}</x-global::forms.button>
             </form>
 

--- a/app/Domain/Projects/Templates/newProject.blade.php
+++ b/app/Domain/Projects/Templates/newProject.blade.php
@@ -57,7 +57,7 @@
                                         <x-global::forms.button tag="a" link="{{ BASE_URL }}/projects/delProject/{{ $project['id'] }}" class="delete" state="danger" variant="outline"><i class="fa fa-trash"></i> {!! __('buttons.delete') !!}</x-global::forms.button>
                                     </div>
                                 @endif
-                                <input type="submit" name="save" id="save" class="button" value="{{ __('buttons.save') }}" class="button" />
+                                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
 
                             </div>
                         </div>

--- a/app/Domain/Projects/Templates/showProject.blade.php
+++ b/app/Domain/Projects/Templates/showProject.blade.php
@@ -191,7 +191,7 @@
                     </div>
                 </div>
                     <br/>
-                    <input type="submit" name="saveUsers" id="save" class="button" value="{{ __('buttons.save') }}" class="button" />
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveUsers" id="save" />
 
                 </form>
 

--- a/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
@@ -26,7 +26,7 @@
             <div class="row padding-top">
                 <div class="col-md-12">
 
-                    <input type="submit" name="save" id="save" class="button" value="{{ __('buttons.save') }}" class="button" />
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                 </div>
 
             </div>

--- a/app/Domain/Sprints/Templates/delSprint.blade.php
+++ b/app/Domain/Sprints/Templates/delSprint.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/sprints/delSprint/{{ $id }}">
     <p>{!! __('text.are_you_sure_delete_sprint') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ session('lastPage') }}">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>
 

--- a/app/Domain/Tickets/Templates/delMilestone.blade.php
+++ b/app/Domain/Tickets/Templates/delMilestone.blade.php
@@ -2,6 +2,6 @@
 
 <form method="post" action="{{ BASE_URL }}/tickets/delMilestone/{{ $ticket->id }}">
     <p>{!! __('text.confirm_milestone_deletion') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/tickets/roadmap/">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>

--- a/app/Domain/Tickets/Templates/delTicket.blade.php
+++ b/app/Domain/Tickets/Templates/delTicket.blade.php
@@ -7,7 +7,7 @@
     @if (is_object($ticket))
         <form method="post" action="{{ BASE_URL }}/tickets/delTicket/{{ $ticket->id }}">
             <p>{!! __('text.confirm_ticket_deletion') !!}</p><br />
-            <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
 
             <x-global::forms.button tag="a" contentRole="tertiary" link="#/tickets/showTicket/{{ $ticket->id }}">{!! __('buttons.back') !!}</x-global::forms.button>
 

--- a/app/Domain/Tickets/Templates/moveTicket.blade.php
+++ b/app/Domain/Tickets/Templates/moveTicket.blade.php
@@ -35,7 +35,7 @@
         @endphp
         </select><br /><br /><br /><br />
         <br />
-        <input type="submit" value="{{ __('buttons.move') }}" name="move" class="button" />
+        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.move')" name="move" />
         <x-global::forms.button tag="a" class="pull-right" link="javascript:void(0);" onclick="jQuery.nmTop().close();" contentRole="tertiary">{!! __('buttons.back') !!}</x-global::forms.button>
         <div class="clearall"></div>
         <br />

--- a/app/Domain/Tickets/Templates/submodules/attachments.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/attachments.blade.php
@@ -19,7 +19,7 @@
          </div>
        </div>
 
-       <input type="submit" name="upload" class="button" value="{{ __('buttons.upload') }}" />
+       <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.upload')" name="upload" />
 
     </form>
 

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -38,7 +38,7 @@ $currentPay = $userHours * $userInfo['wage'];
                         <textarea rows="5" cols="50" id="description" name="description">{{ $values['description'] }}</textarea><br />
                     </span>
                     <input type="hidden" name="saveTimes" value="1" />
-                    <input type="submit" value="{{ __('buttons.save') }}" name="saveTimes" class="button" />
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveTimes" />
 
                 </form>
 

--- a/app/Domain/Timesheets/Templates/addTime.blade.php
+++ b/app/Domain/Timesheets/Templates/addTime.blade.php
@@ -147,10 +147,7 @@ $values = $values ?? [];
 
 
 
-                            @endif <input type="submit" value="{{ __('SAVE') }}"
-                                              name="save" class="button"/> <input type="submit"
-                                                                                  value="{{ __('SAVE_NEW') }}"
-                                                                                  name="saveNew" class="button"/>
+                            @endif <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('SAVE')" name="save" /> <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('SAVE_NEW')" name="saveNew" />
 
 
         </form>

--- a/app/Domain/Timesheets/Templates/delTime.blade.php
+++ b/app/Domain/Timesheets/Templates/delTime.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/timesheets/delTime/{{ $id }}">
     <p>{!! __('text.confirm_delete_timesheet') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ session('lastPage') }}">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>
 

--- a/app/Domain/Timesheets/Templates/editTime.blade.php
+++ b/app/Domain/Timesheets/Templates/editTime.blade.php
@@ -179,6 +179,6 @@ use Leantime\Core\Support\FromFormat;
     <input type="hidden" name="saveForm" value="1"/>
     <p class="stdformbutton">
         <x-global::forms.button tag="a" class="delete editTimeModal pull-right" link="{{ BASE_URL }}/timesheets/delTime/{{ $tpl->escape($_GET['id']) }}" state="danger" variant="outline">{!! __('links.delete') !!}</x-global::forms.button>
-        <input type="submit" value="{{ __('buttons.save') }}" name="save" class="button" />
+        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" />
     </p>
 </form>

--- a/app/Domain/Timesheets/Templates/showAll.blade.php
+++ b/app/Domain/Timesheets/Templates/showAll.blade.php
@@ -340,7 +340,7 @@
 
                         <td>
                             @if ($login::userIsAtLeast($roles::$manager))
-                            <input type="submit" class="button" value="{{ __('buttons.save') }}" name="saveInvoice" />
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveInvoice" />
                             @endif
                         </td>
                         <td>

--- a/app/Domain/TwoFA/Templates/edit.blade.php
+++ b/app/Domain/TwoFA/Templates/edit.blade.php
@@ -36,8 +36,7 @@
                                 <input type="hidden" name="secret" value="{{ $secret }}" />
                                 <br/>
                                 <p class='stdformbutton'>
-                                    <input type="submit" name="save" id="save"
-                                           value="{{ __('buttons.save') }}" class="button"/>
+                                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                                 </p>
                             </form>
                         @else
@@ -45,8 +44,7 @@
                                 <h5>{!! __('text.twoFA_already_enabled') !!}</h5>
                                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                                 <p class='stdformbutton'>
-                                    <input type="submit" name="disable" id="disable"
-                                           value="{{ __('buttons.remove') }}" class="button"/>
+                                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.remove')" name="disable" id="disable" />
                                     <x-global::forms.button tag="a" link="{{ BASE_URL }}/users/editOwn">{!! __('buttons.back') !!}</x-global::forms.button>
                                 </p>
                             </form>

--- a/app/Domain/Users/Templates/delUser.blade.php
+++ b/app/Domain/Users/Templates/delUser.blade.php
@@ -20,7 +20,7 @@
             <form method="post">
                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                 <p>{!! __('text.confirm_user_deletion') !!}</p><br />
-                <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/users/showAll">{!! __('buttons.back') !!}</x-global::forms.button>
             </form>
 

--- a/app/Domain/Users/Templates/editOwn.blade.php
+++ b/app/Domain/Users/Templates/editOwn.blade.php
@@ -67,7 +67,7 @@
                                         <p class='stdformbutton'>
                                             <input type="hidden" name="profileInfo" value="1" />
 
-                                            <input type="submit" name="save" id="save" value="{{ __('buttons.save') }}" class="button"/>
+                                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                                         </p>
                                         <br />
                                         <h4 class="widgettitle title-light">{{ __('label.employee_information') }}</h4>
@@ -185,7 +185,7 @@
                             </div>
                             @if (!session("userdata.isExternalAuth") )
                                 <input type="hidden" name="savepw" value="1" />
-                                <input type="submit" name="save" id="savePw" value="{{ __('buttons.save') }}" class="button"/>
+                                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="savePw" />
                             @endif
                         </form>
                         <br /><br />
@@ -272,7 +272,7 @@
                                 </div>
                             </div>
                             <input type="hidden" name="saveSettings" value="1" />
-                            <input type="submit" name="save" id="saveSettings" value="{{ __('buttons.save') }}" class="button"/>
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="saveSettings" />
                         </form>
                     </div>
 
@@ -348,7 +348,7 @@
                             </div>
                             <br /><br />
                             <input type="hidden" name="saveTheme" value="1" />
-                            <input type="submit" name="save" id="saveTheme" value="{{ __('buttons.save') }}" class="button"/>
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="saveTheme" />
                         </form>
 
                         @dispatchEvent('themecontent')
@@ -478,7 +478,7 @@
                             </div>
 
                             <input type="hidden" name="savenotifications" value="1" />
-                            <input type="submit" name="save" value="{{ __('buttons.save') }}" class="button"/>
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" />
                         </form>
                     </div>
 

--- a/app/Domain/Users/Templates/editUser.blade.php
+++ b/app/Domain/Users/Templates/editUser.blade.php
@@ -122,7 +122,7 @@
 
 
                     <p class="stdformbutton">
-                        <input type="submit" name="save" id="save" value="{{ __('buttons.save') }}" class="button" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="save" id="save" />
                     </p>
                     </div>
                 </div>

--- a/app/Domain/Users/Templates/newUser.blade.php
+++ b/app/Domain/Users/Templates/newUser.blade.php
@@ -78,7 +78,7 @@
 
                     <p class="stdformbutton">
                         <input type="hidden" name="save" value="1" />
-                        <input type="submit" name="save" id="save" value="{{ __('buttons.invite_user') }}" class="button" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.invite_user')" name="save" id="save" />
                     </p>
 
         </div>

--- a/app/Domain/Wiki/Templates/delArticle.blade.php
+++ b/app/Domain/Wiki/Templates/delArticle.blade.php
@@ -10,7 +10,7 @@
 
 <form method="post" action="{{ BASE_URL }}/wiki/delArticle/{{ (int) $_GET['id'] }}">
     <p>{!! __('text.are_you_sure_delete_article') !!}</p><br />
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/wiki/show/">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>
 

--- a/app/Domain/Wiki/Templates/delWiki.blade.php
+++ b/app/Domain/Wiki/Templates/delWiki.blade.php
@@ -6,7 +6,7 @@
 
 <form method="post" action="{{ BASE_URL }}/wiki/delWiki/{{ $tpl->escape($_GET['id']) }}">
     <p>{!! __('text.are_you_sure_delete_wiki') !!}</p>
-    <input type="submit" value="{{ __('buttons.yes_delete') }}" name="del" class="button" />
+    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/wiki/show">{!! __('buttons.back') !!}</x-global::forms.button>
 </form>
 

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -191,8 +191,13 @@ tags for `<?php` / `<?=` before committing.
 
 The no-op migration deliberately defers buttons it can't migrate without changing the rendered
 class set / behavior. Categories found (to revisit, some need a design decision):
-- **`class="button"` (not `btn`)** — many form submit inputs use `.button`. Need to confirm
-  whether `.button` styling == `.btn` in forms.css; if so, add it to the component/migration.
+- ~~**`class="button"` (not `btn`)**~~ — DONE (PR follow-up): a CSS audit found `.button` has **no rule at
+  all**; `input[type='submit']` is styled by the `.btn-primary` element-selector group (forms.css:313), so
+  these 44 submits already render as primary buttons. Migrated all 44 to
+  `<x-global::forms.button tag="input" inputType="submit" contentRole="primary">` (no-op). Also cleaned up a
+  few pre-existing duplicate `class="button" class="button"` attrs. **Follow-up:** ~16 are `del*` confirmation
+  submits that look primary today — candidates for `state="danger"` in a later semantic pass (a visual change,
+  not a no-op).
 - **Unstyled `<input type="submit">`** (no class) — adding `btn` is a *design* change, not a no-op. Defer.
 - **Unmapped btn variants** — `btn-sm`/`btn-lg` (vs Leantime `btn-small`/`btn-large`),
   `btn-danger-outline`, `btn-circle`, `btn-inverse`, `btn-file`. Add mappings (after confirming CSS) or keep deferred.

--- a/tests/Acceptance/TimesheetCest.php
+++ b/tests/Acceptance/TimesheetCest.php
@@ -182,7 +182,7 @@ class TimesheetCest
         $I->clickWithRetry('#editTimesheet-1');
         $I->waitForElementVisible('#hours');
         $I->fillField('#hours', 2);
-        $I->clickWithRetry('.stdformbutton .button');
+        $I->clickWithRetry('.stdformbutton input[type=submit]');
         $I->waitForElement('.growl', 120);
 
         $I->seeInDatabase('zp_timesheets', [
@@ -213,7 +213,7 @@ class TimesheetCest
         $I->waitForElementVisible('#hours');
         $I->fillField('#hours', 4);
 
-        $I->clickWithRetry('.formModal .button');
+        $I->clickWithRetry('.formModal input[type=submit][name=saveTimes]');
         $I->wait(1);
 
         // Go and see if the total is correct.
@@ -244,21 +244,21 @@ class TimesheetCest
 
         // Maker paid
         $I->checkOption('//*//input[@id="checkAllPaid"]');
-        $I->clickWithRetry('#allTimesheetsTable_wrapper .button');
+        $I->clickWithRetry('#allTimesheetsTable_wrapper input[name=saveInvoice]');
         $I->waitForElementVisible('#allTimesheetsTable_wrapper');
         $I->wait(2);
         $I->cantSeeElement('//*//input[@class="paid"]');
 
         // Make Invoiced
         $I->checkOption('//*/input[@id="checkAllEmpl"]');
-        $I->clickWithRetry('#allTimesheetsTable_wrapper .button');
+        $I->clickWithRetry('#allTimesheetsTable_wrapper input[name=saveInvoice]');
         $I->waitForElementVisible('#allTimesheetsTable_wrapper');
         $I->wait(2);
         $I->cantSeeElement('//*//input[@class="invoicedEmpl"]');
 
         // Make MGR Approval
         $I->checkOption('//*//input[@id="checkAllComp"]');
-        $I->clickWithRetry('#allTimesheetsTable_wrapper .button');
+        $I->clickWithRetry('#allTimesheetsTable_wrapper input[name=saveInvoice]');
         $I->waitForElementVisible('#allTimesheetsTable_wrapper');
         $I->wait(2);
         $I->cantSeeElement('//*//input[@class="invoicedComp"]');
@@ -281,7 +281,7 @@ class TimesheetCest
         $I->wait(5);
         $I->see('Should the timesheet really be deleted?');
 
-        $I->clickWithRetry('.nyroModalLink .button');
+        $I->clickWithRetry('.nyroModalLink input[type=submit]');
 
         $I->waitForElementVisible('#allTimesheetsTable');
         $I->wait(5);


### PR DESCRIPTION
## What

Completes the deferred **`class="button"`** item from the button PR (#3531). While reviewing the
textarea PR you spotted a stray un-componentized submit button in `timesheet.blade.php`:
```html
<input type="submit" value="{{ __('buttons.save') }}" name="saveTimes" class="button" />
```
There were **44** of these across 38 files — all `input[type="submit"]` with `class="button"`.

## Why they were deferred (and why it's now safe)

The button component always emits `btn …`, so the deferral was: is migrating `.button` → `btn` a no-op?
A CSS audit answers it:
- **`.button` has no CSS rule anywhere** (dead class, like `.input`/`.form-control` were).
- `input[type='submit']` is part of the **`.btn-primary` element-selector group** (`forms.css:313`), so
  these submits **already render as primary buttons today**.

So migrating each to `contentRole="primary"` reproduces the current look — a genuine no-op.

## Change

Each becomes:
```blade
<x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="…" name="…" />
```
`value` → `:labelText`, `type` → `inputType`, `class="button"` → `contentRole="primary"`, all other attrs
pass through. Also removed a few pre-existing **duplicate `class="button" class="button"`** attributes
(showProject, projectDetails).

## Verification
- **0 `class="button"` remaining**; diff is pure tag swaps (value→:labelText, type→inputType, class→role).
- `view:cache` + Pint clean (38 files).
- Static audit of every `tag="input"` button = 0 problems (no stray `type=`, no duplicate attrs, no nested quotes).

## Follow-up (separate, not a no-op)
~16 of these are `del*` confirmation submits (Delete Ticket, Delete Project, …) that render **primary**
today. They're natural candidates for `state="danger"` in a later semantic pass — but that's a visual
change, so it's intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
