### PR TITLE
fix: batch of open bug fixes (#3540, #3331, #3310, #3589, #3330, #3546)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,65 @@ jobs:
         with:
           ref: latest
           description: Latest Release of Leantime.
+
+  # Publishes the official Docker image from .docker/Dockerfile (#3546 - the
+  # Docker Hub image was previously built out-of-band and had gone stale,
+  # missing pdo_pgsql). The Dockerfile installs Leantime from the release
+  # tarball, so this runs after build_release publishes it.
+  publish_docker:
+    name: publish_docker_image
+    needs: build_release
+    if: github.event_name != 'pull_request' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
+
+      - name: version
+        run: echo "version=$(make get-version)" >> $GITHUB_OUTPUT
+        id: version
+
+      # Secrets can't be referenced in job-level `if`, so probe them in a step and
+      # skip publishing (with a visible warning) when they aren't configured yet.
+      - name: Check Docker Hub credentials
+        id: creds
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets are not configured — skipping Docker image publish"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            LEAN_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            leantime/leantime:${{ steps.version.outputs.version }}
+            leantime/leantime:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,13 @@ jobs:
         run: echo "version=$(make get-version)" >> $GITHUB_OUTPUT
         id: version
 
+      # COMPOSER_AUTH prevents GitHub API rate-limiting; without it composer silently
+      # falls back to source (git clone) installs, shipping .git dirs and package build/
+      # test artifacts that ballooned release archives (#3330).
       - name: build artifacts
         run: make package
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"}}'
 
       - name: Extract changelog section
         run: |

--- a/app/Core/Configuration/laravelConfig.php
+++ b/app/Core/Configuration/laravelConfig.php
@@ -243,9 +243,15 @@ return [
                 'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
                 'replace_placeholders' => true,
             ],
-            'deprecations' => [
+            // Deprecation notices are development signal — in production they only grew an
+            // unrotated deprecations.log (#3589). Discard them unless debugging or explicitly
+            // enabled via LEAN_LOG_DEPRECATIONS.
+            'deprecations' => env('LEAN_LOG_DEPRECATIONS', env('LEAN_DEBUG', 0)) ? [
                 'driver' => 'single',
                 'path' => storage_path('logs/deprecations.log'),
+            ] : [
+                'driver' => 'monolog',
+                'handler' => \Monolog\Handler\NullHandler::class,
             ],
             'sentry' => [
                 'driver' => 'sentry',

--- a/app/Domain/Menu/Templates/partials/projectGroup.blade.php
+++ b/app/Domain/Menu/Templates/partials/projectGroup.blade.php
@@ -34,7 +34,9 @@
 
                 <div class="clear"></div>
 
-                @if(!empty($project['children']) && count($project['children']) >0)
+                {{-- Depth cap: the hierarchy is cycle-guarded server-side, but a runaway
+                     tree (e.g. mutated by a plugin filter) must never recurse unbounded --}}
+                @if(!empty($project['children']) && count($project['children']) >0 && $level < 20)
                     @include('menu::partials.projectGroup', ['projects' => $project['children'], 'parent' => $project['id'], 'level'=> $level+1, 'prefx' => $prefix, "currentProject"=>$currentProject])
                 @endif
             </li>

--- a/app/Domain/Menu/Templates/partials/projectGroup.blade.php
+++ b/app/Domain/Menu/Templates/partials/projectGroup.blade.php
@@ -37,7 +37,7 @@
                 {{-- Depth cap: the hierarchy is cycle-guarded server-side, but a runaway
                      tree (e.g. mutated by a plugin filter) must never recurse unbounded --}}
                 @if(!empty($project['children']) && count($project['children']) >0 && $level < 20)
-                    @include('menu::partials.projectGroup', ['projects' => $project['children'], 'parent' => $project['id'], 'level'=> $level+1, 'prefx' => $prefix, "currentProject"=>$currentProject])
+                    @include('menu::partials.projectGroup', ['projects' => $project['children'], 'parent' => $project['id'], 'level'=> $level+1, 'prefix' => $prefix, "currentProject"=>$currentProject])
                 @endif
             </li>
 

--- a/app/Domain/Projects/Repositories/Projects.php
+++ b/app/Domain/Projects/Repositories/Projects.php
@@ -247,6 +247,76 @@ class Projects
     }
 
     /**
+     * Gets all users that can access a project, honoring the project's access level.
+     *
+     * Directly assigned users are always included. On top of that the project's
+     * psettings widen the set: 'all' adds every active user, 'clients' adds the
+     * active users of the project's client. This mirrors isUserAssignedToProject(),
+     * which grants those users access — they must therefore also be offered in
+     * assignee dropdowns (#3331).
+     *
+     * @param  int  $id  The ID of the project.
+     * @param  bool  $includeApiUsers  Whether to include API service-account users.
+     * @return array The users with access to the project.
+     */
+    public function getUsersWithAccessToProject($id, $includeApiUsers = false): array
+    {
+        $project = $this->getProject($id);
+        if ($project === false) {
+            return [];
+        }
+
+        $query = $this->connection->table('zp_user')
+            ->select([
+                'zp_user.id',
+                'zp_user.firstname',
+                'zp_user.lastname',
+                'zp_user.username',
+                'zp_user.notifications',
+                'zp_user.profileId',
+                'zp_user.jobTitle',
+                'zp_user.source',
+                'zp_user.status',
+                'zp_user.modified',
+                'zp_user.role',
+                'zp_relationuserproject.projectRole',
+            ])
+            ->distinct()
+            ->leftJoin('zp_relationuserproject', function ($join) use ($id) {
+                $join->on('zp_user.id', '=', 'zp_relationuserproject.userId')
+                    ->where('zp_relationuserproject.projectId', '=', $id);
+            })
+            ->where(function ($q) use ($project) {
+                $q->whereNotNull('zp_relationuserproject.userId');
+
+                if (($project['psettings'] ?? '') == 'all') {
+                    $q->orWhere('zp_user.status', 'a');
+                } elseif (($project['psettings'] ?? '') == 'clients') {
+                    $q->orWhere(function ($q2) use ($project) {
+                        $q2->where('zp_user.status', 'a')
+                            ->where('zp_user.clientId', $project['clientId']);
+                    });
+                }
+            });
+
+        if ($includeApiUsers === false) {
+            $query->where(function ($q) {
+                $q->whereNull('zp_user.source')
+                    ->orWhere('zp_user.source', '<>', 'api');
+            });
+        }
+
+        $results = $query->orderBy('zp_user.lastname')->get();
+
+        return $results->map(function ($item) {
+            $arr = (array) $item;
+            $arr['firstname'] = $arr['firstname'] ?? $arr['username'];
+
+            return $arr;
+        })->toArray();
+    }
+
+    /**
      * Retrieves the relationship of users assigned to a specific project.
      *
      * @param  int  $id  The ID of the project.

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -864,17 +864,41 @@ class Projects extends BaseService implements ChecksProjectAccess
      */
     public function findMyChildren($currentParentId, array $projects): array
     {
+        $childrenByParent = [];
+        foreach ($projects as $project) {
+            $childrenByParent[$project['parent'] ?? 0][] = $project;
+        }
 
+        return $this->buildProjectBranch($currentParentId, $childrenByParent, []);
+    }
+
+    /**
+     * Assembles one branch of the project tree from a parentId => children map.
+     *
+     * The visited set guards against self-referential or cyclic parent data —
+     * without it a project whose parent chain loops back on itself recurses
+     * until memory is exhausted (rendered on every page via the project selector).
+     *
+     * @param  mixed  $parentId  The parent project ID to collect children for.
+     * @param  array  $childrenByParent  Projects grouped by their parent ID.
+     * @param  array<int|string, true>  $visited  Project IDs already on this branch's path.
+     * @return array The assembled branch.
+     */
+    private function buildProjectBranch($parentId, array $childrenByParent, array $visited): array
+    {
         $branch = [];
 
-        foreach ($projects as $project) {
-            if ($project['parent'] == $currentParentId) {
-                $children = $this->findMyChildren($project['id'], $projects);
-                if ($children) {
-                    $project['children'] = $children;
-                }
-                $branch[] = $project;
+        foreach ($childrenByParent[$parentId] ?? [] as $project) {
+            if (isset($visited[$project['id']])) {
+                continue;
             }
+            $visited[$project['id']] = true;
+
+            $children = $this->buildProjectBranch($project['id'], $childrenByParent, $visited);
+            if ($children) {
+                $project['children'] = $children;
+            }
+            $branch[] = $project;
         }
 
         return $branch;
@@ -893,22 +917,49 @@ class Projects extends BaseService implements ChecksProjectAccess
     public function cleanParentRelationship(array $projects): array
     {
 
-        $parents = [];
+        $parentIds = [];
         foreach ($projects as $project) {
-            $parents[$project['id']] = $project;
+            $parentIds[$project['id']] = $project['parent'];
         }
 
         $cleanList = [];
         foreach ($projects as $project) {
-            if (isset($parents[$project['parent']])) {
-                $cleanList[] = $project;
-            } else {
+            if (! isset($parentIds[$project['parent']]) || $this->parentChainLoops($project['id'], $parentIds)) {
                 $project['parent'] = 0;
-                $cleanList[] = $project;
             }
+            $cleanList[] = $project;
         }
 
         return $cleanList;
+    }
+
+    /**
+     * Checks whether a project's parent chain loops back on itself
+     * (self-parent or a longer cycle like A → B → A) within the given set.
+     *
+     * @param  mixed  $projectId  The project ID whose ancestry to walk.
+     * @param  array  $parentIds  Map of project ID => parent ID.
+     * @return bool True when the chain revisits a project (cycle).
+     */
+    private function parentChainLoops($projectId, array $parentIds): bool
+    {
+        $seen = [];
+        $current = $parentIds[$projectId] ?? 0;
+
+        while (! empty($current) && isset($parentIds[$current])) {
+            if ($current == $projectId) {
+                return true;
+            }
+            // An ancestor further up is cyclic, but this project isn't part of the
+            // loop itself — the cycle members get re-rooted, so this link stays valid.
+            if (isset($seen[$current])) {
+                return false;
+            }
+            $seen[$current] = true;
+            $current = $parentIds[$current];
+        }
+
+        return false;
     }
 
     /**
@@ -1854,7 +1905,45 @@ class Projects extends BaseService implements ChecksProjectAccess
     #[RequiresPermission(ProjectsPermissions::EDIT, global: true)]
     public function patch($id, $params): bool
     {
+        $params = $this->rejectCyclicParent((int) $id, $params);
+
         return $this->projectRepository->patch($id, $params);
+    }
+
+    /**
+     * Drops a parent assignment that would make the project its own ancestor.
+     *
+     * A project pointing at itself (or at one of its descendants) creates a cycle in
+     * the hierarchy, which used to hang the project selector on every page. Invalid
+     * assignments are removed from the value set so the stored parent stays unchanged.
+     *
+     * @param  int  $projectId  The project being written.
+     * @param  array  $values  The values about to be persisted.
+     * @return array The values with any cyclic parent assignment removed.
+     */
+    private function rejectCyclicParent(int $projectId, array $values): array
+    {
+        if (empty($values['parent'])) {
+            return $values;
+        }
+
+        $current = (int) $values['parent'];
+        $steps = 0;
+
+        while ($current > 0 && $steps < 100) {
+            if ($current === $projectId) {
+                Log::warning("Rejected parent assignment for project {$projectId}: parent {$values['parent']} would create a hierarchy cycle.");
+                unset($values['parent']);
+
+                return $values;
+            }
+
+            $parentProject = $this->projectRepository->getProject($current);
+            $current = (int) ($parentProject['parent'] ?? 0);
+            $steps++;
+        }
+
+        return $values;
     }
 
     /**
@@ -2321,6 +2410,8 @@ class Projects extends BaseService implements ChecksProjectAccess
     #[RequiresPermission(ProjectsPermissions::EDIT, global: true)]
     public function editProject($values, $id)
     {
+        $values = $this->rejectCyclicParent((int) $id, $values);
+
         // Preserve existing type if not provided
         if (! isset($values['type'])) {
             $currentProject = $this->getProject($id);

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -1486,6 +1486,35 @@ class Projects extends BaseService implements ChecksProjectAccess
     }
 
     /**
+     * Gets all users that can access a project, honoring the project's access level
+     * (psettings): directly assigned users plus — depending on the setting — all
+     * active users ('all') or the client's active users ('clients').
+     *
+     * Use this for assignee/user pickers; use getUsersAssignedToProject() when only
+     * the directly assigned team is wanted (e.g. notifications).
+     *
+     * @param  int  $projectId  The ID of the project.
+     * @return array The users with access to the project.
+     *
+     * @api
+     */
+    #[RequiresPermission(ProjectsPermissions::VIEW, projectIdParam: 'projectId')]
+    public function getUsersWithAccessToProject(int $projectId): array
+    {
+        $users = $this->projectRepository->getUsersWithAccessToProject($projectId);
+
+        foreach ($users as $key => $user) {
+            if (dtHelper()->isValidDateString($user['modified'])) {
+                $users[$key]['modified'] = dtHelper()->parseDbDateTime($user['modified'])->toIso8601ZuluString();
+            } else {
+                $users[$key]['modified'] = null;
+            }
+        }
+
+        return $users;
+    }
+
+    /**
      * Checks if a user is assigned to a particular project.
      *
      * @param  int  $userId  The ID of the user being checked.

--- a/app/Domain/Tickets/Controllers/EditMilestone.php
+++ b/app/Domain/Tickets/Controllers/EditMilestone.php
@@ -72,7 +72,7 @@ class EditMilestone extends Controller
 
         $allProjectMilestones = $this->ticketService->getAllMilestones(['sprint' => '', 'type' => 'milestone', 'currentProject' => session('currentProject')]);
         $this->tpl->assign('milestones', $allProjectMilestones);
-        $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
+        $this->tpl->assign('users', $this->projectService->getUsersWithAccessToProject((int) session('currentProject')));
         $this->tpl->assign('milestone', $milestone);
 
         return $this->tpl->displayPartial('tickets.milestoneDialog');

--- a/app/Domain/Tickets/Controllers/NewTicket.php
+++ b/app/Domain/Tickets/Controllers/NewTicket.php
@@ -83,7 +83,7 @@ class NewTicket extends Controller
         $this->tpl->assign('remainingHours', 0);
 
         $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
-        $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
+        $this->tpl->assign('users', $this->projectService->getUsersWithAccessToProject((int) session('currentProject')));
 
         $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
         $this->tpl->assign('allAssignedprojects', $allAssignedprojects);
@@ -135,7 +135,7 @@ class NewTicket extends Controller
                 $this->tpl->assign('remainingHours', 0);
 
                 $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
-                $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject(session('currentProject')));
+                $this->tpl->assign('users', $this->projectService->getUsersWithAccessToProject((int) session('currentProject')));
 
                 $allAssignedprojects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
                 $this->tpl->assign('allAssignedprojects', $allAssignedprojects);

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -131,7 +131,7 @@ class ShowTicket extends Controller
         $this->tpl->assign('remainingHours', $this->timesheetService->getRemainingHours($ticket));
 
         $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
-        $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject($ticket->projectId));
+        $this->tpl->assign('users', $this->projectService->getUsersWithAccessToProject((int) $ticket->projectId));
 
         $projectData = $this->projectService->getProject($ticket->projectId);
         $this->tpl->assign('projectData', $projectData);

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3771,7 +3771,7 @@ class Tickets extends BaseService
         $sprints = $this->sprintService->getAllSprints(session('currentProject'));
         $futureSprints = $this->sprintService->getAllFutureSprints((int) session('currentProject'));
 
-        $users = $this->projectService->getUsersAssignedToProject(session('currentProject'));
+        $users = $this->projectService->getUsersWithAccessToProject((int) session('currentProject'));
 
         $milestones = $this->getAllMilestones([
             'sprint' => '',
@@ -3895,11 +3895,11 @@ class Tickets extends BaseService
                 $milestones[$milestone->id] = $milestone;
             }
 
-            // Users: one light indexed lookup per child project (bounded by child count). No bulk
-            // variant exists, and a correct one must replicate each project's psettings/client
-            // access rules, so we keep the per-project call and dedupe by id.
+            // Users: one light indexed lookup per child project (bounded by child count).
+            // getUsersWithAccessToProject applies each project's psettings/client access
+            // rules, so we keep the per-project call and dedupe by id.
             foreach ($childIds as $pid) {
-                foreach ($this->projectService->getUsersAssignedToProject($pid) as $user) {
+                foreach ($this->projectService->getUsersWithAccessToProject((int) $pid) as $user) {
                     $users[$user['id']] = $user;
                 }
             }

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -280,7 +280,13 @@ class Timesheets extends Repository
             $fromDate = $fromDate->copy()->setTimezone('UTC');
         }
 
-        $endDate = $fromDate->copy()->addDays(7);
+        // Entries are stored as the user's local midnight converted to UTC, so rows logged
+        // under a different UTC offset (DST) can sit up to an hour outside a flat +7d window —
+        // they'd show up in the adjacent week's grid instead (#3310). Widen the window by 12h
+        // on both sides; the service buckets by local calendar day, so over-fetched rows that
+        // don't belong to this week simply don't render.
+        $startDate = $fromDate->copy()->subHours(12);
+        $endDate = $fromDate->copy()->addDays(7)->addHours(12);
 
         $query = $this->db->table('zp_timesheets')
             ->select(
@@ -309,7 +315,7 @@ class Timesheets extends Repository
             ->leftJoin('zp_tickets', 'zp_tickets.id', '=', 'zp_timesheets.ticketId')
             ->leftJoin('zp_projects', 'zp_tickets.projectId', '=', 'zp_projects.id')
             ->leftJoin('zp_clients', 'zp_clients.id', '=', 'zp_projects.clientId')
-            ->where('zp_timesheets.workDate', '>=', $fromDate->format('Y-m-d H:i:s'))
+            ->where('zp_timesheets.workDate', '>=', $startDate->format('Y-m-d H:i:s'))
             ->where('zp_timesheets.workDate', '<', $endDate->format('Y-m-d H:i:s'))
             ->where('zp_timesheets.userId', $userId)
             ->where('hours', '>', 0);

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -602,6 +602,11 @@ class Timesheets extends BaseService
             userId: $userId
         );
 
+        // The week's day columns follow the user's LOCAL calendar days. Flat UTC +Nd math
+        // drifts an hour across a DST transition, which put Monday entries into the previous
+        // week's Sunday column (#3310).
+        $weekStartLocal = CarbonImmutable::instance($fromDate)->setToUserTimezone()->startOfDay();
+
         // Timesheets are grouped by ticketId + type
         $timesheetGroups = [];
         foreach ($allTimesheets as $timesheet) {
@@ -624,8 +629,6 @@ class Timesheets extends BaseService
 
             $groupKey = $timesheet['ticketId'].'-'.$timesheet['kind'].'-'.$timezonedTime;
             if (! isset($timesheetGroups[$groupKey])) {
-                // Build an array of 7 days for the weekly timesheet. Include the start date of the current users
-                // timezone in UTC. That way we can compare the dates coming from the db
                 $timesheetGroups[$groupKey] = [
                     'kind' => $timesheet['kind'],
                     'clientName' => $timesheet['clientName'],
@@ -633,98 +636,51 @@ class Timesheets extends BaseService
                     'headline' => $timesheet['headline'],
                     'ticketId' => $timesheet['ticketId'],
                     'hasTimesheetOffset' => $workdateOffsetStart !== 0,
-                    'day1' => [
-                        'start' => $fromDate,
-                        'end' => $fromDate->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day2' => [
-                        'start' => $fromDate->addDays(1),
-                        'end' => $fromDate->addDays(1)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(1)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day3' => [
-                        'start' => $fromDate->addDays(2),
-                        'end' => $fromDate->addDays(2)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(2)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day4' => [
-                        'start' => $fromDate->addDays(3),
-                        'end' => $fromDate->addDays(3)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(3)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day5' => [
-                        'start' => $fromDate->addDays(4),
-                        'end' => $fromDate->addDays(4)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(4)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day6' => [
-                        'start' => $fromDate->addDays(5),
-                        'end' => $fromDate->addDays(5)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(5)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
-                    'day7' => [
-                        'start' => $fromDate->addDays(6),
-                        'end' => $fromDate->addDays(6)->addHours(23)->addMinutes(59),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $fromDate->addDays(6)->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
-                        'hours' => 0,
-                        'description' => '',
-                    ],
                     'rowSum' => 0,
                 ];
+
+                // Build the 7 day columns from the user's local calendar days and convert the
+                // boundaries back to UTC. addDays() in the local timezone keeps each column
+                // anchored at local midnight even when the week contains a DST transition.
+                for ($i = 1; $i < 8; $i++) {
+                    $dayStartLocal = $weekStartLocal->addDays($i - 1);
+                    $timesheetGroups[$groupKey]['day'.$i] = [
+                        'start' => $dayStartLocal->setToDbTimezone(),
+                        'end' => $dayStartLocal->addDay()->setToDbTimezone(),
+                        'localDay' => $dayStartLocal->toDateString(),
+                        'actualWorkDate' => $workdateOffsetStart === 0 ? $dayStartLocal->setToDbTimezone()->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
+                        'hours' => 0,
+                        'description' => '',
+                    ];
+                }
             }
 
-            // Check if timesheet entry falls within the day range of the weekly grouped timesheets that we are trying
-            // to pull up.
-            //
-            // Why would that be different you might ask?
-            //
-            // If a user adds time entries and then changes timezones (even just 1 hour) the values in the db
-            // will be different since it is based on start of the day 00:00:00 in the current users timezone and then
-            // stored as UTC timezone shoifted value in the db.
-            // If the value is not exact but falls within the time period we're adding a new row
+            // The stored workDate is the user's local midnight converted to UTC — but possibly
+            // under a different UTC offset than today (entry logged before a DST switch, or the
+            // user changed timezones). Converted to the current user timezone such an entry sits
+            // shortly before or after midnight; rounding to the nearest midnight recovers the
+            // calendar day the user actually logged, so a Monday entry can never render in the
+            // previous week's Sunday column (#3310).
+            $entryLocalTime = $currentWorkDate->setToUserTimezone();
+            $intendedDay = $entryLocalTime->hour >= 12
+                ? $entryLocalTime->addDay()->toDateString()
+                : $entryLocalTime->toDateString();
+
             for ($i = 1; $i < 8; $i++) {
-
-                $start = $timesheetGroups[$groupKey]['day'.$i]['start'];
-                $end = $timesheetGroups[$groupKey]['day'.$i]['end'];
-
-                if ($currentWorkDate->gte($start) && $currentWorkDate->lt($end)) {
+                if ($intendedDay === $timesheetGroups[$groupKey]['day'.$i]['localDay']) {
                     $timesheetGroups[$groupKey]['day'.$i]['hours'] += $timesheet['hours'];
                     $timesheetGroups[$groupKey]['day'.$i]['actualWorkDate'] = $currentWorkDate;
                     $timesheetGroups[$groupKey]['day'.$i]['description'] = $timesheet['description'];
+                    $timesheetGroups[$groupKey]['rowSum'] += $timesheet['hours'];
 
-                    // No need to check further, we found what we came for
                     break;
                 }
             }
-
-            /*for ($i = 1; $i < 8; $i++) {
-                if ($timesheetGroups[$groupKey]["day" . $i]['actualWorkDate'] == $currentWorkDate) {
-                    $timesheetGroups[$groupKey]["day" . $i]['hours'] += $timesheet['hours'];
-                    $timesheetGroups[$groupKey]["day" . $i]['description'] = $timesheet['description'];
-                    // No need to check further, we found what we came for
-                    break;
-                }
-            }*/
-
-            // Add to rowsum
-            $timesheetGroups[$groupKey]['rowSum'] += $timesheet['hours'];
         }
 
-        return $timesheetGroups;
+        // The repository over-fetches by 12h on both sides of the week; drop groups whose
+        // entries all belong to an adjacent week so they don't render as empty rows.
+        return array_filter($timesheetGroups, fn (array $group) => $group['rowSum'] > 0);
     }
 
     /**

--- a/app/Domain/Timesheets/Services/Timesheets.php
+++ b/app/Domain/Timesheets/Services/Timesheets.php
@@ -644,11 +644,16 @@ class Timesheets extends BaseService
                 // anchored at local midnight even when the week contains a DST transition.
                 for ($i = 1; $i < 8; $i++) {
                     $dayStartLocal = $weekStartLocal->addDays($i - 1);
+                    $dayStartUtc = $dayStartLocal->setToDbTimezone();
                     $timesheetGroups[$groupKey]['day'.$i] = [
-                        'start' => $dayStartLocal->setToDbTimezone(),
+                        'start' => $dayStartUtc,
                         'end' => $dayStartLocal->addDay()->setToDbTimezone(),
                         'localDay' => $dayStartLocal->toDateString(),
-                        'actualWorkDate' => $workdateOffsetStart === 0 ? $dayStartLocal->setToDbTimezone()->setTime($currentWorkDate->hour, $currentWorkDate->minute, $currentWorkDate->second) : '',
+                        // Empty cells seed the workDate a new entry would get: that day's exact
+                        // local midnight (in UTC). Not derived from the first entry's time-of-day,
+                        // which would drift by the DST hour across a transition and store the new
+                        // entry an hour off local midnight (it feeds upsertTime via the form key).
+                        'actualWorkDate' => $workdateOffsetStart === 0 ? $dayStartUtc : '',
                         'hours' => 0,
                         'description' => '',
                     ];

--- a/config/sample.env
+++ b/config/sample.env
@@ -46,6 +46,7 @@ LEAN_LANGUAGE = 'en-US'                            # Default language
 LEAN_DEFAULT_TIMEZONE = 'America/Los_Angeles'      # Set default timezone
 LEAN_LOG_PATH = ''                                 # Default Log Path (including filename), if not set /logs/error.log will be used
 LEAN_LOG_CHANNELS = 'single,syslog,sentry'         # Logging channels (comma-separated): single, syslog, sentry, stderr. Use 'stderr' for container logging.
+LEAN_LOG_DEPRECATIONS = 0                          # Write PHP deprecation notices to logs/deprecations.log (off by default; also enabled by LEAN_DEBUG)
 LEAN_DISABLE_LOGIN_FORM = false                    # If true then don't show the login form (useful only if additional auth method[s] are available)
 #LEAN_TRUSTED_PROXIES = '127.0.0.1,REMOTE_ADDR'    # Set trusted proxy ips. Can be used to restrict access or define access from certain proxies only. Default is access from anywhere
 

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ install-deps-dev:
 
 install-deps:
 	npm install
-	composer install --no-dev --optimize-autoloader
+	composer install --no-dev --optimize-autoloader --prefer-dist
 
 build: install-deps clear-cache
 	npx mix --production
@@ -61,6 +61,14 @@ package: clean build
 
 	# Removing unneeded items for release
 	rm -rf $(TARGET_DIR)/public/dist/images/Screenshots
+
+	# Strip vendor bloat (#3330): composer source-fallback installs ship .git dirs
+	# and aws-sdk build/test artifacts that ballooned releases from ~50MB to ~860MB
+	find $(TARGET_DIR)/vendor -type d -name ".git" -prune -exec rm -rf {} +
+	rm -rf $(TARGET_DIR)/vendor/aws/aws-sdk-php/build
+	rm -rf $(TARGET_DIR)/vendor/aws/aws-sdk-php/features
+	rm -rf $(TARGET_DIR)/vendor/aws/aws-sdk-php/tests
+	rm -rf $(TARGET_DIR)/vendor/aws/aws-sdk-php/.changes
 
 	# Removing javascript directories
 	find  $(TARGET_DIR)/app/Domain/ -depth -maxdepth 2 -name "js" -exec rm -rf {} \;

--- a/tests/Unit/app/Domain/Projects/Services/ProjectsServiceTest.php
+++ b/tests/Unit/app/Domain/Projects/Services/ProjectsServiceTest.php
@@ -608,4 +608,61 @@ class ProjectsServiceTest extends TestCase
 
         $this->assertSame(1, $capturedUserId, 'a non-admin must not be able to read another user\'s project assignments');
     }
+
+    // ---- Project hierarchy safety (#3540: cyclic parents hung every page via the project selector) ----
+
+    public function test_find_my_children_builds_nested_hierarchy(): void
+    {
+        $projects = [
+            ['id' => 1, 'parent' => 0, 'name' => 'Program'],
+            ['id' => 2, 'parent' => 1, 'name' => 'Project'],
+            ['id' => 3, 'parent' => 2, 'name' => 'Subproject'],
+            ['id' => 4, 'parent' => 0, 'name' => 'Standalone'],
+        ];
+
+        $hierarchy = $this->makeService()->findMyChildren(0, $projects);
+
+        $this->assertCount(2, $hierarchy);
+        $this->assertSame(2, $hierarchy[0]['children'][0]['id']);
+        $this->assertSame(3, $hierarchy[0]['children'][0]['children'][0]['id']);
+        $this->assertArrayNotHasKey('children', $hierarchy[1]);
+    }
+
+    public function test_find_my_children_does_not_recurse_on_self_referential_parent(): void
+    {
+        $projects = [
+            ['id' => 1, 'parent' => 0, 'name' => 'Root'],
+            ['id' => 2, 'parent' => 2, 'name' => 'Self-parented'],
+        ];
+
+        $hierarchy = $this->makeService()->findMyChildren(0, $projects);
+
+        $this->assertCount(1, $hierarchy, 'must terminate instead of recursing on a self-parented project');
+        $this->assertSame(1, $hierarchy[0]['id']);
+    }
+
+    public function test_clean_parent_relationship_reroots_self_parent_and_cycles(): void
+    {
+        $projects = [
+            ['id' => 1, 'parent' => 1, 'name' => 'Self-parented'],
+            ['id' => 2, 'parent' => 3, 'name' => 'Cycle A'],
+            ['id' => 3, 'parent' => 2, 'name' => 'Cycle B'],
+            ['id' => 4, 'parent' => 99, 'name' => 'Orphan'],
+            ['id' => 5, 'parent' => 1, 'name' => 'Valid child'],
+        ];
+
+        $service = $this->makeService();
+        $clean = $service->cleanParentRelationship($projects);
+        $byId = array_column($clean, null, 'id');
+
+        $this->assertSame(0, $byId[1]['parent'], 'self-parent must be re-rooted');
+        $this->assertSame(0, $byId[2]['parent'], 'cycle members must be re-rooted');
+        $this->assertSame(0, $byId[3]['parent'], 'cycle members must be re-rooted');
+        $this->assertSame(0, $byId[4]['parent'], 'orphans must be re-rooted');
+        $this->assertSame(1, $byId[5]['parent'], 'valid parent links must be preserved');
+
+        // The full pipeline must terminate and surface every project.
+        $hierarchy = $service->findMyChildren(0, $clean);
+        $this->assertCount(4, $hierarchy);
+    }
 }

--- a/tests/Unit/app/Domain/Timesheets/Services/TimesheetsServiceTest.php
+++ b/tests/Unit/app/Domain/Timesheets/Services/TimesheetsServiceTest.php
@@ -409,4 +409,99 @@ class TimesheetsServiceTest extends TestCase
 
         $this->assertSame(1, $captured['userId'], 'A non-manager must be pinned to their own userId');
     }
+
+    // ---- Weekly grid bucketing across DST (#3310: Monday entry echoed on previous week's Sunday) ----
+
+    /** Switches the datetime helpers to America/New_York for the DST bucketing tests. */
+    private function useNewYorkTimezone(): void
+    {
+        session(['usersettings.timezone' => 'America/New_York']);
+        CarbonImmutable::mixin(new CarbonMacros('America/New_York', 'en-US', 'Y-m-d', 'H:i'));
+    }
+
+    /** A timesheet row as returned by the repository's weekly query. */
+    private function weeklyRow(string $workDate, float $hours = 1.0): array
+    {
+        return [
+            'workDate' => $workDate,
+            'ticketId' => 42,
+            'kind' => 'GENERAL_BILLABLE',
+            'hours' => $hours,
+            'description' => 'work',
+            'clientName' => 'Acme',
+            'name' => 'Project',
+            'headline' => 'Ticket',
+        ];
+    }
+
+    public function test_weekly_grid_buckets_entry_into_its_local_calendar_day(): void
+    {
+        $this->useNewYorkTimezone();
+
+        // Week of Mon 2026-01-05 (EST, UTC-5): anchor is local midnight in UTC.
+        $fromDate = CarbonImmutable::parse('2026-01-05 05:00:00', 'UTC');
+        // Entry logged for Wednesday 2026-01-07 (local midnight EST → 05:00 UTC).
+        $repo = $this->make(TimesheetRepository::class, [
+            'getWeeklyTimesheets' => fn () => [$this->weeklyRow('2026-01-07 05:00:00', 2.5)],
+        ]);
+
+        $groups = $this->makeService(timesheetsRepo: $repo)->getWeeklyTimesheets(-1, $fromDate, 1);
+
+        $this->assertCount(1, $groups);
+        $group = array_values($groups)[0];
+        $this->assertSame(2.5, (float) $group['day3']['hours'], 'Wednesday entry must land in the Wednesday column');
+        $this->assertSame(2.5, (float) $group['rowSum']);
+    }
+
+    public function test_monday_entry_does_not_render_in_previous_weeks_sunday_column(): void
+    {
+        $this->useNewYorkTimezone();
+
+        // US DST 2026 starts Sun 2026-03-08. An entry logged for Monday 2026-03-09
+        // (local midnight EDT) is stored as 04:00 UTC — inside the PREVIOUS week's flat
+        // +168h UTC window anchored at Mon 2026-03-02 05:00 UTC (EST).
+        $previousWeekAnchor = CarbonImmutable::parse('2026-03-02 05:00:00', 'UTC');
+        $repo = $this->make(TimesheetRepository::class, [
+            'getWeeklyTimesheets' => fn () => [$this->weeklyRow('2026-03-09 04:00:00')],
+        ]);
+
+        $groups = $this->makeService(timesheetsRepo: $repo)->getWeeklyTimesheets(-1, $previousWeekAnchor, 1);
+
+        $this->assertSame([], $groups, 'A Monday entry must not appear in the previous week (was rendered on Sunday)');
+    }
+
+    public function test_monday_entry_renders_on_monday_in_its_own_week(): void
+    {
+        $this->useNewYorkTimezone();
+
+        // The same entry viewed in ITS week: anchor Mon 2026-03-09 local midnight EDT = 04:00 UTC.
+        $weekAnchor = CarbonImmutable::parse('2026-03-09 04:00:00', 'UTC');
+        $repo = $this->make(TimesheetRepository::class, [
+            'getWeeklyTimesheets' => fn () => [$this->weeklyRow('2026-03-09 04:00:00')],
+        ]);
+
+        $groups = $this->makeService(timesheetsRepo: $repo)->getWeeklyTimesheets(-1, $weekAnchor, 1);
+
+        $this->assertCount(1, $groups);
+        $group = array_values($groups)[0];
+        $this->assertSame(1.0, (float) $group['day1']['hours'], 'Monday entry must land in the Monday column');
+    }
+
+    public function test_entry_stored_under_previous_dst_offset_still_buckets_to_intended_day(): void
+    {
+        $this->useNewYorkTimezone();
+
+        // Entry logged for Monday 2026-03-09 while the clock was still EST (05:00 UTC),
+        // viewed in the EDT-anchored week (anchor 04:00 UTC). Locally that's Mon 01:00 —
+        // rounding to the nearest midnight keeps it on Monday.
+        $weekAnchor = CarbonImmutable::parse('2026-03-09 04:00:00', 'UTC');
+        $repo = $this->make(TimesheetRepository::class, [
+            'getWeeklyTimesheets' => fn () => [$this->weeklyRow('2026-03-09 05:00:00')],
+        ]);
+
+        $groups = $this->makeService(timesheetsRepo: $repo)->getWeeklyTimesheets(-1, $weekAnchor, 1);
+
+        $group = array_values($groups)[0];
+        $this->assertSame(1.0, (float) $group['day1']['hours'], 'Offset-drifted Monday entry must stay in the Monday column');
+    }
 }


### PR DESCRIPTION
## Summary

Second July batch from the open-issue triage — six per-issue commits:

- **#3540 — /files & project pages hang → 256MB OOM.** Root cause was not the Files domain: the header project selector (rendered on every page) recursed unbounded when a project's parent chain looped back on itself. `findMyChildren` is now O(n) with a visited-set, `cleanParentRelationship` re-roots self-parented/cyclic projects, the recursive Blade partial gets a depth cap, and `editProject`/`patch` reject parent assignments that would create a cycle. Unit tests cover self-parent, two-node cycles and orphans.
- **#3331 — client-scoped projects couldn't assign to-dos to client users.** Visibility honors `psettings` but the assignee dropdowns read only the direct-assignment table. New `getUsersWithAccessToProject()` (repo + service) unions directly assigned users with the client's active users ('clients') or all active users ('all'); ticket controllers/user lists now use it. Notification and team-management paths intentionally keep the direct-assignment method.
- **#3310 — Monday timesheet entry echoed on previous week's Sunday.** Weekly grid used flat UTC +Nd math, which drifts an hour across DST transitions. Day columns now follow the user's local calendar days and entries bucket by their intended local day (local time rounded to nearest midnight); the fetch window over-scans ±12h and non-matching groups are dropped. Regression tests span the 2026 US spring-forward.
- **#3589 — deprecations.log grew unbounded.** Deprecations go to the null handler unless `LEAN_DEBUG` or the new `LEAN_LOG_DEPRECATIONS` is set.
- **#3330 — release archives ballooned (~50MB → ~860MB in vendor/aws).** The release runner's unauthenticated composer install got rate-limited and fell back to source (git clone) installs. The workflow now authenticates composer via `COMPOSER_AUTH`; the makefile prefers dists and strips `.git`/aws-sdk build artifacts from the package.
- **#3546 — published Docker image stale (missing pdo_pgsql).** New `publish_docker` job in the release workflow builds the multi-arch image from `.docker/Dockerfile` against the release tarball and pushes `leantime/leantime:{version}` + `:latest`. ⚠️ Requires `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets — until configured the job skips with a warning.

## Test plan

- [x] Pint clean, PHPStan (level 5) clean, `php -l` on all changed files
- [x] Full unit suite: 663 tests / 1662 assertions passing (includes 3 new hierarchy tests + 4 new DST bucketing tests)
- [ ] Acceptance groups `ticket`/`timesheet` in Docker (see CI)
- [ ] Configure Docker Hub secrets before the next release to activate image publishing

Fixes #3540
Fixes #3331
Fixes #3310
Fixes #3589
Fixes #3330
Fixes #3546

🤖 Generated with [Claude Code](https://claude.com/claude-code)