### PR TITLE
chore(phpstan): raise static analysis to level 4 (227→0, dead-code removal)

### DIFF
--- a/.phpstan/phpstan.neon
+++ b/.phpstan/phpstan.neon
@@ -6,7 +6,7 @@ includes:
 parameters:
     bootstrapFiles:
         - bootstrap.php
-    level: 3
+    level: 4
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - ../public

--- a/app/Command/CheckEventListeners.php
+++ b/app/Command/CheckEventListeners.php
@@ -168,7 +168,7 @@ class CheckEventListeners extends Command
         preg_match_all('/\{RGX:(.*?):RGX\}/', $listener, $regexMatches);
 
         $key = strtr($listener, [
-            ...collect($regexMatches[0] ?? [])->mapWithKeys(fn ($match, $i) => [$match => "REGEX_MATCH_$i"])->toArray(),
+            ...collect($regexMatches[0])->mapWithKeys(fn ($match, $i) => [$match => "REGEX_MATCH_$i"])->toArray(),
             '*' => 'RANDOM_STRING',
             '?' => 'RANDOM_CHARACTER',
         ]);
@@ -179,7 +179,7 @@ class CheckEventListeners extends Command
         $pattern = strtr($pattern, [
             'RANDOM_STRING' => '.*?', // 0 or more (lazy) - asterisk (*)
             'RANDOM_CHARACTER' => '.', // 1 character - question mark (?)
-            ...collect($regexMatches[1] ?? [])->mapWithKeys(fn ($match, $i) => ["REGEX_MATCH_$i" => $match])->toArray(),
+            ...collect($regexMatches[1])->mapWithKeys(fn ($match, $i) => ["REGEX_MATCH_$i" => $match])->toArray(),
         ]);
 
         foreach ($events as $event) {

--- a/app/Command/ListPluginCommand.php
+++ b/app/Command/ListPluginCommand.php
@@ -64,14 +64,14 @@ EOL);
         // Filter by “installed" if requested.
         $installed = $this->input->getOption('installed');
         if ($installed !== null) {
-            $installed = $installed === null || filter_var($installed, FILTER_VALIDATE_BOOLEAN);
+            $installed = filter_var($installed, FILTER_VALIDATE_BOOLEAN);
             $plugins = array_filter($plugins, fn (InstalledPlugin $p) => ! ($installed xor isset($p->id)));
         }
 
         // Filter by “enabled" if requested.
         $enabled = $this->input->getOption('enabled');
         if ($enabled !== null) {
-            $enabled = $enabled === null || filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
+            $enabled = filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
             $plugins = array_filter($plugins, fn (InstalledPlugin $p) => ! ($enabled xor $p->enabled));
         }
 

--- a/app/Command/UpdateLeantime.php
+++ b/app/Command/UpdateLeantime.php
@@ -101,13 +101,13 @@ class UpdateLeantime extends Command
 
         $io->text('Extracting Archive...');
 
-        try {
-            $zip = new \ZipArchive;
-        } catch (\Exception $e) {
+        if (! class_exists(\ZipArchive::class)) {
             $io->text('ZipArchive not found.  Cannot auto-update until the php zip extension is installed. On linux, \'sudo apt install php-zip\'');
 
             return self::FAILURE;
         }
+
+        $zip = new \ZipArchive;
         if ($zip->open($zipFile) === true) {
             $zip->extractTo(storage_path('/framework/cache/leantime'));
             $zip->close();

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -22,11 +22,6 @@ class Application extends \Illuminate\Foundation\Application
     use DispatchesEvents;
 
     /**
-     * Application bootstrap status
-     */
-    private static bool $bootstrapped = false;
-
-    /**
      * Constructor for the class.
      *
      * @param  string  $basePath  The base path for the application.

--- a/app/Core/Auth/Permissions/DefaultRolePermissions.php
+++ b/app/Core/Auth/Permissions/DefaultRolePermissions.php
@@ -116,7 +116,7 @@ final class DefaultRolePermissions
         $rules = [];
         foreach (self::ROLES as $role) {
             if ($role['level'] <= $level) {
-                foreach (self::GRANTS[$role['name']] ?? [] as $rule) {
+                foreach (self::GRANTS[$role['name']] as $rule) {
                     $rules[] = $rule;
                 }
             }

--- a/app/Core/Configuration/Environment.php
+++ b/app/Core/Configuration/Environment.php
@@ -107,22 +107,6 @@ class Environment extends Repository implements ArrayAccess, ConfigContract
     }
 
     /**
-     * getBool - get a boolean value from the environment
-     */
-    private function getBool(string $envVar, bool $default): bool
-    {
-        return $this->environmentHelper($envVar, $default, 'boolean');
-    }
-
-    /**
-     * getString - get a string value from the environment
-     */
-    private function getString(string $envVar, string $default = ''): string
-    {
-        return $this->environmentHelper($envVar, $default, 'string');
-    }
-
-    /**
      * environmentHelper - helper function to get a value from the environment
      */
     private function environmentHelper(string $envVar, mixed $default, string $dataType = 'string'): mixed

--- a/app/Core/Console/ConsoleKernel.php
+++ b/app/Core/Console/ConsoleKernel.php
@@ -120,7 +120,7 @@ class ConsoleKernel extends Kernel implements ConsoleKernelContract
         }
 
         // Load Dynamic command paths for leantime
-        $ltCommands = collect(glob(APP_ROOT.'/app/Domain/**/Command/') ?? []);
+        $ltCommands = collect(glob(APP_ROOT.'/app/Domain/**/Command/'));
 
         // Load commands from enabled plugins
         try {
@@ -143,7 +143,7 @@ class ConsoleKernel extends Kernel implements ConsoleKernelContract
             }
         } catch (\Exception $e) {
             // Fallback to scanning all plugin directories if service unavailable
-            $ltPluginCommands = collect(glob(APP_ROOT.'/app/Plugins/**/Command/') ?? []);
+            $ltPluginCommands = collect(glob(APP_ROOT.'/app/Plugins/**/Command/'));
             foreach ($ltPluginCommands as $pluginPath) {
                 $this->load($pluginPath);
             }

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -23,22 +23,7 @@ class Frontcontroller
 {
     use DispatchesEvents;
 
-    /**
-     * @var string - last action that was fired
-     */
-    private string $lastAction = '';
-
-    /**
-     * @var string - fully parsed action
-     */
-    private string $fullAction = '';
-
     private IncomingRequest $incomingRequest;
-
-    /**
-     * @var array - valid status codes
-     */
-    private array $validStatusCodes = ['100', '101', '200', '201', '202', '203', '204', '205', '206', '300', '301', '302', '303', '304', '305', '306', '307', '400', '401', '402', '403', '404', '405', '406', '407', '408', '409', '410', '411', '412', '413', '414', '415', '416', '417', '500', '501', '502', '503', '504', '505'];
 
     protected $defaultRoute = 'dashboard.home';
 
@@ -73,8 +58,6 @@ class Frontcontroller
 
         // Setting default response code to 200, can be changed in controller
         $this->setResponseCode(200);
-
-        $this->lastAction = $moduleName.'.'.$controllerName.'.'.$method;
 
         $this->dispatchEvent('execute_action_end', ['action' => $controllerName, 'module' => $moduleName]);
 
@@ -182,7 +165,7 @@ class Frontcontroller
         // Enforce #[RequiresPermission] on the resolved action before instantiating the
         // controller. This is the single chokepoint for every convention-routed controller,
         // regardless of which base class (if any) it extends.
-        $this->permissionEnforcer->enforce($controller, $method, is_array($parameters) ? $parameters : []);
+        $this->permissionEnforcer->enforce($controller, $method, $parameters);
 
         $controllerClass = app()->make($controller);
 
@@ -419,8 +402,6 @@ class Frontcontroller
         if (is_array($actionParts)) {
             return $actionParts[0];
         }
-
-        return '';
     }
 
     /**

--- a/app/Core/Db/Repository.php
+++ b/app/Core/Db/Repository.php
@@ -4,7 +4,6 @@ namespace Leantime\Core\Db;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Database;
-use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Events\DispatchesEvents;
 use PDO;
 use PDOStatement;
@@ -22,10 +21,6 @@ abstract class Repository
 
     protected string $model;
 
-    public function __construct(
-        private DbCore $db
-    ) {}
-
     /**
      * dbcall - creates a new dbcall object
      *
@@ -35,13 +30,11 @@ abstract class Repository
     {
         return new class($args, $this)
         {
-            private PDOStatement $stmn;
+            private ?PDOStatement $stmn = null;
 
             private array $args;
 
             private Repository $caller_class;
-
-            private Db $Db;
 
             /**
              * @var \Closure|mixed|object|null

--- a/app/Core/Events/EventDispatcher.php
+++ b/app/Core/Events/EventDispatcher.php
@@ -4,7 +4,6 @@ namespace Leantime\Core\Events;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Events\QueuedClosure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -339,7 +338,7 @@ class EventDispatcher implements Dispatcher
      *
      * @throws BindingResolutionException
      */
-    private static function defineParams(mixed $paramAttr, string $eventName): array|object
+    private static function defineParams(mixed $paramAttr, string $eventName): array
     {
         // Cache the current route for the duration of the request since it doesn't change
         static $current_route = null;
@@ -357,37 +356,6 @@ class EventDispatcher implements Dispatcher
         $paramAttr = array_merge($default_params, $paramAttr);
 
         return $paramAttr;
-
-        // Not entirely sure about all of this...
-        //
-
-        // $finalParams = [];
-
-        if (is_array($paramAttr)) {
-            $default_params = array_merge($default_params, $paramAttr);
-
-            return $default_params;
-        }
-
-        if (is_object($paramAttr)) {
-            $default_params['payload'] = $paramAttr;
-
-            return $default_params;
-        }
-
-        return $default_params;
-
-        //
-        //        if (is_object($paramAttr) && get_class($paramAttr) == 'stdClass') {
-        //            $finalParams = (object) array_merge($default_params, (array) $paramAttr);
-        //
-        //            return $finalParams;
-        //        }
-
-        //        $finalParams = $default_params;
-        //        array_push($finalParams, $paramAttr);
-        //
-        //        return $finalParams;
     }
 
     /**
@@ -519,98 +487,6 @@ class EventDispatcher implements Dispatcher
         return $isEvent ? null : $filteredPayload;
     }
 
-    private static function executeLeantimeEvent(array $registry,
-        string $registryType,
-        string $hookName,
-        mixed $payload,
-        array|object $available_params = [])
-    {
-
-        // Won't be a filter, cause it's an event
-
-        // sort matches by priority
-        usort($registry, fn ($a, $b) => match (true) {
-            $a['priority'] > $b['priority'] => 1,
-            $a['priority'] == $b['priority'] => 0,
-            default => -1,
-        });
-
-        foreach ($registry as $index => $listener) {
-            // Leantime events are strings.
-            // the handler can be either ca closure a class string or a callable
-
-        }
-
-    }
-
-    private static function isLaravelEvent($payload): bool
-    {
-        if (isset($payload[0]) && is_object($payload[0])) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static function isHandleableClass($handler): bool
-    {
-
-        // Option Handler is a class and we just need to call the handle string
-        return is_object($handler) && method_exists($handler, 'handle');
-    }
-
-    private static function isHandleableObject($handler): bool
-    {
-
-        // Option $handler is an array
-        if (is_array($handler) && is_object($handler[0]) && method_exists($handler[0], $handler[1] ?? 'handle')) {
-            return true;
-        }
-
-        return false;
-
-    }
-
-    private static function handleLaravelEvent($handler, $payload): void
-    {
-
-        if (! is_object($payload) && class_exists($payload)) {
-            $payload = app()->make($payload);
-        }
-
-        if (is_callable($handler)) {
-            $handler($payload);
-        } elseif (self::isHandleableClass($handler)) {
-            $handler->handle($payload);
-        }
-    }
-
-    private static function executeCallable($handler, $payload, $available_params, $index, $isEvent)
-    {
-        // Handle Laravel style events with reflection
-        if ($handler instanceof \Closure) {
-            $reflection = new \ReflectionFunction($handler);
-            $parameters = $reflection->getParameters();
-
-            if (count($parameters) === 1 && is_object($payload)) {
-                $handler($payload);
-
-                return null;
-            }
-        }
-
-        if ($isEvent) {
-            $handler($payload);
-
-            return null;
-        }
-
-        return $handler(
-            $payload,
-            $available_params
-        );
-    }
-
     /**
      * Finds all the event and filter listeners and registers them
      * (should only be executed once at the beginning of the program)
@@ -644,10 +520,9 @@ class EventDispatcher implements Dispatcher
         }
 
         // Call system plugins (defined via config)
-        if (
-            isset(app(Environment::class)->plugins)
-            && $configplugins = explode(',', app(Environment::class)->plugins)
-        ) {
+        if (isset(app(Environment::class)->plugins)) {
+            $configplugins = explode(',', app(Environment::class)->plugins);
+
             // TODO: Do phar plugins get to be system plugins? Right now they dont
             foreach ($configplugins as $plugin) {
                 if (file_exists($pluginEventsPath = APP_ROOT.'/app/Plugins/'.$plugin.'/register.php')) {
@@ -787,15 +662,6 @@ class EventDispatcher implements Dispatcher
                 });
 
             return;
-        } elseif ($events instanceof QueuedClosure) {
-            collect($this->firstClosureParameterTypes($events->closure))
-                ->each(function ($event) use ($events) {
-                    $this->listen($event, $events->resolve());
-                });
-
-            return;
-        } elseif ($listener instanceof QueuedClosure) {
-            $listener = $listener->resolve();
         }
 
         foreach ((array) $events as $event) {
@@ -913,28 +779,6 @@ class EventDispatcher implements Dispatcher
     public static function get_available_hooks(): array
     {
         return self::$available_hooks;
-    }
-
-    /**
-     * Sorts listeners by priority for a given hook and type
-     */
-    private static function sortByPriority(string $type, string $hookName): void
-    {
-        if ($type !== 'filters' && $type !== 'events') {
-            return;
-        }
-
-        $sorter = fn ($a, $b) => match (true) {
-            $a['priority'] > $b['priority'] => 1,
-            $a['priority'] == $b['priority'] => 0,
-            default => -1,
-        };
-
-        if ($type == 'filters') {
-            usort(self::$filterRegistry[$hookName], $sorter);
-        } elseif ($type == 'events') {
-            usort(self::$eventRegistry[$hookName], $sorter);
-        }
     }
 
     public static function getEventRegistry(): array

--- a/app/Core/Exceptions/HandleExceptions.php
+++ b/app/Core/Exceptions/HandleExceptions.php
@@ -347,6 +347,10 @@ class HandleExceptions
         if (class_exists(ErrorHandler::class)) {
             $instance = ErrorHandler::instance();
 
+            // The closure is rebound to $instance (PHPUnit's ErrorHandler, which has $enabled) via
+            // ->call(); PHPStan analyses it in this class's scope (no $enabled) and wrongly collapses
+            // it to always-false. The check is live at runtime.
+            // @phpstan-ignore-next-line
             if ((fn () => $this->enabled ?? false)->call($instance)) {
                 $instance->disable();
                 $instance->enable();

--- a/app/Core/Http/ApiRequest.php
+++ b/app/Core/Http/ApiRequest.php
@@ -32,7 +32,7 @@ class ApiRequest extends IncomingRequest
                 'REDIRECT_HTTP_AUTHORIZATION',
             ] as $key
         ) {
-            $header = trim($this->headers->get($key));
+            $header = trim($this->headers->get($key, ''));
 
             if (! empty($header)) {
                 return $header;

--- a/app/Core/Http/ApiRequest.php
+++ b/app/Core/Http/ApiRequest.php
@@ -32,7 +32,7 @@ class ApiRequest extends IncomingRequest
                 'REDIRECT_HTTP_AUTHORIZATION',
             ] as $key
         ) {
-            $header = trim($this->headers->get($key)) ?? '';
+            $header = trim($this->headers->get($key));
 
             if (! empty($header)) {
                 return $header;

--- a/app/Core/Http/HttpKernel.php
+++ b/app/Core/Http/HttpKernel.php
@@ -198,12 +198,10 @@ class HttpKernel extends Kernel
 
         try {
             // Try Laravel routing first
-            $route = $this->router->getRoutes()->match($request);
+            $this->router->getRoutes()->match($request);
 
-            if ($route) {
-                // Use Laravel's router to handle the request
-                return $this->router->dispatch($request);
-            }
+            // Use Laravel's router to handle the request
+            return $this->router->dispatch($request);
         } catch (NotFoundHttpException $e) {
             // No Laravel route found, fall back to Frontcontroller
         } catch (\Exception $e) {

--- a/app/Core/Http/IncomingRequest.php
+++ b/app/Core/Http/IncomingRequest.php
@@ -266,11 +266,6 @@ class IncomingRequest extends \Illuminate\Http\Request
         return $pattern === '' ? '/' : $pattern;
     }
 
-    private function getBaseUrlReal(): string
-    {
-        return $this->baseUrl ??= $this->prepareBaseUrl();
-    }
-
     public function setCurrentRoute($route): void
     {
         $this->currentRoute = $route;
@@ -292,8 +287,6 @@ class IncomingRequest extends \Illuminate\Http\Request
         if (is_array($actionParts)) {
             return $actionParts[0];
         }
-
-        return '';
     }
 
     /**

--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -234,7 +234,6 @@ class AuthCheck
         $pathSegments = explode('.', $currentPath);
 
         $routeToCheck = match (count($pathSegments)) {
-            0 => null,
             1 => $pathSegments[0],
             default => $pathSegments[0].'.'.$pathSegments[1],
         };

--- a/app/Core/Middleware/AuthenticateSession.php
+++ b/app/Core/Middleware/AuthenticateSession.php
@@ -7,9 +7,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Session\Middleware\AuthenticatesSessions;
 use Illuminate\Http\Request;
-use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Http\IncomingRequest;
-use Leantime\Core\Language;
 use Leantime\Domain\Setting\Services\Setting;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -22,9 +20,7 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     public function __construct(
         protected AuthFactory $auth,
-        private readonly Setting $settings,
-        private readonly Environment $config,
-        private readonly Language $language) {}
+        private readonly Setting $settings) {}
 
     /**
      * Handle an incoming request.

--- a/app/Core/Middleware/Installed.php
+++ b/app/Core/Middleware/Installed.php
@@ -52,7 +52,7 @@ class Installed
             return $response;
         }
 
-        if (! $session_says && $config_says) {
+        if (! $session_says) {
             $this->setInstalled();
         }
 

--- a/app/Core/Middleware/Localization.php
+++ b/app/Core/Middleware/Localization.php
@@ -9,13 +9,11 @@ use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\Support\CarbonMacros;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
-use Leantime\Domain\Setting\Services\Setting;
 use Symfony\Component\HttpFoundation\Response;
 
 class Localization
 {
     public function __construct(
-        private readonly Setting $settings,
         private readonly SettingRepository $settingsRepo,
         private readonly Environment $config,
         private readonly Language $language,

--- a/app/Core/Middleware/SetCacheHeaders.php
+++ b/app/Core/Middleware/SetCacheHeaders.php
@@ -5,19 +5,11 @@ namespace Leantime\Core\Middleware;
 use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use Leantime\Domain\Auth\Services\Auth as AuthService;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SetCacheHeaders
 {
-    private AuthService $authService;
-
-    public function __construct(AuthService $authService)
-    {
-        $this->authService = $authService;
-    }
-
     /**
      * Specify the options for the middleware.
      *

--- a/app/Core/Middleware/StartSession.php
+++ b/app/Core/Middleware/StartSession.php
@@ -260,7 +260,7 @@ class StartSession
             // Implement exponential backoff retry
             $this->retryWithBackoff($callback, $session);
         } finally {
-            $lock?->release();
+            $lock->release();
         }
     }
 

--- a/app/Core/Routing/RouteLoader.php
+++ b/app/Core/Routing/RouteLoader.php
@@ -65,10 +65,9 @@ class RouteLoader
      */
     private static function loadSystemPluginRoutes(): void
     {
-        if (
-            isset(app(Environment::class)->plugins)
-            && $configPlugins = explode(',', app(Environment::class)->plugins)
-        ) {
+        if (isset(app(Environment::class)->plugins)) {
+            $configPlugins = explode(',', app(Environment::class)->plugins);
+
             Route::middleware([CheckPermissions::class])->group(function () use ($configPlugins) {
                 foreach ($configPlugins as $plugin) {
                     if (file_exists($pluginRoutesPath = APP_ROOT.'/app/Plugins/'.$plugin.'/routes.php')) {

--- a/app/Core/Support/Build.php
+++ b/app/Core/Support/Build.php
@@ -69,7 +69,6 @@ class Build
                 if (
                     in_array(true, [
                         is_object($currentElement) && ! property_exists($currentElement, $propName),
-                        is_array($currentElement) && ! isset($currentElement[$propName]),
                     ])
                 ) {
                     continue;

--- a/app/Core/Support/Cast.php
+++ b/app/Core/Support/Cast.php
@@ -157,8 +157,6 @@ class Cast
         if (is_string($value)) {
             return dtHelper()->parseDbDateTime($value);
         }
-
-        throw new \InvalidArgumentException('Value cannot be casted datetime');
     }
 
     protected function handleIterator(iterable $iterator, array $mappings = []): array|object

--- a/app/Core/UI/Template.php
+++ b/app/Core/UI/Template.php
@@ -35,10 +35,6 @@ class Template
     /** @var array - vars that are set in the action */
     private array $vars = [];
 
-    private string $notifcation = '';
-
-    private string $notificationType = '';
-
     private string $hookContext = '';
 
     public string $tmpError = '';
@@ -71,9 +67,6 @@ class Template
      * @throws \ReflectionException
      */
     public function __construct(
-        /** @var Theme */
-        private Theme $theme,
-
         /** @var Language */
         public Language $language,
 
@@ -783,11 +776,10 @@ class Template
         $printedLength = 0;
         $position = 0;
         $tags = [];
-        $isUtf8 = true;
         $truncate = '';
         $html = $this->convertRelativePaths($html);
         // For UTF-8, we need to count multibyte sequences as one character.
-        $re = $isUtf8 ? '{</?([a-z]+)[^>]*>|&#?[a-zA-Z0-9]+;|[\x80-\xFF][\x80-\xBF]*}' : '{</?([a-z]+)[^>]*>|&#?[a-zA-Z0-9]+;}';
+        $re = '{</?([a-z]+)[^>]*>|&#?[a-zA-Z0-9]+;|[\x80-\xFF][\x80-\xBF]*}';
 
         while ($printedLength < $maxLength && preg_match($re, $html, $match, PREG_OFFSET_CAPTURE, $position)) {
             [$tag, $tagPosition] = $match[0];

--- a/app/Core/UI/Theme.php
+++ b/app/Core/UI/Theme.php
@@ -163,10 +163,6 @@ class Theme
         return $scheme;
     }
 
-    private array $backgroundTypes = ['gradient', 'image'];
-
-    private array $backgroundSources = ['unsplash', 'upload'];
-
     /**
      * possible font choices
      */

--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -25,11 +25,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Jsonrpc extends Controller
 {
-    /**
-     * @var array - holds json data from request body
-     */
-    private array $json_data = [];
-
     private PermissionEnforcer $permissionEnforcer;
 
     /**

--- a/app/Domain/Api/Controllers/StaticAsset.php
+++ b/app/Domain/Api/Controllers/StaticAsset.php
@@ -51,7 +51,7 @@ class StaticAsset extends Controller
             function (BinaryFileResponse $response) use ($type, $debug) {
                 $response->headers->set('Content-Type', StaticAssetType::getMimeTypeByExtension($type));
                 $response->headers->set('Content-length', filesize(
-                    ($filepath = $response->getFile()) instanceof \SplFileInfo ? $filepath->getPathname() : $filepath
+                    $response->getFile()->getPathname()
                 ));
 
                 if (in_array(true, [! $this->incomingRequest->query->has('id'), $debug])) {

--- a/app/Domain/Auth/Controllers/Redirect.php
+++ b/app/Domain/Auth/Controllers/Redirect.php
@@ -4,8 +4,6 @@ namespace Leantime\Domain\Auth\Controllers;
 
 use Laravel\Socialite\Facades\Socialite;
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Auth\Services\AccessToken;
-use Leantime\Domain\Auth\Services\Auth as AuthService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -13,21 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Redirect extends Controller
 {
-    private AuthService $authService;
-
-    private AccessToken $personalToken;
-
-    /**
-     * Initializes dependencies.
-     */
-    public function init(
-        AuthService $authService,
-        AccessToken $personalToken
-    ): void {
-        $this->authService = $authService;
-        $this->personalToken = $personalToken;
-    }
-
     /**
      * Redirects to the GitHub OAuth login page.
      *

--- a/app/Domain/Auth/Controllers/ResetPw.php
+++ b/app/Domain/Auth/Controllers/ResetPw.php
@@ -101,6 +101,6 @@ class ResetPw extends Controller
             'error'
         );
 
-        return FrontcontrollerCore::redirect(BASE_URL.'/auth/resetPw/'.$params['id'] ?? '');
+        return FrontcontrollerCore::redirect(BASE_URL.'/auth/resetPw/'.$params['id']);
     }
 }

--- a/app/Domain/Auth/Repositories/Auth.php
+++ b/app/Domain/Auth/Repositories/Auth.php
@@ -3,56 +3,12 @@
 namespace Leantime\Domain\Auth\Repositories;
 
 use Illuminate\Database\ConnectionInterface;
-use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Db\DatabaseHelper;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
 class Auth
 {
-    /**
-     * @var int|null user id from DB
-     */
-    private ?int $userId = null;
-
-    /**
-     * @var int|null user id from DB
-     */
-    private ?int $clientId = null;
-
-    /**
-     * @var string|null username from db
-     */
-    private ?string $username = null;
-
-    /**
-     * @var string username from db
-     */
-    private string $name = '';
-
-    /**
-     * @var string profileid (image) from db
-     */
-    private string $profileId = '';
-
-    private ?string $password = null;
-
-    /**
-     * @var string|null username (emailaddress)
-     */
-    private ?string $user = null;
-
-    /**
-     * @var string|null username (emailaddress)
-     */
-    private ?string $mail = null;
-
-    private bool $twoFAEnabled;
-
-    private string $twoFASecret;
-
-    private ?string $session = null;
-
     private ConnectionInterface $db;
 
     /**
@@ -75,14 +31,10 @@ class Auth
 
     public object $hasher;
 
-    private static Auth $instance;
-
     /**
      * How often can a user reset a password before it has to be changed
      */
     public int $pwResetLimit = 5;
-
-    private EnvironmentCore $config;
 
     private UserRepository $userRepo;
 
@@ -90,12 +42,10 @@ class Auth
 
     public function __construct(
         DbCore $db,
-        EnvironmentCore $config,
         UserRepository $userRepo,
         DatabaseHelper $dbHelper
     ) {
         $this->db = $db->getConnection();
-        $this->config = $config;
         $this->userRepo = $userRepo;
         $this->dbHelper = $dbHelper;
     }
@@ -107,18 +57,6 @@ class Auth
     {
         return $this->db->table('zp_user')
             ->where('session', $sessionId)
-            ->update(['session' => '']) >= 0;
-    }
-
-    /**
-     * checkSessions - check all sessions in the database and unset them if necessary
-     */
-    private function invalidateExpiredUserSessions(): bool
-    {
-        $expirationTime = time() - $this->config->sessionExpiration;
-
-        return $this->db->table('zp_user')
-            ->where('sessiontime', '<', $expirationTime)
             ->update(['session' => '']) >= 0;
     }
 

--- a/app/Domain/Auth/Services/Auth.php
+++ b/app/Domain/Auth/Services/Auth.php
@@ -32,41 +32,7 @@ class Auth implements Authenticatable
      */
     private ?int $userId = null;
 
-    /**
-     * @var int|null user id from DB
-     */
-    private ?int $clientId = null;
-
-    /**
-     * @var string|null username from db
-     */
-    private ?string $username = null;
-
-    /**
-     * @var string username from db
-     */
-    private string $name = '';
-
-    /**
-     * @var string profileid (image) from db
-     */
-    private string $profileId = '';
-
     private ?string $password = null;
-
-    /**
-     * @var string|null username (emailaddress)
-     */
-    private ?string $user = null;
-
-    /**
-     * @var string|null username (emailaddress)
-     */
-    private ?string $mail = null;
-
-    private bool $twoFAEnabled;
-
-    private string $twoFASecret;
 
     private ?SessionManager $session = null;
 

--- a/app/Domain/Blueprints/Controllers/ApiCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ApiCanvas.php
@@ -6,7 +6,6 @@ namespace Leantime\Domain\Blueprints\Controllers;
 
 use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Http\IncomingRequest;
-use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
@@ -31,14 +30,12 @@ class ApiCanvas
      *
      * @param  IncomingRequest  $request  Incoming request
      * @param  Template  $tpl  Template handler
-     * @param  Language  $language  Language handler
      * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized item CRUD)
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
     public function __construct(
         private IncomingRequest $request,
         private Template $tpl,
-        private Language $language,
         private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,
     ) {

--- a/app/Domain/Blueprints/Controllers/DelCanvas.php
+++ b/app/Domain/Blueprints/Controllers/DelCanvas.php
@@ -91,7 +91,7 @@ class DelCanvas
                 strtoupper($this->canvasSlug).'canvas_deleted'
             );
 
-            if (! $allCanvas || count($allCanvas) == 0) {
+            if (! $allCanvas) {
                 return Frontcontroller::redirect(BASE_URL.'/blueprints/showBoards');
             }
 

--- a/app/Domain/Blueprints/Controllers/EditCanvasComment.php
+++ b/app/Domain/Blueprints/Controllers/EditCanvasComment.php
@@ -16,9 +16,6 @@ use Leantime\Domain\Blueprints\Services\TemplateRegistry;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
-use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -42,10 +39,7 @@ class EditCanvasComment
      * @param  IncomingRequest  $request  Incoming request
      * @param  Template  $tpl  Template engine
      * @param  Language  $language  Language service
-     * @param  TicketRepository  $ticketRepo  Ticket repository
      * @param  CommentRepository  $commentsRepo  Comment repository
-     * @param  SprintService  $sprintService  Sprint service
-     * @param  TicketService  $ticketService  Ticket service
      * @param  ProjectService  $projectService  Project service
      * @param  BlueprintsService  $blueprintsService  Blueprints service (project-authorized item CRUD)
      * @param  TemplateRegistry  $templateRegistry  Template registry
@@ -54,10 +48,7 @@ class EditCanvasComment
         private IncomingRequest $request,
         private Template $tpl,
         private Language $language,
-        private TicketRepository $ticketRepo,
         private CommentRepository $commentsRepo,
-        private SprintService $sprintService,
-        private TicketService $ticketService,
         private ProjectService $projectService,
         private BlueprintsService $blueprintsService,
         TemplateRegistry $templateRegistry,

--- a/app/Domain/Blueprints/Controllers/Export.php
+++ b/app/Domain/Blueprints/Controllers/Export.php
@@ -6,8 +6,6 @@ namespace Leantime\Domain\Blueprints\Controllers;
 
 use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Http\IncomingRequest;
-use Leantime\Core\Language;
-use Leantime\Core\UI\Template;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Services\BlueprintsExport;
@@ -30,15 +28,11 @@ class Export
      * __construct - resolve dependencies and determine the canvas slug from the request.
      *
      * @param  IncomingRequest  $request  Incoming request
-     * @param  Template  $tpl  Template engine
-     * @param  Language  $language  Language service
      * @param  BlueprintsExport  $exportService  Blueprints export service
      * @param  TemplateRegistry  $templateRegistry  Template registry
      */
     public function __construct(
-        private IncomingRequest $request,
-        private Template $tpl,
-        private Language $language,
+        IncomingRequest $request,
         private BlueprintsExport $exportService,
         TemplateRegistry $templateRegistry,
     ) {

--- a/app/Domain/Blueprints/Controllers/ShowCanvas.php
+++ b/app/Domain/Blueprints/Controllers/ShowCanvas.php
@@ -264,7 +264,7 @@ class ShowCanvas
         $allCanvas = $this->blueprintsRepo->getAllCanvas(session('currentProject'), $canvasType);
 
         // Create a default board when the project has none.
-        if (! $allCanvas || count($allCanvas) == 0) {
+        if (! $allCanvas) {
             $this->blueprintsRepo->addCanvas([
                 'title' => $this->language->__('label.board'),
                 'author' => session('userdata.id'),

--- a/app/Domain/Blueprints/Repositories/Blueprints.php
+++ b/app/Domain/Blueprints/Repositories/Blueprints.php
@@ -6,7 +6,6 @@ use Illuminate\Database\ConnectionInterface;
 use Leantime\Core\Db\DatabaseHelper;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Db\Repository;
-use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Tickets\Repositories\Tickets;
 
 /**
@@ -30,24 +29,19 @@ class Blueprints extends Repository
 
     protected DatabaseHelper $dbHelper;
 
-    private LanguageCore $language;
-
     private Tickets $ticketRepo;
 
     /**
      * @param  DbCore  $db  Database connection
-     * @param  LanguageCore  $language  Language service
      * @param  Tickets  $ticketRepo  Ticket repository
      * @param  DatabaseHelper  $dbHelper  Database helper
      */
     public function __construct(
         DbCore $db,
-        LanguageCore $language,
         Tickets $ticketRepo,
         DatabaseHelper $dbHelper
     ) {
         $this->connection = $db->getConnection();
-        $this->language = $language;
         $this->ticketRepo = $ticketRepo;
         $this->dbHelper = $dbHelper;
     }
@@ -188,7 +182,7 @@ class Blueprints extends Repository
             'projectId' => $values['projectId'],
         ]);
 
-        return $insertId !== false ? (string) $insertId : false;
+        return (string) $insertId;
     }
 
     /**
@@ -484,7 +478,7 @@ class Blueprints extends Repository
             'tags' => $values['tags'] ?? '',
         ]);
 
-        return $id !== false ? (string) $id : false;
+        return (string) $id;
     }
 
     /**

--- a/app/Domain/Calendar/Repositories/Calendar.php
+++ b/app/Domain/Calendar/Repositories/Calendar.php
@@ -9,7 +9,6 @@ use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Db\Repository as RepositoryCore;
 use Leantime\Core\Language as LanguageCore;
-use Leantime\Core\Support\DateTimeHelper;
 use Leantime\Core\Support\EntityRelationshipEnum;
 use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Tickets\Services\Tickets;
@@ -46,14 +45,12 @@ class Calendar extends RepositoryCore
      *
      * @param  DbCore  $dbCore  The DbCore object.
      * @param  LanguageCore  $language  The LanguageCore object.
-     * @param  DateTimeHelper  $dateTimeHelper  The DateTimeHelper object.
      * @param  Environment  $config  The Environment object.
      * @return void
      */
     public function __construct(
         DbCore $dbCore,
         private LanguageCore $language,
-        private DateTimeHelper $dateTimeHelper,
         private Environment $config
     ) {
         $this->db = $dbCore->getConnection();

--- a/app/Domain/Canvas/Controllers/DelCanvasItem.php
+++ b/app/Domain/Canvas/Controllers/DelCanvasItem.php
@@ -2,7 +2,6 @@
 
 namespace Leantime\Domain\Canvas\Controllers;
 
-use Illuminate\Support\Str;
 use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
@@ -20,8 +19,6 @@ class DelCanvasItem extends Controller
      */
     protected const CANVAS_NAME = '??';
 
-    private mixed $canvasRepo;
-
     private BlueprintsService $blueprintsService;
 
     /**
@@ -30,9 +27,6 @@ class DelCanvasItem extends Controller
     public function init(): void
     {
         $this->blueprintsService = app()->make(BlueprintsService::class);
-        $canvasName = Str::studly(static::CANVAS_NAME).'canvas';
-        $repoName = app()->getNamespace()."Domain\\$canvasName\\Repositories\\$canvasName";
-        $this->canvasRepo = app()->make($repoName);
     }
 
     /**

--- a/app/Domain/Canvas/Controllers/EditCanvasComment.php
+++ b/app/Domain/Canvas/Controllers/EditCanvasComment.php
@@ -15,9 +15,6 @@ use Leantime\Domain\Blueprints\Services\Blueprints as BlueprintsService;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
-use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 
 class EditCanvasComment extends Controller
 {
@@ -26,13 +23,7 @@ class EditCanvasComment extends Controller
      */
     protected const CANVAS_NAME = '??';
 
-    private TicketRepository $ticketRepo;
-
     private CommentRepository $commentsRepo;
-
-    private SprintService $sprintService;
-
-    private TicketService $ticketService;
 
     private ProjectService $projectService;
 
@@ -44,16 +35,10 @@ class EditCanvasComment extends Controller
      * init - initialize private variables
      */
     public function init(
-        TicketRepository $ticketRepo,
         CommentRepository $commentsRepo,
-        SprintService $sprintService,
-        TicketService $ticketService,
         ProjectService $projectService
     ) {
-        $this->ticketRepo = $ticketRepo;
         $this->commentsRepo = $commentsRepo;
-        $this->sprintService = $sprintService;
-        $this->ticketService = $ticketService;
         $this->projectService = $projectService;
         $this->blueprintsService = app()->make(BlueprintsService::class);
 

--- a/app/Domain/Canvas/Controllers/ShowCanvas.php
+++ b/app/Domain/Canvas/Controllers/ShowCanvas.php
@@ -129,7 +129,7 @@ class ShowCanvas extends Controller
     {
         $sessionKey = 'current'.strtoupper(static::CANVAS_NAME).'Canvas';
 
-        if (! $allCanvas || count($allCanvas) == 0) {
+        if (! $allCanvas) {
             $values = [
                 'title' => $this->language->__('label.board'),
                 'author' => session('userdata.id'),
@@ -162,7 +162,7 @@ class ShowCanvas extends Controller
             session([$sessionKey => '']);
         }
 
-        if (count($allCanvas) > 0 && session($sessionKey) == '') {
+        if (session($sessionKey) == '') {
             $currentCanvasId = $allCanvas[0]['id'];
             session([$sessionKey => $currentCanvasId]);
         }

--- a/app/Domain/Canvas/Repositories/Canvas.php
+++ b/app/Domain/Canvas/Repositories/Canvas.php
@@ -108,8 +108,6 @@ class Canvas extends BlueprintsRepository
 
     private LanguageCore $language;
 
-    private Tickets $ticketRepo;
-
     /**
      * __construct - get db connection and initialise the underlying Blueprints repository
      */
@@ -120,13 +118,12 @@ class Canvas extends BlueprintsRepository
         DatabaseHelper $dbHelper
     ) {
         // Initialise the Blueprints parent so the delegated methods have a connection.
-        parent::__construct($db, $language, $ticketRepo, $dbHelper);
+        parent::__construct($db, $ticketRepo, $dbHelper);
 
         // Keep local copies for the config accessors and goal-specific queries below.
         $this->db = $db;
         $this->connection = $db->getConnection();
         $this->language = $language;
-        $this->ticketRepo = $ticketRepo;
         $this->dbHelper = $dbHelper;
     }
 

--- a/app/Domain/Clients/Controllers/ShowClient.php
+++ b/app/Domain/Clients/Controllers/ShowClient.php
@@ -68,7 +68,7 @@ class ShowClient extends Controller
 
                 return Frontcontroller::redirect(BASE_URL.'/clients/showClient/'.$id.'#files');
             } else {
-                $this->tpl->setNotification(is_array($result) ? ($result['msg'] ?? '') : '', 'error');
+                $this->tpl->setNotification('', 'error');
             }
         }
 

--- a/app/Domain/Clients/Controllers/ShowClient.php
+++ b/app/Domain/Clients/Controllers/ShowClient.php
@@ -68,7 +68,7 @@ class ShowClient extends Controller
 
                 return Frontcontroller::redirect(BASE_URL.'/clients/showClient/'.$id.'#files');
             } else {
-                $this->tpl->setNotification('', 'error');
+                $this->tpl->setNotification($this->language->__('notifications.file_deleted_error'), 'error');
             }
         }
 

--- a/app/Domain/Comments/Controllers/ShowAll.php
+++ b/app/Domain/Comments/Controllers/ShowAll.php
@@ -7,13 +7,10 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
 
 class ShowAll extends Controller
 {
-    private ProjectService $projectService;
-
     private CommentService $commentService;
 
     private $module;
@@ -28,10 +25,8 @@ class ShowAll extends Controller
      * @throws Exception
      */
     public function init(
-        ProjectService $projectService,
         CommentService $commentService
     ): void {
-        $this->projectService = $projectService;
         $this->commentService = $commentService;
     }
 

--- a/app/Domain/Cron/Services/Cron.php
+++ b/app/Domain/Cron/Services/Cron.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Log;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Console\ConsoleKernel;
 use Leantime\Core\Events\DispatchesEvents;
-use Leantime\Domain\Audit\Repositories\Audit;
-use Leantime\Domain\Queue\Services\Queue;
-use Leantime\Domain\Reports\Services\Reports;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
@@ -18,22 +15,11 @@ class Cron
 {
     use DispatchesEvents;
 
-    private Audit $auditRepo;
-
-    private Queue $queueSvc;
-
     private Environment $environment;
 
-    private Reports $reportService;
-
-    private int $cronExecTimer = 60;
-
-    public function __construct(Audit $auditRepo, Queue $queueSvc, Environment $environment, Reports $reportService)
+    public function __construct(Environment $environment)
     {
-        $this->auditRepo = $auditRepo;
-        $this->queueSvc = $queueSvc;
         $this->environment = $environment;
-        $this->reportService = $reportService;
     }
 
     /**

--- a/app/Domain/CsvImport/Services/CsvImport.php
+++ b/app/Domain/CsvImport/Services/CsvImport.php
@@ -16,8 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CsvImport extends Provider implements ProviderIntegration
 {
-    private array $fields;
-
     /**
      * @var array|array[]
      */

--- a/app/Domain/Dashboard/Repositories/Dashboard.php
+++ b/app/Domain/Dashboard/Repositories/Dashboard.php
@@ -8,8 +8,6 @@ class Dashboard
 {
     public ?DbCore $db;
 
-    private array $defaultWidgets = [1, 3, 9];
-
     /**
      * __construct - neu db connection
      */

--- a/app/Domain/Dashboard/Services/Dashboard.php
+++ b/app/Domain/Dashboard/Services/Dashboard.php
@@ -119,7 +119,7 @@ class Dashboard
     {
         $userReaction = $this->reactionsService->getUserReactions($userId, 'project', $projectId, Reactions::$favorite);
 
-        return $userReaction && is_array($userReaction) && count($userReaction) > 0;
+        return $userReaction && is_array($userReaction);
     }
 
     /**
@@ -134,8 +134,7 @@ class Dashboard
      */
     public function buildDeleteCommentUrlBase(): string
     {
-        $url = parse_url(CURRENT_URL);
-
-        return $url['scheme'].'://'.$url['host'].($url['path'] ?? '').'?delComment=';
+        // Current URL up to (but excluding) any existing query string, plus the delComment flag.
+        return strtok(CURRENT_URL, '?').'?delComment=';
     }
 }

--- a/app/Domain/Entityrelations/Services/Entityrelations.php
+++ b/app/Domain/Entityrelations/Services/Entityrelations.php
@@ -2,7 +2,6 @@
 
 namespace Leantime\Domain\Entityrelations\Services;
 
-use Leantime\Domain\Entityrelations\Repositories\Entityrelations as EntityrelationRepository;
 use Leantime\Domain\Setting\Repositories\Setting;
 
 class Entityrelations
@@ -10,12 +9,10 @@ class Entityrelations
     /**
      * Class constructor.
      *
-     * @param  EntityrelationRepository  $entityRelationshipsRepo  The entity relationships repository.
      * @param  Setting  $settingsRepo  The settings repository.
      * @return void
      */
     public function __construct(
-        private EntityrelationRepository $entityRelationshipsRepo,
         private Setting $settingsRepo
     ) {}
 

--- a/app/Domain/Files/Controllers/Browse.php
+++ b/app/Domain/Files/Controllers/Browse.php
@@ -56,7 +56,7 @@ class Browse extends Controller
                 return Frontcontroller::redirect(BASE_URL.'/files/showAll'.(($_GET['modalPopUp'] ?? '') ? '?modalPopUp=true' : ''));
             }
 
-            $this->tpl->setNotification($this->language->__('notifications.file_delete_error'), 'error');
+            $this->tpl->setNotification($this->language->__('notifications.file_deleted_error'), 'error');
         }
 
         if ($result['action'] === 'upload') {

--- a/app/Domain/Files/Controllers/ShowAll.php
+++ b/app/Domain/Files/Controllers/ShowAll.php
@@ -61,7 +61,7 @@ class ShowAll extends Controller
                 return Frontcontroller::redirect(BASE_URL.'/files/showAll'.(($_GET['modalPopUp'] ?? '') ? '?modalPopUp=true' : ''));
             }
 
-            $this->tpl->setNotification($this->language->__('notifications.file_delete_error'), 'error');
+            $this->tpl->setNotification($this->language->__('notifications.file_deleted_error'), 'error');
         }
 
         if ($result['action'] === 'upload') {

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -385,7 +385,7 @@ class Files extends BaseService
             Log::warning('Unauthorized file access attempt on orphaned project file', [
                 'userId' => $currentUserId,
                 'fileId' => $fileRecord['id'],
-                'module' => $fileRecord['module'] ?? '',
+                'module' => $fileRecord['module'],
             ]);
 
             return new Response('', 403);
@@ -446,6 +446,7 @@ class Files extends BaseService
             if (isset($files['file'])) {
                 try {
                     $result = $this->upload($files, $module, $moduleId);
+                    // @phpstan-ignore-next-line catch.neverThrown — upload() throws AuthorizationException (Files.php:136); PHPStan can't track it through the call.
                 } catch (AuthorizationException) {
                     // A denied upload becomes a clean "upload failed" notification, not a 403 page.
                     return ['action' => 'upload', 'success' => false];

--- a/app/Domain/Goalcanvas/Controllers/BigRock.php
+++ b/app/Domain/Goalcanvas/Controllers/BigRock.php
@@ -10,12 +10,8 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
 use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
-use Leantime\Domain\Goalcanvas\Repositories\Goalcanvas as GoalcanvaRepository;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -23,27 +19,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class BigRock extends Controller
 {
-    private GoalcanvaRepository $canvasRepo;
-
-    private CommentRepository $commentsRepo;
-
-    private TicketService $ticketService;
-
-    private ProjectService $projectService;
-
     private GoalcanvaService $goalService;
 
     public function init(
-        GoalcanvaRepository $canvasRepo,
-        CommentRepository $commentsRepo,
-        TicketService $ticketService,
-        ProjectService $projectService,
         GoalcanvaService $goalService
     ): void {
-        $this->canvasRepo = $canvasRepo;
-        $this->commentsRepo = $commentsRepo;
-        $this->ticketService = $ticketService;
-        $this->projectService = $projectService;
         $this->goalService = $goalService;
     }
 

--- a/app/Domain/Goalcanvas/Controllers/Dashboard.php
+++ b/app/Domain/Goalcanvas/Controllers/Dashboard.php
@@ -133,7 +133,7 @@ class Dashboard extends Controller
      */
     private function ensureDefaultCanvas(array $allCanvas): array
     {
-        if (! $allCanvas || count($allCanvas) == 0) {
+        if (! $allCanvas) {
             $values = [
                 'title' => $this->language->__('label.board'),
                 'author' => session('userdata.id'),

--- a/app/Domain/Goalcanvas/Controllers/DelCanvas.php
+++ b/app/Domain/Goalcanvas/Controllers/DelCanvas.php
@@ -68,7 +68,7 @@ class DelCanvas extends Controller
 
             $this->tpl->setNotification($this->language->__('notification.board_deleted'), 'success', strtoupper(static::CANVAS_NAME).'canvas_deleted');
 
-            if (! $allCanvas || count($allCanvas) == 0) {
+            if (! $allCanvas) {
                 return Frontcontroller::redirect(BASE_URL.'/blueprints/showBoards');
             }
 

--- a/app/Domain/Goalcanvas/Controllers/EditCanvasComment.php
+++ b/app/Domain/Goalcanvas/Controllers/EditCanvasComment.php
@@ -14,9 +14,6 @@ use Leantime\Domain\Goalcanvas\Permissions\GoalcanvasPermissions;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvaService;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
-use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 
 class EditCanvasComment extends Controller
 {
@@ -25,13 +22,7 @@ class EditCanvasComment extends Controller
      */
     protected const CANVAS_NAME = 'goal';
 
-    private TicketRepository $ticketRepo;
-
     private CommentRepository $commentsRepo;
-
-    private SprintService $sprintService;
-
-    private TicketService $ticketService;
 
     private ProjectService $projectService;
 
@@ -43,17 +34,11 @@ class EditCanvasComment extends Controller
      * init - initialize private variables
      */
     public function init(
-        TicketRepository $ticketRepo,
         CommentRepository $commentsRepo,
-        SprintService $sprintService,
-        TicketService $ticketService,
         ProjectService $projectService,
         GoalcanvaService $goalService
     ) {
-        $this->ticketRepo = $ticketRepo;
         $this->commentsRepo = $commentsRepo;
-        $this->sprintService = $sprintService;
-        $this->ticketService = $ticketService;
         $this->projectService = $projectService;
         $this->goalService = $goalService;
 

--- a/app/Domain/Goalcanvas/Controllers/ShowCanvas.php
+++ b/app/Domain/Goalcanvas/Controllers/ShowCanvas.php
@@ -127,7 +127,7 @@ class ShowCanvas extends Controller
     {
         $sessionKey = 'current'.strtoupper(static::CANVAS_NAME).'Canvas';
 
-        if (! $allCanvas || count($allCanvas) == 0) {
+        if (! $allCanvas) {
             $values = [
                 'title' => $this->language->__('label.board'),
                 'author' => session('userdata.id'),
@@ -165,7 +165,7 @@ class ShowCanvas extends Controller
             session([$sessionKey => '']);
         }
 
-        if (count($allCanvas) > 0 && session($sessionKey) == '') {
+        if (session($sessionKey) == '') {
             $currentCanvasId = $allCanvas[0]['id'];
             session([$sessionKey => $currentCanvasId]);
         }

--- a/app/Domain/Goalcanvas/Repositories/Goalcanvas.php
+++ b/app/Domain/Goalcanvas/Repositories/Goalcanvas.php
@@ -86,7 +86,7 @@ class Goalcanvas extends Blueprints
      */
     public function __construct(DbCore $db, LanguageCore $language, Tickets $ticketRepo, DatabaseHelper $dbHelper)
     {
-        parent::__construct($db, $language, $ticketRepo, $dbHelper);
+        parent::__construct($db, $ticketRepo, $dbHelper);
         $this->dbConnection = $db->getConnection();
         $this->canvasLanguage = $language;
     }

--- a/app/Domain/Help/Composers/Helpermodal.php
+++ b/app/Domain/Help/Composers/Helpermodal.php
@@ -75,7 +75,7 @@ class Helpermodal extends Composer
         return [
             'completedOnboarding' => $completedOnboarding,
             'showHelperModal' => $showHelperModal,
-            'currentModal' => is_array($currentModal) ? $currentModal['template'] : $currentModal,
+            'currentModal' => $currentModal['template'],
             'isFirstLogin' => $isFirstLogin,
         ];
     }

--- a/app/Domain/Help/Services/FirstTaskStep.php
+++ b/app/Domain/Help/Services/FirstTaskStep.php
@@ -4,7 +4,6 @@ namespace Leantime\Domain\Help\Services;
 
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Help\Contracts\OnboardingSteps;
-use Leantime\Domain\Projects\Services\Projects;
 use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Tickets\Services\Tickets;
 
@@ -14,7 +13,6 @@ class FirstTaskStep implements OnboardingSteps
 
     public function __construct(
         private Setting $settingsRepo,
-        private Projects $projectService,
         private Tickets $ticketService
     ) {}
 
@@ -62,7 +60,7 @@ class FirstTaskStep implements OnboardingSteps
             $this->ticketService->quickAddTicket(['headline' => $params['headline']]);
         }
 
-        $this->settingsRepo->saveSetting('user.'.session()?->get('userdata.id', -1).'.firstLoginCompleted', true);
+        $this->settingsRepo->saveSetting('user.'.session()->get('userdata.id', -1).'.firstLoginCompleted', true);
 
         return true;
     }

--- a/app/Domain/Help/Services/InviteTeamStep.php
+++ b/app/Domain/Help/Services/InviteTeamStep.php
@@ -6,7 +6,6 @@ use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\UI\Template;
 use Leantime\Domain\Help\Contracts\OnboardingSteps;
 use Leantime\Domain\Projects\Services\Projects;
-use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Users\Services\Users;
 
 class InviteTeamStep implements OnboardingSteps
@@ -14,7 +13,6 @@ class InviteTeamStep implements OnboardingSteps
     use DispatchesEvents;
 
     public function __construct(
-        private Setting $settingsRepo,
         private Projects $projectService,
         private Users $userService,
         private Template $tplService

--- a/app/Domain/Ideas/Controllers/ShowBoards.php
+++ b/app/Domain/Ideas/Controllers/ShowBoards.php
@@ -94,7 +94,7 @@ class ShowBoards extends Controller
      */
     private function resolveCurrentCanvasId(array &$allCanvas, array $params): int
     {
-        if (! $allCanvas || count($allCanvas) == 0) {
+        if (! $allCanvas) {
             $currentCanvasId = $this->ideaService->ensureBoardExists(
                 (int) session('currentProject'),
                 (int) session('userdata.id'),
@@ -112,7 +112,7 @@ class ShowBoards extends Controller
             session(['currentIdeaCanvas' => '']);
         }
 
-        if (count($allCanvas) > 0 && session('currentIdeaCanvas') == '') {
+        if (session('currentIdeaCanvas') == '') {
             $currentCanvasId = $allCanvas[0]['id'];
             session(['currentIdeaCanvas' => $currentCanvasId]);
         }

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -6,7 +6,6 @@ use Illuminate\Database\ConnectionInterface;
 use Leantime\Core\Db\DatabaseHelper;
 use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Language as LanguageCore;
-use Leantime\Domain\Tickets\Repositories\Tickets;
 
 class Ideas
 {
@@ -29,8 +28,6 @@ class Ideas
 
     private LanguageCore $language;
 
-    private Tickets $ticketRepo;
-
     private DatabaseHelper $dbHelper;
 
     /**
@@ -38,11 +35,10 @@ class Ideas
      *
      * @return void
      */
-    public function __construct(DbCore $db, LanguageCore $language, Tickets $ticketRepo, DatabaseHelper $dbHelper)
+    public function __construct(DbCore $db, LanguageCore $language, DatabaseHelper $dbHelper)
     {
         $this->db = $db->getConnection();
         $this->language = $language;
-        $this->ticketRepo = $ticketRepo;
         $this->dbHelper = $dbHelper;
     }
 
@@ -374,14 +370,12 @@ class Ideas
         foreach ($params as $status => $ideaList) {
             $ideas = explode('&', $ideaList);
 
-            if (is_array($ideas) === true && count($ideas) > 0) {
-                foreach ($ideas as $key => $ideaString) {
-                    if (strlen($ideaString) > 0) {
-                        $id = substr($ideaString, 7);
+            foreach ($ideas as $key => $ideaString) {
+                if (strlen($ideaString) > 0) {
+                    $id = substr($ideaString, 7);
 
-                        if ($this->updateIdeaStatus((int) $id, $status) === false) {
-                            return false;
-                        }
+                    if ($this->updateIdeaStatus((int) $id, $status) === false) {
+                        return false;
                     }
                 }
             }

--- a/app/Domain/Ideas/Templates/boardDialog.php
+++ b/app/Domain/Ideas/Templates/boardDialog.php
@@ -24,7 +24,7 @@ $canvasName = $tpl->get('canvasName');
     <div class="modal-footer">
         <?php if (isset($_GET['id'])) {?>
             <input type="submit"  class="btn btn-primary" value="<?= $tpl->__('buttons.save_board') ?>" name="newCanvas" />
-            <input type="hidden" name="editCanvas" value="<?= (int) $_GET['id'] ?? ''?>">
+            <input type="hidden" name="editCanvas" value="<?= (int) $_GET['id'] ?>">
         <?php } else { ?>
             <input type="hidden" name="newCanvas" value="true">
             <input type="submit"  class="btn btn-primary" value="<?= $tpl->__('buttons.create_board') ?>" name="newCanvas" />

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -135,7 +135,7 @@ class Install
      */
     public function getDBObject(): ?PDO
     {
-        return $this->connection?->getPdo();
+        return $this->connection->getPdo();
     }
 
     /**
@@ -2176,11 +2176,11 @@ class Install
                 $this->mergeEntityRelationshipTables($pluralTable, $singularTable);
             }
             // Case A: Only plural exists - rename to singular
-            elseif ($pluralExists && ! $singularExists) {
+            elseif ($pluralExists) {
                 $this->connection->statement("RENAME TABLE `{$pluralTable}` TO `{$singularTable}`");
             }
-            // Case E: Neither exists - create singular with correct schema
-            elseif (! $pluralExists && ! $singularExists) {
+            // Case E: Neither exists - create singular with correct schema (plural already ruled out above)
+            elseif (! $singularExists) {
                 $this->createEntityRelationshipTable();
 
                 return true;
@@ -2385,9 +2385,9 @@ class Install
             // Handle any remaining plural table issues
             if ($pluralExists && $singularExists) {
                 $this->mergeEntityRelationshipTables($pluralTable, $singularTable);
-            } elseif ($pluralExists && ! $singularExists) {
+            } elseif ($pluralExists) {
                 $this->connection->statement("RENAME TABLE `{$pluralTable}` TO `{$singularTable}`");
-            } elseif (! $pluralExists && ! $singularExists) {
+            } elseif (! $singularExists) {
                 $this->createEntityRelationshipTable();
 
                 return true;
@@ -2429,9 +2429,9 @@ class Install
             // Handle any remaining plural table issues
             if ($pluralExists && $singularExists) {
                 $this->mergeEntityRelationshipTables($pluralTable, $singularTable);
-            } elseif ($pluralExists && ! $singularExists) {
+            } elseif ($pluralExists) {
                 $this->connection->statement("RENAME TABLE `{$pluralTable}` TO `{$singularTable}`");
-            } elseif (! $pluralExists && ! $singularExists) {
+            } elseif (! $singularExists) {
                 $this->createEntityRelationshipTable();
 
                 return true;

--- a/app/Domain/Ldap/Services/Ldap.php
+++ b/app/Domain/Ldap/Services/Ldap.php
@@ -288,11 +288,9 @@ class Ldap
 
         $getLdap = explode('@', $username);
 
-        if ($getLdap && is_array($getLdap)) {
+        if (is_array($getLdap)) {
             return $getLdap[0];
         }
-
-        return '';
     }
 
     public function getAllMembers(): array|false

--- a/app/Domain/Menu/Composers/Menu.php
+++ b/app/Domain/Menu/Composers/Menu.php
@@ -115,7 +115,7 @@ class Menu extends Composer
             'projectHierarchy' => $allAssignedprojectsHierarchy,
             'recentProjects' => $recentProjects,
             'currentProject' => $currentProject,
-            'menuStructure' => $this->menuRepo->getMenuStructure($menuType ?? '') ?? [],
+            'menuStructure' => $this->menuRepo->getMenuStructure($menuType ?? ''),
             'menuType' => $menuType,
             'settingsLink' => $settingsLink,
             'redirectUrl' => $redirectUrl,

--- a/app/Domain/Menu/Composers/ProjectSelector.php
+++ b/app/Domain/Menu/Composers/ProjectSelector.php
@@ -7,7 +7,6 @@ use Leantime\Core\Controller\Composer;
 use Leantime\Core\Controller\Frontcontroller as FrontcontrollerCore;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Http\IncomingRequest as IncomingRequestCore;
-use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 
 class ProjectSelector extends Composer
 {
@@ -17,18 +16,14 @@ class ProjectSelector extends Composer
         'menu::projectSelector',
     ];
 
-    private MenuRepository $menuRepo;
-
     private IncomingRequestCore $incomingRequest;
 
     private \Leantime\Domain\Menu\Services\Menu $menuService;
 
     public function init(
-        MenuRepository $menuRepo,
         \Leantime\Domain\Menu\Services\Menu $menuService,
         IncomingRequestCore $request
     ): void {
-        $this->menuRepo = $menuRepo;
         $this->menuService = $menuService;
         $this->incomingRequest = $request;
     }

--- a/app/Domain/Menu/Hxcontrollers/ProjectSelector.php
+++ b/app/Domain/Menu/Hxcontrollers/ProjectSelector.php
@@ -7,7 +7,6 @@ use Leantime\Core\Controller\Frontcontroller as FrontcontrollerCore;
 use Leantime\Core\Controller\HtmxController;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Menu\Services\Menu;
-use Leantime\Domain\Timesheets\Services\Timesheets;
 
 class ProjectSelector extends HtmxController
 {
@@ -15,16 +14,13 @@ class ProjectSelector extends HtmxController
 
     protected static string $view = 'menu::partials.projectSelector';
 
-    private Timesheets $timesheetService;
-
     private Menu $menuService;
 
     /**
      * Controller constructor
      */
-    public function init(Timesheets $timesheetService, Menu $menuService): void
+    public function init(Menu $menuService): void
     {
-        $this->timesheetService = $timesheetService;
         $this->menuService = $menuService;
     }
 

--- a/app/Domain/Menu/Repositories/Menu.php
+++ b/app/Domain/Menu/Repositories/Menu.php
@@ -333,13 +333,6 @@ class Menu
     public function processMenuItem($element, &$structure): void
     {
 
-        // ModuleManager Check
-        if (false) {
-            $structure['type'] = 'disabled';
-
-            return;
-        }
-
         // Update security
         if (isset($element['role'])) {
             $accessGranted = AuthService::userIsAtLeast($element['role'], true);

--- a/app/Domain/Menu/Services/Menu.php
+++ b/app/Domain/Menu/Services/Menu.php
@@ -6,8 +6,6 @@ use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Services\Setting;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users;
 
 class Menu
@@ -15,10 +13,6 @@ class Menu
     use DispatchesEvents;
 
     private ProjectService $projectService;
-
-    private TimesheetService $timesheetService;
-
-    private SprintService $sprintService;
 
     private Users $userService;
 
@@ -28,16 +22,12 @@ class Menu
 
     public function __construct(
         ProjectService $projectService,
-        TimesheetService $timesheetService,
-        SprintService $sprintService,
         Users $userService,
         Setting $settingSvc,
         MenuRepository $menuRepo
     ) {
 
         $this->projectService = $projectService;
-        $this->timesheetService = $timesheetService;
-        $this->sprintService = $sprintService;
         $this->userService = $userService;
         $this->settingSvc = $settingSvc;
         $this->menuRepo = $menuRepo;
@@ -261,7 +251,7 @@ class Menu
             'projectHierarchy' => $allAssignedprojectsHierarchy,
             'recentProjects' => $recentProjects,
             'currentProject' => $currentProject,
-            'menuStructure' => $this->menuRepo->getMenuStructure($menuType) ?? [],
+            'menuStructure' => $this->menuRepo->getMenuStructure($menuType),
             'menuType' => $menuType,
             'settingsLink' => $settingsLink,
             'redirectUrl' => $redirectUrl,

--- a/app/Domain/Modulemanager/Services/Modulemanager.php
+++ b/app/Domain/Modulemanager/Services/Modulemanager.php
@@ -12,31 +12,6 @@ class Modulemanager
 {
     use \Leantime\Core\Events\DispatchesEvents;
 
-    private static array $modules = [
-        'api' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'calendar' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'clients' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'comments' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'dashboard' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'files' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'general' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'help' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'ideas' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'ldap' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'leancanvas' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'projects' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'read' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'reports' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'retroscanvas' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'setting' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'sprints' => ['required' => false, 'enabled' => true, 'dependsOn' => 'tickets', 'scope' => 'project'],
-        'tickets' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'timesheets' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'project'],
-        'twoFA' => ['required' => false, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'users' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-        'modulemanager' => ['required' => true, 'enabled' => true, 'dependsOn' => '', 'scope' => 'system'],
-    ];
-
     private Plugins $pluginService;
 
     /**

--- a/app/Domain/Notifications/Repositories/Notifications.php
+++ b/app/Domain/Notifications/Repositories/Notifications.php
@@ -17,9 +17,6 @@ class Notifications
         $this->db = $db->getConnection();
     }
 
-    /**
-     * @param  false  $showNewOnly
-     */
     public function getAllNotifications(int $userId, bool $showNewOnly = false, int $limitStart = 0, int $limitEnd = 100, array $filterOptions = []): false|array
     {
         $query = $this->db->table('zp_notifications')

--- a/app/Domain/Notifications/Services/News.php
+++ b/app/Domain/Notifications/Services/News.php
@@ -3,25 +3,13 @@
 namespace Leantime\Domain\Notifications\Services;
 
 use Illuminate\Support\Facades\Log;
-use Leantime\Core\Db\Db as DbCore;
-use Leantime\Core\Language as LanguageCore;
-use Leantime\Domain\Notifications\Repositories\Notifications as NotificationRepository;
 use Leantime\Domain\Setting\Services\Setting;
-use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
 /**
  * @api
  */
 class News
 {
-    private DbCore $db;
-
-    private NotificationRepository $notificationsRepo;
-
-    private UserRepository $userRepository;
-
-    private LanguageCore $language;
-
     private Setting $settingService;
 
     /**
@@ -31,16 +19,8 @@ class News
      * @api
      */
     public function __construct(
-        DbCore $db,
-        NotificationRepository $notificationsRepo,
-        UserRepository $userRepository,
-        LanguageCore $language,
         Setting $settingService
     ) {
-        $this->db = $db;
-        $this->notificationsRepo = $notificationsRepo;
-        $this->userRepository = $userRepository;
-        $this->language = $language;
         $this->settingService = $settingService;
     }
 
@@ -59,7 +39,7 @@ class News
             return false;
         }
 
-        $latestGuid = (string) $rss?->channel?->item[0]?->guid;
+        $latestGuid = (string) $rss->channel->item[0]->guid;
         $this->settingService->saveSetting('usersettings.'.$userId.'.lastNewsGuid', strval($latestGuid));
 
         // Todo: check last article the user read
@@ -83,7 +63,7 @@ class News
             return false;
         }
 
-        $latestGuid = (string) $rss?->channel?->item[0]?->guid;
+        $latestGuid = (string) $rss->channel->item[0]->guid;
 
         $lastNewsGuid = $this->settingService->getSetting('usersettings.'.$userId.'.lastNewsGuid');
 

--- a/app/Domain/Notifications/Services/Notifications.php
+++ b/app/Domain/Notifications/Services/Notifications.php
@@ -4,7 +4,6 @@ namespace Leantime\Domain\Notifications\Services;
 
 use DOMDocument;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Mailer as MailerCore;
 use Leantime\Domain\Notifications\Repositories\Notifications as NotificationRepository;
@@ -15,8 +14,6 @@ use Leantime\Domain\Users\Repositories\Users as UserRepository;
  */
 class Notifications
 {
-    private DbCore $db;
-
     private NotificationRepository $notificationsRepo;
 
     private UserRepository $userRepository;
@@ -30,12 +27,10 @@ class Notifications
      * @api
      */
     public function __construct(
-        DbCore $db,
         NotificationRepository $notificationsRepo,
         UserRepository $userRepository,
         LanguageCore $language
     ) {
-        $this->db = $db;
         $this->notificationsRepo = $notificationsRepo;
         $this->userRepository = $userRepository;
         $this->language = $language;
@@ -77,7 +72,7 @@ class Notifications
         }
 
         $notificationArray = [
-            'notification' => session('notification') ?? '',
+            'notification' => session('notification'),
             'type' => session('notificationType') ?? '',
             'eventId' => session('eventId') ?? '',
         ];
@@ -359,7 +354,7 @@ class Notifications
             return;
         }
 
-        $authorName = htmlentities($author['firstname']) ?? $this->language->__('label.team_mate');
+        $authorName = htmlentities($author['firstname']);
 
         for ($i = 0; $i < $links->count(); $i++) {
             $taggedUser = $links->item($i)->getAttribute('data-tagged-user-id');

--- a/app/Domain/Notifications/Services/Push.php
+++ b/app/Domain/Notifications/Services/Push.php
@@ -211,7 +211,7 @@ class Push
             );
         } catch (ClientException $e) {
             $response = $e->getResponse();
-            $bodyText = $response !== null ? (string) $response->getBody() : '';
+            $bodyText = (string) $response->getBody();
 
             // FCM signals dead tokens via UNREGISTERED (404) or
             // INVALID_ARGUMENT (400 with that specific error code).

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -494,19 +494,19 @@ class Oidc
         }
         // load all not yet defined endpoints from well-known configuration
 
-        if (! $this->authUrl || $this->authUrl === '') {
+        if (! $this->authUrl) {
             $this->authUrl = $endpoints['authorization_endpoint'];
         }
 
-        if (! $this->tokenUrl || $this->tokenUrl === '') {
+        if (! $this->tokenUrl) {
             $this->tokenUrl = $endpoints['token_endpoint'];
         }
 
-        if (! $this->jwksUrl || $this->jwksUrl === '') {
+        if (! $this->jwksUrl) {
             $this->jwksUrl = $endpoints['jwks_uri'];
         }
 
-        if (! $this->userInfoUrl || $this->userInfoUrl === '') {
+        if (! $this->userInfoUrl) {
             $this->userInfoUrl = $endpoints['userinfo_endpoint'];
         }
 

--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -21,8 +21,6 @@ class Oidc
 {
     private Environment $config;
 
-    private Language $Language;
-
     private AuthService $authService;
 
     public UserRepository $userRepo;
@@ -567,11 +565,6 @@ class Oidc
         session()->forget('oidc.state');
 
         return $storedState !== '' && hash_equals($storedState, $state);
-    }
-
-    private function encodeBase64Url(string $value): string
-    {
-        return strtr(base64_encode($value), '+/', '-_');
     }
 
     private function decodeBase64Url(string $value): string

--- a/app/Domain/Plugins/Controllers/Marketplace.php
+++ b/app/Domain/Plugins/Controllers/Marketplace.php
@@ -5,19 +5,10 @@ namespace Leantime\Domain\Plugins\Controllers;
 use Leantime\Core\Controller\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
-use Leantime\Domain\Plugins\Services\Plugins as PluginService;
 use Symfony\Component\HttpFoundation\Response;
 
 class Marketplace extends Controller
 {
-    private PluginService $pluginService;
-
-    public function init(
-        PluginService $pluginService,
-    ): void {
-        $this->pluginService = $pluginService;
-    }
-
     public function get(): Response
     {
 

--- a/app/Domain/Plugins/Models/InstalledPlugin.php
+++ b/app/Domain/Plugins/Models/InstalledPlugin.php
@@ -77,8 +77,8 @@ class InstalledPlugin implements PluginDisplayStrategy
             $links[] = $vendor;
         }
 
-        if (! empty($this->authors) && (is_array($this->authors) || is_object($this->authors))) {
-            $author = is_array($this->authors) ? $this->authors[0] : $this->authors;
+        if (! empty($this->authors) && is_array($this->authors)) {
+            $author = $this->authors[0];
 
             if (is_object($author)) {
                 $links[] = [

--- a/app/Domain/Plugins/Services/Plugins.php
+++ b/app/Domain/Plugins/Services/Plugins.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Leantime\Core\Configuration\AppSettings;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
-use Leantime\Core\Console\ConsoleKernel;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Notifications\Services\Notifications;
 use Leantime\Domain\Plugins\Models\InstalledPlugin;
@@ -66,7 +65,6 @@ class Plugins
         private EnvironmentCore $config,
         private SettingsService $settingsService,
         private UsersService $usersService,
-        private ConsoleKernel $leantimeCli,
         private AppSettings $appSettings,
     ) {
         $this->marketplaceUrl = rtrim($config->marketplaceUrl, '/');
@@ -124,10 +122,8 @@ class Plugins
         }
 
         // Gets plugins from the config, which are automatically enabled
-        if (
-            isset($this->config->plugins)
-            && $configplugins = explode(',', $this->config->plugins)
-        ) {
+        if (isset($this->config->plugins)) {
+            $configplugins = explode(',', $this->config->plugins);
             collect($configplugins)
                 ->filter(fn ($plugin) => ! empty($plugin))
                 ->each(function ($plugin) use (&$installedPluginsById) {

--- a/app/Domain/Projects/Controllers/ChangeCurrentProject.php
+++ b/app/Domain/Projects/Controllers/ChangeCurrentProject.php
@@ -5,18 +5,14 @@ namespace Leantime\Domain\Projects\Controllers;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Setting\Services\Setting as SettingService;
 
 class ChangeCurrentProject extends Controller
 {
     private ProjectService $projectService;
 
-    private SettingService $settingService;
-
-    public function init(ProjectService $projectService, SettingService $settingService): void
+    public function init(ProjectService $projectService): void
     {
         $this->projectService = $projectService;
-        $this->settingService = $settingService;
     }
 
     /**

--- a/app/Domain/Projects/Controllers/Createnew.php
+++ b/app/Domain/Projects/Controllers/Createnew.php
@@ -6,24 +6,19 @@ use Leantime\Core\Controller\Controller;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Modulemanager\Services\Modulemanager;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Symfony\Component\HttpFoundation\Response;
 
 class Createnew extends Controller
 {
-    private ProjectService $projectService;
-
     private Modulemanager $modulemanager;
 
     /**
      * Initializes dependencies.
      */
     public function init(
-        Modulemanager $modulemanager,
-        ProjectService $projectService
+        Modulemanager $modulemanager
     ): void {
         $this->modulemanager = $modulemanager;
-        $this->projectService = $projectService;
     }
 
     /**

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -737,7 +737,7 @@ class Projects
             }
         }
 
-        return is_numeric($projectId) ? (int) $projectId : false;
+        return (int) $projectId;
     }
 
     /**
@@ -828,7 +828,7 @@ class Projects
     /**
      * getUserProjectRelation - get all projects related to a user
      *
-     * @param  null  $projectId
+     * @param  int|null  $projectId
      */
     public function getUserProjectRelation($id, $projectId = null): array
     {

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -1052,12 +1052,8 @@ class Projects extends BaseService implements ChecksProjectAccess
 
         $project = $this->projectRepository->getUserProjectRelation($userId, $projectId);
 
-        if (is_array($project)) {
-            if (isset($project[0]['projectRole']) && $project[0]['projectRole'] != '') {
-                return (string) $project[0]['projectRole'];
-            } else {
-                return '';
-            }
+        if (isset($project[0]['projectRole']) && $project[0]['projectRole'] != '') {
+            return (string) $project[0]['projectRole'];
         } else {
             return '';
         }
@@ -1865,8 +1861,6 @@ class Projects extends BaseService implements ChecksProjectAccess
         $avatar = $this->avatarcreator->getAvatar($project['name']);
 
         return self::dispatch_filter('afterGettingAvatar', $avatar, ['projectId' => $id]);
-
-        return $avatar;
     }
 
     /**

--- a/app/Domain/Queue/Services/Queue.php
+++ b/app/Domain/Queue/Services/Queue.php
@@ -2,15 +2,11 @@
 
 namespace Leantime\Domain\Queue\Services;
 
-use Leantime\Core\Language as LanguageCore;
-use Leantime\Core\Mailer as MailerCore;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepository;
 use Leantime\Domain\Queue\Workers\DefaultWorker;
 use Leantime\Domain\Queue\Workers\EmailWorker;
 use Leantime\Domain\Queue\Workers\HttpRequestWorker;
 use Leantime\Domain\Queue\Workers\Workers;
-use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
-use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
 /**
  * @api
@@ -19,40 +15,18 @@ class Queue
 {
     private QueueRepository $queue;
 
-    private UserRepository $userRepo;
-
-    private SettingRepository $settingsRepo;
-
-    private MailerCore $mailer;
-
-    private LanguageCore $language;
-
     public $availableWorkers = ['email', 'httprequest'];
 
     /**
      * Class constructor.
      *
      * @param  QueueRepository  $queue  The queue repository.
-     * @param  UserRepository  $userRepo  The user repository.
-     * @param  SettingRepository  $settingsRepo  The settings repository.
-     * @param  MailerCore  $mailer  The mailer core.
-     * @param  LanguageCore  $language  The language core.
      */
     public function __construct(
-        QueueRepository $queue,
-        UserRepository $userRepo,
-        SettingRepository $settingsRepo,
-        MailerCore $mailer,
-        LanguageCore $language
+        QueueRepository $queue
     ) {
         // NEW Queuing messaging system
         $this->queue = $queue;
-
-        // We need users and settings and a mailer
-        $this->userRepo = $userRepo;
-        $this->settingsRepo = $settingsRepo;
-        $this->mailer = $mailer;
-        $this->language = $language;
     }
 
     /**

--- a/app/Domain/Queue/Workers/DefaultWorker.php
+++ b/app/Domain/Queue/Workers/DefaultWorker.php
@@ -2,20 +2,14 @@
 
 namespace Leantime\Domain\Queue\Workers;
 
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;
 use Leantime\Domain\Queue\Repositories\Queue;
-use Leantime\Domain\Setting\Repositories\Setting;
-use Leantime\Domain\Users\Repositories\Users;
 use PHPUnit\Exception;
 
 class DefaultWorker
 {
     public function __construct(
-        private Users $userRepo,
-        private Setting $settingsRepo,
-        private Queue $queue,
-        private Client $client
+        private Queue $queue
     ) {}
 
     public function handleQueue($messages)

--- a/app/Domain/Queue/Workers/EmailWorker.php
+++ b/app/Domain/Queue/Workers/EmailWorker.php
@@ -53,7 +53,7 @@ class EmailWorker
         foreach ($allMessagesToSend as $currentUserId => $messageToSendToUser) {
             $theuser = $this->userRepo->getUser($currentUserId);
 
-            if ($theuser === null || $theuser === false) {
+            if ($theuser === false) {
                 continue;
             }
 

--- a/app/Domain/Queue/Workers/HttpRequestWorker.php
+++ b/app/Domain/Queue/Workers/HttpRequestWorker.php
@@ -4,17 +4,11 @@ namespace Leantime\Domain\Queue\Workers;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use Leantime\Core\Mailer;
 use Leantime\Domain\Queue\Repositories\Queue;
-use Leantime\Domain\Setting\Repositories\Setting;
-use Leantime\Domain\Users\Repositories\Users;
 
 class HttpRequestWorker
 {
     public function __construct(
-        private Users $userRepo,
-        private Setting $settingsRepo,
-        private Mailer $mailer,
         private Queue $queue,
         private Client $client
     ) {}

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -109,7 +109,7 @@ class Reports extends BaseService
     {
         $allSprints = $this->sprintService->getAllSprints($projectId);
 
-        if ($allSprints === false || count($allSprints) === 0) {
+        if (count($allSprints) === 0) {
             return ['chart' => false, 'currentSprintId' => false];
         }
 

--- a/app/Domain/Reports/Services/Reports.php
+++ b/app/Domain/Reports/Services/Reports.php
@@ -14,7 +14,6 @@ use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\AppSettings as AppSettingCore;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Domains\BaseService;
-use Leantime\Core\UI\Template as TemplateCore;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
 use Leantime\Domain\Clients\Repositories\Clients as ClientRepository;
 use Leantime\Domain\Comments\Repositories\Comments as CommentRepository;
@@ -44,8 +43,6 @@ use Leantime\Domain\Users\Repositories\Users as UserRepository;
  */
 class Reports extends BaseService
 {
-    private TemplateCore $tpl;
-
     private AppSettingCore $appSettings;
 
     private EnvironmentCore $config;
@@ -63,7 +60,6 @@ class Reports extends BaseService
     private SprintService $sprintService;
 
     public function __construct(
-        TemplateCore $tpl,
         AppSettingCore $appSettings,
         EnvironmentCore $config,
         ProjectRepository $projectRepository,
@@ -73,7 +69,6 @@ class Reports extends BaseService
         TicketRepository $ticketRepository,
         SprintService $sprintService
     ) {
-        $this->tpl = $tpl;
         $this->appSettings = $appSettings;
         $this->config = $config;
         $this->projectRepository = $projectRepository;
@@ -341,7 +336,7 @@ class Reports extends BaseService
             'phpUname' => php_uname(),
             'isDocker' => $this->isRunningInDocker(),
             'phpSapiName' => php_sapi_name(),
-            'phpOs' => PHP_OS ?? 'unknown',
+            'phpOs' => PHP_OS,
 
         ];
 

--- a/app/Domain/Tickets/Controllers/DelMilestone.php
+++ b/app/Domain/Tickets/Controllers/DelMilestone.php
@@ -46,13 +46,13 @@ class DelMilestone extends Controller
             return $this->tpl->displayPartial('errors.error404', responseCode: 404);
         }
 
-        if ($result = $this->ticketService->deleteMilestone($id = (int) ($_GET['id']))) {
+        if (($result = $this->ticketService->deleteMilestone($id = (int) ($_GET['id']))) === true) {
             $this->tpl->setNotification($this->language->__('notification.milestone_deleted'), 'success');
 
             return Frontcontroller::redirect(BASE_URL.'/tickets/roadmap');
         }
 
-        $this->tpl->setNotification($this->language->__(is_array($result) ? ($result['msg'] ?? '') : ''), 'error');
+        $this->tpl->setNotification($this->language->__($result['msg']), 'error');
         $this->tpl->assign('ticket', $this->ticketService->getTicket($id));
 
         return $this->tpl->displayPartial('tickets.delMilestone');

--- a/app/Domain/Tickets/Controllers/MoveTicket.php
+++ b/app/Domain/Tickets/Controllers/MoveTicket.php
@@ -53,7 +53,7 @@ class MoveTicket extends Controller
     #[RequiresPermission(TicketsPermissions::EDIT)]
     public function post($params): Response
     {
-        if (! empty($ticketId = (int) $_GET['id'] ?? null) && ! empty($projectId = (int) $params['projectId'] ?? null)) {
+        if (! empty($ticketId = (int) $_GET['id']) && ! empty($projectId = (int) $params['projectId'])) {
             if ($this->ticketService->moveTicket($ticketId, $projectId)) {
                 $this->tpl->setNotification($this->language->__('text.ticket_moved'), 'success');
             } else {

--- a/app/Domain/Tickets/Controllers/NewTicket.php
+++ b/app/Domain/Tickets/Controllers/NewTicket.php
@@ -7,8 +7,6 @@ use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Support\FromFormat;
-use Leantime\Domain\Comments\Services\Comments as CommentService;
-use Leantime\Domain\Files\Services\Files as FileService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
@@ -26,10 +24,6 @@ class NewTicket extends Controller
 
     private SprintService $sprintService;
 
-    private FileService $fileService;
-
-    private CommentService $commentService;
-
     private TimesheetService $timesheetService;
 
     private UserService $userService;
@@ -38,16 +32,12 @@ class NewTicket extends Controller
         ProjectService $projectService,
         TicketService $ticketService,
         SprintService $sprintService,
-        FileService $fileService,
-        CommentService $commentService,
         TimesheetService $timesheetService,
         UserService $userService
     ): void {
         $this->projectService = $projectService;
         $this->ticketService = $ticketService;
         $this->sprintService = $sprintService;
-        $this->fileService = $fileService;
-        $this->commentService = $commentService;
         $this->timesheetService = $timesheetService;
         $this->userService = $userService;
 

--- a/app/Domain/Tickets/Controllers/ShowAll.php
+++ b/app/Domain/Tickets/Controllers/ShowAll.php
@@ -4,33 +4,18 @@ namespace Leantime\Domain\Tickets\Controllers;
 
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
-use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
 class ShowAll extends Controller
 {
-    private ProjectService $projectService;
-
     private TicketService $ticketService;
 
-    private SprintService $sprintService;
-
-    private TimesheetService $timesheetService;
-
     public function init(
-        ProjectService $projectService,
         TicketService $ticketService,
-        SprintService $sprintService,
-        TimesheetService $timesheetService
     ): void {
 
-        $this->projectService = $projectService;
         $this->ticketService = $ticketService;
-        $this->sprintService = $sprintService;
-        $this->timesheetService = $timesheetService;
 
         session(['lastPage' => CURRENT_URL]);
         session(['lastTicketView' => 'table']);

--- a/app/Domain/Tickets/Controllers/ShowAllMilestones.php
+++ b/app/Domain/Tickets/Controllers/ShowAllMilestones.php
@@ -3,32 +3,17 @@
 namespace Leantime\Domain\Tickets\Controllers;
 
 use Leantime\Core\Controller\Controller;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
-use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
 class ShowAllMilestones extends Controller
 {
-    private ProjectService $projectService;
-
     private TicketService $ticketService;
 
-    private SprintService $sprintService;
-
-    private TimesheetService $timesheetService;
-
     public function init(
-        ProjectService $projectService,
-        TicketService $ticketService,
-        SprintService $sprintService,
-        TimesheetService $timesheetService
+        TicketService $ticketService
     ): void {
-        $this->projectService = $projectService;
         $this->ticketService = $ticketService;
-        $this->sprintService = $sprintService;
-        $this->timesheetService = $timesheetService;
 
         session(['lastPage' => CURRENT_URL]);
         session(['lastMilestoneView' => 'milestonetable']);

--- a/app/Domain/Tickets/Controllers/ShowList.php
+++ b/app/Domain/Tickets/Controllers/ShowList.php
@@ -5,32 +5,17 @@ namespace Leantime\Domain\Tickets\Controllers;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
-use Leantime\Domain\Projects\Services\Projects as ProjectService;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
-use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Symfony\Component\HttpFoundation\Response;
 
 class ShowList extends Controller
 {
-    private ProjectService $projectService;
-
     private TicketService $ticketService;
 
-    private SprintService $sprintService;
-
-    private TimesheetService $timesheetService;
-
     public function init(
-        ProjectService $projectService,
-        TicketService $ticketService,
-        SprintService $sprintService,
-        TimesheetService $timesheetService
+        TicketService $ticketService
     ): void {
-        $this->projectService = $projectService;
         $this->ticketService = $ticketService;
-        $this->sprintService = $sprintService;
-        $this->timesheetService = $timesheetService;
 
         session(['lastPage' => CURRENT_URL]);
         session(['lastTicketView' => 'list']);

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -85,7 +85,7 @@ class ShowTicket extends Controller
                 return Frontcontroller::redirect(BASE_URL.'/tickets/showTicket/'.$id.'#files');
             }
 
-            $this->tpl->setNotification(is_array($result) ? ($result['msg'] ?? '') : '', 'error');
+            $this->tpl->setNotification('', 'error');
         }
 
         // Delete comment

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -85,7 +85,7 @@ class ShowTicket extends Controller
                 return Frontcontroller::redirect(BASE_URL.'/tickets/showTicket/'.$id.'#files');
             }
 
-            $this->tpl->setNotification('', 'error');
+            $this->tpl->setNotification($this->language->__('notifications.file_deleted_error'), 'error');
         }
 
         // Delete comment

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -326,7 +326,7 @@ class Tickets
      *
      * @param  null  $limit
      */
-    public function getAllBySearchCriteria(array $searchCriteria, string $sort = 'standard', $limit = null, $includeCounts = true, $offset = null): bool|array
+    public function getAllBySearchCriteria(array $searchCriteria, string $sort = 'standard', ?int $limit = null, $includeCounts = true, ?int $offset = null): bool|array
     {
         $requestorId = session()->exists('userdata') ? session('userdata.id') : -1;
         $userId = $searchCriteria['currentUser'] ?? session('userdata.id') ?? '-1';
@@ -1591,8 +1591,6 @@ class Tickets
 
             return $ticketId;
         }
-
-        return false;
     }
 
     /**

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -11,21 +11,18 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Leantime\Core\Auth\Permissions\RequiresPermission;
-use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Exceptions\NotFoundException;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\DateTimeHelper;
-use Leantime\Core\UI\Template as TemplateCore;
 use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Auth\Services\Auth;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
-use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
@@ -62,10 +59,7 @@ class Tickets extends BaseService
     /**
      * Constructor method for the class.
      *
-     * @param  TemplateCore  $tpl  The template core instance.
      * @param  LanguageCore  $language  The language core instance.
-     * @param  EnvironmentCore  $config  The environment core instance.
-     * @param  ProjectRepository  $projectRepository  The project repository instance.
      * @param  TicketRepository  $ticketRepository  The ticket repository instance.
      * @param  TimesheetRepository  $timesheetsRepo  The timesheet repository instance.
      * @param  SettingRepository  $settingsRepo  The setting repository instance.
@@ -79,10 +73,7 @@ class Tickets extends BaseService
      * @param  ClientService  $clientService  The clients service instance.
      */
     public function __construct(
-        private TemplateCore $tpl,
         private LanguageCore $language,
-        private EnvironmentCore $config,
-        private ProjectRepository $projectRepository,
         private TicketRepository $ticketRepository,
         private TimesheetRepository $timesheetsRepo,
         private SettingRepository $settingsRepo,
@@ -3384,13 +3375,10 @@ class Tickets extends BaseService
         // Editor+ in the milestone's project AND access to it (was access-only, no role gate).
         $this->authorize(TicketsPermissions::DELETE, (int) $ticket->projectId);
 
-        if ($this->ticketRepository->delMilestone($id)) {
-            MilestoneDeleted::dispatch(milestoneId: (int) $id, legacyHook: __FUNCTION__);
+        $this->ticketRepository->delMilestone($id);
+        MilestoneDeleted::dispatch(milestoneId: (int) $id, legacyHook: __FUNCTION__);
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**
@@ -4039,7 +4027,7 @@ class Tickets extends BaseService
 
         // Sort groups by their order
         uasort($tickets, function ($a, $b) {
-            return ($a['order'] ?? 999) <=> ($b['order'] ?? 999);
+            return $a['order'] <=> $b['order'];
         });
 
         return $tickets;

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -4321,7 +4321,7 @@ class Tickets extends BaseService
                     $values['dateToFinish'] = $values['dateToFinish']->formatDateTimeForDb();
                 } elseif (
                     is_string($values['dateToFinish'])
-                    && (empty($values['timeToFinish']) || $values['timeToFinish'] === null)
+                    && empty($values['timeToFinish'])
                     && preg_match('/^\d{4}-\d{2}-\d{2}$/', $values['dateToFinish'])
                 ) {
                     // Calendar-date input (e.g. "2026-05-21" from mobile) — store as

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -388,7 +388,7 @@ class Users
             'modified' => now(),
         ]);
 
-        return $userId !== false ? (string) $userId : false;
+        return (string) $userId;
     }
 
     /**

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -1160,7 +1160,7 @@ class Users extends BaseService
             return 'passwords_dont_match';
         }
 
-        if (isset($post['password']) && ($post['password'] ?? null) != ($post['password2'] ?? null)) {
+        if (isset($post['password']) && $post['password'] != ($post['password2'] ?? null)) {
             return 'enter_email';
         }
 

--- a/app/Domain/Wiki/Repositories/Wiki.php
+++ b/app/Domain/Wiki/Repositories/Wiki.php
@@ -5,7 +5,6 @@ namespace Leantime\Domain\Wiki\Repositories;
 use Illuminate\Database\ConnectionInterface;
 use Leantime\Core\Db\DatabaseHelper;
 use Leantime\Core\Db\Db as DbCore;
-use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Blueprints\Repositories\Blueprints;
 use Leantime\Domain\Tickets\Repositories\Tickets;
 use Leantime\Domain\Wiki\Models\Article;
@@ -21,9 +20,9 @@ class Wiki extends Blueprints
 
     protected ConnectionInterface $dbConnection;
 
-    public function __construct(DbCore $db, LanguageCore $language, Tickets $ticketRepo, DatabaseHelper $dbHelper)
+    public function __construct(DbCore $db, Tickets $ticketRepo, DatabaseHelper $dbHelper)
     {
-        parent::__construct($db, $language, $ticketRepo, $dbHelper);
+        parent::__construct($db, $ticketRepo, $dbHelper);
         $this->dbConnection = $db->getConnection();
     }
 

--- a/app/Domain/Wiki/Services/Wiki.php
+++ b/app/Domain/Wiki/Services/Wiki.php
@@ -73,7 +73,7 @@ class Wiki extends BaseService
 
         $wikis = $this->wikiRepository->getAllProjectWikis($projectId);
 
-        if (! $wikis || count($wikis) == 0) {
+        if (! $wikis) {
 
             $wiki = app()->make(\Leantime\Domain\Wiki\Models\Wiki::class);
             $wiki->title = $this->language->__('label.default');

--- a/app/Views/Composers/Header.php
+++ b/app/Views/Composers/Header.php
@@ -67,8 +67,8 @@ class Header extends Composer
             'theme' => $theme,
             'version' => $this->appSettings->appVersion ?? '',
             'themeScripts' => [
-                $this->themeCore->getJsUrl() ?? '',
-                $this->themeCore->getCustomJsUrl() ?? '',
+                $this->themeCore->getJsUrl(),
+                $this->themeCore->getCustomJsUrl(),
             ],
             'themeColorMode' => $colorMode,
             'themeColorScheme' => $colorScheme,
@@ -76,10 +76,10 @@ class Header extends Composer
             'themeStyles' => [
                 [
                     'id' => 'themeStyleSheet',
-                    'url' => $this->themeCore->getStyleUrl() ?? '',
+                    'url' => $this->themeCore->getStyleUrl(),
                 ],
                 [
-                    'url' => $this->themeCore->getCustomStyleUrl() ?? '',
+                    'url' => $this->themeCore->getCustomStyleUrl(),
                 ],
             ],
             'accents' => [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -27,16 +27,20 @@ if (! function_exists('array_sort')) {
     /**
      * sort array of arrqays by value
      *
-     * @param  string  $sortyBy
+     * @param  string|array<int, array{0: string, 1: string}>  $sortyBy  Column name (string) or multi-sort spec (array)
      */
     function array_sort(array $array, mixed $sortyBy): array
     {
 
-        $collection = collect($array);
+        if (is_string($sortyBy)) {
+            $collection = collect($array);
 
-        $sorted = $collection->sortBy($sortyBy, SORT_NATURAL);
+            $sorted = $collection->sortBy($sortyBy, SORT_NATURAL);
 
-        return $sorted->values()->all();
+            return $sorted->values()->all();
+        } else {
+            return \Illuminate\Support\Collection::make($array)->sortBy($sortyBy)->all();
+        }
     }
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -32,15 +32,11 @@ if (! function_exists('array_sort')) {
     function array_sort(array $array, mixed $sortyBy): array
     {
 
-        if (is_string($sortyBy)) {
-            $collection = collect($array);
+        $collection = collect($array);
 
-            $sorted = $collection->sortBy($sortyBy, SORT_NATURAL);
+        $sorted = $collection->sortBy($sortyBy, SORT_NATURAL);
 
-            return $sorted->values()->all();
-        } else {
-            return \Illuminate\Support\Collection::make($array)->sortBy($sortyBy)->all();
-        }
+        return $sorted->values()->all();
     }
 }
 
@@ -95,7 +91,7 @@ if (! function_exists('format')) {
      * @param  string|int|float|DateTime|Carbon|null  $value
      * @param  string|int|float|DateTime|null  $value2
      */
-    function format(string|int|float|null|\DateTime|\Carbon\CarbonInterface $value, string|int|float|null|\DateTime|\Carbon\CarbonInterface $value2 = null, ?FromFormat $fromFormat = FromFormat::DbDate): Format|string
+    function format(string|int|float|null|\DateTime|\Carbon\CarbonInterface $value, string|int|float|null|\DateTime|\Carbon\CarbonInterface $value2 = null, ?FromFormat $fromFormat = FromFormat::DbDate): Format
     {
         return new Format($value, $value2, $fromFormat);
     }

--- a/tests/Unit/app/Domain/Menu/Services/MenuServiceTest.php
+++ b/tests/Unit/app/Domain/Menu/Services/MenuServiceTest.php
@@ -6,8 +6,6 @@ use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Menu\Services\Menu;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Setting\Services\Setting;
-use Leantime\Domain\Sprints\Services\Sprints as SprintService;
-use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users;
 use Unit\TestCase;
 
@@ -28,8 +26,6 @@ class MenuServiceTest extends TestCase
     {
         return new Menu(
             $this->make(ProjectService::class),
-            $this->make(TimesheetService::class),
-            $this->make(SprintService::class),
             $this->make(Users::class),
             $this->make(Setting::class),
             $this->make(MenuRepository::class),

--- a/tests/Unit/app/Domain/Notifications/Services/NotificationsServiceTest.php
+++ b/tests/Unit/app/Domain/Notifications/Services/NotificationsServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace Unit\app\Domain\Notifications\Services;
 
-use Leantime\Core\Db\Db as DbCore;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Notifications\Repositories\Notifications as NotificationRepository;
 use Leantime\Domain\Notifications\Services\Notifications;
@@ -25,7 +24,6 @@ class NotificationsServiceTest extends TestCase
     private function makeService(): Notifications
     {
         return new Notifications(
-            $this->make(DbCore::class),
             $this->make(NotificationRepository::class),
             $this->make(UserRepository::class),
             $this->make(LanguageCore::class),
@@ -98,7 +96,6 @@ class NotificationsServiceTest extends TestCase
         ]);
 
         $service = new Notifications(
-            $this->make(DbCore::class),
             $repo,
             $this->make(UserRepository::class),
             $this->make(LanguageCore::class),
@@ -122,7 +119,6 @@ class NotificationsServiceTest extends TestCase
         ]);
 
         $service = new Notifications(
-            $this->make(DbCore::class),
             $repo,
             $this->make(UserRepository::class),
             $this->make(LanguageCore::class),

--- a/tests/Unit/app/Domain/Reports/Services/ReportsServiceTest.php
+++ b/tests/Unit/app/Domain/Reports/Services/ReportsServiceTest.php
@@ -4,7 +4,6 @@ namespace Unit\app\Domain\Reports\Services;
 
 use Leantime\Core\Configuration\AppSettings as AppSettingCore;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
-use Leantime\Core\UI\Template as TemplateCore;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Reports\Repositories\Reports as ReportRepository;
 use Leantime\Domain\Reports\Services\Reports;
@@ -81,7 +80,6 @@ class ReportsServiceTest extends TestCase
     private function makeService(SprintService $sprintService): Reports
     {
         return new Reports(
-            $this->make(TemplateCore::class),
             $this->make(AppSettingCore::class),
             $this->make(EnvironmentCore::class),
             $this->make(ProjectRepository::class),

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -82,10 +82,7 @@ class TicketsServiceTest extends TestCase
 
         // Instantiate the service with mocked dependencies
         $this->ticketsService = new TicketsService(
-            tpl: $tpl,
             language: $language,
-            config: $config,
-            projectRepository: $projectRepository,
             ticketRepository: $ticketRepository,
             timesheetsRepo: $timesheetsRepo,
             settingsRepo: $settingsRepo,
@@ -291,10 +288,7 @@ class TicketsServiceTest extends TestCase
     private function buildServiceWithClientService(ClientService $clientService): TicketsService
     {
         return new TicketsService(
-            tpl: $this->make(TemplateCore::class),
             language: $this->make(LanguageCore::class),
-            config: $this->make(EnvironmentCore::class),
-            projectRepository: $this->make(ProjectRepository::class),
             ticketRepository: $this->make(TicketRepository::class),
             timesheetsRepo: $this->make(TimesheetRepository::class),
             settingsRepo: $this->make(SettingRepository::class),
@@ -316,10 +310,7 @@ class TicketsServiceTest extends TestCase
     private function buildServiceWithTicketRepository(TicketRepository $ticketRepository): TicketsService
     {
         return new TicketsService(
-            tpl: $this->make(TemplateCore::class),
             language: $this->make(LanguageCore::class),
-            config: $this->make(EnvironmentCore::class),
-            projectRepository: $this->make(ProjectRepository::class),
             ticketRepository: $ticketRepository,
             timesheetsRepo: $this->make(TimesheetRepository::class),
             settingsRepo: $this->make(SettingRepository::class),

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -339,10 +339,7 @@ class TicketsServiceTest extends TestCase
         $service = $this->construct(
             TicketsService::class,
             [
-                $this->make(TemplateCore::class),
                 $this->make(LanguageCore::class),
-                $this->make(EnvironmentCore::class),
-                $this->make(ProjectRepository::class),
                 $this->make(TicketRepository::class),
                 $this->make(TimesheetRepository::class),
                 $this->make(SettingRepository::class),


### PR DESCRIPTION
## Raise PHPStan from level 3 → 4 (dead-code removal)

Follow-up to #3561. Climbs to **level 4** (config `level: 3` → `4`), fix-forward, no baseline. `make phpstan` is green at level 4 (**0 errors**). Clean master had **227** level-4 findings.

Level 4 is **dead-code / always-true-or-false analysis** — a different beast from the type-correctness of levels 2–3. This is a large, mostly-deletion diff. It was done conservatively (grep-guarded removals, skip-on-doubt), and the runtime behaviour is validated by the **unit + acceptance** CI suites — please lean on those for review.

### What was removed (the bulk, ~200 findings)
- **Never-read properties** (and their writes + constructor injections) — mostly dependencies that were injected but never used.
- **Unused private methods** — including a dead `EventDispatcher` event-handling cluster (methods that only called each other, with no live entry point).
- **Unreachable statements, always-true/false dead branches, redundant `??`/`?->`, impossible-type checks.**

Cross-file constructor-injection removals were updated together:
- **Blueprints repo** drops its unused `$language` param; `Wiki`/`Goalcanvas`/`Canvas` `parent::__construct` calls updated (`Goalcanvas`/`Canvas` keep their own `$language`, which they use).
- **Tickets service** drops unused `$tpl`/`$config`/`$projectRepository`; `TicketsServiceTest` instantiations updated to match.

### 🐛 Real bugs surfaced and fixed
- **`DelMilestone`**: `if ($result = $this->ticketService->deleteMilestone(...))` treated the **failure array** (`['msg' => ...]`, truthy) as **success** — delete failures were shown as "deleted" and the error branch was dead code. Now checks `=== true`, so failures surface their message.
- **`UpdateLeantime`**: an ineffective `catch (\Exception)` around `new \ZipArchive` (a missing zip extension raises `\Error`, not `\Exception`) → replaced with a `class_exists()` check that actually handles the missing extension.
- Several always-false defensive clauses removed (`Reports`, `EmailWorker`, `Oidc`, `ListPluginCommand`, `Tickets`).

### Over-narrow types corrected (the cause of several "always-false")
`getUserProjectRelation` `@param null`→`int|null`; `getAllBySearchCriteria` `$limit`/`$offset`→`?int`; `Repository::$stmn`→`?PDOStatement`; `defineParams()`/`format()` return types narrowed to what they actually return.

### Two targeted ignores (genuine framework false-positives)
- `HandleExceptions`: a `Closure::call()`-rebound closure that PHPStan analyses in the wrong scope (collapses to always-false, but it's live against PHPUnit's `ErrorHandler`).
- `Files`: a `catch (AuthorizationException)` that `upload()` genuinely throws (`Files.php:136`) but PHPStan can't track through the call.

### Safety / blind-spots
- Removals were grep-guarded for dynamic dispatch and cross-file reads; uncertain cases were skipped and handled by hand.
- **Plugin blind-spot** (plugins aren't in CI): the only removed public-ish members were `private` (`getBool`/`getString`), and no plugin extends the classes whose constructors changed — verified against the local plugins checkout.
- **Please confirm via the `unit` + `acceptance` runs** — that's the real gate for the runtime behaviour of the deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
