### PR TITLE
feat(components): button + text-input completion round 2 (53 missed elements)

### DIFF
--- a/app/Domain/Auth/Templates/partials/tokens.blade.php
+++ b/app/Domain/Auth/Templates/partials/tokens.blade.php
@@ -6,10 +6,7 @@
             <p>{{ __('text.create_tokens_to_authenticate') }}</p>
             <br />
 
-            <a class="btn btn-primary"
-                     href="#/auth/tokenNew">
-                {{ __('buttons.create_token') }}
-            </a> <br />
+            <x-global::forms.button tag="a" contentRole="primary" link="#/auth/tokenNew">{{ __('buttons.create_token') }}</x-global::forms.button> <br />
 
             <div class="clearfix"></div>
 
@@ -29,12 +26,7 @@
                         <td>{{ $token['last_used_at'] ? format($token['last_used_at'])->date() . ' ' . format($token['last_used_at'])->time(): 'Never' }}</td>
                         <td>{{ format($token['created_at'])->date(). ' ' . format($token['created_at'])->time() }}</td>
                         <td>
-                            <button class="btn btn-danger btn-sm"
-                                    hx-delete="{{ BASE_URL }}/hx/auth/personalTokens/delete/{{ $token['id'] }}"
-                                    hx-confirm="{{ __('notifications.confirm_token_delete') }}"
-                                    hx-target="#personalTokens">
-                                <i class="fa fa-trash"></i>
-                            </button>
+                            <x-global::forms.button state="danger" class="btn-sm" hx-delete="{{ BASE_URL }}/hx/auth/personalTokens/delete/{{ $token['id'] }}" hx-confirm="{{ __('notifications.confirm_token_delete') }}" hx-target="#personalTokens"><i class="fa fa-trash"></i></x-global::forms.button>
                         </td>
                     </tr>
                 @endforeach

--- a/app/Domain/Auth/Templates/requestPwLink.blade.php
+++ b/app/Domain/Auth/Templates/requestPwLink.blade.php
@@ -22,7 +22,7 @@
                 <a href="{{ BASE_URL }}/" class="forgotPw">{!! __('links.back_to_login') !!}</a>
             </div>
             @dispatchEvent('beforeSubmitButton')
-            <input type="submit" name="resetPassword" value="{{ __('buttons.reset_password') }}" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.reset_password')" name="resetPassword" />
         </div>
         @dispatchEvent('beforeFormClose')
     </form>

--- a/app/Domain/Auth/Templates/resetPw.blade.php
+++ b/app/Domain/Auth/Templates/resetPw.blade.php
@@ -30,7 +30,7 @@
         <div class="">
 
             @dispatchEvent('beforeSubmitButton')
-            <input type="submit" name="resetPassword" value="{{ __('buttons.reset_password') }}" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.reset_password')" name="resetPassword" />
             <div class="forgotPwContainer">
                 <a href="{{ BASE_URL }}/" class="forgotPw">{!! __('links.back_to_login') !!}</a>
             </div>

--- a/app/Domain/Auth/Templates/token-created.blade.php
+++ b/app/Domain/Auth/Templates/token-created.blade.php
@@ -1,16 +1,10 @@
 <h4 class="widgettitle title-light">{{ __('headlines.token_created') }}</h4>
 <p>{{ __('text.copy_token_now') }}</p>
 <div class="form-group">
-    <input type="text" class="form-control" value="{{ $newToken }}" onclick="this.select();" />
+    <x-global::forms.text-input value="{{ $newToken }}" onclick="this.select();" />
 </div>
 
 <div class="align-right">
-    <button type="button" class="btn btn-default"
-            onclick="leantime.modals.closeModal();">
-        {{ __('buttons.close') }}
-    </button>
-    <button type="button" class="btn btn-primary"
-            onclick="leantime.snippets.copyToClipboard('{{ $newToken }}')">
-        {{ __('buttons.copy_to_clipboard') }}
-    </button>
+    <x-global::forms.button inputType="button" contentRole="default" onclick="leantime.modals.closeModal();">{{ __('buttons.close') }}</x-global::forms.button>
+    <x-global::forms.button inputType="button" contentRole="primary" onclick="leantime.snippets.copyToClipboard('{{ $newToken }}')">{{ __('buttons.copy_to_clipboard') }}</x-global::forms.button>
 </div>

--- a/app/Domain/Auth/Templates/tokenNew.blade.php
+++ b/app/Domain/Auth/Templates/tokenNew.blade.php
@@ -6,21 +6,15 @@
 
         <div class="form-group">
             <label for="tokenName">{{ __('label.token_name') }}</label>
-            <input type="text" class="form-control" id="tokenName"
-                   name="name" required>
+            <x-global::forms.text-input id="tokenName" name="name" required />
             <small class="form-text text-muted">
                 <br/>{{ __('text.token_name_description') }}
             </small>
         </div>
         <br />
         <div class="align-right">
-            <button type="button" class="btn btn-default"
-                    onclick="jQuery('#modal').modal('hide');">
-                {{ __('buttons.close') }}
-            </button>
-            <button type="submit" class="btn btn-primary">
-                {{ __('buttons.create_token') }}
-            </button>
+            <x-global::forms.button inputType="button" contentRole="default" onclick="jQuery('#modal').modal('hide');">{{ __('buttons.close') }}</x-global::forms.button>
+            <x-global::forms.button inputType="submit" contentRole="primary">{{ __('buttons.create_token') }}</x-global::forms.button>
         </div>
     </form>
 </div>

--- a/app/Domain/Auth/Templates/userInvite5.blade.php
+++ b/app/Domain/Auth/Templates/userInvite5.blade.php
@@ -32,7 +32,7 @@
             intentions<br />to get the work done.</p> <br />
 
         <br />
-        <input type="submit" name="createAccount" value="Complete Sign up" />
+        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" labelText="Complete Sign up" name="createAccount" />
 
 
     </form>

--- a/app/Domain/Blueprints/Templates/canvasDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/canvasDialog.blade.php
@@ -107,7 +107,7 @@
         @endif
 
         @if($login::userIsAtLeast($roles::$editor))
-            <input type="submit" value="{{ __('buttons.save') }}" id="primaryCanvasSubmitButton"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="primaryCanvasSubmitButton" />
             <x-global::forms.button inputType="submit" contentRole="secondary" value="closeModal" id="saveAndClose" onclick="leantime.blueprintsController.setCloseModal();">{!! __('buttons.save_and_close') !!}</x-global::forms.button>
         @endif
 

--- a/app/Domain/Calendar/Templates/export.blade.php
+++ b/app/Domain/Calendar/Templates/export.blade.php
@@ -30,7 +30,7 @@
 
             @dispatchEvent('beforeSubmitButton')
 
-            <br /><input type="submit" value="{{ __('buttons.generate_ical_url') }}"/>
+            <br /><x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.generate_ical_url')" />
 
         </div>
         <div class="col-md-6 align-right">

--- a/app/Domain/Canvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Canvas/Templates/canvasDialog.blade.php
@@ -105,7 +105,7 @@
         @endif
 
         @if($login::userIsAtLeast($roles::$editor))
-            <input type="submit" value="{{ __('buttons.save') }}" id="primaryCanvasSubmitButton"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="primaryCanvasSubmitButton" />
             <x-global::forms.button inputType="submit" contentRole="secondary" value="closeModal" id="saveAndClose" onclick="leantime.{{ $canvasName }}CanvasController.setCloseModal();">{!! __('buttons.save_and_close') !!}</x-global::forms.button>
         @endif
 

--- a/app/Domain/Comments/Templates/components/input.blade.php
+++ b/app/Domain/Comments/Templates/components/input.blade.php
@@ -3,12 +3,7 @@
         <x-users::profile-image :user="$user" />
     </div>
     <div class="commentReply">
-        <input
-            type="submit"
-            value="{{ __('links.reply') }}"
-            name="comment"
-            class="btn btn-default"
-        />
+        <x-global::forms.button tag="input" inputType="submit" contentRole="default" :labelText="__('links.reply')" name="comment" />
     </div>
     <div class="clearall"></div>
 </div>

--- a/app/Domain/Errors/Templates/error403.blade.php
+++ b/app/Domain/Errors/Templates/error403.blade.php
@@ -9,7 +9,7 @@
     <span class="animate2 bounceIn">0</span>
     <span class="animate3 bounceIn">3</span>
     <div class="errorbtns animate4 fadeInUp">
-        <a onclick="history.back()" class="btn btn-default">{!! __('buttons.back') !!}</a>
+        <x-global::forms.button tag="a" contentRole="default" onclick="history.back()">{!! __('buttons.back') !!}</x-global::forms.button>
         <x-global::forms.button tag="a" link="{{ BASE_URL }}" contentRole="primary">{!! __('links.dashboard') !!}</x-global::forms.button>
     </div><br/><br/><br/><br/>
 

--- a/app/Domain/Errors/Templates/error404.blade.php
+++ b/app/Domain/Errors/Templates/error404.blade.php
@@ -9,7 +9,7 @@
     <span class="animate2 bounceIn">0</span>
     <span class="animate3 bounceIn">4</span>
     <div class="errorbtns animate4 fadeInUp">
-        <a onclick="history.back()" class="btn btn-default">{!! __('buttons.back') !!}</a>
+        <x-global::forms.button tag="a" contentRole="default" onclick="history.back()">{!! __('buttons.back') !!}</x-global::forms.button>
         <x-global::forms.button tag="a" link="{{ BASE_URL }}" contentRole="primary">{!! __('links.dashboard') !!}</x-global::forms.button>
     </div><br/><br/><br/><br/>
 

--- a/app/Domain/Errors/Templates/error500.blade.php
+++ b/app/Domain/Errors/Templates/error500.blade.php
@@ -9,7 +9,7 @@
     <span class="animate2 bounceIn">0</span>
     <span class="animate3 bounceIn">0</span>
     <div class="errorbtns animate4 fadeInUp">
-        <a onclick="history.back()" class="btn btn-default">{!! __('buttons.back') !!}</a>
+        <x-global::forms.button tag="a" contentRole="default" onclick="history.back()">{!! __('buttons.back') !!}</x-global::forms.button>
         <x-global::forms.button tag="a" link="{{ BASE_URL }}" contentRole="primary">{!! __('links.dashboard') !!}</x-global::forms.button>
     </div><br/><br/><br/><br/>
 

--- a/app/Domain/Errors/Templates/error501.blade.php
+++ b/app/Domain/Errors/Templates/error501.blade.php
@@ -9,7 +9,7 @@
     <span class="animate2 bounceIn">0</span>
     <span class="animate3 bounceIn">1</span>
     <div class="errorbtns animate4 fadeInUp">
-        <a onclick="history.back()" class="btn btn-default">{!! __('buttons.back') !!}</a>
+        <x-global::forms.button tag="a" contentRole="default" onclick="history.back()">{!! __('buttons.back') !!}</x-global::forms.button>
         <x-global::forms.button tag="a" link="{{ BASE_URL }}" contentRole="primary">{!! __('links.dashboard') !!}</x-global::forms.button>
     </div><br/><br/><br/><br/>
 

--- a/app/Domain/Files/Templates/browse.blade.php
+++ b/app/Domain/Files/Templates/browse.blade.php
@@ -30,7 +30,7 @@
         @if ($login::userIsAtLeast($roles::$editor))
         <div class="uploadWrapper">
 
-            <a href="javascript:void(0);" id="cancelLink" class="btn btn-default" style="display:none;">{!! __('links.cancel') !!}</a>
+            <x-global::forms.button tag="a" contentRole="default" id="cancelLink" link="javascript:void(0);" style="display:none;">{!! __('links.cancel') !!}</x-global::forms.button>
             <div class="extra" style="margin-top:5px;"></div>
             <div class="fileUploadDrop">
                 <p><i>{!! __('text.drop_files') !!}</i></p>

--- a/app/Domain/Files/Templates/submodules/showAll.blade.php
+++ b/app/Domain/Files/Templates/submodules/showAll.blade.php
@@ -10,7 +10,7 @@
 
     <div class="uploadWrapper">
 
-        <a href="javascript:void(0);" id="cancelLink" class="btn btn-default" style="display:none;">{!! __('links.cancel') !!}</a>
+        <x-global::forms.button tag="a" contentRole="default" id="cancelLink" link="javascript:void(0);" style="display:none;">{!! __('links.cancel') !!}</x-global::forms.button>
         <div class="extra" style="margin-top:5px;"></div>
         <div class="fileUploadDrop">
             <p><i>{!! __('text.drop_files') !!}</i></p>

--- a/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
@@ -13,7 +13,7 @@
     <br />
     <div class="row">
         <div class="col-md-6">
-            <input type="submit" value="{{ __('buttons.save') }}" id="saveBtn" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="saveBtn" />
         </div>
         <div class="col-md-6 align-right padding-top-sm">
 

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -82,7 +82,7 @@
 
                     <br>
                     @if ($login::userIsAtLeast($roles::$editor))
-                        <input type="submit" value="{{ __('buttons.save') }}" id="primaryCanvasSubmitButton">
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="primaryCanvasSubmitButton" />
                         <x-global::forms.button inputType="submit" contentRole="secondary" id="saveAndClose" value="closeModal"
                             onclick="leantime.goalCanvasController.setCloseModal();">{{ __('buttons.save_and_close') }}</x-global::forms.button>
                     @endif

--- a/app/Domain/Help/Templates/inviteTeamStep.blade.php
+++ b/app/Domain/Help/Templates/inviteTeamStep.blade.php
@@ -19,7 +19,7 @@
     <div class="row">
         <div class="col-md-12 tw-text-right">
             <x-global::forms.button tag="a" link="javascript:void(0);" contentRole="tertiary" onclick="jQuery.nmTop().close();">{{ __('links.skip_for_now') }}</x-global::forms.button>
-            <input type="submit" value="{{ __('buttons.lets_go') }}"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.lets_go')" />
         </div>
     </div>
 

--- a/app/Domain/Help/Templates/projectDefinitionStep.blade.php
+++ b/app/Domain/Help/Templates/projectDefinitionStep.blade.php
@@ -24,7 +24,7 @@
         </div>
         <div class="row">
             <div class="col-md-12 tw-text-right">
-                <input type="submit" value="{{ __('buttons.next') }}" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.next')" />
             </div>
         </div>
     </form>

--- a/app/Domain/Help/Templates/projectIntroStep.blade.php
+++ b/app/Domain/Help/Templates/projectIntroStep.blade.php
@@ -18,7 +18,7 @@
         </div>
         <div class="row">
             <div class="col-md-12 tw-text-right">
-                <input type="submit" value="{{ __('buttons.next') }}" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.next')" />
             </div>
         </div>
     </form>

--- a/app/Domain/Help/Templates/support.blade.php
+++ b/app/Domain/Help/Templates/support.blade.php
@@ -147,7 +147,7 @@
                         <h1 class="fancyLink">Ready to make a direct impact?</h1><p>Every contribution—from $1 to $100—goes directly to making Leantime better for everyone.</p>
                         <br />
                         <div class="tw-text-center">
-                            <x-global::forms.button tag="a" contentRole="primary" class="btn-lg" link="https://github.com/sponsors/Leantime" target="_blank">Start Sponsoring Today</x-global::forms.button>
+                            <x-global::forms.button tag="a" contentRole="primary" class="btn-lg" link="https://github.com/sponsors/Leantime" target="_blank" rel="noopener noreferrer">Start Sponsoring Today</x-global::forms.button>
                         </div>
                     </center>
                 </div>

--- a/app/Domain/Help/Templates/support.blade.php
+++ b/app/Domain/Help/Templates/support.blade.php
@@ -147,7 +147,7 @@
                         <h1 class="fancyLink">Ready to make a direct impact?</h1><p>Every contribution—from $1 to $100—goes directly to making Leantime better for everyone.</p>
                         <br />
                         <div class="tw-text-center">
-                            <a href="https://github.com/sponsors/Leantime" class="btn btn-primary btn-lg" target="_blank">Start Sponsoring Today</a>
+                            <x-global::forms.button tag="a" contentRole="primary" class="btn-lg" link="https://github.com/sponsors/Leantime" target="_blank">Start Sponsoring Today</x-global::forms.button>
                         </div>
                     </center>
                 </div>

--- a/app/Domain/Ideas/Templates/ideaDialog.blade.php
+++ b/app/Domain/Ideas/Templates/ideaDialog.blade.php
@@ -37,7 +37,7 @@
         <textarea rows="3" cols="10" name="data" class="tiptapComplex"
                   placeholder="">{!! $tpl->escapeMinimal($canvasItem['data']) !!}</textarea><br/>
 
-        <input type="submit" value="{{ __('buttons.save') }}" id="primaryCanvasSubmitButton"/>
+        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="primaryCanvasSubmitButton" />
         <x-global::forms.button contentRole="secondary" inputType="submit" value="closeModal" id="saveAndClose">{!! __('buttons.save_and_close') !!}</x-global::forms.button>
 
         @if ($id !== '')

--- a/app/Domain/Projects/Templates/duplicateProject.blade.php
+++ b/app/Domain/Projects/Templates/duplicateProject.blade.php
@@ -27,7 +27,7 @@
 
     <div class="row">
         <div class="col-md-6">
-            <input type="submit" value="{{ __('buttons.duplicate') }}"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.duplicate')" />
         </div>
         <div class="col-md-6 align-right padding-top-sm">
 

--- a/app/Domain/Projects/Templates/showProject.blade.php
+++ b/app/Domain/Projects/Templates/showProject.blade.php
@@ -23,7 +23,7 @@
         <div class="inlineDropDownContainer" style="float:right; z-index:9; padding-top:2px;">
 
             <x-global::forms.button tag="a" link="{{ BASE_URL }}/projects/duplicateProject/{{ $project['id'] }}" contentRole="default" class="duplicateProjectModal" data-tippy-content="{{ __('link.duplicate_project') }}"><i class="fa-regular fa-copy"></i> Copy</x-global::forms.button>
-            <a href="{{ BASE_URL }}/projects/delProject/{{ $project['id'] }}" data-tippy-content="{{ __('link.delete_project') }}" class="btn btn-danger-outline delete"><i class="fa fa-trash"></i> Delete</a>
+            <x-global::forms.button tag="a" state="danger" variant="outline" class="delete" link="{{ BASE_URL }}/projects/delProject/{{ $project['id'] }}" data-tippy-content="{{ __('link.delete_project') }}"><i class="fa fa-trash"></i> Delete</x-global::forms.button>
 
 
         </div>
@@ -219,7 +219,7 @@
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
                             <x-global::forms.text-input name="mattermostWebhookURL" id="mattermostWebhookURL" value="{{ e($mattermostWebhookURL) }}" />
                             <br />
-                            <input type="submit" value="{{ __('buttons.save') }}" name="mattermostSave" />
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="mattermostSave" />
                         </form>
                     </div>
                 </div>
@@ -238,7 +238,7 @@
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
                             <x-global::forms.text-input name="slackWebhookURL" id="slackWebhookURL" value="{{ e($slackWebhookURL) }}" />
                             <br />
-                            <input type="submit" value="{{ __('buttons.save') }}" name="slackSave" />
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="slackSave" />
                         </form>
                     </div>
                 </div>
@@ -270,7 +270,7 @@
                             <strong>{!! __('label.topic') !!}</strong><br />
                             <x-global::forms.text-input name="zulipTopic" id="zulipTopic" placeholder="" value="{{ $tpl->escape($zulipHook['zulipTopic']) }}" />
                             <br />
-                            <input type="submit" value="{{ __('buttons.save') }}" name="zulipSave" />
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="zulipSave" />
                         </form>
                     </div>
                 </div>
@@ -292,7 +292,7 @@
                             @php $discordVarName = 'discordWebhookURL'.$i; $discordVarVal = $$discordVarName ?? ''; @endphp
                             <input type="text" name="discordWebhookURL{{ $i }}" id="discordWebhookURL{{ $i }}" placeholder="{{ __('input.placeholders.discord_url') }}" value="{{ e($discordVarVal) }}"/><br/>
                             @endfor
-                            <input type="submit" value="{{ __('buttons.save') }}" name="discordSave"/>
+                            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="discordSave" />
                         </form>
                     </div>
                 </div>

--- a/app/Domain/Reports/Templates/show.blade.php
+++ b/app/Domain/Reports/Templates/show.blade.php
@@ -90,9 +90,9 @@
 
                                 <div class="pull-right">
                                     <div class="btn-group mt-1 mx-auto" role="group">
-                                        <a href="javascript:void(0)" id="NumChartButtonSprint" class="btn btn-sm btn-secondary active chartButtons">{!! __('label.num_tickets') !!}</a>
-                                        <a href="javascript:void(0)" id="EffortChartButtonSprint" class="btn btn-sm btn-secondary chartButtons">{!! __('label.effort') !!}</a>
-                                        <a href="javascript:void(0)" id="HourlyChartButtonSprint" class="btn btn-sm btn-secondary chartButtons">{!! __('label.hours') !!}</a>
+                                        <x-global::forms.button tag="a" id="NumChartButtonSprint" class="btn-sm btn-secondary active chartButtons" link="javascript:void(0)">{!! __('label.num_tickets') !!}</x-global::forms.button>
+                                        <x-global::forms.button tag="a" id="EffortChartButtonSprint" class="btn-sm btn-secondary chartButtons" link="javascript:void(0)">{!! __('label.effort') !!}</x-global::forms.button>
+                                        <x-global::forms.button tag="a" id="HourlyChartButtonSprint" class="btn-sm btn-secondary chartButtons" link="javascript:void(0)">{!! __('label.hours') !!}</x-global::forms.button>
                                     </div>
 
                                 </div>
@@ -111,9 +111,9 @@
 
                         <div class="pull-right">
                             <div class="btn-group mt-1 mx-auto" role="group">
-                                <a href="javascript:void(0)" id="NumChartButtonBacklog" class="btn btn-sm btn-secondary active backlogChartButtons">{!! __('label.num_tickets') !!}</a>
-                                <a href="javascript:void(0)" id="EffortChartButtonBacklog" class="btn btn-sm btn-secondary backlogChartButtons">{!! __('label.effort') !!}</a>
-                                <a href="javascript:void(0)" id="HourlyChartButtonBacklog" class="btn btn-sm btn-secondary backlogChartButtons">{!! __('label.hours') !!}</a>
+                                <x-global::forms.button tag="a" id="NumChartButtonBacklog" class="btn-sm btn-secondary active backlogChartButtons" link="javascript:void(0)">{!! __('label.num_tickets') !!}</x-global::forms.button>
+                                <x-global::forms.button tag="a" id="EffortChartButtonBacklog" class="btn-sm btn-secondary backlogChartButtons" link="javascript:void(0)">{!! __('label.effort') !!}</x-global::forms.button>
+                                <x-global::forms.button tag="a" id="HourlyChartButtonBacklog" class="btn-sm btn-secondary backlogChartButtons" link="javascript:void(0)">{!! __('label.hours') !!}</x-global::forms.button>
                             </div>
 
                         </div>

--- a/app/Domain/Setting/Templates/editBoxDialog.blade.php
+++ b/app/Domain/Setting/Templates/editBoxDialog.blade.php
@@ -12,7 +12,7 @@
 
     <div class="row">
         <div class="col-md-6">
-            <input type="submit" value="{{ __('buttons.save') }}"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" />
         </div>
 
     </div>

--- a/app/Domain/Setting/Templates/editCompanySettings.blade.php
+++ b/app/Domain/Setting/Templates/editCompanySettings.blade.php
@@ -144,7 +144,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <input type="submit" value="{{ __('buttons.save') }}" id="saveBtn"/>
+                                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="saveBtn" />
                                 </form>
                             </div>
                             <div class="col-md-4">

--- a/app/Domain/Sprints/Templates/sprintdialog.blade.php
+++ b/app/Domain/Sprints/Templates/sprintdialog.blade.php
@@ -43,7 +43,7 @@
 
     <div class="row">
         <div class="col-md-6">
-            <input type="submit" value="{{ __('buttons.save') }}"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" />
         </div>
         <div class="col-md-6 align-right padding-top-sm">
             @if (isset($currentSprint->id) && $currentSprint->id != '' && $login::userIsAtLeast($roles::$editor))

--- a/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
@@ -10,7 +10,7 @@
                 <input type="hidden" value="new" name="subtaskId" />
                 <input type="hidden" value="1" name="subtaskSave" />
                 <x-global::forms.text-input name="headline" title="{{ __('label.headline') }}" style="width:100%" placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />
-                <input type="submit" value="{{ __('buttons.save') }}" name="quickadd"  />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="quickadd" />
                 <input type="hidden" name="dateToFinish" id="dateToFinish" value="" />
                 <input type="hidden" name="status" value="3" />
                 <input type="hidden" name="sprint" value="{{ session('currentSprint') }}" />

--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
@@ -140,7 +140,7 @@
                     <input type="hidden" name="saveTicket" value="1" />
                     <input type="hidden" id="saveAndCloseButton" name="saveAndCloseTicket" value="0" />
 
-                    <input type="submit" name="saveTicket" class="saveTicketBtn" value="{{ __('buttons.save') }}"/>
+                    <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveTicket" class="saveTicketBtn" />
                     <x-global::forms.button tag="input" inputType="submit" variant="outline" name="saveAndCloseTicket" onclick="jQuery('#saveAndCloseButton').val('1');" :labelText="__('buttons.save_and_close')" />
                 </div>
             </div>

--- a/app/Domain/Timesheets/Templates/showAll.blade.php
+++ b/app/Domain/Timesheets/Templates/showAll.blade.php
@@ -218,7 +218,7 @@
                     </td>
                     <td>
                         <input type="hidden" name='filterSubmit' value="1"/>
-                        <input type="submit" value="{{ __('buttons.search') }}" class="reload" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.search')" class="reload" />
                     </td>
                 </tr>
             </table>

--- a/app/Domain/Timesheets/Templates/showMy.blade.php
+++ b/app/Domain/Timesheets/Templates/showMy.blade.php
@@ -384,7 +384,7 @@ jQuery(document).ready(function(){
                 </tfoot>
             </table>
             <div class="right">
-                <input type="submit" name="saveTimeSheet" class="saveTimesheetBtn" value="Save" />
+                <x-global::forms.button tag="input" inputType="submit" contentRole="primary" labelText="Save" name="saveTimeSheet" class="saveTimesheetBtn" />
             </div>
             <div class="clearall"></div>
         </form>

--- a/app/Domain/Timesheets/Templates/showMyList.blade.php
+++ b/app/Domain/Timesheets/Templates/showMyList.blade.php
@@ -52,7 +52,7 @@
                     </div>
                     <div class="filterBoxLeft">
                         <label>&nbsp;</label>
-                        <input type="submit" value="{{ __('buttons.search') }}" class="reload" />
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.search')" class="reload" />
                     </div>
                     <div class="clearall"></div>
                 </div>

--- a/app/Domain/Users/Templates/importLdapDialog.blade.php
+++ b/app/Domain/Users/Templates/importLdapDialog.blade.php
@@ -17,7 +17,7 @@
             @endforeach
             <br />
             <input type="hidden" name="importSubmit" value="1"/>
-            <input type="submit" value="{{ __('buttons.import') }}" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.import')" />
         </form>
 
     @else
@@ -25,7 +25,7 @@
             <label>{!! __('label.please_enter_password') !!} </label>
             <x-global::forms.text-input type="password" name="password" />
             <input type="hidden" name="pwSubmit" value="1"/>
-            <input type="submit" value="{{ __('buttons.find_users') }}" />
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.find_users')" />
         </form>
 
     @endif

--- a/app/Domain/Widgets/Templates/widgetManager.blade.php
+++ b/app/Domain/Widgets/Templates/widgetManager.blade.php
@@ -1,6 +1,6 @@
 <div class="" style="min-width:50%;">
     <h1>{{ __("headlines.widget_manager") }}</h1>
-    <a href="{{ BASE_URL }}/dashboard/home?resetDashboard=true" class="btn btn-outline pull-right" style="margin-bottom:10px;"><i class="fa-solid fa-arrow-rotate-left"></i> Reset Dashboard</a>
+    <x-global::forms.button tag="a" contentRole="secondary" class="pull-right" link="{{ BASE_URL }}/dashboard/home?resetDashboard=true" style="margin-bottom:10px;"><i class="fa-solid fa-arrow-rotate-left"></i> Reset Dashboard</x-global::forms.button>
     <p>{{ __("text.choose_widgets") }}</p>
     <br />
     <div class="row">

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -169,7 +169,7 @@
                         <br />
                         <input type="hidden" name="saveTicket" value="1" />
                         <input type="hidden" id="saveAndCloseButton" name="saveAndCloseArticle" value="0" />
-                        <input type="submit" name="saveArticle" value="{{ __('buttons.save') }}" id="primaryArticleSubmitButton"/>
+                        <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="saveArticle" id="primaryArticleSubmitButton" />
                         <x-global::forms.button tag="input" inputType="submit" contentRole="secondary" name="saveAndCloseArticle" onclick="jQuery('#saveAndCloseButton').val('1');" :labelText="__('buttons.save_and_close')" />
                     </div>
                     <div class="col-md-2 align-right padding-top-sm">

--- a/app/Domain/Wiki/Templates/wikiDialog.blade.php
+++ b/app/Domain/Wiki/Templates/wikiDialog.blade.php
@@ -26,7 +26,7 @@
 
     <div class="row">
         <div class="col-md-6">
-            <input type="submit" value="{{ __('buttons.save') }}" id="saveBtn"/>
+            <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" id="saveBtn" />
         </div>
         <div class="col-md-6 align-right padding-top-sm">
             @if (isset($currentWiki->id) && $currentWiki->id != '' && $login::userIsAtLeast($roles::$editor))

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -193,7 +193,9 @@ The no-op migration deliberately defers buttons it can't migrate without changin
 class set / behavior. Categories found (to revisit, some need a design decision):
 - **`class="button"` (not `btn`)** — many form submit inputs use `.button`. Need to confirm
   whether `.button` styling == `.btn` in forms.css; if so, add it to the component/migration.
-- **Unstyled `<input type="submit">`** (no class) — adding `btn` is a *design* change, not a no-op. Defer.
+- ~~**Unstyled `<input type="submit">`** (no class)~~ — DONE (round 2): NOT a design change after all —
+  `input[type='submit']` is in the `.btn-primary` element-selector group (forms.css:313), so bare submits
+  already render primary. Migrated to `contentRole="primary"` (no-op). ~30 of them.
 - **Unmapped btn variants** — `btn-sm`/`btn-lg` (vs Leantime `btn-small`/`btn-large`),
   `btn-danger-outline`, `btn-circle`, `btn-inverse`, `btn-file`. Add mappings (after confirming CSS) or keep deferred.
 - **role+state combo** (`btn btn-default btn-success`) — component currently emits one color; allow coexistence.
@@ -304,3 +306,16 @@ Only visually-distinct treatments earn a variant. Verdicts:
   canonical one being .secretInput) but its call-sites are the deferred async-save fields, so it's a planned
   variant; `legacy`(.input) = REDUNDANT (no `.input` CSS rule exists anywhere). **Dropped `variant="legacy"`**
   (1 call-site, TwoFA/edit → bare; removed the arm). Component now exposes only `headline`/`large`/`small`.
+- _button + text-input completion (round 2)_: swept blade for buttons/inputs missed by #3531/#3558.
+  **53 migrated across 38 files**: 29 bare `<input type=submit>` (no class — render primary via
+  forms.css:313, so `contentRole="primary"` is a no-op), 4 token-UI text inputs/buttons, Errors back ×4,
+  support sponsor, Auth token UI (create/copy/close/delete), Files cancel ×2, widgetManager reset
+  (btn-outline→secondary), Reports chart toggles ×6, showProject delete (btn-danger-outline→state=danger
+  variant=outline), 1 comment reply. `btn-sm`/`btn-lg`/`btn-secondary` (own CSS, ≠ Leantime's
+  small/large/outline) passed through `class=` pending a design-phase scale/role mapping.
+  **Left deferred (correct):** 3 comment `btn-success` role+state combos (component emits one color);
+  `partials/subtasks` quickadd (nested `__("…")` + HTMX file); dynamic-class links (calendarSettings,
+  Dashboard favoriteProject); `ticketFilter` raw `<a>` (whitespace-sensitive, intentional); custom non-`btn`
+  widget buttons (Wiki collapse/panel, calendar day-button, todoItem reset); modal `data-dismiss`/`.close`,
+  Files `.delete` icons, file-upload `picSubmit`, dropdown-toggles, `<?php echo` invite variants.
+  Verified: compile + Pint clean, 0 button-tag problems, diff is tag swaps (multiline tags collapse to 1 line).

--- a/app/Views/Templates/components/COMPONENTS.md
+++ b/app/Views/Templates/components/COMPONENTS.md
@@ -200,7 +200,9 @@ class set / behavior. Categories found (to revisit, some need a design decision)
   not a no-op).
 - ~~**Unstyled `<input type="submit">`** (no class)~~ — DONE (#3564, round 2): NOT a design change after all —
   `input[type='submit']` is in the `.btn-primary` element-selector group (forms.css:313), so bare submits
-  already render primary. Migrated to `contentRole="primary"` (no-op). ~30 of them.
+  **already looked primary**. Migrated to `contentRole="primary"` (~30 of them). **Intended visual no-op**, not
+  strictly byte-identical: the component adds the shared `.btn` base (`input.btn { vertical-align: top; … }`)
+  which a bare submit lacked — imperceptible, but worth stating precisely.
 - **Unmapped btn variants** — `btn-sm`/`btn-lg` (vs Leantime `btn-small`/`btn-large`),
   `btn-danger-outline`, `btn-circle`, `btn-inverse`, `btn-file`. Add mappings (after confirming CSS) or keep deferred.
 - **role+state combo** (`btn btn-default btn-success`) — component currently emits one color; allow coexistence.
@@ -320,8 +322,9 @@ Only visually-distinct treatments earn a variant. Verdicts:
   through the component. No `variant` arm (plain textareas carry no distinct style class; the only textarea
   classes are editor-coupled).
 - _button + text-input completion (round 2)_: swept blade for buttons/inputs missed by #3531/#3558.
-  **53 migrated across 38 files**: 29 bare `<input type=submit>` (no class — render primary via
-  forms.css:313, so `contentRole="primary"` is a no-op), 4 token-UI text inputs/buttons, Errors back ×4,
+  **53 migrated across 38 files**: 29 bare `<input type=submit>` (no class — already looked primary via
+  forms.css:313, so `contentRole="primary"` is an intended **visual** no-op; the `.btn` base adds minor props
+  like `vertical-align`, imperceptible), 4 token-UI text inputs/buttons, Errors back ×4,
   support sponsor, Auth token UI (create/copy/close/delete), Files cancel ×2, widgetManager reset
   (btn-outline→secondary), Reports chart toggles ×6, showProject delete (btn-danger-outline→state=danger
   variant=outline), 1 comment reply. `btn-sm`/`btn-lg`/`btn-secondary` (own CSS, ≠ Leantime's


### PR DESCRIPTION
## What

A completion sweep after `forms.button` (#3531) and `forms.text-input` (#3558): migrates **53 buttons/inputs across 38 files** that were missed or that postdate those PRs (this is what surfaced from the "did we miss any?" audit).

## Root cause for the bulk

#3531's backlog deferred *"unstyled `<input type="submit">` (no class)"* believing adding `btn` was a design change. But **`input[type='submit']` is in the `.btn-primary` element-selector group** (`forms.css:313`) — so bare submits **already render as primary buttons**. That makes `contentRole="primary"` a genuine no-op for all of them.

## Migrated (no-op)

- **29 bare `<input type=submit>`** → `forms.button` primary (Auth, canvas dialogs, Help steps, Projects integrations, Settings, Sprints, Timesheets, Wiki, LDAP, etc.)
- **2 Auth token-UI text inputs** (`token-created`, `tokenNew`) → `forms.text-input`
- **Plain buttons/links**: Errors “Back” ×4, support sponsor, Auth token UI (create/copy/close/delete), Files cancel ×2, widgetManager reset (`btn-outline`→`secondary`), Reports chart toggles ×6, `showProject` delete (`btn-danger-outline` → `state="danger" variant="outline"`), 1 comment reply.
- `btn-sm` / `btn-lg` / `btn-secondary` (which have **their own CSS**, distinct from Leantime's `small`/`large`/`outline`) are passed through via `class=` (component still adds `btn`, so no-op) pending a design-phase scale/role mapping.

## Deliberately deferred (correct, not misses)

- 3 comment `btn-default/primary btn-success` **role+state combos** (component emits one color)
- `partials/subtasks` quickadd (nested `__("…")` quote + it's the HTMX inline-edit file)
- **dynamic-class** links (`calendarSettings`, Dashboard `favoriteProject`)
- `ticketFilter` raw `<a>` (whitespace-sensitive — intentionally kept since #3531)
- custom **non-`btn`** widget buttons (Wiki collapse/panel toggles, calendar day-button, todoItem reset)
- modal `data-dismiss`/`.close`, file-upload `picSubmit`, dropdown-toggles, `<?php echo` invite variants

## Verification

`view:cache` + Pint clean; 0 button-tag problems (no stray `type=`, no nested quotes); diff is `<input>`/`<button>`/`<a>` → `<x-global::forms.button>` tag swaps (multiline tags collapse to one line — render-irrelevant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
