### PR TITLE
harden(plugins): require permission for plugin management + tighten install input

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.9.5';
 
-    public string $dbVersion = '3.5.18';
+    public string $dbVersion = '3.5.19';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -90,6 +90,7 @@ class Install
         // Pre-release, so no installed DB ran the intermediate versions; fresh installs are
         // covered by SchemaBuilder + setupDB().
         30518,
+        30519,
     ];
 
     /**
@@ -2756,6 +2757,44 @@ class Install
             Log::error('Migration 30518: '.$e->getMessage());
 
             return ['Migration 30518 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30519 — grant the new `plugins.manage` capability to existing installs.
+     *
+     * The plugin-management surface (marketplace/folder install, enable, disable, remove,
+     * discover) is now gated by `plugins.manage`. Fresh installs pick this up through the
+     * built-in seed, but installs already past 30518 have no row for the new key — which would
+     * deny everyone, including admins. Sync the vocabulary and grant the key to admin + owner
+     * only. This is a targeted grant, NOT a full reseed, so any custom role edits/revocations
+     * an operator has made are preserved.
+     */
+    public function update_sql_30519(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+
+            $repo = app(\Leantime\Core\Auth\Permissions\PermissionRepository::class);
+
+            foreach (['admin', 'owner'] as $roleName) {
+                $role = $repo->getRoleByName($roleName);
+
+                if ($role !== null) {
+                    $repo->grant((int) $role['id'], \Leantime\Domain\Plugins\Permissions\PluginsPermissions::MANAGE);
+                }
+            }
+
+            app(\Leantime\Core\Auth\Permissions\PermissionService::class)->flushCache();
+        } catch (\Exception $e) {
+            Log::error('Migration 30519: '.$e->getMessage());
+
+            return ['Migration 30519 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Plugins/Hxcontrollers/Details.php
+++ b/app/Domain/Plugins/Hxcontrollers/Details.php
@@ -4,7 +4,9 @@ namespace Leantime\Domain\Plugins\Hxcontrollers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\Client\RequestException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Controller\HtmxController;
+use Leantime\Domain\Plugins\Permissions\PluginsPermissions;
 use Leantime\Domain\Plugins\Services\Plugins as PluginService;
 
 class Details extends HtmxController
@@ -22,6 +24,7 @@ class Details extends HtmxController
     /**
      * @throws BindingResolutionException
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function install(): string
     {
         $pluginProps = $this->incomingRequest->request->all()['plugin'];

--- a/app/Domain/Plugins/Permissions/PluginsPermissions.php
+++ b/app/Domain/Plugins/Permissions/PluginsPermissions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Leantime\Domain\Plugins\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Plugins (extension management) permission vocabulary — the verbs only.
+ *
+ * Managing plugins (installing from the marketplace or a folder, enabling, disabling, updating,
+ * removing, and discovering new ones) is an installation-wide administrative capability, not a
+ * per-project one. So the single verb below is COMPANY-WIDE (`projectScoped = false`) and call
+ * sites gate with `#[RequiresPermission(PluginsPermissions::MANAGE, global: true)]`, evaluated
+ * against the user's GLOBAL role. By the default role map it lands on admin/owner only (the
+ * `scope:any verbs:['*']` admin rule), matching the existing marketplace/my-apps UI gate.
+ *
+ * Reading which plugins are enabled (boot, menu, composers) is NOT gated by this — that is
+ * internal plumbing every request needs and carries no `plugins.*` requirement.
+ */
+final class PluginsPermissions implements ProvidesPermissions
+{
+    /** Install, enable, disable, update, remove, or discover plugins (company-wide). */
+    public const MANAGE = 'plugins.manage';
+
+    public function domain(): string
+    {
+        return 'plugins';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::MANAGE, 'Manage plugins', false),
+        ];
+    }
+}

--- a/app/Domain/Plugins/Services/Plugins.php
+++ b/app/Domain/Plugins/Services/Plugins.php
@@ -10,12 +10,14 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Configuration\AppSettings;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Notifications\Services\Notifications;
 use Leantime\Domain\Plugins\Models\InstalledPlugin;
 use Leantime\Domain\Plugins\Models\MarketplacePlugin;
+use Leantime\Domain\Plugins\Permissions\PluginsPermissions;
 use Leantime\Domain\Plugins\Repositories\Plugins as PluginRepository;
 use Leantime\Domain\Setting\Services\Setting as SettingsService;
 use Leantime\Domain\Users\Services\Users as UsersService;
@@ -26,6 +28,22 @@ use Leantime\Domain\Users\Services\Users as UsersService;
 class Plugins
 {
     use DispatchesEvents;
+
+    /**
+     * Properties accepted from the request when building a MarketplacePlugin for install.
+     * A positive allowlist (fail-closed): control fields such as `type` and `marketplaceUrl`
+     * are deliberately absent so they can't be mass-assigned from client input.
+     */
+    private const MARKETPLACE_INSTALL_PROPS = [
+        'identifier',
+        'license',
+        'version',
+        'name',
+        'icon',
+        'marketplaceId',
+        'compatibility',
+        'categories',
+    ];
 
     private string $pluginDirectory = ROOT.'/../app/Plugins/';
 
@@ -203,6 +221,7 @@ class Plugins
      *
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function discoverNewPlugins(): array
     {
         $this->clearCache();
@@ -263,6 +282,7 @@ class Plugins
      *
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function installPlugin($pluginFolder): false|string
     {
         $this->clearCache();
@@ -296,6 +316,7 @@ class Plugins
     /**
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function enablePlugin(int $id): bool
     {
         $this->clearCache();
@@ -317,6 +338,7 @@ class Plugins
     /**
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function disablePlugin(int $id): bool
     {
         $this->clearCache();
@@ -339,6 +361,7 @@ class Plugins
      *
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function removePlugin(int $id): bool
     {
         $this->clearCache();
@@ -537,11 +560,20 @@ class Plugins
      *
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function buildMarketplacePluginFromRequest(array $pluginProps): MarketplacePlugin
     {
         $builder = build(new MarketplacePlugin);
 
         foreach ($pluginProps as $key => $value) {
+            // Only accept the properties the install round-trip legitimately carries. Everything
+            // else — notably control fields like `type` and `marketplaceUrl` — is ignored, so a
+            // request can't mass-assign arbitrary model state (the download always targets the
+            // server-configured marketplace, keyed by identifier).
+            if (! in_array($key, self::MARKETPLACE_INSTALL_PROPS, true)) {
+                continue;
+            }
+
             if (is_string($value)) {
                 $newValue = json_decode(json: $value, flags: JSON_OBJECT_AS_ARRAY);
 
@@ -898,6 +930,7 @@ class Plugins
      *
      * @api
      */
+    #[RequiresPermission(PluginsPermissions::MANAGE, global: true)]
     public function performPluginAction(string $action, mixed $id): array
     {
         $allowedActions = ['install', 'enable', 'disable', 'remove'];

--- a/app/Domain/Plugins/Services/Plugins.php
+++ b/app/Domain/Plugins/Services/Plugins.php
@@ -31,18 +31,27 @@ class Plugins
 
     /**
      * Properties accepted from the request when building a MarketplacePlugin for install.
-     * A positive allowlist (fail-closed): control fields such as `type` and `marketplaceUrl`
-     * are deliberately absent so they can't be mass-assigned from client input.
+     * A positive allowlist (fail-closed): the security-sensitive control fields `type` and
+     * `marketplaceUrl` are deliberately absent so they can't be mass-assigned from client input,
+     * and `version` is intentionally excluded because the caller handles it separately. Everything
+     * here is benign marketplace descriptor/display data carried by the install round-trip.
      */
     private const MARKETPLACE_INSTALL_PROPS = [
         'identifier',
         'license',
-        'version',
         'name',
+        'excerpt',
+        'description',
+        'imageUrl',
         'icon',
+        'vendorDisplayName',
+        'vendorId',
         'marketplaceId',
         'compatibility',
         'categories',
+        'tags',
+        'rating',
+        'reviewCount',
     ];
 
     private string $pluginDirectory = ROOT.'/../app/Plugins/';

--- a/tests/Unit/app/Domain/Plugins/Services/PluginsServiceTest.php
+++ b/tests/Unit/app/Domain/Plugins/Services/PluginsServiceTest.php
@@ -49,6 +49,23 @@ class PluginsServiceTest extends TestCase
         $this->assertSame('Not json', $plugin->excerpt);
     }
 
+    public function test_build_marketplace_plugin_from_request_ignores_disallowed_control_fields(): void
+    {
+        /** @var PluginService $service */
+        $service = $this->make(PluginService::class);
+
+        $plugin = $service->buildMarketplacePluginFromRequest([
+            'identifier' => 'acme-plugin',
+            'type' => 'system',
+            'marketplaceUrl' => 'https://attacker.example.com',
+        ]);
+
+        // Allowlisted field is set; sensitive control fields are ignored and keep their defaults.
+        $this->assertSame('acme-plugin', $plugin->identifier);
+        $this->assertSame('marketplace', $plugin->type);
+        $this->assertSame('', $plugin->marketplaceUrl);
+    }
+
     public function test_is_bundle_true_when_bundles_category_present(): void
     {
         /** @var PluginService $service */


### PR DESCRIPTION
Hardens authorization and input handling around plugin management.

## What this does

- **Adds a `plugins.manage` permission** (company-wide) and gates the full plugin-management surface with it — installing (marketplace + folder), enabling, disabling, removing, and discovering plugins. Applied to both the HTMX controller action and the `@api` service methods, so the same rule is enforced on the web/HTMX path *and* the JSON-RPC path. By default it's granted to admin/owner only, matching the existing marketplace/my-apps UI gate.
- **Restricts marketplace-plugin model construction to an explicit property allowlist**, so request input can only set the fields the install round-trip actually needs (control fields are ignored rather than mass-assigned).
- **Migration `30519`** syncs the new permission and grants it to admin/owner on existing installs (a targeted grant — any custom role permission edits are preserved). Fresh installs receive it through the built-in role seed.

## Verification

- Permission discovery + default grant matrix confirmed via the registry: `plugins.manage` resolves to **admin + owner only** (readonly/commenter/editor/manager excluded), consistent with the current UI restriction.
- Internal/CLI/boot callers (e.g. the `plugin:*` console commands, plugin loading) call the service directly and don't pass through the enforcer, so they're unaffected.
- Pint + `php -l` clean on all changed files.
- `dbVersion` bumped to 3.5.19 so the migration runs on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
