### PR TITLE
fix: batch of open bug fixes (#3555, #3575, #3571, #3568, #3569, #3570)

### DIFF
--- a/app/Domain/Oidc/Services/Oidc.php
+++ b/app/Domain/Oidc/Services/Oidc.php
@@ -248,6 +248,12 @@ class Oidc
 
             $user['role'] = $this->getUserRole($userInfo, $user);
 
+            // $user carries the full zp_user row from getUserByEmail(), including the stored
+            // bcrypt password hash and session/reset tokens. Passing those back into editUser()
+            // would re-hash the already-hashed password on every login and clobber local
+            // credentials, so drop them — OIDC never manages the local password.
+            unset($user['password'], $user['session'], $user['pwReset'], $user['pwResetExpiration']);
+
             $this->userRepo->editUser($user, $user['id']);
 
             // Get updated user

--- a/app/Domain/Projects/Js/projectsController.js
+++ b/app/Domain/Projects/Js/projectsController.js
@@ -417,13 +417,13 @@ leantime.projectsController = (function () {
                             view_modes: ['Day', 'Week', 'Month'],
                             view_mode: viewMode,
                             custom_popup_html: function (project) {
-                                // the task object will contain the updated
+                                // the project object will contain the updated
                                 // dates and progress value
-                                var end_date = task._end;
+                                var end_date = project._end;
 
                                 var popUpHTML = '<div class="details-container" style="min-width:600px;"> ';
 
-                                if (task.projectName !== undefined) {
+                                if (project.projectName !== undefined) {
                                     popUpHTML +=  '<h3><b>' + project.name + '</b></h3>';
                                 }
 

--- a/app/Domain/Projects/Js/projectsController.js
+++ b/app/Domain/Projects/Js/projectsController.js
@@ -417,9 +417,6 @@ leantime.projectsController = (function () {
                             view_modes: ['Day', 'Week', 'Month'],
                             view_mode: viewMode,
                             custom_popup_html: function (project) {
-                                // the project object will contain the updated
-                                // dates and progress value
-                                var end_date = project._end;
 
                                 var popUpHTML = '<div class="details-container" style="min-width:600px;"> ';
 

--- a/app/Domain/Projects/Js/projectsController.js
+++ b/app/Domain/Projects/Js/projectsController.js
@@ -291,6 +291,11 @@ leantime.projectsController = (function () {
         jQuery(document).ready(
             function () {
 
+                // The Gantt constructor fires on_view_change once while building. Persisting that
+                // event would overwrite the user's saved scale with the default, so ignore any
+                // view change until construction is finished; only user-driven changes save.
+                var ganttInitializing = true;
+
                 if (readonly === false) {
                     var gantt_chart = new Gantt(
                         "#gantt",
@@ -305,7 +310,7 @@ leantime.projectsController = (function () {
                             bar_corner_radius: 10,
                             arrow_curve: 10,
                             padding:20,
-                            view_mode: 'Month',
+                            view_mode: viewMode,
                             date_format: leantime.i18n.__("language.momentJSDate"),
                             language: 'en', // or 'es', 'it', 'ru', 'ptBr', 'fr', 'tr', 'zh'
                             additional_rows: 5,
@@ -391,6 +396,7 @@ leantime.projectsController = (function () {
                             },
                             on_view_change: function (mode) {
 
+                                if (ganttInitializing) { return; }
                                 leantime.usersRepository.updateUserViewSettings("projectGantt", mode);
 
                             },
@@ -408,6 +414,8 @@ leantime.projectsController = (function () {
                             resizing: false,
                             progress: false,
                             is_draggable: false,
+                            view_modes: ['Day', 'Week', 'Month'],
+                            view_mode: viewMode,
                             custom_popup_html: function (project) {
                                 // the task object will contain the updated
                                 // dates and progress value
@@ -438,6 +446,7 @@ leantime.projectsController = (function () {
                             },
                             on_view_change: function (mode) {
 
+                                if (ganttInitializing) { return; }
                                 leantime.usersRepository.updateUserViewSettings("projectGantt", mode);
 
                             }
@@ -460,7 +469,9 @@ leantime.projectsController = (function () {
                     }
                 );
 
-                gantt_chart.change_view_mode(viewMode);
+                // Constructor already built the chart at the saved viewMode; construction is done,
+                // so from here on real user-driven view changes are allowed to persist.
+                ganttInitializing = false;
 
             }
         );

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -241,6 +241,11 @@ leantime.ticketsController = (function () {
         jQuery(document).ready(
             function () {
 
+                // The Gantt constructor fires on_view_change once while building. Persisting that
+                // event would overwrite the user's saved scale with the default, so ignore any
+                // view change until construction is finished; only user-driven changes save.
+                var ganttInitializing = true;
+
                 if (readonly === false) {
                     var gantt_chart = new Gantt(
                         "#gantt",
@@ -255,7 +260,7 @@ leantime.ticketsController = (function () {
                             bar_corner_radius: 10,
                             arrow_curve: 10,
                             padding:20,
-                            view_mode: 'Month',
+                            view_mode: viewMode,
                             date_format: leantime.i18n.__("language.momentJSDate"),
                             language: leantime.i18n.__("language.code").slice(0, 2), //Get first 2 characters of language code
                             additional_rows: 5,
@@ -318,6 +323,7 @@ leantime.ticketsController = (function () {
                             },
                             on_view_change: function (mode) {
 
+                                if (ganttInitializing) { return; }
                                 leantime.usersRepository.updateUserViewSettings("roadmap", mode);
 
                             },
@@ -335,6 +341,8 @@ leantime.ticketsController = (function () {
                             resizing: false,
                             progress: false,
                             is_draggable: false,
+                            view_modes: ['Day', 'Week', 'Month'],
+                            view_mode: viewMode,
                             custom_popup_html: function (task) {
 
 
@@ -377,6 +385,7 @@ leantime.ticketsController = (function () {
                             },
                             on_view_change: function (mode) {
 
+                                if (ganttInitializing) { return; }
                                 leantime.usersRepository.updateUserViewSettings("roadmap", mode);
 
                             }
@@ -399,7 +408,9 @@ leantime.ticketsController = (function () {
                     }
                 );
 
-                gantt_chart.change_view_mode(viewMode);
+                // Constructor already built the chart at the saved viewMode; construction is done,
+                // so from here on real user-driven view changes are allowed to persist.
+                ganttInitializing = false;
 
             }
         );

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -721,8 +721,11 @@ class Tickets extends BaseService
                         case 'milestoneid':
                             $label = 'No Milestone Set';
                             $sortId = 'zzz_no_milestone'; // Sort "No Milestone" last alphabetically
-                            if ($ticket['milestoneid'] > 0) {
-                                $milestone = $this->getTicket($ticket['milestoneid']);
+                            // getTicket() returns false when the current user can't access the
+                            // milestone's project (e.g. a cross-project milestone linked to a goal).
+                            // Fall back to the "No Milestone Set" default rather than dereferencing false.
+                            $milestone = $ticket['milestoneid'] > 0 ? $this->getTicket($ticket['milestoneid']) : false;
+                            if ($milestone) {
                                 $color = $milestone->tags;
                                 $class = '';
                                 $groupColor = $color;
@@ -3910,10 +3913,18 @@ class Tickets extends BaseService
                         $milestoneId = $ticket['milestoneid'];
 
                         if (! isset($milestoneCache[$milestoneId])) {
-                            $milestoneCache[$milestoneId] = (array) $this->getTicket($milestoneId);
+                            // getTicket() returns false when the user can't access the milestone's
+                            // project (e.g. a cross-project milestone linked to a goal). Casting false
+                            // to an array injects an empty "ticket" that later 500s the widget render,
+                            // so cache null and skip it instead.
+                            $milestone = $this->getTicket($milestoneId);
+                            $milestoneCache[$milestoneId] = $milestone ? (array) $milestone : null;
                         }
-                        $ticketGroup['tickets'][] = $milestoneCache[$milestoneId];
-                        $milestoneIds[$ticketGroup['groupValue']][] = $milestoneId;
+
+                        if ($milestoneCache[$milestoneId] !== null) {
+                            $ticketGroup['tickets'][] = $milestoneCache[$milestoneId];
+                            $milestoneIds[$ticketGroup['groupValue']][] = $milestoneId;
+                        }
                     }
                 }
             }

--- a/app/Domain/Tickets/Templates/roadmap.blade.php
+++ b/app/Domain/Tickets/Templates/roadmap.blade.php
@@ -124,9 +124,12 @@
 
                 $dependencyList = [];
 
-                if ($mlst->dependingTicketId != 0) {
+                // Use explicit > 0 checks: new milestones store dependingTicketId as an empty
+                // string, and under PHP 8 `'' != 0` is true — which pushed an empty dependency and
+                // skipped the real milestoneid, so a dependency set in table mode never rendered here.
+                if ((int) $mlst->dependingTicketId > 0) {
                     $dependencyList[] = $mlst->dependingTicketId;
-                } elseif ($mlst->milestoneid != 0) {
+                } elseif ((int) $mlst->milestoneid > 0) {
                     $dependencyList[] = $mlst->milestoneid;
                 }
 

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -591,7 +591,6 @@ class Timesheets extends Repository
      */
     public function addTime(array $values): void
     {
-        $description = $values['description'] ?? '';
         $now = date('Y-m-d H:i:s');
 
         // Portable upsert on the (userId, ticketId, workDate, kind) unique key: accumulate hours
@@ -605,21 +604,20 @@ class Timesheets extends Repository
         );
 
         if ($existing) {
-            $this->db->table('zp_timesheets')
-                ->where('id', $existing->id)
-                ->update([
-                    'hours' => (float) $existing->hours + (float) $values['hours'],
-                    'description' => $values['date']."\n".$description."\n--\n\n".($existing->description ?? ''),
-                    'modified' => $now,
-                ]);
-        } else {
+            $this->accumulateAddTimeRow($existing, $values, $now);
+            $this->cleanUpEmptyTimesheets();
+
+            return;
+        }
+
+        try {
             $this->db->table('zp_timesheets')->insert([
                 'userId' => $values['userId'],
                 'ticketId' => $values['ticket'],
                 'workDate' => $values['date'],
                 'hours' => $values['hours'],
                 'kind' => $values['kind'],
-                'description' => $description,
+                'description' => $values['description'] ?? '',
                 'invoicedEmpl' => $values['invoicedEmpl'] ?? '',
                 'invoicedComp' => $values['invoicedComp'] ?? '',
                 'invoicedEmplDate' => $values['invoicedEmplDate'] ?? '',
@@ -629,6 +627,25 @@ class Timesheets extends Repository
                 'paidDate' => $values['paidDate'] ?? '',
                 'modified' => $now,
             ]);
+        } catch (QueryException $e) {
+            // A concurrent request created the entry between our read and insert; the unique key
+            // rejects this insert, so accumulate onto the row that now exists instead of 500ing.
+            if (! $this->isUniqueConstraintViolation($e)) {
+                throw $e;
+            }
+
+            $existing = $this->findTimesheetRow(
+                (int) $values['userId'],
+                (int) $values['ticket'],
+                $values['date'],
+                $values['kind'],
+            );
+
+            if (! $existing) {
+                throw $e;
+            }
+
+            $this->accumulateAddTimeRow($existing, $values, $now);
         }
 
         $this->cleanUpEmptyTimesheets();
@@ -767,32 +784,78 @@ class Timesheets extends Repository
 
     /**
      * accumulateHours - Add $hours to the day's timesheet entry for a ticket/kind, inserting the
-     * row if it doesn't exist yet. Portable replacement for MySQL-only ON DUPLICATE KEY UPDATE.
+     * row if it doesn't exist yet. Portable, atomic replacement for MySQL-only
+     * ON DUPLICATE KEY UPDATE that also runs on PostgreSQL.
      */
     private function accumulateHours(int $userId, int $ticketId, string $workDate, string $kind, float $hours): void
     {
-        $existing = $this->findTimesheetRow($userId, $ticketId, $workDate, $kind);
         $now = date('Y-m-d H:i:s');
 
-        if ($existing) {
-            $this->db->table('zp_timesheets')
-                ->where('id', $existing->id)
-                ->update([
-                    'hours' => (float) $existing->hours + $hours,
-                    'modified' => $now,
-                ]);
+        // Atomic, DB-side increment. Only affects the row if it already exists, so concurrent
+        // callers can't lose an update the way a read-modify-write would.
+        $affected = $this->db->table('zp_timesheets')
+            ->where('userId', $userId)
+            ->where('ticketId', $ticketId)
+            ->where('workDate', $workDate)
+            ->where('kind', $kind)
+            ->increment('hours', $hours, ['modified' => $now]);
 
+        if ($affected > 0) {
             return;
         }
 
-        $this->db->table('zp_timesheets')->insert([
-            'userId' => $userId,
-            'ticketId' => $ticketId,
-            'workDate' => $workDate,
-            'hours' => $hours,
-            'kind' => $kind,
-            'modified' => $now,
-        ]);
+        // No row yet: insert one. Wrapped in a nested transaction so that on PostgreSQL a
+        // unique-key violation from a concurrent insert rolls back to a savepoint instead of
+        // aborting the surrounding punchOut transaction. On conflict, fall back to the increment.
+        try {
+            $this->db->transaction(function () use ($userId, $ticketId, $workDate, $kind, $hours, $now) {
+                $this->db->table('zp_timesheets')->insert([
+                    'userId' => $userId,
+                    'ticketId' => $ticketId,
+                    'workDate' => $workDate,
+                    'hours' => $hours,
+                    'kind' => $kind,
+                    'modified' => $now,
+                ]);
+            });
+        } catch (QueryException $e) {
+            if (! $this->isUniqueConstraintViolation($e)) {
+                throw $e;
+            }
+
+            $this->db->table('zp_timesheets')
+                ->where('userId', $userId)
+                ->where('ticketId', $ticketId)
+                ->where('workDate', $workDate)
+                ->where('kind', $kind)
+                ->increment('hours', $hours, ['modified' => $now]);
+        }
+    }
+
+    /**
+     * accumulateAddTimeRow - Add hours to and prepend the description of an existing timesheet row,
+     * shared by addTime's initial-match path and its concurrent-insert fallback.
+     */
+    private function accumulateAddTimeRow(object $existing, array $values, string $now): void
+    {
+        $description = $values['description'] ?? '';
+
+        $this->db->table('zp_timesheets')
+            ->where('id', $existing->id)
+            ->update([
+                'hours' => (float) $existing->hours + (float) $values['hours'],
+                'description' => $values['date']."\n".$description."\n--\n\n".($existing->description ?? ''),
+                'modified' => $now,
+            ]);
+    }
+
+    /**
+     * isUniqueConstraintViolation - True when a QueryException is a duplicate/unique-key violation
+     * (SQLSTATE 23000 on MySQL, 23505 on PostgreSQL), used to retry upserts as updates.
+     */
+    private function isUniqueConstraintViolation(QueryException $e): bool
+    {
+        return in_array((string) $e->getCode(), ['23000', '23505'], true);
     }
 
     /**

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -591,63 +591,45 @@ class Timesheets extends Repository
      */
     public function addTime(array $values): void
     {
-        // Laravel Query Builder doesn't support ON DUPLICATE KEY UPDATE well
-        // Use raw query for this MySQL-specific feature
-        $query = "INSERT INTO zp_timesheets (
-            userId,
-            ticketId,
-            workDate,
-            hours,
-            kind,
-            description,
-            invoicedEmpl,
-            invoicedComp,
-            invoicedEmplDate,
-            invoicedCompDate,
-            rate,
-            paid,
-            paidDate,
-            modified
-        ) VALUES (
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?,
-            ?
-        ) ON DUPLICATE KEY UPDATE
-             hours = hours + ?,
-             description = CONCAT(?, '\n', ?, '\n', '--', '\n\n', description)";
+        $description = $values['description'] ?? '';
+        $now = date('Y-m-d H:i:s');
 
-        $query = self::dispatch_filter('sql', $query);
-
-        $this->db->insert($query, [
-            $values['userId'],
-            $values['ticket'],
+        // Portable upsert on the (userId, ticketId, workDate, kind) unique key: accumulate hours
+        // and prepend the new description onto the existing entry. Replaces MySQL-only
+        // ON DUPLICATE KEY UPDATE so this also runs on PostgreSQL.
+        $existing = $this->findTimesheetRow(
+            (int) $values['userId'],
+            (int) $values['ticket'],
             $values['date'],
-            $values['hours'],
             $values['kind'],
-            $values['description'] ?? '',
-            $values['invoicedEmpl'] ?? '',
-            $values['invoicedComp'] ?? '',
-            $values['invoicedEmplDate'] ?? '',
-            $values['invoicedCompDate'] ?? '',
-            $values['rate'] ?? '',
-            $values['paid'] ?? '',
-            $values['paidDate'] ?? '',
-            date('Y-m-d H:i:s'),
-            $values['hours'],
-            $values['date'],
-            $values['description'] ?? '',
-        ]);
+        );
+
+        if ($existing) {
+            $this->db->table('zp_timesheets')
+                ->where('id', $existing->id)
+                ->update([
+                    'hours' => (float) $existing->hours + (float) $values['hours'],
+                    'description' => $values['date']."\n".$description."\n--\n\n".($existing->description ?? ''),
+                    'modified' => $now,
+                ]);
+        } else {
+            $this->db->table('zp_timesheets')->insert([
+                'userId' => $values['userId'],
+                'ticketId' => $values['ticket'],
+                'workDate' => $values['date'],
+                'hours' => $values['hours'],
+                'kind' => $values['kind'],
+                'description' => $description,
+                'invoicedEmpl' => $values['invoicedEmpl'] ?? '',
+                'invoicedComp' => $values['invoicedComp'] ?? '',
+                'invoicedEmplDate' => $values['invoicedEmplDate'] ?? '',
+                'invoicedCompDate' => $values['invoicedCompDate'] ?? '',
+                'rate' => $values['rate'] ?? '',
+                'paid' => $values['paid'] ?? '',
+                'paidDate' => $values['paidDate'] ?? '',
+                'modified' => $now,
+            ]);
+        }
 
         $this->cleanUpEmptyTimesheets();
     }
@@ -720,19 +702,17 @@ class Timesheets extends Repository
             /** @var \Carbon\CarbonImmutable $userStartOfDay */
             $userStartOfDay = dtHelper()::createFromTimestamp($inTimestamp, 'UTC')->setToUserTimezone()->startOfDay();
 
-            // Use raw query for ON DUPLICATE KEY UPDATE (MySQL specific)
-            $query = "INSERT INTO `zp_timesheets` (userId, ticketId, workDate, hours, kind, modified)
-                      VALUES (?, ?, ?, ?, 'GENERAL_BILLABLE', ?)
-                      ON DUPLICATE KEY UPDATE hours = hours + ?";
-
-            $this->db->insert($query, [
-                session('userdata.id'),
+            // Accumulate onto the day's existing entry for this ticket/kind. Done as a portable
+            // read-then-write instead of MySQL-only ON DUPLICATE KEY UPDATE so it also runs on
+            // PostgreSQL. The (userId, ticketId, workDate, kind) unique key + surrounding
+            // transaction keep this atomic.
+            $this->accumulateHours(
+                (int) session('userdata.id'),
                 $ticketId,
                 $userStartOfDay->formatDateTimeForDb(),
+                'GENERAL_BILLABLE',
                 $hoursWorked,
-                date('Y-m-d H:i:s'),
-                $hoursWorked,
-            ]);
+            );
 
             return $hoursWorked;
         });
@@ -745,58 +725,74 @@ class Timesheets extends Repository
      */
     public function upsertTimesheetEntry(array $values): void
     {
-        // Use raw query for ON DUPLICATE KEY UPDATE (MySQL specific)
-        $query = 'INSERT INTO zp_timesheets (
-                userId,
-                ticketId,
-                workDate,
-                hours,
-                kind,
-                invoicedEmpl,
-                invoicedComp,
-                invoicedEmplDate,
-                invoicedCompDate,
-                rate,
-                paid,
-                paidDate,
-                modified
-            ) VALUES (
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?,
-                ?
-            ) ON DUPLICATE KEY UPDATE
-                 hours = ?';
-
-        $query = self::dispatch_filter('sql', $query);
-
-        $this->db->insert($query, [
-            $values['userId'],
-            $values['ticket'],
-            $values['date'],
-            $values['hours'],
-            $values['kind'],
-            $values['invoicedEmpl'] ?? '',
-            $values['invoicedComp'] ?? '',
-            $values['invoicedEmplDate'] ?? '',
-            $values['invoicedCompDate'] ?? '',
-            $values['rate'] ?? '',
-            $values['paid'] ?? '',
-            $values['paidDate'] ?? '',
-            date('Y-m-d H:i:s'),
-            $values['hours'],
-        ]);
+        // Cross-DB upsert on the (userId, ticketId, workDate, kind) unique key. Laravel's upsert()
+        // emits the correct dialect per driver (MySQL ON DUPLICATE KEY, PostgreSQL ON CONFLICT).
+        // On conflict only `hours` is overwritten, matching the previous behaviour.
+        $this->db->table('zp_timesheets')->upsert(
+            [[
+                'userId' => $values['userId'],
+                'ticketId' => $values['ticket'],
+                'workDate' => $values['date'],
+                'hours' => $values['hours'],
+                'kind' => $values['kind'],
+                'invoicedEmpl' => $values['invoicedEmpl'] ?? '',
+                'invoicedComp' => $values['invoicedComp'] ?? '',
+                'invoicedEmplDate' => $values['invoicedEmplDate'] ?? '',
+                'invoicedCompDate' => $values['invoicedCompDate'] ?? '',
+                'rate' => $values['rate'] ?? '',
+                'paid' => $values['paid'] ?? '',
+                'paidDate' => $values['paidDate'] ?? '',
+                'modified' => date('Y-m-d H:i:s'),
+            ]],
+            ['userId', 'ticketId', 'workDate', 'kind'],
+            ['hours'],
+        );
 
         $this->cleanUpEmptyTimesheets();
+    }
+
+    /**
+     * findTimesheetRow - Look up a single timesheet entry by its natural unique key
+     * (userId, ticketId, workDate, kind), used by the portable upsert paths.
+     */
+    private function findTimesheetRow(int $userId, int $ticketId, string $workDate, string $kind): ?object
+    {
+        return $this->db->table('zp_timesheets')
+            ->where('userId', $userId)
+            ->where('ticketId', $ticketId)
+            ->where('workDate', $workDate)
+            ->where('kind', $kind)
+            ->first();
+    }
+
+    /**
+     * accumulateHours - Add $hours to the day's timesheet entry for a ticket/kind, inserting the
+     * row if it doesn't exist yet. Portable replacement for MySQL-only ON DUPLICATE KEY UPDATE.
+     */
+    private function accumulateHours(int $userId, int $ticketId, string $workDate, string $kind, float $hours): void
+    {
+        $existing = $this->findTimesheetRow($userId, $ticketId, $workDate, $kind);
+        $now = date('Y-m-d H:i:s');
+
+        if ($existing) {
+            $this->db->table('zp_timesheets')
+                ->where('id', $existing->id)
+                ->update([
+                    'hours' => (float) $existing->hours + $hours,
+                    'modified' => $now,
+                ]);
+
+            return;
+        }
+
+        $this->db->table('zp_timesheets')->insert([
+            'userId' => $userId,
+            'ticketId' => $ticketId,
+            'workDate' => $workDate,
+            'hours' => $hours,
+            'kind' => $kind,
+            'modified' => $now,
+        ]);
     }
 
     /**

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -596,15 +596,8 @@ class Timesheets extends Repository
         // Portable upsert on the (userId, ticketId, workDate, kind) unique key: accumulate hours
         // and prepend the new description onto the existing entry. Replaces MySQL-only
         // ON DUPLICATE KEY UPDATE so this also runs on PostgreSQL.
-        $existing = $this->findTimesheetRow(
-            (int) $values['userId'],
-            (int) $values['ticket'],
-            $values['date'],
-            $values['kind'],
-        );
-
-        if ($existing) {
-            $this->accumulateAddTimeRow($existing, $values, $now);
+        if ($this->findTimesheetRow((int) $values['userId'], (int) $values['ticket'], $values['date'], $values['kind'])) {
+            $this->accumulateAddTimeRow($values, $now);
             $this->cleanUpEmptyTimesheets();
 
             return;
@@ -628,24 +621,13 @@ class Timesheets extends Repository
                 'modified' => $now,
             ]);
         } catch (QueryException $e) {
-            // A concurrent request created the entry between our read and insert; the unique key
+            // A concurrent request created the entry between our check and insert; the unique key
             // rejects this insert, so accumulate onto the row that now exists instead of 500ing.
             if (! $this->isUniqueConstraintViolation($e)) {
                 throw $e;
             }
 
-            $existing = $this->findTimesheetRow(
-                (int) $values['userId'],
-                (int) $values['ticket'],
-                $values['date'],
-                $values['kind'],
-            );
-
-            if (! $existing) {
-                throw $e;
-            }
-
-            $this->accumulateAddTimeRow($existing, $values, $now);
+            $this->accumulateAddTimeRow($values, $now);
         }
 
         $this->cleanUpEmptyTimesheets();
@@ -833,20 +815,34 @@ class Timesheets extends Repository
     }
 
     /**
-     * accumulateAddTimeRow - Add hours to and prepend the description of an existing timesheet row,
-     * shared by addTime's initial-match path and its concurrent-insert fallback.
+     * accumulateAddTimeRow - Atomically add hours to and prepend the description of the existing
+     * timesheet row on the (userId, ticketId, workDate, kind) unique key. Done as a single DB-side
+     * UPDATE (hours = hours + ?, description via CONCAT) so concurrent addTime() calls can't lose an
+     * update; CONCAT and bound parameters are portable across MySQL and PostgreSQL.
      */
-    private function accumulateAddTimeRow(object $existing, array $values, string $now): void
+    private function accumulateAddTimeRow(array $values, string $now): void
     {
-        $description = $values['description'] ?? '';
+        $descriptionPrefix = $values['date']."\n".($values['description'] ?? '')."\n--\n\n";
 
-        $this->db->table('zp_timesheets')
-            ->where('id', $existing->id)
-            ->update([
-                'hours' => (float) $existing->hours + (float) $values['hours'],
-                'description' => $values['date']."\n".$description."\n--\n\n".($existing->description ?? ''),
-                'modified' => $now,
-            ]);
+        $this->db->update(
+            'UPDATE zp_timesheets
+                SET hours = hours + ?,
+                    description = CONCAT(?, description),
+                    modified = ?
+              WHERE userId = ?
+                AND ticketId = ?
+                AND workDate = ?
+                AND kind = ?',
+            [
+                (float) $values['hours'],
+                $descriptionPrefix,
+                $now,
+                (int) $values['userId'],
+                (int) $values['ticket'],
+                $values['date'],
+                $values['kind'],
+            ]
+        );
     }
 
     /**

--- a/app/Domain/Users/Repositories/Users.php
+++ b/app/Domain/Users/Repositories/Users.php
@@ -298,7 +298,7 @@ class Users
             'modified' => now(),
         ];
 
-        if (isset($values['password']) && $values['password'] != '') {
+        if (isset($values['password']) && $values['password'] != '' && ! $this->isHashedPassword($values['password'])) {
             $updateData['password'] = password_hash($values['password'], PASSWORD_DEFAULT);
         }
 
@@ -355,13 +355,22 @@ class Users
             'modified' => now(),
         ];
 
-        if (isset($values['password']) && $values['password'] != '') {
+        if (isset($values['password']) && $values['password'] != '' && ! $this->isHashedPassword($values['password'])) {
             $updateData['password'] = password_hash($values['password'], PASSWORD_DEFAULT);
         }
 
         $this->connection->table('zp_user')
             ->where('id', $id)
             ->update($updateData);
+    }
+
+    /**
+     * isHashedPassword - Detect a value that is already a password hash so callers that pass a
+     * full user row (e.g. the OIDC login sync) don't re-hash the stored hash and lock the user out.
+     */
+    private function isHashedPassword(string $password): bool
+    {
+        return ! empty(password_get_info($password)['algo']);
     }
 
     /**

--- a/app/Domain/Wiki/Templates/show.blade.php
+++ b/app/Domain/Wiki/Templates/show.blade.php
@@ -797,7 +797,14 @@ jQuery(document).ready(function() {
             defaultText: 'Add tag...',
             placeholderColor: 'var(--secondary-font-color)',
             onChange: function(elem, elem_tags) {
-                saveField('tags', elem_tags, function() { updateLastSaved(); });
+                // The tagsInput plugin passes only the single tag that changed as elem_tags, and
+                // fires once with `undefined` during its initial import. Saving elem_tags directly
+                // overwrote the column with just the last tag (and the literal "undefined" on load).
+                // Ignore the init call and persist the full delimited value instead.
+                if (typeof elem_tags === 'undefined') {
+                    return;
+                }
+                saveField('tags', jQuery('#wikiTagsInput').val(), function() { updateLastSaved(); });
             }
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,18 +115,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
@@ -160,28 +148,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.1.tgz",
-      "integrity": "sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helpers": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -243,12 +233,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.1.tgz",
-      "integrity": "sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -451,9 +442,10 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -473,12 +465,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2028,6 +2021,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -8281,9 +8284,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10174,10 +10177,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -10899,10 +10903,20 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11449,13 +11463,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-      "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/layout-base": {
@@ -11582,9 +11597,19 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -11864,14 +11889,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -17119,9 +17154,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -17145,7 +17180,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",


### PR DESCRIPTION
Fixes a batch of open, un-triaged GitHub bugs (all root-caused; each commit maps to one issue).

## Fixes

- **#3555 — OIDC login overrides user password.** The existing-user branch passed the full `zp_user` row (including the stored bcrypt hash) into `editUser()`, which re-hashed it on every OIDC login → local email/password login broke permanently. Drops credential fields before the update and hardens `editUser`/`editOwn` against re-hashing an already-hashed value.
- **#3575 — Cannot stop task timer on PostgreSQL (500).** `punchOut`/`addTime`/`upsertTimesheetEntry` used MySQL-only `INSERT … ON DUPLICATE KEY UPDATE` with backticks. Replaced with a portable read-then-write accumulation and Laravel's `upsert()` keyed on the `(userId, ticketId, workDate, kind)` unique index.
- **#3571 — To-Dos page 500 after linking task→milestone→goal.** `getTicket()` returns `false` for a milestone in a project the viewer can't access; dereferencing it (`$milestone->tags`) and casting `false` into the widget list 500'd the page. Both sites now guard and skip the inaccessible milestone.
- **#3568 — Docs/Wiki tags: only the last tag saved, "undefined" after re-login.** The `tagsInput` `onChange` saved its single-tag argument (overwriting the column) and persisted the literal `"undefined"` fired during the plugin's initial import. Now persists the full delimited value and ignores the init call.
- **#3569 — Timeline scale resets to Month.** The Gantt constructor hard-coded `view_mode: 'Month'` and its construction-time `view_change` raced the restore, clobbering the saved Day/Week scale. Seeds the constructor with the saved scale and ignores view changes until construction finishes (roadmap + portfolio Gantts).
- **#3570 — Dependency set in table mode not shown on timeline.** New milestones store `dependingTicketId` as `''`; under PHP 8 `'' != 0` is true, so an empty dependency was pushed and the real `milestoneid` skipped. Uses explicit `> 0` checks.

## Not included (documented for follow-up)

- **#3546 — official Docker image missing `pdo_pgsql`.** The `.docker/Dockerfile` is correct (pgsql added in #3447); `release.yml` has no docker build/push step, so the published image is stale. Needs a build-push job (Docker Hub secrets) or a republish — ops, not core code.
- **#3567 — StrategyPro renders raw HTML in the editor.** Lives in the private plugin submodule (local is 1.4.0; reporter on 1.5.0) and needs a live repro to confirm whether the `tiptapComplex` class + build shipped.

## Verification

- `php -l`, Laravel Pint, and PHPStan clean on the changed files.
- Suggested manual checks per issue in the linked issues (timer stop on PG, To-Dos with a cross-project milestone, wiki multi-tag save/re-login, timeline scale + dependency round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
