### PR TITLE
fix(mcp): repair runtime bugs in domain tools found in live e2e testing

### DIFF
--- a/.phpstan/phpstan.neon
+++ b/.phpstan/phpstan.neon
@@ -14,9 +14,6 @@ parameters:
         - ../.phpstan/Rules
     excludePaths:
         - ../app/Plugins/*
-        # MCP tool classes extend Laravel\Mcp\Server\Tool which is not installed
-        # until `composer require laravel/mcp`. Remove this exclusion after install.
-        - ../app/Domain/*/Tools/*
     scanDirectories:
         - ../vendor
         - ../config

--- a/app/Core/Configuration/DefaultConfig.php
+++ b/app/Core/Configuration/DefaultConfig.php
@@ -555,4 +555,10 @@ class DefaultConfig
      * @var int rate limit on auth requests
      */
     public int $ratelimitAuth = 20;
+
+    /**
+     * @var int rate limit on MCP endpoint requests (per user+IP per minute). Higher than the API
+     *          limit because agentic LLM clients burst many parallel tool calls per turn.
+     */
+    public int $ratelimitMcp = 300;
 }

--- a/app/Core/Http/IncomingRequest.php
+++ b/app/Core/Http/IncomingRequest.php
@@ -196,6 +196,20 @@ class IncomingRequest extends \Illuminate\Http\Request
     }
 
     /**
+     * Determines whether the current request targets the MCP server endpoint.
+     *
+     * @return bool Returns true if the request is an MCP request, false otherwise.
+     */
+    public function isMcpRequest(): bool
+    {
+        $requestUri = strtolower($this->getRequestUri());
+
+        return $requestUri === '/mcp'
+            || str_starts_with($requestUri, '/mcp/')
+            || str_starts_with($requestUri, '/mcp?');
+    }
+
+    /**
      * Determines whether the current request is an Htmx request.
      *
      * @return bool Returns true if the request is an Htmx request, false otherwise.

--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -4,6 +4,7 @@ namespace Leantime\Core\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthManager;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -56,6 +57,16 @@ class AuthCheck
 
         if ($this->isPublicController($request->getCurrentRoute())) {
             return $next($request);
+        }
+
+        // Throttle credential brute force on token-authenticated endpoints (/api, /mcp). This
+        // must live here rather than in RequestRateLimiter: that middleware runs AFTER AuthCheck,
+        // so a failed-auth 401 short-circuits the pipeline before any request limit is counted.
+        if ($request instanceof ApiRequest && $this->tooManyFailedAuthAttempts($request)) {
+            return new Response(
+                json_encode(['error' => 'Too many failed authentication attempts. Try again later.']),
+                Response::HTTP_TOO_MANY_REQUESTS
+            );
         }
 
         $loginRedirect = self::dispatch_filter('loginRoute', 'auth.login', ['request' => $request]);
@@ -111,6 +122,7 @@ class AuthCheck
 
         if (! $authenticated && ! $response) {
             if ($request instanceof APIRequest) {
+                $this->hitFailedAuthLimiter($request);
                 $response = new Response(json_encode(['error' => 'Invalid API Key']), 401);
             } else {
                 $response = $this->redirectWithOrigin($loginRedirect, $request->getRequestUri(), $request) ?: $next($request);
@@ -169,7 +181,36 @@ class AuthCheck
             }
         }
 
+        $this->hitFailedAuthLimiter($request);
+
         return new Response(json_encode(['error' => 'Unauthorized']), 401);
+    }
+
+    /**
+     * Whether this client IP has exceeded the failed-authentication budget (shared with the
+     * login attempt limit, LEAN_RATELIMIT_AUTH). Counted per minute.
+     */
+    protected function tooManyFailedAuthAttempts(IncomingRequest $request): bool
+    {
+        $limit = $this->config->ratelimitAuth ?? 20;
+
+        return app(RateLimiter::class)->tooManyAttempts($this->failedAuthKey($request), $limit);
+    }
+
+    /**
+     * Record a failed authentication attempt for this client IP (1-minute decay).
+     */
+    protected function hitFailedAuthLimiter(IncomingRequest $request): void
+    {
+        app(RateLimiter::class)->hit($this->failedAuthKey($request), 60);
+    }
+
+    /**
+     * Rate limiter key for failed token-auth attempts, scoped to the client IP.
+     */
+    protected function failedAuthKey(IncomingRequest $request): string
+    {
+        return 'api-auth-failures:'.$request->getClientIp();
     }
 
     /**

--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -121,7 +121,7 @@ class AuthCheck
         }
 
         if (! $authenticated && ! $response) {
-            if ($request instanceof APIRequest) {
+            if ($request instanceof ApiRequest) {
                 $this->hitFailedAuthLimiter($request);
                 $response = new Response(json_encode(['error' => 'Invalid API Key']), 401);
             } else {

--- a/app/Core/Middleware/RequestRateLimiter.php
+++ b/app/Core/Middleware/RequestRateLimiter.php
@@ -57,8 +57,8 @@ class RequestRateLimiter
 
         $route = $request->getCurrentRoute();
 
-        // Only check rate limits for login page and api calls
-        if ($route != 'auth.login' && ! $request->isApiOrCronRequest()) {
+        // Only check rate limits for login page, api calls, and the MCP endpoint
+        if ($route != 'auth.login' && ! $request->isApiOrCronRequest() && ! $request->isMcpRequest()) {
             return $next($request);
         }
 
@@ -66,11 +66,13 @@ class RequestRateLimiter
         $rateLimitGeneral = $this->config->ratelimitGeneral ?? 10000;
         $rateLimitApi = $this->config->ratelimitApi ?? 100;
         $rateLimitAuth = $this->config->ratelimitAuth ?? 20;
+        $rateLimitMcp = $this->config->ratelimitMcp ?? 300;
 
         if (config('app.debug')) {
             $rateLimitGeneral = 999999999;
             $rateLimitApi = 999999999;
             $rateLimitAuth = 999999999;
+            $rateLimitMcp = 999999999;
         }
 
         // Key
@@ -90,6 +92,12 @@ class RequestRateLimiter
             $apiKey = '';
             // $key = app()->make(Api::class)->getAPIKeyUser($apiKey);
             $limit = $rateLimitApi;
+        }
+
+        // MCP endpoint gets its own (higher) budget: agentic LLM clients legitimately burst
+        // many parallel tool calls per conversation turn, which the API limit would choke on.
+        if ($request->isMcpRequest()) {
+            $limit = $rateLimitMcp;
         }
 
         if ($route == 'auth.login') {

--- a/app/Domain/Calendar/Tools/AddCalendarEventTool.php
+++ b/app/Domain/Calendar/Tools/AddCalendarEventTool.php
@@ -47,7 +47,7 @@ class AddCalendarEventTool extends Tool
             'description' => $arguments['eventTitle'],
             'dateFrom' => $arguments['dateFrom'],
             'dateTo' => $arguments['dateTo'],
-            'allDay' => $request->get('allDay', false),
+            'allDay' => $arguments['allDay'] ?? false,
         ]);
 
         if ($result) {

--- a/app/Domain/Calendar/Tools/EditCalendarEventTool.php
+++ b/app/Domain/Calendar/Tools/EditCalendarEventTool.php
@@ -50,7 +50,7 @@ class EditCalendarEventTool extends Tool
             'description' => $arguments['eventTitle'],
             'dateFrom' => $arguments['dateFrom'],
             'dateTo' => $arguments['dateTo'],
-            'allDay' => $request->get('allDay', false),
+            'allDay' => $arguments['allDay'] ?? false,
         ]);
 
         if ($result) {

--- a/app/Domain/Calendar/Tools/GetCalendarTool.php
+++ b/app/Domain/Calendar/Tools/GetCalendarTool.php
@@ -78,6 +78,10 @@ class GetCalendarTool extends Tool
             }
         }
 
-        return ToolResult::text($response ?: 'No calendar events found.');
+        if ($numEvents === 0) {
+            return ToolResult::text('No calendar events found for the specified date range.');
+        }
+
+        return ToolResult::text($response);
     }
 }

--- a/app/Domain/Calendar/Tools/ScheduleDayTool.php
+++ b/app/Domain/Calendar/Tools/ScheduleDayTool.php
@@ -58,14 +58,16 @@ class ScheduleDayTool extends Tool
         $existingEvents = $this->calendarService->getCalendar(session('userdata.id'), $dateFrom, $dateTo);
         $existingTasks = $this->ticketService->getScheduledTasks($dateFrom, $dateTo, session('userdata.id'));
 
-        if ($workingHoursStart !== '' && ($timeparts = explode(':', $workingHoursStart))) {
-            $workStart = $dateObj->setTime($timeparts[0], $timeparts[1]);
+        if ($workingHoursStart !== '') {
+            $timeparts = explode(':', $workingHoursStart);
+            $workStart = $dateObj->setTime((int) $timeparts[0], (int) ($timeparts[1] ?? 0));
         } else {
             $workStart = $dateObj->setTime(9, 0);
         }
 
-        if ($workingHoursEnd !== '' && ($timeparts = explode(':', $workingHoursEnd))) {
-            $workEnd = $dateObj->setTime($timeparts[0], $timeparts[1]);
+        if ($workingHoursEnd !== '') {
+            $timeparts = explode(':', $workingHoursEnd);
+            $workEnd = $dateObj->setTime((int) $timeparts[0], (int) ($timeparts[1] ?? 0));
         } else {
             $workEnd = $dateObj->setTime(18, 0);
         }

--- a/app/Domain/Goalcanvas/Tools/EditGoalTool.php
+++ b/app/Domain/Goalcanvas/Tools/EditGoalTool.php
@@ -48,22 +48,25 @@ class EditGoalTool extends Tool
      */
     public function handle(array $arguments): ToolResult
     {
-        $values = ['id' => (int) ($arguments['id'] ?? 0)];
+        $id = (int) ($arguments['id'] ?? 0);
 
         $optionalFields = [
             'title', 'description', 'startValue', 'currentValue', 'endValue',
             'startDate', 'endDate', 'milestoneId', 'metricType', 'status',
         ];
 
+        $params = [];
         foreach ($optionalFields as $field) {
-            $value = $request->get($field);
+            $value = $arguments[$field] ?? null;
             if ($value !== null) {
-                $values[$field] = $value;
+                $params[$field] = $value;
             }
         }
 
-        $this->goalcanvasService->editCanvasItem($values);
+        if ($this->goalcanvasService->patchGoalItem($id, $params)) {
+            return ToolResult::text('Goal updated successfully.');
+        }
 
-        return ToolResult::text('Goal updated successfully.');
+        return ToolResult::error('Failed to update goal.');
     }
 }

--- a/app/Domain/Goalcanvas/Tools/EditGoalTool.php
+++ b/app/Domain/Goalcanvas/Tools/EditGoalTool.php
@@ -5,6 +5,7 @@ namespace Leantime\Domain\Goalcanvas\Tools;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\ToolInputSchema;
 use Laravel\Mcp\Server\Tools\ToolResult;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Domain\Goalcanvas\Services\Goalcanvas;
 
 /**
@@ -49,6 +50,9 @@ class EditGoalTool extends Tool
     public function handle(array $arguments): ToolResult
     {
         $id = (int) ($arguments['id'] ?? 0);
+        if ($id <= 0) {
+            return ToolResult::error('A valid goal id is required.');
+        }
 
         $optionalFields = [
             'title', 'description', 'startValue', 'currentValue', 'endValue',
@@ -63,7 +67,19 @@ class EditGoalTool extends Tool
             }
         }
 
-        if ($this->goalcanvasService->patchGoalItem($id, $params)) {
+        if ($params === []) {
+            return ToolResult::error('Provide at least one field to update.');
+        }
+
+        try {
+            $updated = $this->goalcanvasService->patchGoalItem($id, $params);
+        } catch (AuthorizationException) {
+            // Unknown, foreign, or unauthorized goal id — one message for all three, so the
+            // response does not leak whether a goal id exists in another project.
+            return ToolResult::error("Goal with ID {$id} not found.");
+        }
+
+        if ($updated) {
             return ToolResult::text('Goal updated successfully.');
         }
 

--- a/app/Domain/Goalcanvas/Tools/GetGoalTool.php
+++ b/app/Domain/Goalcanvas/Tools/GetGoalTool.php
@@ -42,7 +42,7 @@ class GetGoalTool extends Tool
     public function handle(array $arguments): ToolResult
     {
         $goalId = (int) ($arguments['goalId'] ?? 0);
-        $goal = $this->goalcanvasService->getSingleCanvas($goalId);
+        $goal = $this->goalcanvasService->getGoalItem($goalId);
 
         if (! $goal) {
             return ToolResult::error("Goal with ID {$goalId} not found.");
@@ -53,7 +53,15 @@ class GetGoalTool extends Tool
             'id' => $goal['id'],
             'title' => Str::sanitizeForLLM($goal['title']),
             'description' => Str::sanitizeForLLM($goal['description']),
-            'projectId' => $goal['projectId'],
+            'board' => Str::sanitizeForLLM($goal['boardTitle'] ?? ''),
+            'startValue' => $goal['startValue'],
+            'currentValue' => $goal['currentValue'],
+            'endValue' => $goal['endValue'],
+            'metricType' => $goal['metricType'],
+            'status' => $goal['status'],
+            'startDate' => $goal['startDate'],
+            'endDate' => $goal['endDate'],
+            'milestone' => Str::sanitizeForLLM($goal['milestoneHeadline'] ?? ''),
             'author' => $goal['authorFirstname'].' '.$goal['authorLastname'],
             'created' => $goal['created'],
         ];

--- a/app/Domain/Projects/Tools/GetAllProjectsTool.php
+++ b/app/Domain/Projects/Tools/GetAllProjectsTool.php
@@ -43,10 +43,10 @@ class GetAllProjectsTool extends Tool
      */
     public function handle(array $arguments): ToolResult
     {
-        $showClosedProjects = $request->get('showClosedProjects', false);
-        $includeProgressDetails = $request->get('includeProgressDetails', true);
+        $showClosedProjects = $arguments['showClosedProjects'] ?? false;
+        $includeProgressDetails = $arguments['includeProgressDetails'] ?? true;
 
-        $projects = $this->projectService->getAll($showClosedProjects ?? false);
+        $projects = $this->projectService->getAll($showClosedProjects);
 
         $response = "## All Projects Overview\n";
 

--- a/app/Domain/Projects/Tools/GetFullProjectOverviewTool.php
+++ b/app/Domain/Projects/Tools/GetFullProjectOverviewTool.php
@@ -49,7 +49,7 @@ class GetFullProjectOverviewTool extends Tool
     public function handle(array $arguments): ToolResult
     {
         $projectId = (int) ($arguments['projectId'] ?? 0);
-        $includeTimesheets = $request->get('includeTimesheets', false);
+        $includeTimesheets = $arguments['includeTimesheets'] ?? false;
         $dateFrom = ($arguments['dateFrom'] ?? '');
         $dateTo = ($arguments['dateTo'] ?? '');
 
@@ -91,7 +91,7 @@ class GetFullProjectOverviewTool extends Tool
                 foreach ($comments as $comment) {
                     $status = $this->formatRagStatus($comment['status'] ?? '');
                     $response .= "**{$comment['date']}** - {$status}\n";
-                    $response .= "*{$comment['firstname']} {$comment['lastname']}:* {$comment['comment']}\n\n";
+                    $response .= "*{$comment['firstname']} {$comment['lastname']}:* {$comment['text']}\n\n";
                 }
             }
 
@@ -108,7 +108,11 @@ class GetFullProjectOverviewTool extends Tool
                 }
 
                 try {
-                    $timesheets = app(Timesheets::class)->getProjectTimesheets($projectId, $dateFrom, $dateTo);
+                    $timesheets = app(Timesheets::class)->getAll(
+                        dateFrom: dtHelper()->parseUserDateTime($dateFrom)->startOfDay(),
+                        dateTo: dtHelper()->parseUserDateTime($dateTo)->endOfDay(),
+                        projectId: $projectId
+                    );
 
                     if (empty($timesheets)) {
                         $response .= "*No timesheet entries found for the specified period.*\n\n";

--- a/app/Domain/Projects/Tools/GetProjectsAssignedToUserTool.php
+++ b/app/Domain/Projects/Tools/GetProjectsAssignedToUserTool.php
@@ -49,10 +49,6 @@ class GetProjectsAssignedToUserTool extends Tool
         $clientId = ($arguments['clientId'] ?? null);
         $projectTypes = ($arguments['projectTypes'] ?? 'all');
 
-        if ($projectTypes === null) {
-            $projectTypes = 'all';
-        }
-
         if ($userId === 0) {
             $userId = session('userdata.id') ?? '';
         }

--- a/app/Domain/Projects/Tools/GetUsersAssignedToProjectTool.php
+++ b/app/Domain/Projects/Tools/GetUsersAssignedToProjectTool.php
@@ -43,9 +43,9 @@ class GetUsersAssignedToProjectTool extends Tool
     public function handle(array $arguments): ToolResult
     {
         $projectId = (int) ($arguments['projectId'] ?? 0);
-        $teamOnly = $request->get('teamOnly', false);
+        $teamOnly = $arguments['teamOnly'] ?? false;
 
-        $users = $this->projectService->getUsersAssignedToProject($projectId, $teamOnly ?? false);
+        $users = $this->projectService->getUsersAssignedToProject($projectId, $teamOnly);
 
         if (empty($users)) {
             return ToolResult::text('No users assigned to this project.');

--- a/app/Domain/Tickets/Tools/FindTasksTool.php
+++ b/app/Domain/Tickets/Tools/FindTasksTool.php
@@ -85,7 +85,7 @@ class FindTasksTool extends Tool
 
             $tickets = $this->ticketsService->getAll($searchCriteria, $limit);
 
-            if ($tickets && count($tickets) > 0) {
+            if (! empty($tickets)) {
                 $allResults[$projectId] = $tickets;
                 $totalTasks += count($tickets);
             }

--- a/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
+++ b/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
@@ -6,6 +6,7 @@ use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Laravel\Mcp\Server\Tools\ToolInputSchema;
 use Laravel\Mcp\Server\Tools\ToolResult;
+use Leantime\Domain\Auth\Models\Roles;
 use Leantime\Domain\Projects\Services\Projects;
 use Leantime\Domain\Timesheets\Services\Timesheets;
 
@@ -49,10 +50,19 @@ class GetProjectTimesheetsTool extends Tool
     {
         $projectId = (int) ($arguments['projectId'] ?? 0);
 
-        $userRole = session('userdata.role');
-        $projectRole = $this->projectsService->getProjectRole(session('userdata.id'), $projectId);
-        if (! in_array($userRole, ['admin', 'manager', 'owner']) && $projectRole !== 'manager') {
-            return ToolResult::error("You don't have permission to view project-wide timesheet data. Only managers and admins can access this information.");
+        $globalRole = session('userdata.role');
+        if (! in_array($globalRole, [Roles::$manager, Roles::$admin, Roles::$owner], true)) {
+            // getProjectRole() returns a stored role key (usually a numeric string like "30");
+            // resolve it to a role name before comparing (same pattern as
+            // Tickets::userIsAtLeastForProject).
+            $projectRoleKey = $this->projectsService->getProjectRole(session('userdata.id'), $projectId);
+            $projectRole = ctype_digit((string) $projectRoleKey)
+                ? Roles::getRoleString((int) $projectRoleKey)
+                : $projectRoleKey;
+
+            if ($projectRole !== Roles::$manager) {
+                return ToolResult::error("You don't have permission to view project-wide timesheet data. Only managers and admins can access this information.");
+            }
         }
 
         $fromDate = dtHelper()->parseUserDateTime($arguments['dateFrom']);

--- a/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
+++ b/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
@@ -61,7 +61,7 @@ class GetProjectTimesheetsTool extends Tool
                 : $projectRoleKey;
 
             if ($projectRole !== Roles::$manager) {
-                return ToolResult::error("You don't have permission to view project-wide timesheet data. Only managers and admins can access this information.");
+                return ToolResult::error("You don't have permission to view project-wide timesheet data. This requires a manager role or above, or a manager role in this project.");
             }
         }
 

--- a/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
+++ b/app/Domain/Timesheets/Tools/GetProjectTimesheetsTool.php
@@ -50,7 +50,8 @@ class GetProjectTimesheetsTool extends Tool
         $projectId = (int) ($arguments['projectId'] ?? 0);
 
         $userRole = session('userdata.role');
-        if (! in_array($userRole, ['admin', 'manager']) && ! $this->projectsService->isUserProjectManager($projectId, session('userdata.id'))) {
+        $projectRole = $this->projectsService->getProjectRole(session('userdata.id'), $projectId);
+        if (! in_array($userRole, ['admin', 'manager', 'owner']) && $projectRole !== 'manager') {
             return ToolResult::error("You don't have permission to view project-wide timesheet data. Only managers and admins can access this information.");
         }
 

--- a/app/Domain/Timesheets/Tools/GetTimesheetSummaryTool.php
+++ b/app/Domain/Timesheets/Tools/GetTimesheetSummaryTool.php
@@ -47,11 +47,13 @@ class GetTimesheetSummaryTool extends Tool
      */
     public function handle(array $arguments): ToolResult
     {
-        $currentUserId = session('userdata.id');
+        $currentUserId = (int) session('userdata.id');
         $userRole = session('userdata.role');
-        $userId = ($arguments['userId'] ?? null);
 
-        if ($userId !== null && $userId !== $currentUserId && ! in_array($userRole, ['admin', 'manager'])) {
+        // User ID 0 (or omitted) means the current user per server instructions
+        $userId = (int) ($arguments['userId'] ?? 0) ?: $currentUserId;
+
+        if ($userId !== $currentUserId && ! in_array($userRole, ['admin', 'manager', 'owner'])) {
             return ToolResult::error("You don't have permission to view other users' timesheet data.");
         }
 
@@ -59,7 +61,7 @@ class GetTimesheetSummaryTool extends Tool
         $toDate = dtHelper()->parseUserDateTime($arguments['dateTo']);
         $groupBy = $arguments['groupBy'];
         $projectId = ($arguments['projectId'] ?? null);
-        $targetUserId = $userId ?? $currentUserId;
+        $targetUserId = $userId;
 
         $timesheets = $this->timesheetsService->getAll(
             dateFrom: $fromDate,

--- a/app/Domain/Timesheets/Tools/GetWeeklyTimesheetsTool.php
+++ b/app/Domain/Timesheets/Tools/GetWeeklyTimesheetsTool.php
@@ -42,17 +42,19 @@ class GetWeeklyTimesheetsTool extends Tool
      */
     public function handle(array $arguments): ToolResult
     {
-        $currentUserId = session('userdata.id');
+        $currentUserId = (int) session('userdata.id');
         $userRole = session('userdata.role');
-        $userId = ($arguments['userId'] ?? null);
 
-        if ($userId !== null && $userId !== $currentUserId && ! in_array($userRole, ['admin', 'manager'])) {
+        // User ID 0 (or omitted) means the current user per server instructions
+        $userId = (int) ($arguments['userId'] ?? 0) ?: $currentUserId;
+
+        if ($userId !== $currentUserId && ! in_array($userRole, ['admin', 'manager', 'owner'])) {
             return ToolResult::error("You don't have permission to view other users' timesheet data.");
         }
 
         $fromDate = dtHelper()->parseUserDateTime($arguments['weekStart'])->startOfWeek();
         $projectId = ($arguments['projectId'] ?? null);
-        $targetUserId = $userId ?? $currentUserId;
+        $targetUserId = $userId;
 
         $timesheetGroups = $this->timesheetsService->getWeeklyTimesheets(
             projectId: $projectId ?? -1,

--- a/composer.json
+++ b/composer.json
@@ -102,8 +102,6 @@
         "hkulekci/qdrant": "^0.5.8",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-path-prefixing": "^3.0",
-        "php-mcp/server": "dev-main as 3.1.1",
-        "php-mcp/laravel": "3.0.0",
         "laravel/mcp": "^0.1.1"
     },
     "require-dev": {
@@ -160,14 +158,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/leantime/leantime-documentor.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/leantime/php-mcp-server.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/Leantime/reactphp-http.git"
         }
     ],
     "config": {
@@ -198,11 +188,6 @@
             "ignore-duplicates": true,
             "include": [
                 "app/Plugins/*/composer.json"
-            ]
-        },
-        "laravel": {
-            "dont-discover": [
-                "php-mcp/laravel"
             ]
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c128ea8f86d096462c8c33e959eb1113",
+    "content-hash": "5a225115281a6ded15fea77c3b21141c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1287,53 +1287,6 @@
                 }
             ],
             "time": "2025-05-10T14:28:45+00:00"
-        },
-        {
-            "name": "evenement/evenement",
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/igorw/evenement.git",
-                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
-                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9 || ^6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Evenement\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                }
-            ],
-            "description": "Événement is a very simple event dispatching library for PHP",
-            "keywords": [
-                "event-dispatcher",
-                "event-emitter"
-            ],
-            "support": {
-                "issues": "https://github.com/igorw/evenement/issues",
-                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
-            },
-            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -4882,196 +4835,6 @@
             "time": "2024-09-09T07:06:30+00:00"
         },
         {
-            "name": "opis/json-schema",
-            "version": "2.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/opis/json-schema.git",
-                "reference": "712827751c62b465daae6e725bf0cf5ffbf965e1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/opis/json-schema/zipball/712827751c62b465daae6e725bf0cf5ffbf965e1",
-                "reference": "712827751c62b465daae6e725bf0cf5ffbf965e1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "opis/string": "^2.0",
-                "opis/uri": "^1.0",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "ext-bcmath": "*",
-                "ext-intl": "*",
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Opis\\JsonSchema\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Sorin Sarca",
-                    "email": "sarca_sorin@hotmail.com"
-                },
-                {
-                    "name": "Marius Sarca",
-                    "email": "marius.sarca@gmail.com"
-                }
-            ],
-            "description": "Json Schema Validator for PHP",
-            "homepage": "https://opis.io/json-schema",
-            "keywords": [
-                "json",
-                "json-schema",
-                "schema",
-                "validation",
-                "validator"
-            ],
-            "support": {
-                "issues": "https://github.com/opis/json-schema/issues",
-                "source": "https://github.com/opis/json-schema/tree/2.4.1"
-            },
-            "time": "2024-12-30T20:20:21+00:00"
-        },
-        {
-            "name": "opis/string",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/opis/string.git",
-                "reference": "ba0b9607b9809462b0e28a11e4881a8d77431feb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/opis/string/zipball/ba0b9607b9809462b0e28a11e4881a8d77431feb",
-                "reference": "ba0b9607b9809462b0e28a11e4881a8d77431feb",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Opis\\String\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Marius Sarca",
-                    "email": "marius.sarca@gmail.com"
-                },
-                {
-                    "name": "Sorin Sarca",
-                    "email": "sarca_sorin@hotmail.com"
-                }
-            ],
-            "description": "Multibyte strings as objects",
-            "homepage": "https://opis.io/string",
-            "keywords": [
-                "multi-byte",
-                "opis",
-                "string",
-                "string manipulation",
-                "utf-8"
-            ],
-            "support": {
-                "issues": "https://github.com/opis/string/issues",
-                "source": "https://github.com/opis/string/tree/2.0.2"
-            },
-            "time": "2024-12-30T21:43:22+00:00"
-        },
-        {
-            "name": "opis/uri",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/opis/uri.git",
-                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
-                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
-                "shasum": ""
-            },
-            "require": {
-                "opis/string": "^2.0",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Opis\\Uri\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Marius Sarca",
-                    "email": "marius.sarca@gmail.com"
-                },
-                {
-                    "name": "Sorin Sarca",
-                    "email": "sarca_sorin@hotmail.com"
-                }
-            ],
-            "description": "Build, parse and validate URIs and URI-templates",
-            "homepage": "https://opis.io",
-            "keywords": [
-                "URI Template",
-                "parse url",
-                "punycode",
-                "uri",
-                "uri components",
-                "url",
-                "validate uri"
-            ],
-            "support": {
-                "issues": "https://github.com/opis/uri/issues",
-                "source": "https://github.com/opis/uri/tree/1.1.0"
-            },
-            "time": "2021-05-22T15:57:08+00:00"
-        },
-        {
             "name": "overtrue/pinyin",
             "version": "4.1.0",
             "source": {
@@ -5511,389 +5274,6 @@
             "time": "2024-03-15T13:55:21+00:00"
         },
         {
-            "name": "php-mcp/laravel",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-mcp/laravel.git",
-                "reference": "8c523941e8035fc6174c138999de53109c1e8f5e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-mcp/laravel/zipball/8c523941e8035fc6174c138999de53109c1e8f5e",
-                "reference": "8c523941e8035fc6174c138999de53109c1e8f5e",
-                "shasum": ""
-            },
-            "require": {
-                "laravel/framework": "^9.46 || ^10.34 || ^11.29 || ^12.0",
-                "php": "^8.1",
-                "php-mcp/server": "^3.1"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.13",
-                "mockery/mockery": "^1.6",
-                "orchestra/pest-plugin-testbench": "^2.1",
-                "orchestra/testbench": "^8.0 || ^9.0",
-                "pestphp/pest": "^2.0",
-                "pestphp/pest-plugin-laravel": "^2.0",
-                "phpunit/phpunit": "^10.0 || ^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "PhpMcp\\Laravel\\McpServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpMcp\\Laravel\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kyrian Obikwelu",
-                    "email": "koshnawaza@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Laravel SDK for building Model Context Protocol (MCP) servers - Seamlessly integrate MCP tools, resources, and prompts into Laravel applications",
-            "homepage": "https://github.com/php-mcp/laravel",
-            "keywords": [
-                "ai",
-                "laravel",
-                "laravel mcp",
-                "laravel mcp prompts",
-                "laravel mcp resources",
-                "laravel mcp sdk",
-                "laravel mcp server",
-                "laravel mcp tools",
-                "laravel model context protocol",
-                "llm",
-                "mcp",
-                "model-context-protocol",
-                "tools"
-            ],
-            "support": {
-                "issues": "https://github.com/php-mcp/laravel/issues",
-                "source": "https://github.com/php-mcp/laravel/tree/3.0.0"
-            },
-            "time": "2025-06-26T00:29:08+00:00"
-        },
-        {
-            "name": "php-mcp/schema",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-mcp/schema.git",
-                "reference": "de8a32e00a007b696a0fcc55cb813bd98f1ce42c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-mcp/schema/zipball/de8a32e00a007b696a0fcc55cb813bd98f1ce42c",
-                "reference": "de8a32e00a007b696a0fcc55cb813bd98f1ce42c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpMcp\\Schema\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kyrian Obikwelu",
-                    "email": "koshnawaza@gmail.com"
-                }
-            ],
-            "description": "PHP Data Transfer Objects (DTOs) and Enums for the Model Context Protocol (MCP) schema.",
-            "support": {
-                "issues": "https://github.com/php-mcp/schema/issues",
-                "source": "https://github.com/php-mcp/schema/tree/1.0.1"
-            },
-            "time": "2025-06-25T04:27:57+00:00"
-        },
-        {
-            "name": "php-mcp/server",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Leantime/php-mcp-server.git",
-                "reference": "25e0ab7cd2339c69548d399ce8285bde0dfd7ebb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Leantime/php-mcp-server/zipball/25e0ab7cd2339c69548d399ce8285bde0dfd7ebb",
-                "reference": "25e0ab7cd2339c69548d399ce8285bde0dfd7ebb",
-                "shasum": ""
-            },
-            "require": {
-                "opis/json-schema": "^2.4",
-                "php": ">=8.1",
-                "php-mcp/schema": "^1.0",
-                "phpdocumentor/reflection-docblock": "^5.6",
-                "psr/clock": "^1.0",
-                "psr/container": "^1.0 || ^2.0",
-                "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-                "react/event-loop": "^1.5",
-                "react/promise": "^3.0",
-                "react/stream": "^1.4",
-                "symfony/finder": "^6.4 || ^7.2"
-            },
-            "replace": {
-                "php-mcp/server": "3.1.1"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.75",
-                "mockery/mockery": "^1.6",
-                "pestphp/pest": "^2.36.0|^3.5.0",
-                "react/async": "^4.0",
-                "react/child-process": "^0.6.6",
-                "symfony/var-dumper": "^6.4.11|^7.1.5"
-            },
-            "suggest": {
-                "react/http": "Required for using the ReactPHP HTTP transport handler (^1.11 recommended)."
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpMcp\\Server\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "PhpMcp\\Server\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "vendor/bin/pest"
-                ],
-                "test:coverage": [
-                    "XDEBUG_MODE=coverage ./vendor/bin/pest --coverage"
-                ],
-                "lint": [
-                    "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kyrian Obikwelu",
-                    "email": "koshnawaza@gmail.com"
-                }
-            ],
-            "description": "PHP SDK for building Model Context Protocol (MCP) servers - Create MCP tools, resources, and prompts",
-            "keywords": [
-                "mcp",
-                "model context protocol",
-                "php",
-                "php mcp",
-                "php mcp prompts",
-                "php mcp resources",
-                "php mcp sdk",
-                "php mcp server",
-                "php mcp tools",
-                "php model context protocol",
-                "server"
-            ],
-            "support": {
-                "source": "https://github.com/Leantime/php-mcp-server/tree/main"
-            },
-            "time": "2025-06-27T20:56:22+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.1",
-                "ext-filter": "*",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1 || ^2"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.5 || ~1.6.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-webmozart-assert": "^1.2",
-                "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
-            },
-            "time": "2026-03-18T20:47:46+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
-            },
-            "time": "2025-11-21T15:09:14+00:00"
-        },
-        {
             "name": "phpmailer/phpmailer",
             "version": "v6.10.0",
             "source": {
@@ -6158,53 +5538,6 @@
                 }
             ],
             "time": "2026-04-27T07:02:15+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
-            },
-            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "prism-php/prism",
@@ -6937,229 +6270,6 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
-        },
-        {
-            "name": "react/event-loop",
-            "version": "v1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
-            },
-            "suggest": {
-                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\EventLoop\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
-            "keywords": [
-                "asynchronous",
-                "event-loop"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/reactphp",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2023-11-13T13:48:05+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v3.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "1.10.39 || 1.4.10",
-                "phpunit/phpunit": "^9.6 || ^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/reactphp",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2024-05-24T10:39:05+00:00"
-        },
-        {
-            "name": "react/stream",
-            "version": "v1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/stream.git",
-                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
-                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
-                "shasum": ""
-            },
-            "require": {
-                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-                "php": ">=5.3.8",
-                "react/event-loop": "^1.2"
-            },
-            "require-dev": {
-                "clue/stream-filter": "~1.2",
-                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
-            "keywords": [
-                "event-driven",
-                "io",
-                "non-blocking",
-                "pipe",
-                "reactphp",
-                "readable",
-                "stream",
-                "writable"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/stream/issues",
-                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/reactphp",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",
@@ -14395,6 +13505,228 @@
             "time": "2025-06-06T13:39:18+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
+            },
+            "time": "2026-03-18T20:47:46+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.12.27",
             "source": {
@@ -17308,18 +16640,10 @@
             "time": "2021-12-20T20:01:29+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "php-mcp/server",
-            "version": "dev-main",
-            "alias": "3.1.1",
-            "alias_normalized": "3.1.1.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "leantime/leantime-documentor": 20,
-        "php-mcp/server": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/config/sample.env
+++ b/config/sample.env
@@ -209,6 +209,7 @@ LEAN_REDIS_SCHEME = ''
 LEAN_RATELIMIT_GENERAL = 1000
 LEAN_RATELIMIT_API = 10
 LEAN_RATELIMIT_AUTH = 20
+LEAN_RATELIMIT_MCP = 300                                # MCP endpoint requests/minute; agentic LLM clients burst many tool calls per turn
 
 ## News Service
 LEAN_NEWS_ENABLED = true                                # Set to false to disable news service in airgapped environments

--- a/tests/Acceptance/API/McpCest.php
+++ b/tests/Acceptance/API/McpCest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Acceptance\API;
+
+use Codeception\Attribute\Group;
+use Codeception\Scenario;
+use PHPUnit\Framework\Assert;
+use Tests\Support\AcceptanceTester;
+use Tests\Support\Page\Acceptance\Install;
+
+/**
+ * MCP server contract test (laravel/mcp over the /mcp HTTP transport).
+ *
+ * Sibling to BearerApiCest: same Bearer-token mint (a row in zp_access_tokens), but against the
+ * MCP endpoint the McpServer plugin registers instead of the JSON-RPC API. Exists because the MCP
+ * tool layer is exercised by AI clients (Claude Code, MCP inspector), not by the web UI, so
+ * nothing else in CI notices when it breaks — e.g. tools calling since-removed service methods, or
+ * the protocol-version handshake rejecting current clients (both happened in 2026-07 and were only
+ * caught by live testing).
+ *
+ * Group `mcp` is NOT part of the default CI groups: the McpServer plugin lives in the private
+ * app/Plugins submodule, which is absent in OSS CI. Every test therefore skips itself when the
+ * endpoint 404s. Run locally (plugins checked out) with:
+ *
+ *   docker compose ... exec leantime-dev php vendor/bin/codecept run -g mcp --steps
+ *
+ * Each test is self-contained (token + plugin row minted per test) because the Db module rolls
+ * back haveInDatabase() rows after each test.
+ */
+class McpCest
+{
+    private const MCP_PATH = '/mcp';
+
+    public function _before(AcceptanceTester $I, Install $installPage)
+    {
+        // Fresh install — same fixture as ApiCest/BearerApiCest.
+        $installPage->install('test@leantime.io', 'Test123456!', 'John', 'Smith', 'Smith & Co');
+    }
+
+    #[Group('mcp')]
+    public function mcpEndpointRequiresAuth(AcceptanceTester $I, Scenario $scenario)
+    {
+        $this->enableMcpPluginOrSkip($I, $scenario);
+
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPost(self::MCP_PATH, json_encode($this->initializeRequest('2025-06-18'), JSON_THROW_ON_ERROR));
+        $I->seeResponseCodeIs(401);
+    }
+
+    #[Group('mcp')]
+    public function mcpHandshakeNegotiatesProtocolVersions(AcceptanceTester $I, Scenario $scenario)
+    {
+        $this->enableMcpPluginOrSkip($I, $scenario);
+        $this->mintBearerToken($I);
+
+        // Baseline: a revision from laravel/mcp v0.1.1's built-in list.
+        $response = $this->mcp($I, $this->initializeRequest('2025-06-18'));
+        Assert::assertSame('2025-06-18', $response['result']['protocolVersion'] ?? null, 'initialize failed: '.json_encode($response));
+        Assert::assertNotEmpty($response['result']['serverInfo']['name'] ?? null);
+
+        // Regression gate for the Claude Code handshake: current clients request 2025-11-25.
+        // v0.1.1 rejects unknown revisions instead of downgrading (spec says downgrade), so the
+        // server class must keep newer revisions in $supportedProtocolVersion (plugins#60).
+        $response = $this->mcp($I, $this->initializeRequest('2025-11-25'));
+        Assert::assertArrayNotHasKey(
+            'error',
+            $response,
+            'Server rejected protocol 2025-11-25 — Claude Code cannot connect. '
+                .'LeantimeMcpServer::$supportedProtocolVersion must include it: '.json_encode($response)
+        );
+    }
+
+    #[Group('mcp')]
+    public function mcpListsAllRegisteredTools(AcceptanceTester $I, Scenario $scenario)
+    {
+        $this->enableMcpPluginOrSkip($I, $scenario);
+        $this->mintBearerToken($I);
+
+        // tools/list paginates (15 per page in v0.1.1) — walk every cursor.
+        $toolNames = [];
+        $cursor = null;
+        $guard = 0;
+        do {
+            $params = $cursor === null ? new \stdClass : ['cursor' => $cursor];
+            $response = $this->mcp($I, [
+                'jsonrpc' => '2.0',
+                'id' => 2,
+                'method' => 'tools/list',
+                'params' => $params,
+            ]);
+            Assert::assertArrayNotHasKey('error', $response, 'tools/list failed: '.json_encode($response));
+            foreach ($response['result']['tools'] ?? [] as $tool) {
+                $toolNames[] = $tool['name'];
+            }
+            $cursor = $response['result']['nextCursor'] ?? null;
+        } while ($cursor !== null && ++$guard < 20);
+
+        Assert::assertGreaterThanOrEqual(56, count($toolNames), 'Expected the full tool catalog, got: '.implode(', ', $toolNames));
+
+        // One representative per domain — catches a whole domain falling out of the registry.
+        foreach (['findTasks', 'getAllProjects', 'getAllGoals', 'getCalendar', 'getComments', 'logTime'] as $expected) {
+            Assert::assertContains($expected, $toolNames, "Tool {$expected} missing from tools/list");
+        }
+    }
+
+    #[Group('mcp')]
+    public function mcpToolCallLifecycle(AcceptanceTester $I, Scenario $scenario)
+    {
+        $this->enableMcpPluginOrSkip($I, $scenario);
+        $this->mintBearerToken($I);
+
+        // Create a task, read it back, patch it — the minimal write→read→write contract that
+        // exercises DI-constructed tools, session auth context, and the Tickets service layer.
+        $response = $this->callTool($I, 'addTask', [
+            'headline' => 'MCP contract test task',
+            'projectId' => 1,
+        ]);
+        $text = $this->toolText($response);
+        Assert::assertFalse($response['result']['isError'] ?? true, 'addTask errored: '.$text);
+        Assert::assertSame(1, preg_match('/ID:?\s*(\d+)/', $text, $matches), 'addTask did not return an id: '.$text);
+        $taskId = (int) $matches[1];
+
+        $response = $this->callTool($I, 'getTicket', ['id' => $taskId]);
+        Assert::assertFalse($response['result']['isError'] ?? true, 'getTicket errored');
+        Assert::assertStringContainsString('MCP contract test task', $this->toolText($response));
+
+        $response = $this->callTool($I, 'editTask', [
+            'id' => $taskId,
+            'params' => ['headline' => 'MCP contract test task (edited)'],
+        ]);
+        Assert::assertFalse($response['result']['isError'] ?? true, 'editTask errored: '.$this->toolText($response));
+
+        $response = $this->callTool($I, 'getTicket', ['id' => $taskId]);
+        Assert::assertStringContainsString('(edited)', $this->toolText($response), 'edit did not persist');
+    }
+
+    #[Group('mcp')]
+    public function mcpRejectsUnknownTool(AcceptanceTester $I, Scenario $scenario)
+    {
+        $this->enableMcpPluginOrSkip($I, $scenario);
+        $this->mintBearerToken($I);
+
+        // laravel/mcp reports unknown tools as an isError tool result ("Tool not found"),
+        // not a JSON-RPC error object.
+        $response = $this->callTool($I, 'definitelyNotATool', []);
+        Assert::assertTrue($response['result']['isError'] ?? false, 'Unknown tool should produce an error result: '.json_encode($response));
+    }
+
+    /**
+     * Enable the McpServer plugin for this test (row is rolled back by the Db module afterwards),
+     * or skip when the plugin code is not present (public OSS checkout — app/Plugins is a private
+     * submodule). The test runner shares the app container, so the folder check is authoritative.
+     */
+    private function enableMcpPluginOrSkip(AcceptanceTester $I, Scenario $scenario): void
+    {
+        if (! is_dir(dirname(__DIR__, 3).'/app/Plugins/McpServer')) {
+            $scenario->skip('McpServer plugin not present (app/Plugins submodule not checked out)');
+        }
+
+        $I->haveInDatabase('zp_plugins', [
+            'name' => 'leantime/mcpServer',
+            'enabled' => 1,
+            'description' => 'MCP Server (acceptance fixture)',
+            'version' => '1.0.0',
+            'installdate' => date('Y-m-d H:i:s'),
+            'foldername' => 'McpServer',
+            'homepage' => 'https://leantime.io',
+            'authors' => '[]',
+            'license' => '',
+            'format' => 'folder',
+        ]);
+    }
+
+    /**
+     * Mint a Bearer token directly in the DB — sha256 of an opaque string, exactly as
+     * AccessTokenRepository::createToken persists it (same approach as BearerApiCest).
+     */
+    private function mintBearerToken(AcceptanceTester $I): void
+    {
+        $userId = $I->grabFromDatabase('zp_user', 'id', ['username' => 'test@leantime.io']);
+        Assert::assertNotEmpty($userId, 'Test user not found after install');
+
+        $token = bin2hex(random_bytes(20));
+        $I->haveInDatabase('zp_access_tokens', [
+            'tokenable_type' => 'Leantime\\Domain\\Auth\\Services\\Auth',
+            'tokenable_id' => (int) $userId,
+            'name' => 'mcp-cest',
+            'token' => hash('sha256', $token),
+            'abilities' => json_encode(['*']),
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $I->haveHttpHeader('Authorization', 'Bearer '.$token);
+    }
+
+    /**
+     * POST a JSON-RPC payload to /mcp and return the decoded response.
+     */
+    private function mcp(AcceptanceTester $I, array $payload): array
+    {
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->sendPost(self::MCP_PATH, json_encode($payload, JSON_THROW_ON_ERROR));
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+
+        return json_decode($I->grabResponse(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Invoke an MCP tool via tools/call.
+     */
+    private function callTool(AcceptanceTester $I, string $name, array $arguments): array
+    {
+        return $this->mcp($I, [
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => $name,
+                'arguments' => $arguments === [] ? new \stdClass : $arguments,
+            ],
+        ]);
+    }
+
+    /**
+     * Text content of a tools/call response ('' when the shape is unexpected).
+     */
+    private function toolText(array $response): string
+    {
+        return $response['result']['content'][0]['text'] ?? '';
+    }
+
+    /**
+     * A spec-shaped initialize request for the given protocol revision.
+     */
+    private function initializeRequest(string $protocolVersion): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => $protocolVersion,
+                'capabilities' => new \stdClass,
+                'clientInfo' => ['name' => 'mcp-cest', 'version' => '1.0'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Live-tested **all 56 MCP tools** end-to-end against a running instance through the `/mcp` HTTP transport (Bearer-token auth) and fixed every failure found. Also completes the post-migration cleanup now that `laravel/mcp` is installed.

### Runtime bug fixes

- **Six tools** still used the v0.8-style `$request->get()` — leftovers from the interrupted API-conversion pass. In v0.1.1 the only input is the `$arguments` array. (AddCalendarEventTool, EditCalendarEventTool, EditGoalTool, GetFullProjectOverviewTool, GetUsersAssignedToProjectTool, GetAllProjectsTool)
- **GetProjectTimesheetsTool** called nonexistent `Projects::isUserProjectManager()` (broken in the old plugin too). Now uses `getProjectRole()` and includes the `owner` role, which was previously denied.
- **GetTimesheetSummaryTool / GetWeeklyTimesheetsTool** rejected `userId: 0`, which the server instructions define as "current user". Also add `owner` to the privileged roles.
- **EditGoalTool** called nonexistent `Goalcanvas::editCanvasItem()`. Now uses `patchGoalItem()`, which authorizes against the item's real project (fail-closed canvas pattern).
- **GetGoalTool** fetched a goal *board* (`getSingleCanvas`) instead of the goal *item* — every lookup failed. Now uses `getGoalItem()` and returns the goal metric fields.
- **GetFullProjectOverviewTool** called nonexistent `Timesheets::getProjectTimesheets()` and read `$comment['comment']` where rows use `text`.
- **ScheduleDayTool** passed strings to `Carbon::setTime()`.
- **GetCalendarTool** had an unreachable "no events" fallback.

### Cleanup

- **Drop the phpstan exclusion for `app/Domain/*/Tools/*`** — this temporary exclusion (pending laravel/mcp install) is what let the undefined-method calls through CI. phpstan level 5 is now clean over the tools.
- **Remove `php-mcp/server` + `php-mcp/laravel`**, their VCS fork repository entries (`leantime/php-mcp-server`, `Leantime/reactphp-http`), and the `dont-discover` block. Nothing references them anymore.
- **Bump `app/Plugins` submodule** to the merged laravel/mcp-based plugin (Leantime/plugins#54).

## Test plan

- [x] All 56 tools called live over `/mcp` (initialize, paginated tools/list, tools/call) — reads, writes, bulk ops, timers, scheduling all succeed
- [x] `phpstan` level 5 clean (tools no longer excluded)
- [x] `pint` clean
- [x] Site + MCP endpoint verified working after php-mcp removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)