### PR TITLE
feat(users): getMyDaySchedule @api (work hours + timezone)

### DIFF
--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -755,6 +755,40 @@ class Users extends BaseService
     }
 
     /**
+     * The authenticated user's work-day schedule (workStart / lunch / workEnd
+     * hours) plus their timezone. A lean, self-scoped read for clients that
+     * only need the schedule — e.g. the mobile app seeds reminder times and the
+     * day-progress marker from it — rather than the heavy getOwnProfileSettings
+     * payload. Values are null when the user hasn't set a schedule (caller
+     * applies its own defaults).
+     *
+     * Self-scoped: always the session user, never a caller-supplied id.
+     *
+     * @api
+     *
+     * @return array{workStart: mixed, lunch: mixed, workEnd: mixed, timezone: string}
+     */
+    public function getMyDaySchedule(): array
+    {
+        $userId = (int) session('userdata.id');
+
+        $daySchedule = $this->settingsService->getSetting('usersettings.'.$userId.'.daySchedule');
+        $daySchedule = $daySchedule ? safe_unserialize($daySchedule, []) : [];
+
+        $timezone = $this->settingsService->getSetting('usersettings.'.$userId.'.timezone');
+        if (! $timezone) {
+            $timezone = date_default_timezone_get();
+        }
+
+        return [
+            'workStart' => $daySchedule['workStart'] ?? null,
+            'lunch' => $daySchedule['lunch'] ?? null,
+            'workEnd' => $daySchedule['workEnd'] ?? null,
+            'timezone' => $timezone,
+        ];
+    }
+
+    /**
      * Gathers the notification preferences for the "edit own profile" screen,
      * applying company defaults and the per-project notification levels
      * (including the lazy migration from the legacy muted-projects format).

--- a/app/Domain/Users/Services/Users.php
+++ b/app/Domain/Users/Services/Users.php
@@ -772,8 +772,23 @@ class Users extends BaseService
     {
         $userId = (int) session('userdata.id');
 
+        // No authenticated user → don't fall through to usersettings.0.*.
+        if ($userId === 0) {
+            return [
+                'workStart' => null,
+                'lunch' => null,
+                'workEnd' => null,
+                'timezone' => date_default_timezone_get(),
+            ];
+        }
+
         $daySchedule = $this->settingsService->getSetting('usersettings.'.$userId.'.daySchedule');
         $daySchedule = $daySchedule ? safe_unserialize($daySchedule, []) : [];
+        // safe_unserialize can yield a non-array (e.g. false for a corrupt or
+        // scalar value); normalize so the array reads below are safe.
+        if (! is_array($daySchedule)) {
+            $daySchedule = [];
+        }
 
         $timezone = $this->settingsService->getSetting('usersettings.'.$userId.'.timezone');
         if (! $timezone) {


### PR DESCRIPTION
A lean, **self-scoped** `@api` read of the authenticated user's day schedule (`workStart` / `lunch` / `workEnd`) + timezone, from `usersettings.{id}.daySchedule` — the same setting onboarding writes and the Copilot plugin reads.

**Why:** the mobile app is adding on-device reminders (morning cue + evening 'plan tomorrow') and a day-progress marker. This lets it **seed those from the user's real work hours** instead of asking again — without pulling the heavy `getOwnProfileSettings` payload (which returns fonts/themes/etc.). Also returns `timezone`, which closes the mobile timezone-lookup gap (currently falls back to device TZ because the generic `getSetting` isn't `@api`-exposed).

Self-scoped (session user only), values null when unset (caller applies defaults). Mobile syncs it **once per launch** and caches it (slow-moving data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)