### PR TITLE
fix(tickets): record status→Done in history + report real last-updated

### DIFF
--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -412,6 +412,7 @@ class Tickets
                 't2.profileId as editorProfileId',
                 'milestone.headline as milestoneHeadline',
                 'parent.headline as parentHeadline',
+                'zp_tickets.modified',
             ])
             ->selectRaw("CASE WHEN zp_tickets.type <> '' THEN zp_tickets.type ELSE 'task' END AS type")
             ->selectRaw('CASE WHEN ('.$this->dbHelper->wrapColumn('milestone.tags').' IS NULL OR '.$this->dbHelper->wrapColumn('milestone.tags')." = '') THEN 'var(--grey)' ELSE ".$this->dbHelper->wrapColumn('milestone.tags').' END AS '.$this->dbHelper->wrapColumn('milestoneColor'))
@@ -969,6 +970,7 @@ class Tickets
                 't3.firstname as editorFirstname',
                 't3.lastname as editorLastname',
                 'parent.headline as parentHeadline',
+                'zp_tickets.modified',
             ])
             ->selectRaw("CASE WHEN zp_tickets.type <> '' THEN zp_tickets.type ELSE 'task' END AS type")
             ->leftJoin('zp_projects', 'zp_tickets.projectId', '=', 'zp_projects.id')
@@ -1825,7 +1827,12 @@ class Tickets
                 isset($values[$dbTable]) === true &&
                 isset($oldValues[$dbTable]) === true &&
                 ($oldValues[$dbTable] != $values[$dbTable]) &&
-                ($values[$dbTable] != '')
+                // Skip genuine "cleared to empty" writes, but STRICTLY — a loose
+                // `!= ''` also drops valid falsy values, most importantly
+                // status 0 (Done). That silently kept ticket-closures out of
+                // zp_tickethistory, so burndown/throughput and the mobile
+                // Progress "closed on date" reflection never saw them.
+                ($values[$dbTable] !== '' && $values[$dbTable] !== null)
             ) {
                 $historyRows[] = [
                     'userId' => $userId,

--- a/app/Domain/Tickets/Support/TicketFormatter.php
+++ b/app/Domain/Tickets/Support/TicketFormatter.php
@@ -98,7 +98,11 @@ class TicketFormatter extends AbstractEntityFormatter
             'tags' => $this->sanitizeValue($this->ticket->tags),
             'dependingTicketId' => $this->ticket->dependingTicketId,
             'parentHeadline' => $this->sanitizeValue($this->ticket->parentHeadline),
-            'lastUpdated' => $this->formatDate($this->ticket->date),
+            // "Last updated" must reflect the last modification, not creation.
+            // It was reading ->date (the create timestamp), so every ticket
+            // reported its creation date as "last updated". Fall back to date
+            // only when modified is absent (legacy rows / partial selects).
+            'lastUpdated' => $this->formatDate($this->ticket->modified ?: $this->ticket->date),
             'bookedHours' => $this->sanitizeValue($this->ticket->bookedHours),
             'hourRemaining' => $this->sanitizeValue($this->ticket->hourRemaining),
             'percentDone' => $this->sanitizeValue($this->ticket->percentDone),


### PR DESCRIPTION
Two related correctness bugs, surfaced while wiring the mobile **Progress** reflection (which reads `zp_tickethistory` to know *what* closed and *when*). cc @marcelfolaron

## 1. Closing a ticket wasn't always recorded in history
`addTicketChange()` compares old vs new tracked fields and writes a `zp_tickethistory` row per change. The guard was:

```php
($oldValues[$dbTable] != $values[$dbTable]) &&
($values[$dbTable] != '')
```

That last **loose** `!= ''` treats valid falsy values as "empty" — most importantly **status `0` (Done)**. So a status change *to Done* could be silently skipped, and the closure never landed in history. Downstream that means **burndown / throughput / any "closed on date" reporting** (and the mobile Progress "Closed today/this week" reflection) never see the close.

**Fix:** strict check — `$values[$dbTable] !== '' && $values[$dbTable] !== null`. Genuine cleared-to-empty writes are still skipped; valid falsy values (status 0) are always recorded. Version-independent (the loose form only bit on PHP 7 / certain value types, which is exactly the kind of latent bug worth removing).

## 2. "Last updated" reported the creation date
`TicketFormatter` set `lastUpdated` from `$this->ticket->date` — the **create** timestamp — and `getTicket` didn't even `select` `modified`. So every ticket reported its creation time as "last updated" (very visible through the MCP `getTask` tool — it's what sent me chasing a phantom "silent write" bug). `getTicket` now selects `zp_tickets.modified`, and the formatter uses it, falling back to `date` only when `modified` is absent (legacy rows / partial selects).

## Risk
Low. No change for non-status fields or genuinely empty writes; additive column in `getTicket`'s select; `TicketFormatter` fallback keeps old behavior when `modified` is missing. Pint + `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)