### PR TITLE
fix(mcp): accept Leantime API keys on the /mcp endpoint

### DIFF
--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -89,7 +89,7 @@ class AuthCheck
 
     protected function authenticate($request, array $guards, $loginRedirect, $next)
     {
-        if ($request->isApiOrCronRequest()) {
+        if ($request->isApiOrCronRequest() || $request->isMcpRequest()) {
             return $this->authenticateApi($request, $guards);
         }
 


### PR DESCRIPTION
## Problem

Connecting an MCP client to Leantime with a **regular Leantime API key** (`lt_{user}_{key}` sent via the `x-api-key` header) fails, while Sanctum Bearer tokens were the only credential the endpoint accepted. API keys are the mainstream/service-account credential and work everywhere else (`/api/jsonrpc`), so `/mcp` should accept them too.

## Root cause

Two things combined to block `x-api-key`:

1. **Core auth routed `/mcp` down the web branch.** `AuthCheck::authenticate()` gated the API auth path on `isApiOrCronRequest()`, which matches only `/api/jsonrpc` and `/cron` — not `/mcp`. So MCP took the **web** branch (`authenticateWeb`), which never calls `establishApiUserSession()` (a Bearer/Sanctum user authenticates but `session('userdata')` stays empty, and every MCP tool reads `session('userdata.id')`), and redirects to the login page on failure instead of returning a JSON 401.
2. **The route pinned `auth:sanctum`** in the plugins submodule, hard-rejecting any request without a Bearer token — see the companion PR below.

## Fix (this PR — core half)

```diff
-        if ($request->isApiOrCronRequest()) {
+        if ($request->isApiOrCronRequest() || $request->isMcpRequest()) {
             return $this->authenticateApi($request, $guards);
         }
```

- Reuses the existing `IncomingRequest::isMcpRequest()` — no new helper.
- **Deliberately does not modify `isApiOrCronRequest()` itself**: six other callers branch on it (`StartSession`, `Installed`, `Updated`, `Language`, `RequestRateLimiter`) and must keep their current `/mcp` behavior. The change is localized to the auth decision.
- Effect: `/mcp` now runs `authenticateApi()` — full guard chain (`x-api-key`), Bearer fallback (Sanctum PAT + native `getUserByToken()`), uniform `session('userdata')` via `establishApiUserSession()`, and a JSON 401 on failure.

## Companion PR (required, merge together)

Leantime/plugins#68 removes the `auth:sanctum` route pin on `/mcp`. This PR bumps the submodule pointer to that change. Both are needed: without the core change Bearer users have an empty user context; without the plugin change the sanctum-only route guard still 401s valid `x-api-key` requests.

> Submodule pointer currently references the plugins PR branch commit; it should be re-bumped to `main` after Leantime/plugins#68 merges.

## Verification

- ✅ Confirmed live: unauthenticated `POST /mcp` now returns `401 {"error":"Unauthorized"}` (API-style JSON) instead of a 302 HTML login redirect — proving `/mcp` now flows through the API auth path.
- End-to-end `lt_`-key round-trip:
  ```bash
  curl -sk -X POST https://<host>/mcp \
    -H 'x-api-key: lt_<user>_<key>' \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
  ```
- Regression: `/api/jsonrpc` with an `lt_` key still works (the gate change is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)