### PR TITLE
fix(sessions): isolate sessions into their own redis database

### DIFF
--- a/app/Core/Cache/Redis/RedisServiceProvider.php
+++ b/app/Core/Cache/Redis/RedisServiceProvider.php
@@ -60,6 +60,13 @@ class RedisServiceProvider extends ServiceProvider
                     'parameters' => ['timeout' => 1.0],
                 ]);
             } else {
+                // Sessions live in their OWN redis database. Cache and sessions previously
+                // shared db 0 (differing only by key prefix), so ANY cache flush — Laravel's
+                // RedisStore::flush() issues FLUSHDB — destroyed every session and logged every
+                // user out (e.g. whenever `cache:clear` ran against production). Redis Cluster
+                // does not support SELECT, so isolation only applies to non-cluster setups.
+                $sessionsConfig['database'] = env('LEAN_REDIS_SESSION_DB', 1);
+
                 $app['config']->set('redis.cache', $cacheConfig);
                 $app['config']->set('redis.installation', $installationConfig);
                 $app['config']->set('redis.sessions', $sessionsConfig);

--- a/app/Core/Cache/Redis/RedisServiceProvider.php
+++ b/app/Core/Cache/Redis/RedisServiceProvider.php
@@ -65,7 +65,8 @@ class RedisServiceProvider extends ServiceProvider
                 // RedisStore::flush() issues FLUSHDB — destroyed every session and logged every
                 // user out (e.g. whenever `cache:clear` ran against production). Redis Cluster
                 // does not support SELECT, so isolation only applies to non-cluster setups.
-                $sessionsConfig['database'] = env('LEAN_REDIS_SESSION_DB', 1);
+$cacheDb = (int) ($cacheConfig['database'] ?? 0);
+$sessionsConfig['database'] = (int) env('LEAN_REDIS_SESSION_DB', $cacheDb === 0 ? 1 : 0);
 
                 $app['config']->set('redis.cache', $cacheConfig);
                 $app['config']->set('redis.installation', $installationConfig);

--- a/config/sample.env
+++ b/config/sample.env
@@ -205,7 +205,7 @@ LEAN_REDIS_HOST = ''
 LEAN_REDIS_PORT = 6379
 LEAN_REDIS_PASSWORD = ''
 LEAN_REDIS_SCHEME = ''
-LEAN_REDIS_SESSION_DB = 1                          # Redis database for SESSIONS (cache stays on db 0). Keeping them apart means cache flushes (FLUSHDB) can never log users out. Non-cluster setups only.
+LEAN_REDIS_SESSION_DB = 1                          # Redis database for SESSIONS. Set this to a different DB than the cache connection (LEAN_REDIS_DB, default 0) so cache FLUSHDB can never log users out. Non-cluster setups only.
 
 ## Rate limiting (per minute; keyed by client IP + session user id when available)
 LEAN_RATELIMIT_GENERAL = 2000                           # Cron (/cron) and other non-API requests routed through the limiter

--- a/config/sample.env
+++ b/config/sample.env
@@ -205,6 +205,7 @@ LEAN_REDIS_HOST = ''
 LEAN_REDIS_PORT = 6379
 LEAN_REDIS_PASSWORD = ''
 LEAN_REDIS_SCHEME = ''
+LEAN_REDIS_SESSION_DB = 1                          # Redis database for SESSIONS (cache stays on db 0). Keeping them apart means cache flushes (FLUSHDB) can never log users out. Non-cluster setups only.
 
 ## Rate limiting (per minute; keyed by client IP + session user id when available)
 LEAN_RATELIMIT_GENERAL = 2000                           # Cron (/cron) and other non-API requests routed through the limiter


### PR DESCRIPTION
## Problem

Cache and sessions share **redis db 0**, differing only by key prefix (`leantime_cache:` vs `leantime_sessions:`). Laravel's `RedisStore::flush()`/`clear()` issues **`FLUSHDB`** — so *any* cache clear destroys every session and logs every user out.

The killer instance is `Install.php:338`: `Cache::store('installation')->clear()` runs inside the **per-tenant post-update flow**. Live-captured on Leantime Cloud: a single tenant running `/install/update` flushed the shared redis and logged out every user on every workspace (session count 296 → 2 at the exact second, 117 historical FLUSHDBs on the instance). On any multi-tenant or shared-redis deployment, every release causes days of "random" fleet-wide logouts as tenants trickle through their update.

## Fix

- Sessions get their **own redis database** (`LEAN_REDIS_SESSION_DB`, default `1`) in the non-cluster path of `RedisServiceProvider`. Cache flushes on db 0 can no longer touch sessions; `Install.php:338` keeps its intent (clearing stale route/plugin caches after a version change) without the logout blast radius.
- Redis Cluster doesn't support `SELECT`, so cluster deployments keep the shared db (commented in code).
- `config/sample.env` documents the new knob.

## Deploy note

The first deploy with this change relocates session storage → all users are logged out **once**. After that, cache clears are permanently harmless to sessions.

## Verification

- `php -l` + Pint clean.
- Post-deploy: `redis-cli INFO keyspace` shows session keys accumulating in `db1` while `leantime_cache:*` stays in `db0`; trigger a tenant `/install/update` (or any `Cache::store('installation')->clear()`) and confirm logged-in sessions survive.

## Follow-up (separate, perf-only)

Scope `Install.php:338` to prefix-scan deletion so one tenant's update stops wiping all tenants' *cache* (stampede; no longer a logout risk after this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)