### PR TITLE
fix(js): encode avatar-src user id to clear CodeQL xss-through-dom alerts

### DIFF
--- a/app/Domain/Blueprints/Js/blueprintsController.js
+++ b/app/Domain/Blueprints/Js/blueprintsController.js
@@ -160,7 +160,7 @@ leantime.blueprintsController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + encodeURIComponent(userId));
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Canvas/Js/canvasController.js
+++ b/app/Domain/Canvas/Js/canvasController.js
@@ -137,7 +137,7 @@ leantime.canvasController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + encodeURIComponent(userId));
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Goalcanvas/Js/goalCanvasController.js
+++ b/app/Domain/Goalcanvas/Js/goalCanvasController.js
@@ -124,7 +124,7 @@ leantime.goalCanvasController = (function () {
                         }
                     ).done(
                         function () {
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + encodeURIComponent(userId));
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
                         }
                     );

--- a/app/Domain/Ideas/Js/ideasController.js
+++ b/app/Domain/Ideas/Js/ideasController.js
@@ -157,7 +157,7 @@ leantime.ideasController = (function () {
                     leantime.rpc('Ideas.Ideas.patchIdeaItem', { id: canvasId, params: { author: userId } })
                         .then(function (success) {
                             if (! success) { return; }
-                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
+                            jQuery("#userDropdownMenuLink" + canvasId + " span.text span#userImage" + canvasId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + encodeURIComponent(userId));
 
                             jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated")});
                         })

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -836,7 +836,7 @@ leantime.ticketsController = (function () {
                 leantime.rpc('Tickets.Tickets.patchTicket', { id: ticketId, values: { editorId: userId } })
                     .then(
                     function () {
-                        jQuery("#userDropdownMenuLink" + ticketId + " span.text span#userImage" + ticketId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + userId);
+                        jQuery("#userDropdownMenuLink" + ticketId + " span.text span#userImage" + ticketId + " img").attr("src", leantime.appUrl + "/users/profileImage/" + encodeURIComponent(userId));
                         jQuery("#userDropdownMenuLink" + ticketId + " span.text span#user" + ticketId).text(dataLabel);
                         jQuery.growl({message: leantime.i18n.__("short_notifications.user_updated"), style: "success"});
 


### PR DESCRIPTION
Clears the 5 high-severity **`js/xss-through-dom`** CodeQL alerts that surfaced on #3557 (they pre-existed on master; #3557 just re-anchored them by editing those lines).

## The finding

The avatar-reassignment handlers read the target user id from the dropdown link's `data-value` attribute and interpolated it directly into the profile-image `src` URL:

```js
var userId = dataValue[1]; // from jQuery(this).attr("data-value").split("_")
...
img.attr("src", leantime.appUrl + "/users/profileImage/" + userId);
```

CodeQL traces the DOM-sourced `userId` into the `src` sink and rates it a high `js/xss-through-dom`. Fix: wrap the id in `encodeURIComponent()` at all 5 sites (Blueprints, Canvas, Goalcanvas, Ideas, Tickets). Ids are numeric, so there's **no behavioral change** — it just escapes the value and breaks the taint flow.

## Not included (separate, lower priority)

Two other `js/xss-through-dom` alerts remain on master — `ticketsController.js:1150` and `:1192`, where the ticket-search form values flow into `window.location.href`. Those need care: several of those inputs (e.g. `users`, `milestones`) are multi-selects whose `.val()` returns arrays, so a naive `encodeURIComponent` would comma-encode them and break the filters. I left them out to keep this PR safe and focused; happy to do a follow-up that URL-encodes those query params correctly.

## Verification

- `node --check` clean on all 5 files.
- No runtime change (numeric ids encode to themselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
