### PR TITLE
fix(projects): getProjectsByUserActivity excludes archived projects (projectStatus 'open')

### DIFF
--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -1207,7 +1207,11 @@ class Projects extends BaseService implements ChecksProjectAccess
             return false;
         }
 
-        $projects = $this->projectRepository->getUserProjects(userId: $userId, accessStatus: 'all');
+        // projectStatus 'open' excludes archived projects (state === -1) at the
+        // query level — "projects I'm actively working in" shouldn't surface
+        // archived ones. Without it this defaulted to 'all' and returned
+        // archived projects too (they were padding the mobile project picker).
+        $projects = $this->projectRepository->getUserProjects(userId: $userId, projectStatus: 'open', accessStatus: 'all');
         if (! $projects) {
             return false;
         }


### PR DESCRIPTION
**For review.** One-liner Marcel identified.

`getProjectsByUserActivity` calls `getUserProjects` with `accessStatus: 'all'` but leaves `projectStatus` at its default `'all'` — so it returns **active AND archived** projects. "Projects I'm actively working in" shouldn't include archived ones, and they were padding the **mobile project picker** (a user saw ~60 extra entries under "+N more").

```php
// Domain/Projects/Services/Projects.php  (getProjectsByUserActivity)
- getUserProjects(userId: $userId, accessStatus: 'all');
+ getUserProjects(userId: $userId, projectStatus: 'open', accessStatus: 'all');
```

`projectStatus: 'open'` applies `project.state <> -1` at the query level (verified in `getUserProjects`), excluding archived — the same default every other project-list method (`getProjectsAssignedToUser`, the hierarchy methods) already uses. Also benefits web callers of this method.

**Scope:** only `getProjectsByUserActivity` (the mobile-oriented, activity-sorted method). Left `getProjectsUserHasAccessTo` untouched (more general, potentially web-relied-upon) — the mobile client keeps a defensive `state === -1` filter that covers the fallback path and older self-hosted backends that predate this fix.

`php -l` + Pint clean.