### PR TITLE
Release v3.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Version: 3.9.8
+
+## Bug Fixes
+- **Milestones** - Fixed reports showing 0% completion and the timeline "Show Tasks" view displaying nothing (#3624, #3625, #3628)
+- **Milestone Modal** - Resolved focus loss, restored save-and-close, and fixed a 500 error when saving goals (#3605)
+- **To-Dos** - Kept To-Dos from closed projects browsable once the project is reopened (#3626, #3627)
+- **Post-3.9.7 Regressions** - Fixed a file browser out-of-memory issue, strategy grouping, and 403 errors for legacy roles (#3621)
+- **MCP Endpoint** - The /mcp endpoint now accepts Leantime API keys, and a shim for the removed php-mcp provider lets in-place upgrades boot (#3601, #3602, #3607)
+- **Program Board** - Moved the card status dropdown below the field row (#3599)
+
+## Improvements
+- **Sessions** - Isolated sessions into their own Redis database to avoid clashes with other cached data (#3604)
+
+## Dependency Updates
+- Bumped the McpServer submodule to include the bulkAddTasks fix (#3620, #3622)
+- Synced composer.lock content hash with composer.json (#3603)
+
+---
+
 # Version: 3.9.7
 
 ## Highlights

--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -7,7 +7,7 @@ namespace Leantime\Core\Configuration;
  */
 class AppSettings
 {
-    public string $appVersion = '3.9.7';
+    public string $appVersion = '3.9.8';
 
     public string $dbVersion = '3.5.20';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leantime",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leantime",
-      "version": "3.9.7",
+      "version": "3.9.8",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leantime",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "Open source innovation management system",
   "dependencies": {
     "@assuradeurengilde/fontawesome-iconpicker": "^3.2.3",


### PR DESCRIPTION
Automated release PR. Review and edit the changelog below (it ships as CHANGELOG.md and as the GitHub release notes), wait for CI, then merge - the release publishes automatically.

---

# Version: 3.9.8

## Bug Fixes
- **Milestones** - Fixed reports showing 0% completion and the timeline "Show Tasks" view displaying nothing (#3624, #3625, #3628)
- **Milestone Modal** - Resolved focus loss, restored save-and-close, and fixed a 500 error when saving goals (#3605)
- **To-Dos** - Kept To-Dos from closed projects browsable once the project is reopened (#3626, #3627)
- **Post-3.9.7 Regressions** - Fixed a file browser out-of-memory issue, strategy grouping, and 403 errors for legacy roles (#3621)
- **MCP Endpoint** - The /mcp endpoint now accepts Leantime API keys, and a shim for the removed php-mcp provider lets in-place upgrades boot (#3601, #3602, #3607)
- **Program Board** - Moved the card status dropdown below the field row (#3599)

## Improvements
- **Sessions** - Isolated sessions into their own Redis database to avoid clashes with other cached data (#3604)

## Dependency Updates
- Bumped the McpServer submodule to include the bulkAddTasks fix (#3620, #3622)
- Synced composer.lock content hash with composer.json (#3603)
