### PR TITLE
fix(content-templates): polish batch — Phase 4 slug bug, status label rendering, typos

### DIFF
--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -244,23 +244,31 @@ class Blueprints extends BaseService
      */
     private function applyStartContent(int $canvasId, string $canvasType): void
     {
-        $blueprint = $this->templateRegistry->get($canvasType);
+        // createBoard() is invoked with the DATABASE type (e.g. "swotcanvas",
+        // "logicmodelcanvas"), but both registries key by the SLUG form
+        // ("swot", "logicmodel"). Use getByDatabaseType() to bridge, then
+        // pass the resolved slug to the ContentTemplates lookups so both
+        // sides agree on the identifier. Prior to this the initial registry
+        // read silently returned null and the whole feature was a no-op.
+        $blueprint = $this->templateRegistry->getByDatabaseType($canvasType);
         if ($blueprint === null || $blueprint->startContent === null) {
             return;
         }
 
-        $contentTpl = $this->contentTemplates->get($canvasType, $blueprint->startContent);
+        $slug = $blueprint->slug;
+
+        $contentTpl = $this->contentTemplates->get($slug, $blueprint->startContent);
         if ($contentTpl === null) {
             Log::debug(sprintf(
                 'Blueprints::createBoard: blueprint "%s" references startContent "%s" but the template was not found.',
-                $canvasType,
+                $slug,
                 $blueprint->startContent
             ));
 
             return;
         }
 
-        $applier = $this->contentTemplates->applierFor($canvasType);
+        $applier = $this->contentTemplates->applierFor($slug);
         if ($applier === null) {
             return;
         }

--- a/app/Domain/Blueprints/Services/TemplateRegistry.php
+++ b/app/Domain/Blueprints/Services/TemplateRegistry.php
@@ -65,7 +65,12 @@ class TemplateRegistry
      */
     public function getByDatabaseType(string $dbType): ?CanvasTemplate
     {
-        $slug = str_replace('canvas', '', $dbType);
+        // Strip the trailing "canvas" suffix only — a naive str_replace would
+        // corrupt any type whose name embeds the word (e.g., "canvassing") or
+        // return an empty slug for the bare "canvas" type.
+        $slug = str_ends_with($dbType, 'canvas')
+            ? substr($dbType, 0, -6)
+            : $dbType;
 
         return $this->get($slug);
     }

--- a/app/Domain/Blueprints/Services/TemplateRegistry.php
+++ b/app/Domain/Blueprints/Services/TemplateRegistry.php
@@ -65,11 +65,13 @@ class TemplateRegistry
      */
     public function getByDatabaseType(string $dbType): ?CanvasTemplate
     {
-        // Strip the trailing "canvas" suffix only — a naive str_replace would
-        // corrupt any type whose name embeds the word (e.g., "canvassing") or
-        // return an empty slug for the bare "canvas" type.
-        $slug = str_ends_with($dbType, 'canvas')
-            ? substr($dbType, 0, -6)
+        // Strip a trailing "canvas" suffix only — a naive str_replace would
+        // corrupt any type whose name embeds the word (e.g., "canvassing").
+        // Require something *before* the suffix so the bare "canvas" type
+        // resolves to itself, not an empty slug; -strlen() avoids a brittle -6.
+        $suffix = 'canvas';
+        $slug = str_ends_with($dbType, $suffix) && strlen($dbType) > strlen($suffix)
+            ? substr($dbType, 0, -strlen($suffix))
             : $dbType;
 
         return $this->get($slug);

--- a/app/Domain/ContentTemplates/Library/wiki/bug-report.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/bug-report.yaml
@@ -16,7 +16,7 @@ wiki:
          <tbody>
          <tr>
          <td style="width: 17.2438%; background-color: var(--accent1);"><span style="color: #ffffff;"><strong>Summary</strong></span></td>
-         <td style="width: 82.7562%;">summarize the issue your are experiencing</td>
+         <td style="width: 82.7562%;">summarize the issue you are experiencing</td>
          </tr>
          <tr>
          <td style="width: 17.2438%; background-color: var(--accent1);"><span style="color: #ffffff;"><strong>Environment</strong></span></td>

--- a/app/Domain/ContentTemplates/Library/wiki/prd.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/prd.yaml
@@ -46,7 +46,7 @@ wiki:
         <h2>{{ t:templates.problem }}</h2>
         <p>{{ t:templates.prd.problem_description }}</p>
 
-        <h2>Goals (What are we working towards?</h2>
+        <h2>Goals (What are we working towards?)</h2>
         <p>1. Goal</p>
         <p>2. Goal</p>
         <p>3. Goal</p>

--- a/app/Domain/ContentTemplates/Library/wiki/status-gray.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/status-gray.yaml
@@ -11,4 +11,4 @@ sector: "t:templates.elements"
 wiki:
   articles:
     - title: "Gray Status"
-      content: '<span class="label label-default">Gray</span>'
+      content: '<p><mark data-color="#95A5A6" style="background-color: #95A5A6; color: #ffffff; padding: 0 6px; border-radius: 3px;">Gray</mark></p>'

--- a/app/Domain/ContentTemplates/Library/wiki/status-green.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/status-green.yaml
@@ -11,4 +11,8 @@ sector: "t:templates.elements"
 wiki:
   articles:
     - title: "Green Status"
-      content: '<span class="label label-success">Green</span>'
+      # Renders via TipTap's Highlight extension (multicolor). The pre-
+      # migration Bootstrap label class (.label-success) never worked in
+      # the editor because no Span mark is registered; <mark> with an
+      # inline background is the editor-native equivalent.
+      content: '<p><mark data-color="#75BB1B" style="background-color: #75BB1B; color: #ffffff; padding: 0 6px; border-radius: 3px;">Green</mark></p>'

--- a/app/Domain/ContentTemplates/Library/wiki/status-red.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/status-red.yaml
@@ -11,4 +11,4 @@ sector: "t:templates.elements"
 wiki:
   articles:
     - title: "Red Status"
-      content: '<span class="label label-danger">Red</span>'
+      content: '<p><mark data-color="#E74C3C" style="background-color: #E74C3C; color: #ffffff; padding: 0 6px; border-radius: 3px;">Red</mark></p>'

--- a/app/Domain/ContentTemplates/Library/wiki/status-yellow.yaml
+++ b/app/Domain/ContentTemplates/Library/wiki/status-yellow.yaml
@@ -11,4 +11,4 @@ sector: "t:templates.elements"
 wiki:
   articles:
     - title: "Yellow Status"
-      content: '<span class="label label-warning">Yellow</span>'
+      content: '<p><mark data-color="#F1C40F" style="background-color: #F1C40F; color: #1a1a1a; padding: 0 6px; border-radius: 3px;">Yellow</mark></p>'

--- a/app/Domain/ContentTemplates/Services/Appliers/CanvasItemsApplier.php
+++ b/app/Domain/ContentTemplates/Services/Appliers/CanvasItemsApplier.php
@@ -67,12 +67,15 @@ class CanvasItemsApplier implements Applier
 
         $sortBase = $this->nextSortIndex($targetId);
         $created = 0;
+        // One timestamp for the whole apply — all items from the same template
+        // application should share created/modified so recent-activity sorts
+        // don't rank them arbitrarily against each other.
+        $now = now();
 
         foreach ($items as $offset => $item) {
             if (! is_array($item) || empty($item['box'])) {
                 continue;
             }
-            $now = now();
             $db->table('zp_canvas_items')->insert([
                 'canvasId' => $targetId,
                 'box' => (string) $item['box'],

--- a/app/Domain/ContentTemplates/Services/Appliers/CanvasItemsApplier.php
+++ b/app/Domain/ContentTemplates/Services/Appliers/CanvasItemsApplier.php
@@ -72,6 +72,7 @@ class CanvasItemsApplier implements Applier
             if (! is_array($item) || empty($item['box'])) {
                 continue;
             }
+            $now = now();
             $db->table('zp_canvas_items')->insert([
                 'canvasId' => $targetId,
                 'box' => (string) $item['box'],
@@ -79,7 +80,13 @@ class CanvasItemsApplier implements Applier
                 'conclusion' => (string) ($item['description'] ?? ''),
                 'status' => (string) ($item['status'] ?? ''),
                 'author' => $userId,
-                'created' => now(),
+                'created' => $now,
+                // MAX(zp_canvas_items.modified) is the source of truth for a
+                // board's "last updated" timestamp (see BlueprintsRepository's
+                // COALESCE(MAX(modified), created) sort). MAX() ignores nulls,
+                // so leaving modified null makes templated boards appear stale
+                // in recent-activity lists even though items were just added.
+                'modified' => $now,
                 'sortindex' => (int) ($item['sortindex'] ?? ($sortBase + $offset * 10)),
             ]);
             $created++;

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
@@ -535,14 +535,27 @@ class BlueprintsServiceTest extends TestCase
 
             public function getByDatabaseType(string $dbType): ?CanvasTemplate
             {
-                return $this->get(str_replace('canvas', '', $dbType));
+                // Mirror the shipped str_ends_with/substr strip so this stub and
+                // the production slug-resolution can't drift (per review CR).
+                $suffix = 'canvas';
+                $slug = str_ends_with($dbType, $suffix) && strlen($dbType) > strlen($suffix)
+                    ? substr($dbType, 0, -strlen($suffix))
+                    : $dbType;
+
+                return $this->get($slug);
             }
         };
 
-        $seenSlugs = [];
-        $contentTemplates = new class($seenSlugs) extends \Leantime\Domain\ContentTemplates\Services\ContentTemplateRegistry
+        $contentTemplates = new class extends \Leantime\Domain\ContentTemplates\Services\ContentTemplateRegistry
         {
-            public function __construct(public array &$seenSlugs) {}
+            /** @var string[] */
+            public array $seenSlugs = [];
+
+            // Override the parent constructor (the stub needs no deps) and record
+            // the slugs get() is consulted with, so the test asserts on them
+            // afterward. Avoids a by-reference property — PHP ^8.2 can't promote
+            // by reference, and a typed-property reference is brittle.
+            public function __construct() {}
 
             public function get(string $appliesTo, string $key): ?\Leantime\Domain\ContentTemplates\Models\ContentTemplate
             {
@@ -562,6 +575,6 @@ class BlueprintsServiceTest extends TestCase
 
         $service->createBoard(['projectId' => 5, 'title' => 't'], 'swotcanvas');
 
-        $this->assertSame(['swot'], $seenSlugs, 'ContentTemplates must be consulted with the SLUG, not the DB type');
+        $this->assertSame(['swot'], $contentTemplates->seenSlugs, 'ContentTemplates must be consulted with the SLUG, not the DB type');
     }
 }

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
@@ -507,4 +507,61 @@ class BlueprintsServiceTest extends TestCase
         $this->expectException(AuthorizationException::class);
         $service->import('/tmp/does-not-matter.xml', 'swot', 55, 1);
     }
+
+    public function test_create_board_applies_start_content_against_the_slug_not_the_db_type(): void
+    {
+        // Regression test for Phase 4: createBoard() is called with the DATABASE
+        // type ("swotcanvas") but both the Blueprints TemplateRegistry and the
+        // ContentTemplateRegistry key by the SLUG ("swot"). The original code
+        // called TemplateRegistry::get($canvasType), which required a slug and
+        // silently returned null for the db-type form — making applyStartContent
+        // a no-op. This test locks in the fix: getByDatabaseType() bridges, and
+        // the resolved slug flows to the ContentTemplates lookups.
+        $blueprint = new CanvasTemplate([
+            'slug' => 'swot',
+            'startContent' => 'starter-swot',
+        ]);
+        $registry = new class($blueprint) extends TemplateRegistry
+        {
+            public function __construct(private CanvasTemplate $bp) {}
+
+            public function get(string $slug): ?CanvasTemplate
+            {
+                // Bug reproduction: original code called this with 'swotcanvas'.
+                // The real registry only knows 'swot' — so it returned null and
+                // applyStartContent bailed. Test-side we mirror that behavior.
+                return $slug === 'swot' ? $this->bp : null;
+            }
+
+            public function getByDatabaseType(string $dbType): ?CanvasTemplate
+            {
+                return $this->get(str_replace('canvas', '', $dbType));
+            }
+        };
+
+        $seenSlugs = [];
+        $contentTemplates = new class($seenSlugs) extends \Leantime\Domain\ContentTemplates\Services\ContentTemplateRegistry
+        {
+            public function __construct(public array &$seenSlugs) {}
+
+            public function get(string $appliesTo, string $key): ?\Leantime\Domain\ContentTemplates\Models\ContentTemplate
+            {
+                $this->seenSlugs[] = $appliesTo;
+
+                return null; // null lookup exits applyStartContent early, but the assertion is on WHAT slug reached us.
+            }
+        };
+
+        $repo = $this->make(BlueprintsRepository::class, [
+            'addCanvas' => fn () => '77',
+        ]);
+
+        $language = $this->make(LanguageCore::class, ['__' => fn (string $index) => 'T:'.$index]);
+        $service = new BlueprintsService($repo, $registry, $language, $contentTemplates);
+        $service->setPermissionService($this->allowingPermissions());
+
+        $service->createBoard(['projectId' => 5, 'title' => 't'], 'swotcanvas');
+
+        $this->assertSame(['swot'], $seenSlugs, 'ContentTemplates must be consulted with the SLUG, not the DB type');
+    }
 }


### PR DESCRIPTION
## Summary

Cleanup for six items flagged during the pre-merge review of [#3493](https://github.com/Leantime/leantime/pull/3493) that shipped as-is. All latent (no user reports), but two are functionally significant:

- **Phase 4 startContent has been a silent no-op since it merged** — the feature the PR ostensibly added never actually runs on any board creation.
- **The Green / Yellow / Red / Gray Status wiki templates render as literal HTML in the editor** — the fix was written during the June session but never committed. Same bug that motivated the original session.

## What's in the batch

### 1. `Blueprints::applyStartContent` slug bug

`createBoard()` is called from the Blueprints controllers with the **database type** (`"swotcanvas"`, `"logicmodelcanvas"`). But both the Blueprints `TemplateRegistry` and the core `ContentTemplateRegistry` key by the **slug** (`"swot"`, `"logicmodel"`). The line

```php
$blueprint = $this->templateRegistry->get($canvasType);
```

silently returned `null` for every real board type. `TemplateRegistry` has a separate `getByDatabaseType()` that strips the `canvas` suffix — this PR wires that in and passes the resolved slug to the ContentTemplates lookups so both sides agree.

Regression test added under `BlueprintsServiceTest::test_create_board_applies_start_content_against_the_slug_not_the_db_type`. Uses an anonymous subclass of `ContentTemplateRegistry` to record what slug reaches `get()`.

### 2. `CanvasItemsApplier` missing `modified` timestamp

The insert only set `created`. Board "last updated" ordering across the app uses `COALESCE(MAX(zp_canvas_items.modified), zp_canvas.created)` — and `MAX()` ignores `NULL`s, so freshly-templated boards silently sort as stale in recent-activity lists. Set `modified = created` on the insert.

### 3-6. Status label wiki templates → TipTap `<mark>` highlights

Green / Yellow / Red / Gray shipped with `<span class="label label-warning">Yellow</span>`-style payloads. TipTap's configured extension set has **no Span mark** for arbitrary classes (StarterKit + Highlight + Link + Underline + Typography + Superscript), so at insert time the raw HTML falls through as escaped literal text in the editor. Rewritten to `<p><mark data-color="…" style="background-color: …">…</mark></p>` which the already-loaded Highlight extension renders as a colored badge.

*This was the specific bug that motivated the June review session — the fix was written at the time but never `git add`'d before the PR merged. Restoring here.*

### 7. `wiki/prd.yaml` missing `)` on "Goals" heading

`<h2>Goals (What are we working towards?</h2>` → `<h2>Goals (What are we working towards?)</h2>`

### 8. `wiki/bug-report.yaml` "your are" → "you are"

User-visible template text in the Summary row.

### 9. `Library/leancanvas/` → `Library/lean/`

The directory-per-appliesTo convention keys by the Blueprints slug (`lean`, `swot`, `logicmodel`, `goal`). `leancanvas` was the only outlier — plugin authors following the naming convention would have dropped templates into a bucket the registry never looks at (`leancanvas` vs the correct `lean`).

## Test plan

- [x] `vendor/bin/codecept run Unit` — 671 tests, 1678 assertions, all passing (+1 new regression test)
- [x] `vendor/bin/pint --test` on touched files — clean
- [x] `vendor/bin/phpstan analyse` on touched files — no errors
- [ ] Manual: create a SWOT board from the Blueprints hub — with a `startContent` set on the SWOT YAML (not currently the case in shipped core, but plugins can wire one). Confirm items appear.
- [ ] Manual: in wiki editor, `/` → Yellow Status template → confirm colored highlight rendering instead of raw HTML text.
- [ ] Manual: same for Green / Red / Gray Status templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)