### PR TITLE
harden(security): authz, SSRF, reset-token, LDAP, and stored-XSS fixes

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.9.5';
 
-    public string $dbVersion = '3.5.19';
+    public string $dbVersion = '3.5.20';
 }

--- a/app/Core/Support/OutboundUrlGuard.php
+++ b/app/Core/Support/OutboundUrlGuard.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Leantime\Core\Support;
+
+use Illuminate\Support\Facades\Log;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Shared SSRF guard for server-initiated outbound HTTP requests (external calendars, webhook
+ * notifications, and any other feature that fetches a user-supplied URL).
+ *
+ * Enforces http/https only, resolves every A/AAAA record for the host, and rejects the request
+ * when any resolved address is loopback, private, link-local, CGNAT, or otherwise reserved —
+ * closing the "public hostname, private IP" bypass. {@see redirectOptions()} re-runs the same
+ * check on every redirect hop so an allowed public URL can't 30x-redirect into an internal target.
+ */
+final class OutboundUrlGuard
+{
+    /**
+     * IPv4 ranges that must never be reached by a server-initiated request. Beyond RFC1918 this
+     * adds CGNAT (100.64.0.0/10 — the range the calendar guard was missing), IETF-reserved,
+     * benchmarking, multicast, and broadcast ranges.
+     *
+     * @var array<int, string>
+     */
+    private const IPV4_DENY_RANGES = [
+        '0.0.0.0/8',          // "this" network
+        '10.0.0.0/8',         // RFC1918 private
+        '100.64.0.0/10',      // CGNAT (RFC6598)
+        '127.0.0.0/8',        // loopback
+        '169.254.0.0/16',     // link-local (incl. cloud metadata 169.254.169.254)
+        '172.16.0.0/12',      // RFC1918 private
+        '192.0.0.0/24',       // IETF protocol assignments
+        '192.0.2.0/24',       // TEST-NET-1
+        '192.168.0.0/16',     // RFC1918 private
+        '198.18.0.0/15',      // benchmarking
+        '224.0.0.0/4',        // multicast
+        '240.0.0.0/4',        // reserved
+        '255.255.255.255/32', // broadcast
+    ];
+
+    /**
+     * True when $url is safe for a server-initiated outbound request.
+     */
+    public static function isAllowedUrl(string $url): bool
+    {
+        $parsed = parse_url($url);
+
+        if ($parsed === false || empty($parsed['scheme']) || empty($parsed['host'])) {
+            return false;
+        }
+
+        if (! in_array(strtolower($parsed['scheme']), ['http', 'https'], true)) {
+            Log::warning('SSRF guard: blocked disallowed scheme', ['scheme' => $parsed['scheme']]);
+
+            return false;
+        }
+
+        $host = $parsed['host'];
+
+        // IP literal: validate directly.
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return self::isIpAllowed($host);
+        }
+
+        // Resolve every A and AAAA record; block if any single record is disallowed.
+        $ips = [];
+        foreach ((@dns_get_record($host, DNS_A) ?: []) as $record) {
+            $ips[] = $record['ip'] ?? null;
+        }
+        foreach ((@dns_get_record($host, DNS_AAAA) ?: []) as $record) {
+            $ips[] = $record['ipv6'] ?? null;
+        }
+        $ips = array_filter($ips);
+
+        if ($ips === []) {
+            Log::warning('SSRF guard: unable to resolve host', ['host' => $host]);
+
+            return false;
+        }
+
+        foreach ($ips as $ip) {
+            if (! self::isIpAllowed($ip)) {
+                Log::warning('SSRF guard: blocked private/reserved IP', ['host' => $host, 'ip' => $ip]);
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * True when an IP (v4 or v6) is a public, routable address safe to reach.
+     */
+    public static function isIpAllowed(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            // Decompose an IPv4-mapped IPv6 address (::ffff:a.b.c.d) and apply the IPv4 rules,
+            // so CGNAT/private ranges can't slip through in v6 form.
+            $packed = inet_pton($ip);
+            if ($packed !== false && strlen($packed) === 16 && str_starts_with($packed, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
+                return self::isIpv4Allowed(inet_ntop(substr($packed, 12)));
+            }
+
+            return (bool) filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+        }
+
+        return self::isIpv4Allowed($ip);
+    }
+
+    private static function isIpv4Allowed(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+            return false;
+        }
+
+        foreach (self::IPV4_DENY_RANGES as $range) {
+            if (self::ipv4InRange($ip, $range)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function ipv4InRange(string $ip, string $range): bool
+    {
+        [$subnet, $bits] = explode('/', $range);
+
+        $ipLong = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+
+        $mask = -1 << (32 - (int) $bits);
+
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+
+    /**
+     * Guzzle `allow_redirects` options that re-validate every redirect hop with the same guard,
+     * so a permitted public URL can't be used to bounce the request into an internal target.
+     *
+     * @return array<string, mixed>
+     */
+    public static function redirectOptions(): array
+    {
+        return [
+            'max' => 5,
+            'strict' => true,
+            'referer' => false,
+            'protocols' => ['http', 'https'],
+            'on_redirect' => function (RequestInterface $request, ResponseInterface $response, UriInterface $uri): void {
+                if (! self::isAllowedUrl((string) $uri)) {
+                    throw new \RuntimeException('SSRF guard: blocked redirect to disallowed URL');
+                }
+            },
+        ];
+    }
+}

--- a/app/Core/Support/OutboundUrlGuard.php
+++ b/app/Core/Support/OutboundUrlGuard.php
@@ -102,7 +102,10 @@ final class OutboundUrlGuard
             // so CGNAT/private ranges can't slip through in v6 form.
             $packed = inet_pton($ip);
             if ($packed !== false && strlen($packed) === 16 && str_starts_with($packed, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
-                return self::isIpv4Allowed(inet_ntop(substr($packed, 12)));
+                $mappedV4 = inet_ntop(substr($packed, 12));
+
+                // Fail closed if the mapped address can't be rendered back to IPv4.
+                return $mappedV4 !== false && self::isIpv4Allowed($mappedV4);
             }
 
             return (bool) filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);

--- a/app/Domain/Api/Permissions/ApiPermissions.php
+++ b/app/Domain/Api/Permissions/ApiPermissions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Leantime\Domain\Api\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The API (key management) permission vocabulary — the verbs only.
+ *
+ * Leantime API keys act as service accounts (a key IS a user row with a role), so creating,
+ * listing, and editing them is an installation-wide administrative capability — the management
+ * UI (ApiKey / NewApiKey / DelAPIKey controllers) is already `authOrRedirect([owner, admin])`.
+ * The single verb below is therefore COMPANY-WIDE (`projectScoped = false`); call sites gate with
+ * `#[RequiresPermission(ApiPermissions::MANAGE, global: true)]`, which by the default role map
+ * lands on admin/owner only.
+ *
+ * Note: authenticating WITH an existing key (getAPIKeyUser) is not gated by this — that is the
+ * auth primitive itself, invoked by the AuthCheck middleware, not a management action.
+ */
+final class ApiPermissions implements ProvidesPermissions
+{
+    /** Create, list, edit, or remove API keys / service-account credentials (company-wide). */
+    public const MANAGE = 'api.manage';
+
+    public function domain(): string
+    {
+        return 'api';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::MANAGE, 'Manage API keys', false),
+        ];
+    }
+}

--- a/app/Domain/Api/Services/Api.php
+++ b/app/Domain/Api/Services/Api.php
@@ -6,8 +6,10 @@ use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Domain\Api\Contracts\StaticAssetType;
+use Leantime\Domain\Api\Permissions\ApiPermissions;
 use Leantime\Domain\Api\Repositories\Api as ApiRepository;
 use Leantime\Domain\Auth\Services\UserSessionBuilder;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
@@ -120,6 +122,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function createAPIKey(array $values): bool|array
     {
         $user = $this->randomStr(32);
@@ -148,6 +151,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function getApiKeyFormValues(int $id): array
     {
         if ($id <= 0) {
@@ -186,6 +190,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function updateApiKey(int $id, array $postValues, ?array $projects): bool
     {
         if ($id <= 0) {
@@ -227,6 +232,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function createApiKeyWithProjects(array $values, ?array $projects): array|false
     {
         $apiKeyValues = $this->createAPIKey($values);
@@ -270,6 +276,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function getProjectRelationIds(int $id): array
     {
         $projects = $this->projectRepo->getUserProjectRelation($id);
@@ -322,6 +329,7 @@ class Api
      *
      * @api
      */
+    #[RequiresPermission(ApiPermissions::MANAGE, global: true)]
     public function getAPIKeys(): false|array
     {
         $keys = $this->userRepo->getAllBySource('api');

--- a/app/Domain/Auth/Repositories/Auth.php
+++ b/app/Domain/Auth/Repositories/Auth.php
@@ -103,6 +103,7 @@ class Auth
         return $this->db->table('zp_user')
             ->where('pwReset', $hash)
             ->where('status', 'like', 'a')
+            ->where('pwResetExpiration', '>=', now())
             ->exists();
     }
 
@@ -126,7 +127,8 @@ class Auth
             ->where('username', $username)
             ->update([
                 'pwReset' => $resetLink,
-                'pwResetExpiration' => now(),
+                // Store the EXPIRY moment (not creation): the reset link is valid for 1 hour.
+                'pwResetExpiration' => now()->addHours(1),
                 'pwResetCount' => $this->db->raw('COALESCE('.$this->dbHelper->wrapColumn('pwResetCount').', 0) + 1'),
             ]) >= 0;
     }
@@ -145,6 +147,7 @@ class Auth
 
         $userId = $this->db->table('zp_user')
             ->where('pwReset', $hash)
+            ->where('pwResetExpiration', '>=', now())
             ->value('id');
 
         if (empty($userId)) {

--- a/app/Domain/Calendar/Services/Calendar.php
+++ b/app/Domain/Calendar/Services/Calendar.php
@@ -12,6 +12,7 @@ use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Events\EventDispatcher;
 use Leantime\Core\Exceptions\MissingParameterException;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Core\Support\OutboundUrlGuard;
 use Leantime\Domain\Calendar\Permissions\CalendarPermissions;
 use Leantime\Domain\Calendar\Repositories\Calendar as CalendarRepository;
 use Leantime\Domain\Setting\Repositories\Setting;
@@ -846,148 +847,6 @@ class Calendar extends BaseService
     }
 
     /**
-     * Validates that a URL is safe to fetch, preventing SSRF attacks.
-     *
-     * Checks that the URL uses an allowed scheme (http/https) and that
-     * the resolved IP address is not in a private or reserved range.
-     *
-     * @param  string  $url  The URL to validate.
-     * @return bool True if the URL is safe to fetch, false otherwise.
-     */
-    private function isUrlSafe(string $url): bool
-    {
-        $parsed = parse_url($url);
-
-        if ($parsed === false || ! isset($parsed['scheme']) || ! isset($parsed['host'])) {
-            return false;
-        }
-
-        // Only allow http and https schemes
-        $allowedSchemes = ['http', 'https'];
-        if (! in_array(strtolower($parsed['scheme']), $allowedSchemes, true)) {
-            Log::warning('Calendar SSRF protection: blocked disallowed scheme', [
-                'scheme' => $parsed['scheme'],
-                'url' => $url,
-            ]);
-
-            return false;
-        }
-
-        // Resolve hostname and validate ALL returned IP addresses (A and AAAA records).
-        // This prevents bypasses via multi-homed hosts where one IP is public and another is private.
-        $host = $parsed['host'];
-
-        // If the host is already an IP literal, validate it directly
-        if (filter_var($host, FILTER_VALIDATE_IP)) {
-            if (! $this->isIpAllowed($host)) {
-                Log::warning('Calendar SSRF protection: blocked IP literal', ['ip' => $host]);
-
-                return false;
-            }
-
-            return true;
-        }
-
-        // Resolve all A (IPv4) and AAAA (IPv6) records
-        $ipv4Records = @dns_get_record($host, DNS_A) ?: [];
-        $ipv6Records = @dns_get_record($host, DNS_AAAA) ?: [];
-
-        $allIps = [];
-        foreach ($ipv4Records as $record) {
-            $allIps[] = $record['ip'] ?? null;
-        }
-        foreach ($ipv6Records as $record) {
-            $allIps[] = $record['ipv6'] ?? null;
-        }
-
-        $allIps = array_filter($allIps);
-
-        if (empty($allIps)) {
-            Log::warning('Calendar SSRF protection: unable to resolve hostname', ['host' => $host]);
-
-            return false;
-        }
-
-        // Every resolved IP must be allowed — block if any single record is private/reserved
-        foreach ($allIps as $ip) {
-            if (! $this->isIpAllowed($ip)) {
-                Log::warning('Calendar SSRF protection: blocked private/reserved IP', [
-                    'host' => $host,
-                    'resolved_ip' => $ip,
-                ]);
-
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Checks whether an IP address (IPv4 or IPv6) is allowed for outbound requests.
-     *
-     * Rejects loopback, private, reserved, and link-local addresses.
-     * Uses PHP's built-in FILTER_VALIDATE_IP flags for IPv6 and manual CIDR checks for IPv4.
-     *
-     * @param  string  $ip  The IP address to validate.
-     * @return bool True if the IP is safe for outbound requests.
-     */
-    private function isIpAllowed(string $ip): bool
-    {
-        // IPv6 validation using PHP's built-in filters
-        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-            // Reject any IPv6 address that is loopback, private, or reserved
-            if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                return false;
-            }
-
-            return true;
-        }
-
-        // IPv4 CIDR range checks
-        $denyRanges = [
-            '127.0.0.0/8',      // Loopback
-            '10.0.0.0/8',       // Private (Class A)
-            '172.16.0.0/12',    // Private (Class B)
-            '192.168.0.0/16',   // Private (Class C)
-            '169.254.0.0/16',   // Link-local
-            '0.0.0.0/8',       // Current network
-        ];
-
-        foreach ($denyRanges as $range) {
-            if ($this->ipInRange($ip, $range)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Checks whether an IPv4 address falls within a given CIDR range.
-     *
-     * @param  string  $ip  The IPv4 address to check.
-     * @param  string  $range  The CIDR range (e.g. "10.0.0.0/8").
-     * @return bool True if the IP is within the range, false otherwise.
-     */
-    private function ipInRange(string $ip, string $range): bool
-    {
-        [$subnet, $bits] = explode('/', $range);
-
-        $ipLong = ip2long($ip);
-        $subnetLong = ip2long($subnet);
-
-        if ($ipLong === false || $subnetLong === false) {
-            return false;
-        }
-
-        $mask = -1 << (32 - (int) $bits);
-        $subnetLong &= $mask;
-
-        return ($ipLong & $mask) === $subnetLong;
-    }
-
-    /**
      * Load an iCal URL and return its contents.
      *
      * Validates the URL against SSRF attacks before making the request.
@@ -1003,7 +862,7 @@ class Calendar extends BaseService
             $url = str_replace('webcal://', 'https://', $url);
         }
 
-        if (! $this->isUrlSafe($url)) {
+        if (! OutboundUrlGuard::isAllowedUrl($url)) {
             throw new \Exception('Refused to fetch iCal feed: URL failed SSRF safety check');
         }
 
@@ -1011,6 +870,7 @@ class Calendar extends BaseService
 
         try {
             $response = $client->get($url, [
+                'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                 'headers' => [
                     'Accept' => 'text/calendar',
                     'User-Agent' => 'Leantime Calendar Integration v'.$this->config->appVersion,

--- a/app/Domain/Canvas/Templates/element.blade.php
+++ b/app/Domain/Canvas/Templates/element.blade.php
@@ -51,7 +51,7 @@
                                data="item_{{ $row['id'] }}">{{ $row['description'] }}</a></h4>
 
                         @if($row['conclusion'] != '')
-                            <small>{!! $tpl->convertRelativePaths($row['conclusion']) !!}</small>
+                            <small>{!! $tpl->convertRelativePaths($tpl->escapeMinimal($row['conclusion'])) !!}</small>
                         @endif
 
                         <div class="clearfix" style="padding-bottom: 8px;"></div>

--- a/app/Domain/Canvas/Templates/element.blade.php
+++ b/app/Domain/Canvas/Templates/element.blade.php
@@ -51,7 +51,7 @@
                                data="item_{{ $row['id'] }}">{{ $row['description'] }}</a></h4>
 
                         @if($row['conclusion'] != '')
-                            <small>{!! $tpl->convertRelativePaths($tpl->escapeMinimal($row['conclusion'])) !!}</small>
+                            <small>{!! $tpl->escapeMinimal($row['conclusion']) !!}</small>
                         @endif
 
                         <div class="clearfix" style="padding-bottom: 8px;"></div>

--- a/app/Domain/Connector/Permissions/ConnectorPermissions.php
+++ b/app/Domain/Connector/Permissions/ConnectorPermissions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Leantime\Domain\Connector\Permissions;
+
+use Leantime\Core\Auth\Permissions\Permission;
+use Leantime\Core\Auth\Permissions\ProvidesPermissions;
+
+/**
+ * The Connector (integrations / import) permission vocabulary — the verbs only.
+ *
+ * Connector integrations hold stored third-party credentials and drive data import, so reading,
+ * creating, editing, and deleting them is an installation-wide administrative capability. The
+ * single verb below is COMPANY-WIDE (`projectScoped = false`); call sites gate with
+ * `#[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]`, which by the default role
+ * map lands on admin/owner only.
+ */
+final class ConnectorPermissions implements ProvidesPermissions
+{
+    /** Read, create, edit, delete, or import connector integrations (company-wide). */
+    public const MANAGE = 'connector.manage';
+
+    public function domain(): string
+    {
+        return 'connector';
+    }
+
+    public function permissions(): array
+    {
+        return [
+            new Permission(self::MANAGE, 'Manage integrations', false),
+        ];
+    }
+}

--- a/app/Domain/Connector/Services/Integrations.php
+++ b/app/Domain/Connector/Services/Integrations.php
@@ -3,7 +3,9 @@
 namespace Leantime\Domain\Connector\Services;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Domain\Connector\Models\Integration as IntegrationModel;
+use Leantime\Domain\Connector\Permissions\ConnectorPermissions;
 use Leantime\Domain\Connector\Repositories\Integrations as IntegrationsRepo;
 use Leantime\Domain\Connector\Repositories\LeantimeEntities;
 
@@ -33,6 +35,7 @@ class Integrations
      * @throws BindingResolutionException
      * @throws \ReflectionException
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function get(int $id): object|array|false
     {
         return $this->integrationRepo->get($id);
@@ -43,6 +46,7 @@ class Integrations
      *
      * @api
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function updateTicket(object|array $object): bool
     {
         // TODO: Implement update() method.
@@ -56,6 +60,7 @@ class Integrations
      *
      * @throws \ReflectionException
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function create(object|array $object): int|false
     {
         return $this->integrationRepo->insert($object);
@@ -66,6 +71,7 @@ class Integrations
      *
      * @api
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function delete(int $id): bool
     {
         // TODO: Implement delete() method.
@@ -77,6 +83,7 @@ class Integrations
      *
      * @api
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function getAll(?array $searchparams = null): array|false
     {
         // TODO: Implement getAll() method.
@@ -91,6 +98,7 @@ class Integrations
      * @param  int  $id  Integration id
      * @param  array  $params  Column => value pairs to update
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function patch(int $id, array $params): bool
     {
         return $this->integrationRepo->patch($id, $params);
@@ -103,6 +111,7 @@ class Integrations
      *
      * @return array Map of entity key => entity definition
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function getAvailableEntities(): array
     {
         return $this->leantimeEntities->availableLeantimeEntities;
@@ -116,6 +125,7 @@ class Integrations
      * @param  string  $entity  Entity key (e.g. tickets, projects, users)
      * @return array Map of field key => field definition
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function getEntityFields(string $entity): array
     {
         return $this->leantimeEntities->availableLeantimeEntities[$entity]['fields'] ?? [];
@@ -135,6 +145,7 @@ class Integrations
      * @param  IntegrationModel  $currentIntegration  Integration model to hydrate with the resolved entity
      * @return string|null The resolved entity key, or null when no entity could be determined
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function resolveImportEntity(array $request, IntegrationModel $currentIntegration): ?string
     {
         if (isset($request['leantimeEntities'])) {
@@ -165,6 +176,7 @@ class Integrations
      * @param  object  $provider  Provider instance exposing getFields()
      * @return array List of provider field identifiers
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function resolveProviderFields(IntegrationModel $currentIntegration, object $provider): array
     {
         if (isset($currentIntegration->fields) && $currentIntegration->fields != '') {
@@ -184,6 +196,7 @@ class Integrations
      *
      * @return array{values: array, fields: array} The decoded values and field mappings
      */
+    #[RequiresPermission(ConnectorPermissions::MANAGE, global: true)]
     public function getCachedImportPayload(): array
     {
         return [

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -91,6 +91,7 @@ class Install
         // covered by SchemaBuilder + setupDB().
         30518,
         30519,
+        30520,
     ];
 
     /**
@@ -2795,6 +2796,48 @@ class Install
             Log::error('Migration 30519: '.$e->getMessage());
 
             return ['Migration 30519 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * Migration 30520 — grant the new api.manage and connector.manage capabilities to existing
+     * installs. The API-key management and Connector integration surfaces are now permission-gated;
+     * fresh installs pick these up through the built-in seed, but installs already on the permission
+     * engine have no row for the new keys — which would deny everyone, including admins. Sync the
+     * vocabulary and grant both keys to admin + owner only (targeted grant, not a full reseed, so
+     * any custom role edits/revocations are preserved).
+     */
+    public function update_sql_30520(): bool|array
+    {
+        try {
+            app(\Leantime\Core\Auth\Permissions\PermissionRegistry::class)->flush();
+
+            $seeder = app(\Leantime\Core\Auth\Permissions\PermissionSeeder::class);
+            $seeder->syncDiscoveredPermissions();
+
+            $repo = app(\Leantime\Core\Auth\Permissions\PermissionRepository::class);
+            $keys = [
+                \Leantime\Domain\Api\Permissions\ApiPermissions::MANAGE,
+                \Leantime\Domain\Connector\Permissions\ConnectorPermissions::MANAGE,
+            ];
+
+            foreach (['admin', 'owner'] as $roleName) {
+                $role = $repo->getRoleByName($roleName);
+
+                if ($role !== null) {
+                    foreach ($keys as $key) {
+                        $repo->grant((int) $role['id'], $key);
+                    }
+                }
+            }
+
+            app(\Leantime\Core\Auth\Permissions\PermissionService::class)->flushCache();
+        } catch (\Exception $e) {
+            Log::error('Migration 30520: '.$e->getMessage());
+
+            return ['Migration 30520 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Ldap/Services/Ldap.php
+++ b/app/Domain/Ldap/Services/Ldap.php
@@ -156,7 +156,7 @@ class Ldap
                 }
             } else {
                 // OL requires distinguished name login
-                $usernameDN = $this->ldapKeys->username.'='.$username.','.$this->ldapDn;
+                $usernameDN = $this->ldapKeys->username.'='.ldap_escape($username, '', LDAP_ESCAPE_DN).','.$this->ldapDn;
 
                 $bind = @ldap_bind($this->ldapConnection, $usernameDN, $passwordBind);
             }
@@ -183,7 +183,7 @@ class Ldap
 
             return '';
         }
-        $filter = '('.$this->ldapKeys->username.'='.$this->extractLdapFromUsername($username).')';
+        $filter = '('.$this->ldapKeys->username.'='.ldap_escape($this->extractLdapFromUsername($username), '', LDAP_ESCAPE_FILTER).')';
 
         $attr = [$this->ldapKeys->groups, $this->ldapKeys->firstname, $this->ldapKeys->lastname, $this->ldapKeys->email];
 
@@ -210,7 +210,7 @@ class Ldap
             return false;
         }
 
-        $filter = '('.$this->ldapKeys->username.'='.$this->extractLdapFromUsername($username).')';
+        $filter = '('.$this->ldapKeys->username.'='.ldap_escape($this->extractLdapFromUsername($username), '', LDAP_ESCAPE_FILTER).')';
 
         $attr = [$this->ldapKeys->groups, $this->ldapKeys->firstname, $this->ldapKeys->lastname, $this->ldapKeys->email, $this->ldapKeys->phone, $this->ldapKeys->jobTitle, $this->ldapKeys->jobLevel, $this->ldapKeys->department];
 

--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -4,7 +4,6 @@ namespace Leantime\Domain\Notifications\Services;
 
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Facades\Log;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\OutboundUrlGuard;
@@ -88,7 +87,7 @@ class Messengers
 
             try {
                 if (! OutboundUrlGuard::isAllowedUrl($slackWebhookURL)) {
-                    Log::warning('Blocked Slack webhook to disallowed URL (SSRF guard)', ['url' => $slackWebhookURL]);
+                    Log::warning('Blocked Slack webhook to disallowed URL (SSRF guard)', ['host' => parse_url($slackWebhookURL, PHP_URL_HOST)]);
 
                     return false;
                 }
@@ -100,7 +99,7 @@ class Messengers
                 ]);
 
                 return true;
-            } catch (GuzzleException $e) {
+            } catch (\Throwable $e) {
                 report($e);
 
                 return false;
@@ -135,7 +134,7 @@ class Messengers
 
             try {
                 if (! OutboundUrlGuard::isAllowedUrl($mattermostWebhookURL)) {
-                    Log::warning('Blocked Mattermost webhook to disallowed URL (SSRF guard)', ['url' => $mattermostWebhookURL]);
+                    Log::warning('Blocked Mattermost webhook to disallowed URL (SSRF guard)', ['host' => parse_url($mattermostWebhookURL, PHP_URL_HOST)]);
 
                     return false;
                 }
@@ -191,7 +190,7 @@ class Messengers
 
             try {
                 if (! OutboundUrlGuard::isAllowedUrl($curlUrl)) {
-                    Log::warning('Blocked Zulip webhook to disallowed URL (SSRF guard)', ['url' => $curlUrl]);
+                    Log::warning('Blocked Zulip webhook to disallowed URL (SSRF guard)', ['host' => parse_url($curlUrl, PHP_URL_HOST)]);
 
                     return false;
                 }
@@ -207,7 +206,7 @@ class Messengers
                 ]);
 
                 return true;
-            } catch (GuzzleException $e) {
+            } catch (\Throwable $e) {
                 report($e);
 
                 return false;
@@ -270,7 +269,7 @@ class Messengers
 
                 try {
                     if (! OutboundUrlGuard::isAllowedUrl($discordWebhookURL)) {
-                        Log::warning('Blocked Discord webhook to disallowed URL (SSRF guard)', ['url' => $discordWebhookURL]);
+                        Log::warning('Blocked Discord webhook to disallowed URL (SSRF guard)', ['host' => parse_url($discordWebhookURL, PHP_URL_HOST)]);
 
                         return false;
                     }
@@ -280,7 +279,7 @@ class Messengers
                         'body' => $data_string,
                         'headers' => ['Content-Type' => 'application/json'],
                     ]);
-                } catch (GuzzleException $e) {
+                } catch (\Throwable $e) {
                     report($e);
 
                     return false;

--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -5,7 +5,9 @@ namespace Leantime\Domain\Notifications\Services;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Log;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Core\Support\OutboundUrlGuard;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Tickets\Services\Tickets;
@@ -85,7 +87,14 @@ class Messengers
             $data_string = json_encode($data);
 
             try {
+                if (! OutboundUrlGuard::isAllowedUrl($slackWebhookURL)) {
+                    Log::warning('Blocked Slack webhook to disallowed URL (SSRF guard)', ['url' => $slackWebhookURL]);
+
+                    return false;
+                }
+
                 $this->httpClient->post($slackWebhookURL, [
+                    'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                     'body' => $data_string,
                     'headers' => ['Content-Type' => 'application/json'],
                 ]);
@@ -125,7 +134,14 @@ class Messengers
             $data_string = json_encode($data);
 
             try {
+                if (! OutboundUrlGuard::isAllowedUrl($mattermostWebhookURL)) {
+                    Log::warning('Blocked Mattermost webhook to disallowed URL (SSRF guard)', ['url' => $mattermostWebhookURL]);
+
+                    return false;
+                }
+
                 $this->httpClient->post($mattermostWebhookURL, [
+                    'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                     'body' => $data_string,
                 ]);
 
@@ -174,7 +190,14 @@ class Messengers
             $data_string = json_encode($data);
 
             try {
+                if (! OutboundUrlGuard::isAllowedUrl($curlUrl)) {
+                    Log::warning('Blocked Zulip webhook to disallowed URL (SSRF guard)', ['url' => $curlUrl]);
+
+                    return false;
+                }
+
                 $this->httpClient->post($curlUrl, [
+                    'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                     'body' => $data_string,
                     'headers' => ['Content-Type' => 'application/json'],
                     'auth' => [
@@ -246,7 +269,14 @@ class Messengers
                 ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
                 try {
+                    if (! OutboundUrlGuard::isAllowedUrl($discordWebhookURL)) {
+                        Log::warning('Blocked Discord webhook to disallowed URL (SSRF guard)', ['url' => $discordWebhookURL]);
+
+                        return false;
+                    }
+
                     $this->httpClient->post($discordWebhookURL, [
+                        'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                         'body' => $data_string,
                         'headers' => ['Content-Type' => 'application/json'],
                     ]);

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -759,7 +759,9 @@ class Tickets extends BaseService
 
                             break;
                         case 'sprint':
-                            $label = $ticket['sprintName'];
+                            // Rendered raw ({!! !!}) in the kanban swimlane header, so escape the
+                            // user-controlled sprint name to prevent stored XSS.
+                            $label = htmlspecialchars((string) $ticket['sprintName'], ENT_QUOTES);
                             if ($label == '') {
                                 $label = 'Not assigned to a sprint';
                             }
@@ -770,7 +772,8 @@ class Tickets extends BaseService
                             break;
                         case 'dependingTicketId':
                             if ($ticket['dependingTicketId'] > 0 && ! empty($ticket['parentHeadline'])) {
-                                $label = $ticket['parentHeadline'];
+                                // Rendered raw in the swimlane header — escape the user headline.
+                                $label = htmlspecialchars((string) $ticket['parentHeadline'], ENT_QUOTES);
                                 $sortId = 'a_'.strtolower($ticket['parentHeadline']);
                             } else {
                                 $label = $this->language->__('label.no_parent_task');
@@ -778,7 +781,7 @@ class Tickets extends BaseService
                             }
                             break;
                         default:
-                            $label = $groupedFieldValue;
+                            $label = htmlspecialchars((string) $groupedFieldValue, ENT_QUOTES);
                             break;
                     }
 
@@ -2267,7 +2270,7 @@ class Tickets extends BaseService
         if ($this->ticketRepository->updateTicket($values, $values['id']) === true) {
             $subject = sprintf($this->language->__('email_notifications.todo_update_subject'), $values['id'], strip_tags($values['headline']));
             $actual_link = BASE_URL.'/dashboard/home#/tickets/showTicket/'.$values['id'];
-            $message = sprintf($this->language->__('email_notifications.todo_update_message'), session('userdata.name'), $values['headline']);
+            $message = sprintf($this->language->__('email_notifications.todo_update_message'), session('userdata.name'), strip_tags($values['headline']));
 
             $notification = new NotificationModel;
             $notification->url = [
@@ -2510,6 +2513,13 @@ class Tickets extends BaseService
             return false;
         }
 
+        // Reassigning a ticket to a different project requires edit rights in the TARGET project,
+        // not just the source (which the @api callers already authorized). Without this a user
+        // could move/inject a ticket into a project they have no access to.
+        if (isset($params['projectId']) && (int) $params['projectId'] !== (int) $ticket->projectId) {
+            $this->authorize(TicketsPermissions::EDIT, (int) $params['projectId']);
+        }
+
         // Handle collaborators separately since they live in the relationship table, not on zp_tickets
         $collaboratorsUpdated = false;
         if (array_key_exists('collaborators', $params)) {
@@ -2572,7 +2582,10 @@ class Tickets extends BaseService
             return false;
         }
 
+        // Edit rights in BOTH the source project (above) and the TARGET project — otherwise a
+        // user with access to project A could inject tickets into project B they can't touch.
         $this->authorize(TicketsPermissions::EDIT, (int) $ticket->projectId);
+        $this->authorize(TicketsPermissions::EDIT, $projectId);
 
         if ($ticket->type == 'milestone') {
             $milestoneTickets = $this->getAll(['milestone' => $ticket->id]);

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -761,7 +761,7 @@ class Tickets extends BaseService
                         case 'sprint':
                             // Rendered raw ({!! !!}) in the kanban swimlane header, so escape the
                             // user-controlled sprint name to prevent stored XSS.
-                            $label = htmlspecialchars((string) $ticket['sprintName'], ENT_QUOTES);
+                            $label = htmlspecialchars((string) $ticket['sprintName'], ENT_QUOTES, 'UTF-8');
                             if ($label == '') {
                                 $label = 'Not assigned to a sprint';
                             }
@@ -773,15 +773,15 @@ class Tickets extends BaseService
                         case 'dependingTicketId':
                             if ($ticket['dependingTicketId'] > 0 && ! empty($ticket['parentHeadline'])) {
                                 // Rendered raw in the swimlane header — escape the user headline.
-                                $label = htmlspecialchars((string) $ticket['parentHeadline'], ENT_QUOTES);
-                                $sortId = 'a_'.strtolower($ticket['parentHeadline']);
+                                $label = htmlspecialchars((string) $ticket['parentHeadline'], ENT_QUOTES, 'UTF-8');
+                                $sortId = 'a_'.preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower((string) $ticket['parentHeadline']));
                             } else {
                                 $label = $this->language->__('label.no_parent_task');
                                 $sortId = 'zzz_no_parent';
                             }
                             break;
                         default:
-                            $label = htmlspecialchars((string) $groupedFieldValue, ENT_QUOTES);
+                            $label = htmlspecialchars((string) $groupedFieldValue, ENT_QUOTES, 'UTF-8');
                             break;
                     }
 

--- a/app/Domain/Tickets/Templates/roadmap.blade.php
+++ b/app/Domain/Tickets/Templates/roadmap.blade.php
@@ -142,7 +142,7 @@
                             dependencies :'".implode(',', $dependencyList)."',
                             custom_class :'',
                             type: '".strtolower($mlst->type)."',
-                            bg_color: '".$color."',
+                            bg_color: ".json_encode($color, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP).",
                             thumbnail: '".BASE_URL.'/api/users?profileImage='.$mlst->editorId."',
                             sortIndex: ".$sortIndex.'
                         },';

--- a/app/Domain/Tickets/Templates/roadmap.blade.php
+++ b/app/Domain/Tickets/Templates/roadmap.blade.php
@@ -135,7 +135,7 @@
 
                 echo "{
                             id :'".$mlst->id."',
-                            name :".json_encode($headline).",
+                            name :".json_encode($headline, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP).",
                             start :'".(dtHelper()->isValidDateString($mlst->editFrom) ? $mlst->editFrom : dtHelper()->userNow()->addDays(2)->format('Y-m-d'))."',
                             end :'".(dtHelper()->isValidDateString($mlst->editTo) ? $mlst->editTo : dtHelper()->userNow()->addDays(2)->format('Y-m-d'))."',
                             progress :'".format($mlst->percentDone)->decimal()."',

--- a/app/Domain/Widgets/Templates/partials/todoItem.blade.php
+++ b/app/Domain/Widgets/Templates/partials/todoItem.blade.php
@@ -13,7 +13,7 @@
         'color' =>   'var(--accent2)',
         'enitityType' =>  'ticket',
         'url' =>  BASE_URL.'#/tickets/showTicket/'.$ticket['id'],
-    ]);
+    ], JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP);
 
     $hasChildren = !empty($ticket['children']);
 @endphp

--- a/tests/Unit/app/Core/Support/OutboundUrlGuardTest.php
+++ b/tests/Unit/app/Core/Support/OutboundUrlGuardTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Unit\app\Core\Support;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+use Leantime\Core\Support\OutboundUrlGuard;
+use Unit\TestCase;
+
+/**
+ * Covers the SSRF guard's address classification and redirect re-validation using IP literals and
+ * direct calls, so nothing here depends on live DNS or the network.
+ */
+class OutboundUrlGuardTest extends TestCase
+{
+    /**
+     * @dataProvider ipProvider
+     */
+    public function test_is_ip_allowed(string $ip, bool $expected): void
+    {
+        $this->assertSame($expected, OutboundUrlGuard::isIpAllowed($ip));
+    }
+
+    public static function ipProvider(): array
+    {
+        return [
+            'loopback v4' => ['127.0.0.1', false],
+            'private 10/8' => ['10.1.2.3', false],
+            'private 172.16/12' => ['172.16.5.5', false],
+            'private 192.168/16' => ['192.168.1.1', false],
+            'cgnat 100.64/10' => ['100.64.0.1', false],
+            'link-local metadata' => ['169.254.169.254', false],
+            'reserved 0.0.0.0/8' => ['0.0.0.0', false],
+            'public v4 (google dns)' => ['8.8.8.8', true],
+            'public v4 (cloudflare)' => ['1.1.1.1', true],
+            'loopback v6' => ['::1', false],
+            'public v6 (cloudflare)' => ['2606:4700:4700::1111', true],
+            'ipv4-mapped loopback' => ['::ffff:127.0.0.1', false],
+            'ipv4-mapped cgnat' => ['::ffff:100.64.0.1', false],
+            'ipv4-mapped public' => ['::ffff:8.8.8.8', true],
+        ];
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function test_is_allowed_url(string $url, bool $expected): void
+    {
+        $this->assertSame($expected, OutboundUrlGuard::isAllowedUrl($url));
+    }
+
+    public static function urlProvider(): array
+    {
+        return [
+            'loopback literal' => ['http://127.0.0.1/feed.ics', false],
+            'cgnat literal' => ['http://100.64.0.1/', false],
+            'metadata literal' => ['http://169.254.169.254/latest/meta-data/', false],
+            'public literal' => ['https://8.8.8.8/', true],
+            'non-http scheme' => ['ftp://8.8.8.8/', false],
+            'file scheme' => ['file:///etc/passwd', false],
+            'garbage' => ['not-a-url', false],
+        ];
+    }
+
+    public function test_redirect_options_block_disallowed_hop(): void
+    {
+        $onRedirect = OutboundUrlGuard::redirectOptions()['on_redirect'];
+
+        $this->expectException(\RuntimeException::class);
+
+        $onRedirect(new Request('GET', 'https://8.8.8.8/'), new Response(302), new Uri('http://169.254.169.254/'));
+    }
+
+    public function test_redirect_options_allow_public_hop(): void
+    {
+        $onRedirect = OutboundUrlGuard::redirectOptions()['on_redirect'];
+
+        // A public → public redirect must not throw.
+        $onRedirect(new Request('GET', 'https://8.8.8.8/'), new Response(302), new Uri('https://1.1.1.1/'));
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Hardening batch for the still-open items found in the security-advisory triage sweep (the rest were already fixed or are duplicates of fixed issues). Scoped to discrete, self-contained fixes.

## Authorization (JSON-RPC + HTMX)
- **`api.manage`** permission gating the API-key management surface (create / update / list / form-values / project-relations) — a non-admin could previously mint an owner-level API-key account via JSON-RPC.
- **`connector.manage`** permission gating all Connector `Integrations` methods (they read/write stored third-party credentials).
- **`moveTicket` / `patchTicket`** now authorize the **target** project on reassignment, not just the source (blocks cross-project ticket injection).

## SSRF
- New shared **`OutboundUrlGuard`**: http/https only, resolves every A/AAAA record, blocks loopback / private / link-local (cloud metadata) / **CGNAT (100.64.0.0/10)** / reserved, and **re-validates every redirect hop**.
- Applied to the external-calendar (iCal) fetch (adds the missing CGNAT range + redirect protection) and to the **Slack/Mattermost/Zulip/Discord webhook** posts (previously unguarded).

## Auth flow
- **Password-reset token expiration** now enforced (1-hour TTL) in both `validateResetLink` and `changePW`; the expiry moment is stored at link creation. (Existing/older tokens become invalid on upgrade — users just request a new link.)
- **LDAP** search filters and the bind DN are now escaped with `ldap_escape()`.

## Stored XSS
Escaped five sinks: ToDo-widget `data-event` JSON (HEX flags), roadmap milestone color, kanban sprint/parent-task labels, the ticket update-notification email body, and the canvas conclusion field.

## Migration / rollout
`update_sql_30520` grants `api.manage` + `connector.manage` to admin/owner on existing installs (targeted grant — custom role edits preserved); fresh installs get them via the built-in seed.

**Merge note:** this stacks on the `plugins.manage` PR (migration `30519`). If they land out of order, keep both migration numbers in the `$dbUpdates` list.

## Deferred (need maintainer policy, called out for follow-up)
- **Re-enabling global CSRF** — currently disabled because ~82 legacy `.tpl.php` forms lack tokens; re-enabling requires tokenizing them first (destructive-GET → POST conversions too). Large separate effort.
- **Host-header / open-redirect hardening** — only exploitable when `LEAN_APP_URL` is unset; forcing `appUrl` would break the many self-hosted installs that rely on Host-derived `BASE_URL`.

## Verification
- Permission grant matrix confirmed: `api.manage`/`connector.manage` → admin + owner only (editor/manager excluded).
- SSRF guard verified: blocks metadata / CGNAT / loopback / ftp, allows public.
- Pint + `php -l` clean; affected unit tests pass (Tickets, Calendar, PermissionEnforcer, DefaultRolePermissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
