### PR TITLE
fix(tickets): keep closed-project To-Dos browsable when the project is opened (#3626)

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -502,11 +502,6 @@ class Tickets
                             ->where('zp_projects.clientId', $clientId);
                     })
                     ->orWhere('requestor.role', '>=', 40);
-            })
-            // Exclude tickets from closed projects
-            ->where(function ($q) {
-                $q->where('zp_projects.state', '<>', -1)
-                    ->orWhereNull('zp_projects.state');
             });
 
         // Apply search criteria filters
@@ -537,6 +532,15 @@ class Tickets
             }
         } elseif (isset($searchCriteria['currentProject']) && $searchCriteria['currentProject'] != '') {
             $query->where('zp_tickets.projectId', $searchCriteria['currentProject']);
+        } else {
+            // No explicit project scope (My Work / cross-project aggregation): hide tickets from
+            // closed projects to reduce clutter. When the user has explicitly scoped to a project
+            // or program above, that scope wins and its tickets show regardless of closed state, so
+            // a closed project stays fully browsable when opened directly (#3626).
+            $query->where(function ($q) {
+                $q->where('zp_projects.state', '<>', -1)
+                    ->orWhereNull('zp_projects.state');
+            });
         }
 
         if (isset($searchCriteria['users']) && $searchCriteria['users'] != '') {
@@ -1181,10 +1185,6 @@ class Tickets
             ->leftJoin('zp_user as requestor', function ($join) use ($requestorId) {
                 $join->on('requestor.id', '=', $this->connection->raw((int) $requestorId));
             })
-            ->where(function ($q) {
-                $q->where('zp_projects.state', '<>', -1)
-                    ->orWhereNull('zp_projects.state');
-            })
             ->where(function ($q) use ($userId, $clientId) {
                 $q->whereIn('zp_tickets.projectId', function ($subquery) use ($userId) {
                     $subquery->select('projectId')
@@ -1218,6 +1218,14 @@ class Tickets
             }
         } elseif (isset($searchCriteria['currentProject']) && $searchCriteria['currentProject'] != '') {
             $query->where('zp_tickets.projectId', $searchCriteria['currentProject']);
+        } else {
+            // No explicit project scope: hide milestones from closed projects to reduce clutter in
+            // cross-project views. An explicitly-opened project/program (above) shows its milestones
+            // regardless of closed state, matching getAllBySearchCriteria (#3626).
+            $query->where(function ($q) {
+                $q->where('zp_projects.state', '<>', -1)
+                    ->orWhereNull('zp_projects.state');
+            });
         }
 
         if (isset($searchCriteria['clients']) && $searchCriteria['clients'] != 0 && $searchCriteria['clients'] != '') {


### PR DESCRIPTION
## Problem (customer report)

> Whenever we close out a project, the To-Dos associated with it cease to be accessible by viewing the closed project. However, if we have a saved link directly to a To-Do, we can still view it in full. We rely heavily on retroactively looking at comments for documentation and reporting.

Closing a project is meant only to reduce clutter (hide it from the selector and cross-project screens) — a closed project should still be openable and its To-Dos/comments viewable.

## Root cause

`Tickets\Repositories\Tickets::getAllBySearchCriteria()` applied an **unconditional** `zp_projects.state <> -1` filter. Every board/list/kanban/My-Work view funnels through this method, so when a user explicitly opened a closed project (`currentProject = <closed id>`), the filter ANDed with the project scope and eliminated every row → empty To-Do list. `getAllMilestones()` had the same unconditional filter. A **direct ticket link still worked** because `getTicket($id)` has no state filter — exactly the asymmetry the customer observed.

## Fix

Move the closed-project exclusion into the **unscoped** branch of the project-scoping logic in both methods. It now applies only when there is no explicit `projects`/`currentProject` scope (My Work / cross-project aggregation), preserving the intended clutter reduction. When a specific project or program is opened, its tickets and milestones render regardless of closed state.

## Verification

Static: Pint + PHPStan clean.

Behavioral (live DB fixture — closed a 32-ticket project, then restored):

| Query | Rows |
|-------|------|
| Scoped to the closed project, **old** unconditional filter | **0** (the bug) |
| Scoped to the closed project, **new** logic | **32** (fixed) |
| My Work (unscoped) — closed project still hidden | **0** (clutter reduction preserved) |

Note: a program view (`projects` scope) that contains a closed sub-project will now show that sub-project's tickets — consistent with "explicit scope shows closed", and aligned with the reporting use case.

Fixes #3626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)