### PR TITLE
chore(deps): sync composer.lock content-hash with composer.json

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a225115281a6ded15fea77c3b21141c",
+    "content-hash": "fc642660fb4f53385a1e1b597aa11693",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
## Summary

`composer.lock`'s stored `content-hash` had drifted from `composer.json`, so every `composer install` (including release builds) printed:

> Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies.

`composer.json` was edited at some point without regenerating the hash. **No packages are missing from the lock and no versions need to change** — this only corrects the stale hash.

## Change

Sets `content-hash` to the value computed by Composer's own `Locker::getContentHash()` for the current `composer.json`. One line, no dependency changes.

I deliberately did **not** run `composer update --lock` / re-resolve: on this lock that fails on a guzzle security advisory and would pull in an unrelated version bump. Correcting just the hash keeps the change zero-risk and in-scope. (There *is* a separate guzzle/aws advisory worth addressing on its own — noting it here, not fixing it in this PR.)

## Verification

- [x] `composer validate` → `composer.json is valid` (no lock errors) after the change
- [x] Diff is a single line (the `content-hash`); no package versions touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)