### PR TITLE
fix(timesheets): show a user's own general-work (no-project) time in account reads

### DIFF
--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -215,6 +215,20 @@ class Timesheets extends Repository
                         if ($requesterRole === 'admin' || $requesterRole === 'manager') {
                             $q3->whereRaw('1=1');
                         }
+                    })
+                    ->orWhere(function ($q4) use ($userId) {
+                        // General-work time (virtual ticketId -1 → no matching
+                        // ticket/project after the left joins) has no project to
+                        // gate on, so it fails every project-access branch above
+                        // and silently disappears from this read — e.g. mobile's
+                        // Time tab (which can only call pollForNewTimesheets over
+                        // JSON-RPC) shows 0h even on a day with real general
+                        // hours. Always let a user see their OWN no-project
+                        // entries. Non-managers are AND-scoped to their userId
+                        // just below; managers already match via 1=1, so this
+                        // only rescues the regular-user case.
+                        $q4->whereNull('zp_tickets.projectId')
+                            ->where('zp_timesheets.userId', $userId);
                     });
             });
 


### PR DESCRIPTION
## Problem
A user's **general-work time** (logged with no task → the virtual `ticketId = -1`, `GENERAL_WORK_TICKET_ID`) is saved fine but **disappears from `getAllAccountTimesheets()`**. Every branch of that method's access `WHERE` keys off the entry's **project**, but a general entry has no ticket → after the `leftJoin`s, `zp_tickets.projectId` / `zp_projects.*` are NULL → it matches **none** of the branches and is dropped.

## Why it matters (mobile)
Leantime Mobile's Time tab can only call **`pollForNewTimesheets()`** over JSON-RPC — the user-scoped reads (`getWeeklyTimesheets()`, etc.) take a `CarbonInterface $fromDate`, which can't travel over JSON-RPC. So mobile has no server-side workaround: a user's no-task time is **invisible** in the app. Concretely, a 20h general entry on a day showed the weekly total as **0h**, and the user couldn't view / edit / delete it from mobile.

## Fix
One `orWhere` branch in the same access closure: a user always sees their **own** no-project entries.

```php
->orWhere(function ($q4) use ($userId) {
    $q4->whereNull('zp_tickets.projectId')
       ->where('zp_timesheets.userId', $userId);
});
```

## Scope / safety
- Non-managers are already `AND`-scoped to their own `userId` immediately below this closure, so they only ever see their own entries regardless.
- Managers already match everything via the `1=1` branch, so this is a no-op for them.
- Net effect: **only** the regular-user "see my own general time" case is rescued. No new cross-user exposure.

## Test
- `php -l` clean.
- Manual: as a non-admin, log general time (no task) → it now appears in account timesheet reads (and thus mobile's Time tab) for that user; other users' general time is unaffected.

> ⚠️ Please review before merging (do not auto-merge) — cc @marcelfolaron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)