### PR TITLE
fix: remove cron.run from public actions to prevent unauthenticated CRON access (CWE-306)

### DIFF
--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -36,7 +36,6 @@ class AuthCheck
         'calendar.ical',
         'oidc.login',
         'oidc.callback',
-        'cron.run',
         'auth.callback',
         'auth.redirect',
     ];


### PR DESCRIPTION
## Description

Fixes **CWE-306 (Missing Authentication for Critical Function)** — the CRON endpoint is publicly accessible.

### Vulnerability
The `cron.run` action is registered as a public API method that can be called by **any unauthenticated user**. This allows anonymous attackers to trigger resource-intensive CRON operations (notifications, recurring task processing, calendar sync, LDAP sync) at will.

### Impact (CVSS 5.3)
- Resource exhaustion / DoS — attacker can trigger heavy CRON operations repeatedly
- Email spam — repeated notification processing floods users
- Disruption of scheduled tasks — real CRON jobs may conflict with attacker-triggered runs

### Fix
Removed `cron.run` from the list of publicly accessible API methods. The CRON endpoint should only be called by the system scheduler.

### PoC
```bash
# Any unauthenticated user can trigger the CRON
curl -X POST https://TARGET/api/jsonrpc \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"cron.run","params":{},"id":1}'
```

Researcher: Javokhir Tursunboyev (@javokhir-sec)
Disclosure: Responsible, with fix PR