### PR TITLE
fix(milestones): report shows 0% completion (#3624) + Timeline 'Show Tasks' shows nothing (#3625)

### DIFF
--- a/app/Domain/Reports/Controllers/Show.php
+++ b/app/Domain/Reports/Controllers/Show.php
@@ -79,8 +79,11 @@ class Show extends Controller
 
         $this->tpl->assign('states', $this->ticketService->getStatusLabels());
 
-        // Milestones
+        // Milestones. getAllMilestones no longer computes percentDone in the query, so backfill each
+        // milestone's completion the same way the Roadmap/timeline does — otherwise the report shows
+        // every milestone at 0% (#3624).
         $allProjectMilestones = $this->ticketService->getAllMilestones(['sprint' => '', 'type' => 'milestone', 'currentProject' => $currentProject]);
+        $allProjectMilestones = $this->ticketService->getBulkMilestoneProgress($allProjectMilestones);
         $this->tpl->assign('milestones', $allProjectMilestones);
 
         return $this->tpl->display('reports.show');

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -1199,14 +1199,13 @@ class Tickets
                     ->orWhere('requestor.role', '>=', 40);
             });
 
-        // Restrict to milestone-type rows by default so callers that only want milestones (mobile
-        // milestone picker, default timeline) don't get tasks/subtasks listed as milestones. The
-        // Roadmap "Show Tasks" toggle clears searchCriteria['type'] to '' (via normalizeRoadmapParams)
-        // to pull each milestone's child tasks into the timeline, so honor the requested type and
-        // only apply the restriction when a non-empty type is set (#3625).
-        $milestoneType = $searchCriteria['type'] ?? 'milestone';
-        if ($milestoneType !== '') {
-            $query->where('zp_tickets.type', '=', $milestoneType);
+        // Restrict to milestone-type rows only when the caller didn't specify a type at all (e.g. the
+        // mobile milestone picker), so it doesn't get tasks/subtasks listed as milestones. Any caller
+        // that passes an explicit type — a single type, a comma-separated list, or '' from the Roadmap
+        // "Show Tasks" toggle (via normalizeRoadmapParams) — is handled by the whereIn type filter
+        // further below, so a milestone's child tasks come back and nest under it when requested (#3625).
+        if (! isset($searchCriteria['type'])) {
+            $query->where('zp_tickets.type', '=', 'milestone');
         }
 
         // Apply search criteria filters. A multi-project filter takes precedence over the

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -1199,12 +1199,15 @@ class Tickets
                     ->orWhere('requestor.role', '>=', 40);
             });
 
-        // Restrict to milestone-type rows. Without this, getAllMilestones
-        // returned ALL ticket rows (tasks, subtasks, etc.) for the project
-        // and the consumer (e.g., the mobile milestone picker, web
-        // timeline view) saw tasks listed as "milestones." The function
-        // name has always implied this filter; making it explicit.
-        $query->where('zp_tickets.type', '=', 'milestone');
+        // Restrict to milestone-type rows by default so callers that only want milestones (mobile
+        // milestone picker, default timeline) don't get tasks/subtasks listed as milestones. The
+        // Roadmap "Show Tasks" toggle clears searchCriteria['type'] to '' (via normalizeRoadmapParams)
+        // to pull each milestone's child tasks into the timeline, so honor the requested type and
+        // only apply the restriction when a non-empty type is set (#3625).
+        $milestoneType = $searchCriteria['type'] ?? 'milestone';
+        if ($milestoneType !== '') {
+            $query->where('zp_tickets.type', '=', $milestoneType);
+        }
 
         // Apply search criteria filters. A multi-project filter takes precedence over the
         // single currentProject filter (see getAllBySearchCriteria for rationale).


### PR DESCRIPTION
Two milestone regressions reported on 3.9.7 (both by @breeman1), both rooted in the `getAllMilestones()` refactor.

## #3624 — Project Reports shows every milestone at 0%
The Reports template renders `$row->percentDone`, but the query-builder rewrite of `getAllMilestones()` dropped the child-task rollup that used to compute it, so `percentDone` arrives as `null` → 0%. The Roadmap/timeline view already backfills progress via `getBulkMilestoneProgress()` after fetching; the **Reports controller was simply missing that call**.

**Fix:** `Reports\Controllers\Show` now calls `getBulkMilestoneProgress()` on the milestones, routing the report through the same (working) progress calculation as the timeline.

## #3625 — Timeline "Show Tasks" displays no tasks
`getAllMilestones()` applied an **unconditional** `WHERE type = 'milestone'`, ignoring `searchCriteria['type']`. The "Show Tasks" toggle clears the type filter (`normalizeRoadmapParams` sets `type = ''`) so a milestone's child tasks come back and nest under it by `milestoneid` — but the hard filter stripped every task row, so the toggle did nothing.

**Fix:** honor the requested type — default to `'milestone'` (preserving the guard that keeps the mobile picker / default timeline from listing tasks as milestones), but skip the restriction when the caller explicitly passes an empty type.

## Verification
- Pint + PHPStan clean.
- Live DB: for a project milestone with 3 child tasks (one done), clearing the type returns all 3 tasks (Show Tasks now populates), and the milestone's done-ratio computes to ~33% rather than 0%.

Fixes #3624, #3625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)