### PR TITLE
fix(tickets): assign ticketParents on NewTicket POST validation-failure path (#3640)

### DIFF
--- a/app/Domain/Tickets/Controllers/NewTicket.php
+++ b/app/Domain/Tickets/Controllers/NewTicket.php
@@ -120,6 +120,7 @@ class NewTicket extends Controller
                 $ticket->userLastname = session('userdata.name');
 
                 $this->tpl->assign('ticket', $ticket);
+                $this->tpl->assign('ticketParents', $this->ticketService->getAllPossibleParents($ticket));
                 $this->tpl->assign('statusLabels', $this->ticketService->getStatusLabels());
                 $this->tpl->assign('ticketTypes', $this->ticketService->getTicketTypes());
                 $this->tpl->assign('efforts', $this->ticketService->getEffortLabels());


### PR DESCRIPTION
## Summary

Fixes #3640 — submitting a **New To-Do with an empty title** returns HTTP 500 instead of the validation notification.

`NewTicket::get()` assigns `$ticketParents` before rendering `tickets.newTicketModal`:

```php
$this->tpl->assign('ticketParents', $this->ticketService->getAllPossibleParents($ticket));
```

The `NewTicket::post()` **validation-failure branch** re-renders the same modal but assigned `ticket`, `statusLabels`, `ticketTypes`, `efforts`, `priorities`, `milestones`, `sprints`, etc. — **without `ticketParents`**. The shared partial `app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php` iterates `$ticketParents`, so the failure path threw:

```
Undefined variable $ticketParents
(View: app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php)
Illuminate\View\ViewException  ->  HTTP 500
```

## The change

One line, in the `post()` failure branch, mirroring `get()`:

```php
 $this->tpl->assign('ticket', $ticket);
+$this->tpl->assign('ticketParents', $this->ticketService->getAllPossibleParents($ticket));
 $this->tpl->assign('statusLabels', $this->ticketService->getStatusLabels());
```

- **File:** `app/Domain/Tickets/Controllers/NewTicket.php` (`post()`)
- **Blast radius:** validation-failure path only. Happy path and `get()` unchanged. Not a data-loss / security issue.
- Reporter (@yoosungung) also suggested extracting a shared `assignTicketForm(TicketModel $ticket)` helper used by both `get()` and `post()` to prevent this drift recurring. Left out of this minimal low-risk fix; worth a follow-up cleanup.

## Acceptance checklist (must pass before merge)

1. Submitting a New To-Do with an **empty title** re-renders the modal with the validation notification and **no 500**.
2. The **happy path** (valid title) still creates the ticket and closes/redirects unchanged.
3. CI green: **Pint**, **PHPStan level 5**, **`php -l`**, **full unit suite**.

## Test plan

- [ ] `php -l app/Domain/Tickets/Controllers/NewTicket.php`
- [ ] `./vendor/bin/pint --test`
- [ ] `./vendor/bin/phpstan analyse --level=5`
- [ ] Full unit suite green
- [ ] Manual: New To-Do → empty title → Save → validation notice shown, modal stays open, no 500 in `storage/logs`
- [ ] Regression: recommend adding a controller/feature test covering the empty-title POST path (behavior change — a test guards against future re-drift)

---

⚠️ **Draft — do not merge.** Opened by the OSS Maintainer daily sweep for #3640. Review + merge stay with @marcelfolaron / @broskees; this is the human gate. Not marked ready-for-review by automation.

_Note for maintainers: the fix commit briefly landed on `master` due to a branch-creation quirk in the automation's commit tool; it was immediately reverted on `master` (commit `f5a06e2f`, no functional change to the default branch) and re-applied cleanly on this branch. Master is back to its prior state; the reviewable diff lives entirely here._