### PR TITLE
feat(tickets): getMyClosedTicketsForDate @api + status-change primitive

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -1844,6 +1844,47 @@ class Tickets
     }
 
     /**
+     * Status-change history events for a set of tickets within a date range.
+     *
+     * A general reporting primitive. Every time a ticket's status changes,
+     * addTicketChange() writes a zp_tickethistory row (changeType 'status',
+     * changeValue = the new status id, dateModified = timestamp). This returns
+     * those rows for the given tickets over [fromDate, toDate], newest first.
+     *
+     * Deliberately status-config-agnostic: callers resolve changeValue against
+     * their project's status labels to decide which changes count as "to DONE",
+     * "to in progress", etc. That keeps this one query reusable across mobile's
+     * "done today" reflection, throughput/burndown reporting, and strategy-level
+     * progress rollups.
+     *
+     * @param  int[]  $ticketIds
+     * @param  string  $fromDate  inclusive, 'Y-m-d'
+     * @param  string  $toDate  inclusive, 'Y-m-d'
+     * @return array<int, array{ticketId:int, changeValue:string, dateModified:string}>
+     */
+    public function getStatusChangeEvents(array $ticketIds, string $fromDate, string $toDate): array
+    {
+        if (empty($ticketIds)) {
+            return [];
+        }
+
+        $rows = $this->connection->table('zp_tickethistory')
+            ->select('ticketId', 'changeValue', 'dateModified')
+            ->where('changeType', 'status')
+            ->whereIn('ticketId', $ticketIds)
+            ->whereBetween('dateModified', [$fromDate.' 00:00:00', $toDate.' 23:59:59'])
+            ->orderBy('dateModified', 'desc')
+            ->get();
+
+        $events = [];
+        foreach ($rows as $row) {
+            $events[] = (array) $row;
+        }
+
+        return $events;
+    }
+
+    /**
      * Get all tasks (and optionally subtasks) that belong to a milestone
     /**
      * Get all tasks (and optionally subtasks) that belong to a milestone

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -2407,6 +2407,59 @@ class Tickets extends BaseService
     /**
      * @api
      *
+     * Returns the user's tasks that were marked DONE on a specific date
+     * (default today), each annotated with `dateClosed` (the completion
+     * timestamp). Powers the mobile "Done today" reflection — an accurate,
+     * complete mirror of what actually got finished, including unplanned work.
+     *
+     * "Closed on date" means the ticket is currently DONE *and* its status
+     * was changed to that DONE status on the given date (per zp_tickethistory).
+     * So a task finished on an earlier day is excluded, and a task reopened
+     * then re-completed the same day is included once. Built on the general
+     * getStatusChangeEvents primitive, so throughput/burndown and strategy
+     * reporting can reuse the same query.
+     */
+    #[RequiresPermission(TicketsPermissions::VIEW)]
+    public function getMyClosedTicketsForDate(?int $userId = null, ?string $date = null): array
+    {
+        $date = $date ?: date('Y-m-d');
+
+        // Candidates: the user's currently-DONE tickets (statusType resolved).
+        $doneTickets = $this->getAllDoneUserTickets($userId);
+        if (empty($doneTickets)) {
+            return [];
+        }
+
+        $byId = [];
+        foreach ($doneTickets as $ticket) {
+            $byId[$ticket['id']] = $ticket;
+        }
+
+        $events = $this->ticketRepository->getStatusChangeEvents(array_keys($byId), $date, $date);
+
+        $closed = [];
+        foreach ($events as $event) {
+            $ticketId = (int) $event['ticketId'];
+            $ticket = $byId[$ticketId] ?? null;
+            if ($ticket === null || isset($closed[$ticketId])) {
+                continue;
+            }
+
+            // Only count changes INTO the ticket's current (DONE) status — it
+            // was actually marked done that day, not merely touched. Events are
+            // newest-first, so the first match keeps the latest completion time.
+            if ((string) $event['changeValue'] === (string) $ticket['status']) {
+                $ticket['dateClosed'] = $event['dateModified'];
+                $closed[$ticketId] = $ticket;
+            }
+        }
+
+        return array_values($closed);
+    }
+
+    /**
+     * @api
+     *
      * Companion to markTicketDone for un-completing. Resolves the
      * project's first NEW-statusType status and patches to it. Used by
      * mobile's "Done" filter — tap the checked checkbox to bring a task


### PR DESCRIPTION
## What
Adds an `@api` method the Leantime mobile app needs for its "Done today" reflection — the accurate record of what a user actually finished on a given date — plus a reusable status-change history primitive underneath it.

- **`Repositories/Tickets::getStatusChangeEvents($ticketIds, $fromDate, $toDate)`** — general primitive. Returns `zp_tickethistory` rows (`changeType = 'status'`) for a set of tickets over a date range, newest-first. Deliberately status-config-agnostic (callers resolve `changeValue` against project status labels), so it's reusable for throughput/burndown and strategy-level progress reporting, not just mobile.
- **`Services/Tickets::getMyClosedTicketsForDate($userId, $date = today)`** — `@api`, `RequiresPermission(VIEW)`. Candidates are the user's currently-DONE tickets; it keeps those whose status changed *into* their current DONE status on `$date`, annotating each with `dateClosed`.

## Correctness
- Excludes tasks completed on an earlier day (no status-change event in range).
- A task reopened then re-completed the same day is included once (events are newest-first; first match wins).
- Only counts changes *into* the current DONE status, not incidental edits.

## Why
The mobile app currently hides completed work (done = gone). This exposes an honest, complete record of what actually got finished on a day — the foundation for the "see what you actually got done" reflection — and the history primitive is the same query the upcoming reporting work (logic-model / strategy levels) will build on.

## Testing
`php -l` clean on both files; Pint clean. Query is read-only. No schema changes (uses existing `zp_tickethistory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)