### PR TITLE
Swap invalid "if" for valid name=value pairs in Goal input

### DIFF
--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -59,7 +59,8 @@
                             <label>{{ __('label.current_value') }}</label>
                             <x-global::forms.text-input type="number" step="0.01" name="currentValue" id="currentValueField"
                                 value="{{ $canvasItem['currentValue'] }}"
-                                @if ($canvasItem['setting'] == 'linkAndReport') readonly data-tippy-content="Current value calculated from child goals" @endif
+                                :readonly="$canvasItem['setting'] == 'linkAndReport'"
+                                :data-tippy-content="$canvasItem['setting'] == 'linkAndReport' ? 'Current value calculated from child goals' : null"
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -56,11 +56,12 @@
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">
+                            @php $currentValueIsComputed = $canvasItem['setting'] == 'linkAndReport'; @endphp
                             <label>{{ __('label.current_value') }}</label>
                             <x-global::forms.text-input type="number" step="0.01" name="currentValue" id="currentValueField"
                                 value="{{ $canvasItem['currentValue'] }}"
-                                :readonly="$canvasItem['setting'] == 'linkAndReport'"
-                                :data-tippy-content="$canvasItem['setting'] == 'linkAndReport' ? 'Current value calculated from child goals' : null"
+                                :readonly="$currentValueIsComputed"
+                                :data-tippy-content="$currentValueIsComputed ? __('text.current_value_calculated_from_children') : null"
                                 style="width:105px" />
                         </div>
                         <div class="col-md-3">

--- a/app/Language/en-US.ini
+++ b/app/Language/en-US.ini
@@ -1015,6 +1015,7 @@ input.placeholders.goal.enter_title_for_board = "Name of the collection of goals
 
 label.current_value = "Current Value"
 label.goal_value = "Goal Value"
+text.current_value_calculated_from_children = "Current value calculated from child goals"
 
 label.goal.title_edited = "Edit the your goal collection name"
 


### PR DESCRIPTION


### Description

The "Current Value" field in the goal dialog (app/Domain/Goalcanvas/Templates/canvasDialog.blade.php:60-63) embedded a raw @if (...) readonly ... @endif directive inside the <x-global::forms.text-input> component tag's attribute list. Laravel Blade's component-tag compiler parses attributes with a regex that only understands name="value" pairs (plus special-cased @class()/@style()) — the ( right after @if doesn't match anything in that grammar, so the regex fails to match the whole tag, and Blade leaves it completely uncompiled. The browser then receives a literal <x-global::forms.text-input> custom element, which never self-closes, silently swallowing the rest of the dialog's markup as its children, leading to nothing rendering.

### Link to ticket

https://github.com/Leantime/leantime/issues/3633

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

<img width="1805" height="718" alt="Screenshot_10-Jul_14-31-24_17545" src="https://github.com/user-attachments/assets/bcc14778-7d1e-472a-85e6-257e0cb0b6c7" />

