### PR TITLE
fix(tickets): move ticket status dropdown into the Organization sidebar

### DIFF
--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
@@ -8,25 +8,6 @@
                 <div class="form-group">
                     <x-global::forms.text-input value="{{ $ticket->headline }}" name="headline" variant="headline" autocomplete="off" style="width:99%; margin-bottom:10px;" placeholder="{{ __('input.placeholders.enter_title_of_todo') }}" />
                 </div>
-                <!-- Status -->
-                <div class="form-group tw-flex tw-w-3/5">
-                    <label class="control-label tw-mx-m tw-w-[100px]">{!! __('label.todo_status') !!}</label>
-                    <div class="">
-                        <select
-                            id="status-select"
-                            class=""
-                            name="status"
-                            data-placeholder="{{ isset($ticket->status) ? $statusLabels[$ticket->status]['name'] ?? '' : '' }}"
-                        >
-                            @foreach ($statusLabels as $key => $label)
-                                <option value="{{ $key }}"
-                                    @if ($ticket->status == $key) selected='selected' @endif
-                                >{{ $label['name'] }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                </div>
-
                 <!-- Priority -->
                 <div class="form-group tw-flex tw-w-3/5">
                     <label class="control-label tw-mx-m tw-w-[100px]">{!! __('label.priority') !!}</label>
@@ -218,6 +199,25 @@
                                 >{{ $tpl->escape($project['name']) }}</option>
                             @endforeach
                         </select>
+                    </div>
+
+                    <!-- Status -->
+                    <div class="form-group">
+                        <label class="control-label">{!! __('label.todo_status') !!}</label>
+                        <div class="">
+                            <select
+                                id="status-select"
+                                class="span11"
+                                name="status"
+                                data-placeholder="{{ isset($ticket->status) ? $statusLabels[$ticket->status]['name'] ?? '' : '' }}"
+                            >
+                                @foreach ($statusLabels as $key => $label)
+                                    <option value="{{ $key }}"
+                                        @if ($ticket->status == $key) selected='selected' @endif
+                                    >{{ $label['name'] }}</option>
+                                @endforeach
+                            </select>
+                        </div>
                     </div>
 
                     <!-- Milestones -->


### PR DESCRIPTION
## Summary

On the ticket detail screen, the **Status** dropdown sat by itself at the top of the wide left content column — above the description and visually disconnected from the other categorization fields. This moves it into the right-hand **Organization** panel, between **Project** and **Milestone**, where it belongs alongside the other planning selectors.

Sidebar order is now: **Type → Project → Status → Milestone → Sprint → Related**.

## Details

- Pure relocation + restyle. The field keeps its `id="status-select"`, `name="status"`, `data-placeholder`, and the full options loop unchanged — so form submission and any JS/Chosen.js binding behave exactly as before.
- Restyled to match the sidebar's other fields: dropped the left column's horizontal `tw-flex tw-w-3/5` wrapper / `tw-mx-m tw-w-[100px]` label for the panel's stacked `form-group` + `control-label`, and gave the `<select>` `class="span11"` for full sidebar width.
- The left column now leads with Priority.

## Notes

`initStatusDropdown` in `ticketsController.js` binds the `.statusDropdown` card menus (kanban/list), **not** this form's `#status-select`, so nothing there is affected. Renders on every ticket detail screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)