### PR TITLE
fix(users): strip credentials from getUser API responses (#3556)

### DIFF
--- a/app/Domain/Users/Controllers/EditUser.php
+++ b/app/Domain/Users/Controllers/EditUser.php
@@ -9,6 +9,7 @@ use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Clients\Services\Clients as ClientService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
 use Leantime\Domain\Users\Permissions\UsersPermissions;
+use Leantime\Domain\Users\Repositories\Users as UserRepository;
 use Leantime\Domain\Users\Services\Users;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,17 +21,21 @@ class EditUser extends Controller
 
     private Users $userService;
 
+    private UserRepository $userRepo;
+
     /**
      * Initializes dependencies.
      */
     public function init(
         ProjectService $projectService,
         ClientService $clientService,
-        Users $userService
+        Users $userService,
+        UserRepository $userRepo
     ): void {
         $this->projectService = $projectService;
         $this->clientService = $clientService;
         $this->userService = $userService;
+        $this->userRepo = $userRepo;
     }
 
     /**
@@ -46,7 +51,10 @@ class EditUser extends Controller
         }
 
         $id = (int) $params['id'];
-        $row = $this->userService->getUser($id);
+        // Admin edit form needs the full row (e.g. pwReset for the invite
+        // link), so read from the repository — the service getUser strips
+        // secrets for API safety (#3556).
+        $row = $this->userRepo->getUser($id);
 
         if ($row === false) {
             return $this->tpl->display('errors.error404', responseCode: 404);
@@ -82,7 +90,10 @@ class EditUser extends Controller
         }
 
         $id = (int) $params['id'];
-        $row = $this->userService->getUser($id);
+        // Admin edit form needs the full row (e.g. pwReset for the invite
+        // link), so read from the repository — the service getUser strips
+        // secrets for API safety (#3556).
+        $row = $this->userRepo->getUser($id);
 
         if ($row === false) {
             return $this->tpl->display('errors.error404', responseCode: 404);

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -168,8 +168,46 @@ class Users extends BaseService
             return $this->userCache[$resolvedId];
         }
 
-        $user = $this->userRepo->getUser($resolvedId);
+        $user = $this->stripSensitiveUserFields($this->userRepo->getUser($resolvedId));
         $this->userCache[$resolvedId] = $user;
+
+        return $user;
+    }
+
+    /**
+     * Fields on the zp_user row that must never reach an API caller: the
+     * bcrypt password, the plaintext TOTP seed, the session token, and the
+     * password-reset token/metadata. Authentication, 2FA and session flows
+     * read these straight from the repository (Users\Repositories\Users and
+     * the Auth repos), never through this service — so stripping them here
+     * closes the @api read paths (getUser is intentionally ungated so view
+     * composers keep working — see above) without breaking login.
+     *
+     * @see https://github.com/Leantime/leantime/issues/3556
+     */
+    private const SENSITIVE_USER_FIELDS = [
+        'password',
+        'twoFASecret',
+        'session',
+        'sessiontime',
+        'pwReset',
+        'pwResetExpiration',
+        'pwResetCount',
+    ];
+
+    /**
+     * Remove sensitive fields from a single user row before it is returned to
+     * an API caller. Passes the `false` "not found" shape through untouched.
+     */
+    private function stripSensitiveUserFields(array|bool $user): array|bool
+    {
+        if (! is_array($user)) {
+            return $user;
+        }
+
+        foreach (self::SENSITIVE_USER_FIELDS as $field) {
+            unset($user[$field]);
+        }
 
         return $user;
     }
@@ -180,7 +218,7 @@ class Users extends BaseService
     #[RequiresPermission(UsersPermissions::VIEW, global: true)]
     public function getUserByEmail($email, $status = 'a'): false|array
     {
-        return $this->userRepo->getUserByEmail($email, $status);
+        return $this->stripSensitiveUserFields($this->userRepo->getUserByEmail($email, $status));
     }
 
     /**

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -920,7 +920,10 @@ class Users extends BaseService
         // the RPC entry point is a current-password oracle / takeover vector against any account).
         $userId = (int) session('userdata.id');
 
-        $row = $this->getUser($userId);
+        // Read from the repository, not the service getUser: the latter strips
+        // the password hash (and other secrets) for API safety (#3556), but the
+        // current-password check needs the real hash.
+        $row = $this->userRepo->getUser($userId);
 
         if (! password_verify($currentPassword, $row['password'])) {
             return 'previous_password_incorrect';

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -642,7 +642,10 @@ class Users extends BaseService
 
         $this->userRepo->editOwn($values, $id);
 
-        $user = $this->getUser($id);
+        // Rebuild the session from the FULL row (repo, not the stripped service
+        // getUser): setUserSession -> the session builder needs twoFASecret, or
+        // 2FA verification breaks for the user after a profile edit (#3556).
+        $user = $this->userRepo->getUser($id);
 
         $this->authService->setUserSession($user);
 

--- a/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
+++ b/tests/Unit/app/Domain/Users/Services/UsersServiceTest.php
@@ -465,4 +465,45 @@ class UsersServiceTest extends TestCase
 
         $this->assertSame(7, $seenId, 'self-service must pin to the session user, not the caller-supplied id');
     }
+
+    /**
+     * Regression for #3556: getUser is @api and intentionally ungated, so any
+     * authenticated client can request an arbitrary id. It must never return
+     * credentials — password hash, plaintext 2FA seed, session token, or the
+     * password-reset token/metadata — while keeping the safe profile fields
+     * the view composers rely on.
+     */
+    public function test_get_user_strips_sensitive_fields_from_api_response(): void
+    {
+        $fullRow = [
+            'id' => 5,
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'username' => 'ada@example.com',
+            'role' => '20',
+            'password' => '$2y$10$abcdefghijklmnopqrstuv',
+            'twoFASecret' => 'SECRET2FASEED',
+            'session' => 'sess-token-xyz',
+            'sessiontime' => '1700000000',
+            'pwReset' => 'reset-token',
+            'pwResetExpiration' => '2026-01-01 00:00:00',
+            'pwResetCount' => 2,
+        ];
+
+        $repo = $this->make(UserRepository::class, [
+            'getUser' => fn () => $fullRow,
+        ]);
+
+        $user = $this->makeService($repo)->getUser(5);
+
+        $this->assertIsArray($user);
+        // Safe profile fields survive so composers/avatars keep working.
+        $this->assertSame('Ada', $user['firstname']);
+        $this->assertSame('ada@example.com', $user['username']);
+
+        // Every credential/session/reset field is stripped.
+        foreach (['password', 'twoFASecret', 'session', 'sessiontime', 'pwReset', 'pwResetExpiration', 'pwResetCount'] as $secret) {
+            $this->assertArrayNotHasKey($secret, $user, "getUser must not leak {$secret} over the API");
+        }
+    }
 }


### PR DESCRIPTION
## Security fix for #3556 (authenticated credential dump via `users.getUser`)

`Users\Services\Users::getUser` is `@api` and — by design — **not** gated by `users.view` (dozens of view composers + the mobile "who am I" lookup depend on it; the method's own docblock explains why). The repository returns the **entire `zp_user` row**, so any authenticated client can POST `users.getUser {id: N}` for an arbitrary id and receive that account's **password hash, plaintext TOTP seed (`twoFASecret`), `session` token, and password-reset token** → offline crack + 2FA bypass + session hijack of any user, including admins.

### Why strip instead of gate
Gating breaks the composers — that's precisely why `getUser` is ungated. So the fix removes the sensitive fields on the way out rather than blocking the call:

- `SENSITIVE_USER_FIELDS` + `stripSensitiveUserFields()`, applied in `getUser` (before the request memo) and `getUserByEmail`.
- **Login is unaffected:** authentication, 2FA (`TwoFA::getSetupData`), session-build (`AuthUser::setUser`), and the Bearer-token→user path (`Auth::getUserByToken` → `userRepo->getUser`) all read these fields **straight from the repository / Auth repos**, never through this service. Verified across `AuthUser`, `TwoFA`, `Auth`, and the `AdvancedAuth` plugin.
- Regression test: API response keeps profile fields (name, email) but drops every credential/session/reset field.

### Stripped fields
`password`, `twoFASecret`, `session`, `sessiontime`, `pwReset`, `pwResetExpiration`, `pwResetCount`. Non-secret flags (`twoFAEnabled`, `forcePwReset`) and all profile/PII fields are retained.

### Follow-up (separate PR)
`getAll` / `getAllVisibleToUser` / `getAllBySource` also return full rows, but they're `#[RequiresPermission(users.view)]`-gated → privileged/lower severity. Worth the same strip.

### Related
Same vulnerability **class** (missing authorization on `@api` JSON-RPC methods) as the Notes ownership fix in Leantime/plugins#57. A mirror of this change for `leantime-cloud` follows.

Refs #3556

🤖 Generated with [Claude Code](https://claude.com/claude-code)