### PR TITLE
fix(mcp): shim removed php-mcp provider so in-place upgrades boot (#3601)

### DIFF
--- a/app/Core/Shims/McpServiceProvider.php
+++ b/app/Core/Shims/McpServiceProvider.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PhpMcp\Laravel;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class McpServiceProvider extends ServiceProvider
@@ -50,8 +51,20 @@ class McpServiceProvider extends ServiceProvider
         foreach (['packages.php', 'services.php'] as $file) {
             $path = $this->app->bootstrapPath('cache/'.$file);
 
-            if (is_file($path)) {
-                @unlink($path);
+            if (! is_file($path)) {
+                continue;
+            }
+
+            if (! @unlink($path)) {
+                // The app still boots (this provider is a harmless no-op), but a
+                // non-writable bootstrap/cache means the stale manifest -- and this
+                // shim -- persist on every request, so surface it for operators.
+                // Logging must never break boot, hence the guard.
+                try {
+                    Log::warning("Leantime: could not delete stale package manifest {$path}; check bootstrap/cache permissions.");
+                } catch (\Throwable) {
+                    // no-op
+                }
             }
         }
     }

--- a/app/Core/Shims/PhpMcpMcpServiceProvider.php
+++ b/app/Core/Shims/PhpMcpMcpServiceProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Compatibility shim for upgrades from Leantime <= 3.9.6.
+ *
+ * Through 3.9.6, core depended on php-mcp/laravel, whose service provider
+ * (PhpMcp\Laravel\McpServiceProvider) was auto-discovered by Laravel's package
+ * manifest and baked into bootstrap/cache/packages.php. 3.9.7 replaced php-mcp
+ * with laravel/mcp and dropped the package.
+ *
+ * An in-place (unzip) upgrade does not clear bootstrap/cache, so the stale
+ * compiled manifest survives and still lists the old provider. Laravel then
+ * tries to instantiate PhpMcp\Laravel\McpServiceProvider while registering
+ * providers during bootstrap and fatals with "class not found" -- before the
+ * Leantime updater (which clears the cache) ever gets a chance to run. The app
+ * is fully down (see leantime/leantime#3601).
+ *
+ * This no-op provider stands in for the removed class so the application boots,
+ * then deletes the stale compiled manifests so the next request rebuilds them
+ * against the current (php-mcp-free) dependency set and this shim is no longer
+ * referenced.
+ *
+ * Safe to delete once in-place upgrades from <= 3.9.6 are no longer supported.
+ */
+
+namespace PhpMcp\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+
+class McpServiceProvider extends ServiceProvider
+{
+    /**
+     * Boot far enough to survive a stale package manifest, then flush it so the
+     * next request no longer references the removed php-mcp provider.
+     */
+    public function register(): void
+    {
+        $this->flushStalePackageManifest();
+    }
+
+    /**
+     * Remove the compiled package/service manifests. They were already loaded
+     * into memory for this request, so deleting them here is safe and simply
+     * forces Laravel to recompile them (without php-mcp) on the next request.
+     */
+    private function flushStalePackageManifest(): void
+    {
+        foreach (['packages.php', 'services.php'] as $file) {
+            $path = $this->app->bootstrapPath('cache/'.$file);
+
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,9 @@
                 "app/"
             ]
         },
+        "classmap": [
+            "app/Core/Shims/"
+        ],
         "files": [
             "app/helpers.php"
         ]


### PR DESCRIPTION
## Summary

Fixes #3601 — upgrading in place (unzip method) from **≤ 3.9.6 to 3.9.7** hard-crashes the whole app with:

> `Class "PhpMcp\Laravel\McpServiceProvider" not found`

## Root cause

Through 3.9.6, core depended on `php-mcp/laravel`, whose service provider was **auto-discovered** by Laravel into `bootstrap/cache/packages.php`. 3.9.7 replaced php-mcp with `laravel/mcp` and dropped the package (#3581).

An unzip upgrade doesn't clear `bootstrap/cache/`, so the stale compiled provider manifest survives. Laravel then tries to instantiate `PhpMcp\Laravel\McpServiceProvider` while compiling the manifest during `RegisterProviders` — and fatals, because the class no longer exists in `vendor/`.

Crucially this happens **during bootstrap, before any Leantime code runs** — so the existing update-time cache clear (`UpdateLeantime.php:161`) can never execute. The app is fully down and can't self-heal.

## Fix

- Adds a no-op `PhpMcp\Laravel\McpServiceProvider` shim (`app/Core/Shims/`, autoloaded via a new `autoload.classmap` entry) so the stale manifest resolves and the app boots.
- The shim's `register()` deletes the stale `packages.php` / `services.php`, so the **next** request recompiles the manifest against the current (php-mcp-free) dependency set and the shim is no longer referenced.
- Safe to remove once in-place upgrades from ≤ 3.9.6 are no longer supported.

## Immediate workaround for affected users (no upgrade needed)

Delete the stale compiled manifest and the app boots:
```
rm -f bootstrap/cache/packages.php bootstrap/cache/services.php
```

## Test plan

- [x] `php -l` on the shim
- [x] Shim class autoloads via the generated classmap (`class_exists` passes)
- [x] `register()` deletes `packages.php` + `services.php` from `bootstrap/cache`
- [ ] End-to-end: plant a stale `packages.php` referencing the old provider on a 3.9.7 build and confirm boot + self-heal
- [ ] Ship in a 3.9.8 patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)