### PR TITLE
chore(phpstan): climb to level 5 (argument types)

### DIFF
--- a/.phpstan/phpstan.neon
+++ b/.phpstan/phpstan.neon
@@ -6,7 +6,7 @@ includes:
 parameters:
     bootstrapFiles:
         - bootstrap.php
-    level: 4
+    level: 5
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - ../public

--- a/app/Command/MigrateCommand.php
+++ b/app/Command/MigrateCommand.php
@@ -89,7 +89,7 @@ class MigrateCommand extends Command
                 $installStatus = $install->setupDB($setupConfig);
 
                 if ($installStatus !== true) {
-                    $io->text($installStatus);
+                    $io->text((string) $installStatus);
 
                     return Command::FAILURE;
                 }

--- a/app/Command/MigrateCommand.php
+++ b/app/Command/MigrateCommand.php
@@ -89,7 +89,9 @@ class MigrateCommand extends Command
                 $installStatus = $install->setupDB($setupConfig);
 
                 if ($installStatus !== true) {
-                    $io->text((string) $installStatus);
+                    // setupDB() returns bool; on failure it logs the cause. Give the CLI user a
+                    // concrete pointer instead of the empty string (string) false would produce.
+                    $io->error('Database installation failed. Check the application logs for details.');
 
                     return Command::FAILURE;
                 }

--- a/app/Core/Auth/Tokens/SanctumServiceProvider.php
+++ b/app/Core/Auth/Tokens/SanctumServiceProvider.php
@@ -18,6 +18,7 @@ class SanctumServiceProvider extends ServiceProvider
     {
 
         // Use our custom token model
+        // @phpstan-ignore-next-line argument.type
         SanctumBase::usePersonalAccessTokenModel(AccessToken::class);
 
     }

--- a/app/Core/Domains/DTO.php
+++ b/app/Core/Domains/DTO.php
@@ -34,7 +34,7 @@ abstract class DTO
                 $propertyName = array_shift($propertyPath);
             }
 
-            $placement = implode('.', array_filter([$propertyPath, $propertyName]));
+            $placement = implode('.', array_filter([$propertyName, ...$propertyPath]));
             $attributes = array_filter(
                 $propertyAttributes,
                 fn ($key) => Str::beforeLast('.', $key) == $placement && Str::afterLast('.', $key) !== 'Map',

--- a/app/Core/Exceptions/HandleExceptions.php
+++ b/app/Core/Exceptions/HandleExceptions.php
@@ -333,6 +333,7 @@ class HandleExceptions
         }
 
         while (true) {
+            // @phpstan-ignore-next-line argument.type
             $previousHandler = set_error_handler(static fn () => null);
 
             restore_error_handler();

--- a/app/Core/Http/HttpKernel.php
+++ b/app/Core/Http/HttpKernel.php
@@ -125,6 +125,7 @@ class HttpKernel extends Kernel
             $response = $this->renderException($request, $e);
         }
 
+        // @phpstan-ignore-next-line argument.type
         $this->app['events']->dispatch(new RequestHandled($request, $response));
 
         $response = self::dispatch_filter('beforeSendResponse', $response);

--- a/app/Core/Language.php
+++ b/app/Core/Language.php
@@ -126,7 +126,7 @@ class Language
                         ->withValue($lang)
                         ->withExpires(time() + 60 * 60 * 24 * 30)
                         ->withPath(Str::finish($this->config->appDir, '/'))
-                        ->withSameSite('Lax')
+                        ->withSameSite('lax')
                 ))
             );
         }

--- a/app/Core/Mailer.php
+++ b/app/Core/Mailer.php
@@ -135,8 +135,6 @@ class Mailer
 
     /**
      * setHTML - set Mail html (no function yet)
-     *
-     * @param  false  $hideWrapper
      */
     public function setHtml($html, bool $hideWrapper = false): void
     {

--- a/app/Core/Middleware/RequestRateLimiter.php
+++ b/app/Core/Middleware/RequestRateLimiter.php
@@ -121,7 +121,7 @@ class RequestRateLimiter
             return new Response(
                 json_encode(['error' => 'Too many requests per minute.']),
                 Response::HTTP_TOO_MANY_REQUESTS,
-                $this->getHeaders($key, $limit),
+                $this->getHeaders($key, (int) $limit),
             );
         }
 
@@ -133,7 +133,7 @@ class RequestRateLimiter
     /**
      * Get rate limiter headers for response.
      */
-    private function getHeaders(string $key, string $limit): array
+    private function getHeaders(string $key, int $limit): array
     {
         return [
             'X-RateLimit-Remaining' => $this->limiter->retriesLeft($key, $limit),

--- a/app/Core/UI/Theme.php
+++ b/app/Core/UI/Theme.php
@@ -557,7 +557,7 @@ class Theme
                     ->withValue($id)
                     ->withExpires(time() + 60 * 60 * 24 * 30)
                     ->withPath(Str::finish($this->config->appDir, '/'))
-                    ->withSameSite('Strict')
+                    ->withSameSite('strict')
             ))
         );
     }
@@ -596,7 +596,7 @@ class Theme
                     ->withValue($colorMode)
                     ->withExpires(time() + 60 * 60 * 24 * 30)
                     ->withPath(Str::finish($this->config->appDir, '/'))
-                    ->withSameSite('Strict')
+                    ->withSameSite('strict')
             ))
         );
     }
@@ -625,7 +625,7 @@ class Theme
                     ->withValue($font)
                     ->withExpires(time() + 60 * 60 * 24 * 30)
                     ->withPath(Str::finish($this->config->appDir, '/'))
-                    ->withSameSite('Strict')
+                    ->withSameSite('strict')
             ))
         );
     }
@@ -655,7 +655,7 @@ class Theme
                     ->withValue($colorScheme)
                     ->withExpires(time() + 60 * 60 * 24 * 30)
                     ->withPath(Str::finish($this->config->appDir, '/'))
-                    ->withSameSite('Strict')
+                    ->withSameSite('strict')
             ))
         );
     }

--- a/app/Domain/Api/Controllers/Jsonrpc.php
+++ b/app/Domain/Api/Controllers/Jsonrpc.php
@@ -71,7 +71,7 @@ class Jsonrpc extends Controller
         // params['params'] could be array (single value) or json object
         if (isset($params['params'])) {
             if (! is_array($params['params'])) {
-                $params['params'] = json_decode($params['params'], JSON_OBJECT_AS_ARRAY);
+                $params['params'] = json_decode($params['params'], true);
             }
         }
 
@@ -110,7 +110,7 @@ class Jsonrpc extends Controller
             'jsonrpc' => $params['jsonrpc'] ?? '',
         ];
 
-        $params['params'] = json_decode($params['params'], JSON_OBJECT_AS_ARRAY);
+        $params['params'] = json_decode($params['params'], true);
 
         // check if decode failed
         if ($params == null) {
@@ -131,7 +131,7 @@ class Jsonrpc extends Controller
 
             $bodyContent = json_decode(
                 json: $this->incomingRequest->getContent(),
-                associative: JSON_OBJECT_AS_ARRAY,
+                associative: true,
                 flags: JSON_THROW_ON_ERROR
             );
 

--- a/app/Domain/Api/Controllers/StaticAsset.php
+++ b/app/Domain/Api/Controllers/StaticAsset.php
@@ -50,8 +50,12 @@ class StaticAsset extends Controller
             new BinaryFileResponse($asset['path']),
             function (BinaryFileResponse $response) use ($type, $debug) {
                 $response->headers->set('Content-Type', StaticAssetType::getMimeTypeByExtension($type));
+                // Only set Content-length when filesize() succeeds; on failure let
+                // BinaryFileResponse compute it rather than advertising a bogus 0-length body.
                 $size = filesize($response->getFile()->getPathname());
-                $response->headers->set('Content-length', (string) ($size !== false ? $size : 0));
+                if ($size !== false) {
+                    $response->headers->set('Content-length', (string) $size);
+                }
 
                 if (in_array(true, [! $this->incomingRequest->query->has('id'), $debug])) {
                     return;

--- a/app/Domain/Api/Controllers/StaticAsset.php
+++ b/app/Domain/Api/Controllers/StaticAsset.php
@@ -50,9 +50,8 @@ class StaticAsset extends Controller
             new BinaryFileResponse($asset['path']),
             function (BinaryFileResponse $response) use ($type, $debug) {
                 $response->headers->set('Content-Type', StaticAssetType::getMimeTypeByExtension($type));
-                $response->headers->set('Content-length', filesize(
-                    $response->getFile()->getPathname()
-                ));
+                $size = filesize($response->getFile()->getPathname());
+                $response->headers->set('Content-length', (string) ($size !== false ? $size : 0));
 
                 if (in_array(true, [! $this->incomingRequest->query->has('id'), $debug])) {
                     return;

--- a/app/Domain/Api/Services/I18n.php
+++ b/app/Domain/Api/Services/I18n.php
@@ -40,7 +40,7 @@ class I18n
         ];
 
         foreach ($dateTimeIniSettings as $index) {
-            $languageIni[$index] = $this->language->__($index, true);
+            $languageIni[$index] = $this->language->__($index);
         }
 
         // Fullcalendar and other scripts can handle local to use the browser timezone

--- a/app/Domain/Auth/Services/Auth.php
+++ b/app/Domain/Auth/Services/Auth.php
@@ -287,7 +287,7 @@ class Auth implements Authenticatable
 
     public function updateUserSessionDB(int $userId, string $sessionID): bool
     {
-        return $this->authRepo->updateUserSession($userId, $sessionID, time());
+        return $this->authRepo->updateUserSession($userId, $sessionID, (string) time());
     }
 
     /**

--- a/app/Domain/Blueprints/Repositories/Blueprints.php
+++ b/app/Domain/Blueprints/Repositories/Blueprints.php
@@ -589,9 +589,9 @@ class Blueprints extends Repository
 
     /**
      * @param  int  $canvasId  Target canvas ID
-     * @param  string  $mergeId  Source canvas ID
+     * @param  int  $mergeId  Source canvas ID
      */
-    public function mergeCanvas(int $canvasId, string $mergeId): bool
+    public function mergeCanvas(int $canvasId, int $mergeId): bool
     {
         $columns = [
             'title', 'description', 'assumptions', 'data', 'conclusion', 'box', 'author',

--- a/app/Domain/Comments/Repositories/Comments.php
+++ b/app/Domain/Comments/Repositories/Comments.php
@@ -14,9 +14,9 @@ class Comments
         $this->db = $db->getConnection();
     }
 
-    public function getComments(string $module, int $moduleId, int $parent = 0, string $orderByState = '0'): false|array
+    public function getComments(string $module, int $moduleId, int $parent = 0, int $orderByState = 0): false|array
     {
-        $orderBy = $orderByState == '1' ? 'asc' : 'desc';
+        $orderBy = $orderByState === 1 ? 'asc' : 'desc';
 
         $query = $this->db->table('zp_comment as comment')
             ->select(

--- a/app/Domain/Help/Services/InviteTeamStep.php
+++ b/app/Domain/Help/Services/InviteTeamStep.php
@@ -82,7 +82,9 @@ class InviteTeamStep implements OnboardingSteps
                 if (filter_var($params['email'.$i], FILTER_VALIDATE_EMAIL)) {
                     if ($this->userService->usernameExist($params['email'.$i]) === false) {
                         $userId = $this->userService->createUserInvite($values);
-                        $this->projectService->editUserProjectRelations($userId, [session('currentProject')]);
+                        if ($userId !== false) {
+                            $this->projectService->editUserProjectRelations((int) $userId, [session('currentProject')]);
+                        }
                     }
                 }
 

--- a/app/Domain/Ldap/Services/Ldap.php
+++ b/app/Domain/Ldap/Services/Ldap.php
@@ -179,7 +179,9 @@ class Ldap
     public function getEmail(string $username): string
     {
         if (! $this->ldapConnection) {
-            Log::error('No connection, last error: '.ldap_error($this->ldapConnection));
+            Log::error('LDAP: No connection established');
+
+            return '';
         }
         $filter = '('.$this->ldapKeys->username.'='.$this->extractLdapFromUsername($username).')';
 
@@ -203,7 +205,9 @@ class Ldap
     {
 
         if (! $this->ldapConnection) {
-            Log::error('No connection, last error: '.ldap_error($this->ldapConnection));
+            Log::error('LDAP: No connection established');
+
+            return false;
         }
 
         $filter = '('.$this->ldapKeys->username.'='.$this->extractLdapFromUsername($username).')';
@@ -319,7 +323,7 @@ class Ldap
             return $allUsers;
         }
 
-        Log::error('ldap extension not installed', 0);
+        Log::error('ldap extension not installed');
 
         return false;
     }

--- a/app/Domain/Notifications/Services/Notifications.php
+++ b/app/Domain/Notifications/Services/Notifications.php
@@ -39,7 +39,7 @@ class Notifications
     /**
      * Not exposed via JSON-RPC: it accepts an arbitrary $userId.
      */
-    public function getAllNotifications($userId, int $showNewOnly = 0, int $limitStart = 0, int $limitEnd = 100, array $filterOptions = []): false|array
+    public function getAllNotifications($userId, bool $showNewOnly = false, int $limitStart = 0, int $limitEnd = 100, array $filterOptions = []): false|array
     {
 
         return $this->notificationsRepo->getAllNotifications($userId, $showNewOnly, $limitStart, $limitEnd, $filterOptions);

--- a/app/Domain/Plugins/Services/Registration.php
+++ b/app/Domain/Plugins/Services/Registration.php
@@ -2,7 +2,6 @@
 
 namespace Leantime\Domain\Plugins\Services;
 
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Events\EventDispatcher;
@@ -127,7 +126,7 @@ class Registration
             $completeLanguagePath = $regularPath.$languagePath;
         } else {
             // Language file doesn't exist
-            Cache::store('installation')->set($this->pluginId.'.language.'.$language, false, Carbon::now()->addDays(7));
+            Cache::store('installation')->set($this->pluginId.'.language.'.$language, false, new \DateInterval('P7D'));
 
             return false;
         }
@@ -136,7 +135,7 @@ class Registration
 
         // We're caching the results no matter what, language file is not going to magically appear.
         // So even a false is valid as parse_ini_is too expensive to run every time
-        Cache::store('installation')->set($this->pluginId.'.language.'.$language, $languageArray, Carbon::now()->addDays(7));
+        Cache::store('installation')->set($this->pluginId.'.language.'.$language, $languageArray, new \DateInterval('P7D'));
 
         return $languageArray;
 

--- a/app/Domain/Projects/Controllers/ChangeCurrentProject.php
+++ b/app/Domain/Projects/Controllers/ChangeCurrentProject.php
@@ -20,7 +20,7 @@ class ChangeCurrentProject extends Controller
      */
     public function get($params)
     {
-        $id = filter_var($params['id'] ?? '', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int) ($params['id'] ?? 0);
 
         if (
             ! isset($params['id']) ||

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -378,7 +378,7 @@ class Projects
     }
 
     // This populates the projects show all tab and shows users all the projects that they could access
-    public function getProjectsUserHasAccessTo($userId, string $status = 'all', string $clientId = ''): false|array
+    public function getProjectsUserHasAccessTo($userId, string $status = 'all', int $clientId = 0): false|array
     {
         $query = $this->connection->table('zp_projects as project')
             ->select([

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -1221,7 +1221,7 @@ class Tickets extends BaseService
      * for every role, breaking the mobile Tasks tab.
      *
      * @param  int  $userId  The ID of the user whose tickets are to be retrieved.
-     * @param  int|null  $projectId  Optional project to narrow to; null/0 = across all the user's projects.
+     * @param  int|string|null  $projectId  Optional project to narrow to; null/0/'' = across all the user's projects.
      * @param  bool  $includeDoneTickets  Whether to include tickets marked as done. Default is false.
      * @param  bool  $includeMilestones  Whether to include milestones in the results. Default is false.
      * @return array Returns an array of grouped tickets categorized by their due date (e.g.,

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -574,8 +574,8 @@ class Timesheets extends BaseService
             invEmpl: $invEmpl,
             invComp: $invComp,
             paid: $paid,
-            clientId: $clientId,
-            ticketFilter: $ticketFilter
+            clientId: (int) $clientId,
+            ticketFilter: (int) $ticketFilter
         );
     }
 

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -118,8 +118,6 @@ class Users extends BaseService
     }
 
     /**
-     * @param  false  $activeOnly
-     *
      * @api
      */
     #[RequiresPermission(UsersPermissions::VIEW, global: true)]

--- a/app/Domain/Widgets/Services/Widgets.php
+++ b/app/Domain/Widgets/Services/Widgets.php
@@ -2,7 +2,6 @@
 
 namespace Leantime\Domain\Widgets\Services;
 
-use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Cache;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
@@ -218,7 +217,7 @@ class Widgets
         // Sort Widgets
         $widgets = array_sort($widgets, [['gridY', 'asc'], ['gridX', 'asc']]);
 
-        Cache::set($activeWidgetKey, $widgets, CarbonImmutable::now()->addDays(30));
+        Cache::set($activeWidgetKey, $widgets, new \DateInterval('P30D'));
 
         return $widgets;
     }


### PR DESCRIPTION
Follows #3565 (level 4, now merged). Continues the campaign: #3559 (L2) → #3561 (L3) → #3565 (L4) → this (L5).

Level 5 enables argument-type checking (every call's args vs the callee's param types). Against the green level-4 tree it surfaced **38 errors, all `argument.type`**, spread 1–4 per file. Fixed forward, no baseline.

### Breakdown (all 38 triaged before fixing)

| Category | Count | Nature |
|---|---|---|
| Call-site casts/guards | 12 | low risk |
| Framework type-gaps | 11 | vendor contract looseness |
| Type-hint / docblock widenings | 10 | wrong/too-narrow declared types |
| **Genuine latent bugs** | **4** | worth fixing regardless of level |
| False positive | 1 | fix belonged in the callee docblock |

### The 4 real bugs
- **`Ldap::getEmail` / `getSingleUser`** called `ldap_error()` on a connection handle statically known to be `false` in the no-connection guard — a PHP 8 `TypeError` that **crashed the failure path** instead of degrading. Now logs and short-circuits (`return ''`/`false`; callers already handle both).
- **`DTO`** built a nested array into `implode()` (→ `"Array.x"` + warning) for nested property paths; now flattens the path parts in the correct order.
- **`StaticAsset`** set `Content-length` from `filesize()` which is `int|false`; the `false` case is now guarded.

### Framework gaps
Symfony `Cookie::withSameSite` now gets lowercase `'lax'`/`'strict'` (it `strtolower`s anyway — no behavior change); cache TTLs that passed an absolute `Carbon` datetime now pass an equivalent `new \DateInterval('P7D'/'P30D')`; three narrow `@phpstan-ignore-next-line argument.type` for genuine vendor contract looseness (Sanctum model `class-string`, `set_error_handler` callback return, `RequestHandled` Symfony-vs-Illuminate `Response`).

### Verification
- `./vendor/bin/phpstan analyse -c .phpstan/phpstan.neon` → **`[OK] No errors`** at `level: 5`
- Laravel Pint clean (639 files)
- Every fix triaged for ripple (signature changes traced to all callers) before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
