### PR TITLE
fix(oidc): mobile SSO hardening — TTL, throttle, body-only reads, atomic consume (follow-up to #3637)

### DIFF
--- a/app/Domain/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Domain/Auth/Repositories/AccessTokenRepository.php
@@ -15,7 +15,13 @@ class AccessTokenRepository
         $this->db = $db->getConnection();
     }
 
-    public function createToken(int $userId, string $name, array $abilities = ['*']): array
+    /**
+     * @param  \DateTimeInterface|null  $expiresAt  Optional absolute expiry. Null
+     *                                              keeps the historical non-expiring
+     *                                              behavior; getTokenByUserId() already
+     *                                              honors expires_at when set.
+     */
+    public function createToken(int $userId, string $name, array $abilities = ['*'], ?\DateTimeInterface $expiresAt = null): array
     {
         $token = Str::random(40);
         $hashedToken = hash('sha256', $token);
@@ -26,6 +32,7 @@ class AccessTokenRepository
             'name' => $name,
             'token' => $hashedToken,
             'abilities' => json_encode($abilities),
+            'expires_at' => $expiresAt,
             'created_at' => now(),
         ]);
 

--- a/app/Domain/Oidc/Controllers/Mobile.php
+++ b/app/Domain/Oidc/Controllers/Mobile.php
@@ -2,6 +2,7 @@
 
 namespace Leantime\Domain\Oidc\Controllers;
 
+use Illuminate\Support\Facades\RateLimiter;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
@@ -20,6 +21,13 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Mobile extends Controller
 {
+    /** Per-IP cap on exchange attempts per minute — throttles code/verifier guessing. */
+    private const MAX_ATTEMPTS_PER_MINUTE = 10;
+
+    /** Mobile SSO bearer lifetime. Deliberately NOT non-expiring; a lost device's
+     *  token self-expires, and it can be revoked early via AccessTokenRepository::deleteToken. */
+    private const TOKEN_TTL_DAYS = 30;
+
     private OidcMobileCode $codes;
 
     private AccessTokenRepository $tokens;
@@ -56,9 +64,23 @@ class Mobile extends Controller
             return new JsonResponse(['error' => 'method_not_allowed'], 405, ['Allow' => 'POST']);
         }
 
-        // $params is the framework's merged request params (GET + form body); the
-        // app POSTs code + code_verifier form-encoded, so no manual body parsing.
-        $code = $this->stringParam($params, 'code');
+        // Per-IP throttle: this endpoint is public (allow-listed in AuthCheck) and
+        // returns distinct 400/401 codes, so an unauthenticated caller could probe
+        // codes/verifiers. Even with <=60s single-use codes, cap the attempt rate.
+        $throttleKey = 'oidc.mobile.exchange:'.$this->request->ip();
+        if (RateLimiter::tooManyAttempts($throttleKey, self::MAX_ATTEMPTS_PER_MINUTE)) {
+            return new JsonResponse(
+                ['error' => 'too_many_requests'],
+                429,
+                ['Retry-After' => (string) RateLimiter::availableIn($throttleKey)]
+            );
+        }
+        RateLimiter::hit($throttleKey, 60);
+
+        // Secrets are read from the POST BODY only (->post()), never the query
+        // string — URLs land in access logs, request bodies don't. A ?code=... in
+        // the URL is ignored; $params (the merged bag) is intentionally not used.
+        $code = $this->bodyParam('code');
         if ($code === '') {
             return new JsonResponse(['error' => 'missing_code'], 400);
         }
@@ -76,7 +98,7 @@ class Mobile extends Controller
         // PKCE: the code was bound to a code_challenge at login. Require the
         // matching verifier so a code intercepted from the app-scheme redirect
         // is useless without the secret the app kept and never put in a URL.
-        $verifier = $this->stringParam($params, 'code_verifier');
+        $verifier = $this->bodyParam('code_verifier');
         if (! $this->pkceMatches($data['challenge'] ?? null, $verifier)) {
             return new JsonResponse(['error' => 'invalid_verifier'], 401);
         }
@@ -93,9 +115,23 @@ class Mobile extends Controller
             return new JsonResponse(['error' => 'invalid_user'], 401);
         }
 
-        // All checks passed — burn the code (single-use) and mint the token.
-        $this->codes->consumeCode($code);
-        $token = $this->tokens->createToken($userId, 'mobile-sso');
+        // All checks passed — atomically burn the code. consumeCode() returns
+        // false if a concurrent exchange already consumed it, so only the winner
+        // of that race mints (no double-mint from one single-use code).
+        if (! $this->codes->consumeCode($code)) {
+            return new JsonResponse(['error' => 'invalid_code'], 401);
+        }
+
+        // Mint a 'mobile-sso' bearer with an explicit TTL (see TOKEN_TTL_DAYS) so
+        // it isn't valid forever. Scope stays ['*'] — the mobile app is a full
+        // API client, same as the password-login token — but the TTL plus
+        // AccessTokenRepository::deleteToken give expiry and revocation.
+        $token = $this->tokens->createToken(
+            $userId,
+            'mobile-sso',
+            ['*'],
+            now()->addDays(self::TOKEN_TTL_DAYS)
+        );
 
         return new JsonResponse([
             'token' => $token['token'],
@@ -103,9 +139,15 @@ class Mobile extends Controller
         ]);
     }
 
-    private function stringParam(array $params, string $key): string
+    /**
+     * Read a request value from the POST body ONLY (never the query string), so
+     * the one-time code + verifier can't be supplied via a logged URL.
+     */
+    private function bodyParam(string $key): string
     {
-        return isset($params[$key]) && is_string($params[$key]) ? trim($params[$key]) : '';
+        $value = $this->request->post($key);
+
+        return is_string($value) ? trim($value) : '';
     }
 
     /**

--- a/app/Domain/Oidc/Services/OidcMobileCode.php
+++ b/app/Domain/Oidc/Services/OidcMobileCode.php
@@ -76,13 +76,16 @@ class OidcMobileCode
     }
 
     /**
-     * Burn the code. Cache::forget is idempotent, so an already-consumed
-     * code is a silent no-op — callers should peekCode() first for the
-     * "invalid code" check.
+     * Atomically burn the code and report whether THIS caller consumed it.
+     *
+     * Cache::pull is a single read-and-delete, so of two concurrent exchanges
+     * that both peekCode()'d the same code, exactly one gets true here — the
+     * other gets false and must not mint (closes the peek→consume double-mint
+     * race). Also returns false for an already-consumed or unknown code.
      */
-    public function consumeCode(string $rawCode): void
+    public function consumeCode(string $rawCode): bool
     {
-        Cache::forget($this->key($rawCode));
+        return Cache::pull($this->key($rawCode)) !== null;
     }
 
     private function key(string $rawCode): string

--- a/tests/Unit/app/Domain/Oidc/Controllers/MobileTest.php
+++ b/tests/Unit/app/Domain/Oidc/Controllers/MobileTest.php
@@ -46,14 +46,26 @@ class MobileTest extends \Unit\TestCase
         $this->app->instance(OidcMobileCode::class, $this->codes);
         $this->app->instance(AccessTokenRepository::class, $this->tokens);
         $this->app->instance(UserRepository::class, $this->userRepo);
+
+        // Back the RateLimiter facade with a fresh in-memory store so throttle
+        // state is deterministic and isolated per test.
+        \Illuminate\Support\Facades\Facade::setFacadeApplication($this->app);
+        $this->app->instance(
+            \Illuminate\Cache\RateLimiter::class,
+            new \Illuminate\Cache\RateLimiter(
+                new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore)
+            )
+        );
     }
 
-    private function makeController(string $method = 'POST'): Mobile
+    private function makeController(string $method = 'POST', array $body = []): Mobile
     {
         // IncomingRequest inherits getMethod() from Symfony's Request, where it
         // reads from the request's internal server bag. Building a real instance
         // is simpler and more accurate than mocking through the inheritance chain.
-        $request = IncomingRequest::create('/oidc/mobile/exchange', $method);
+        // $body populates the POST (request) bag — what the controller reads via
+        // ->post(); a query string on the URL is deliberately NOT read.
+        $request = IncomingRequest::create('/oidc/mobile/exchange', $method, $body);
         $this->app->instance(IncomingRequest::class, $request);
 
         return new Mobile($request, $this->createMock(Template::class), $this->createMock(Language::class));
@@ -69,8 +81,8 @@ class MobileTest extends \Unit\TestCase
         // Peek must never be called — the request is rejected before the code store is touched.
         $this->codes->expects($this->never())->method('peekCode');
 
-        $controller = $this->makeController('GET');
-        $response = $controller->exchange(['code' => 'x', 'code_verifier' => 'y']);
+        $controller = $this->makeController('GET', ['code' => 'x', 'code_verifier' => 'y']);
+        $response = $controller->exchange([]);
 
         $this->assertSame(405, $response->getStatusCode());
         $this->assertSame('POST', $response->headers->get('Allow'));
@@ -94,8 +106,8 @@ class MobileTest extends \Unit\TestCase
         // Nothing to consume for an unknown code — but assert it explicitly.
         $this->codes->expects($this->never())->method('consumeCode');
 
-        $controller = $this->makeController();
-        $response = $controller->exchange(['code' => 'bad', 'code_verifier' => 'v']);
+        $controller = $this->makeController('POST', ['code' => 'bad', 'code_verifier' => 'v']);
+        $response = $controller->exchange([]);
 
         $this->assertSame(401, $response->getStatusCode());
         $this->assertSame('invalid_code', $this->bodyOf($response)['error']);
@@ -113,8 +125,8 @@ class MobileTest extends \Unit\TestCase
         $this->codes->expects($this->never())->method('consumeCode');
         $this->tokens->expects($this->never())->method('createToken');
 
-        $controller = $this->makeController();
-        $response = $controller->exchange(['code' => 'good', 'code_verifier' => 'wrong-verifier']);
+        $controller = $this->makeController('POST', ['code' => 'good', 'code_verifier' => 'wrong-verifier']);
+        $response = $controller->exchange([]);
 
         $this->assertSame(401, $response->getStatusCode());
         $this->assertSame('invalid_verifier', $this->bodyOf($response)['error']);
@@ -131,8 +143,8 @@ class MobileTest extends \Unit\TestCase
         $this->codes->expects($this->never())->method('consumeCode');
         $this->tokens->expects($this->never())->method('createToken');
 
-        $controller = $this->makeController();
-        $response = $controller->exchange(['code' => 'good', 'code_verifier' => $verifier]);
+        $controller = $this->makeController('POST', ['code' => 'good', 'code_verifier' => $verifier]);
+        $response = $controller->exchange([]);
 
         $this->assertSame(401, $response->getStatusCode());
         $this->assertSame('invalid_user', $this->bodyOf($response)['error']);
@@ -148,17 +160,77 @@ class MobileTest extends \Unit\TestCase
             'id' => 7, 'firstname' => 'A', 'lastname' => 'B', 'username' => 'a@b',
             'password' => 'SHOULD_NOT_APPEAR', 'twoFAEnabled' => 1,
         ]);
-        // Code consumed exactly once, AFTER all validation.
-        $this->codes->expects($this->once())->method('consumeCode')->with('good');
-        $this->tokens->method('createToken')->willReturn(['token' => 'the-token']);
+        // Code consumed exactly once, AFTER all validation; returns true (this
+        // caller won the single-use race), so minting proceeds.
+        $this->codes->expects($this->once())->method('consumeCode')->with('good')->willReturn(true);
+        // Minted with full scope AND an explicit expiry (not non-expiring).
+        $this->tokens->expects($this->once())->method('createToken')
+            ->with(7, 'mobile-sso', ['*'], $this->isInstanceOf(\DateTimeInterface::class))
+            ->willReturn(['token' => 'the-token']);
 
-        $controller = $this->makeController();
-        $response = $controller->exchange(['code' => 'good', 'code_verifier' => $verifier]);
+        $controller = $this->makeController('POST', ['code' => 'good', 'code_verifier' => $verifier]);
+        $response = $controller->exchange([]);
 
         $this->assertSame(200, $response->getStatusCode());
         $body = $this->bodyOf($response);
         $this->assertSame('the-token', $body['token']);
         // Only safe identity fields — never password / 2FA state.
         $this->assertSame(['id', 'firstname', 'lastname', 'username'], array_keys($body['user']));
+    }
+
+    public function test_secrets_in_query_string_are_ignored(): void
+    {
+        // The code + verifier must come from the POST body, never the URL query
+        // (URLs land in access logs). A ?code=... is not read, so this is a
+        // missing_code — and the code store is never touched.
+        $this->codes->expects($this->never())->method('peekCode');
+
+        $request = IncomingRequest::create('/oidc/mobile/exchange?code=fromquery&code_verifier=v', 'POST');
+        $this->app->instance(IncomingRequest::class, $request);
+        $controller = new Mobile($request, $this->createMock(Template::class), $this->createMock(Language::class));
+        $response = $controller->exchange([]);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('missing_code', $this->bodyOf($response)['error']);
+    }
+
+    public function test_exchange_is_rate_limited_per_ip(): void
+    {
+        // Once the per-IP cap is hit, further attempts are refused with 429
+        // BEFORE the code store is consulted — throttling code/verifier probing.
+        $this->codes->expects($this->never())->method('peekCode');
+
+        for ($i = 0; $i < 10; $i++) {
+            \Illuminate\Support\Facades\RateLimiter::hit('oidc.mobile.exchange:127.0.0.1', 60);
+        }
+
+        $controller = $this->makeController('POST', ['code' => 'x', 'code_verifier' => 'y']);
+        $response = $controller->exchange([]);
+
+        $this->assertSame(429, $response->getStatusCode());
+        $this->assertSame('too_many_requests', $this->bodyOf($response)['error']);
+        $this->assertNotNull($response->headers->get('Retry-After'));
+    }
+
+    public function test_lost_consume_race_does_not_mint(): void
+    {
+        // Two concurrent exchanges both peek the same valid code; the one whose
+        // atomic consumeCode() returns false (the other burned it first) must
+        // NOT mint a second token from a single-use code.
+        $verifier = 'testverifier';
+        $challenge = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+
+        $this->codes->method('peekCode')->willReturn(['userId' => 7, 'challenge' => $challenge]);
+        $this->userRepo->method('getUser')->with(7)->willReturn([
+            'id' => 7, 'firstname' => 'A', 'lastname' => 'B', 'username' => 'a@b',
+        ]);
+        $this->codes->method('consumeCode')->with('good')->willReturn(false);
+        $this->tokens->expects($this->never())->method('createToken');
+
+        $controller = $this->makeController('POST', ['code' => 'good', 'code_verifier' => $verifier]);
+        $response = $controller->exchange([]);
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('invalid_code', $this->bodyOf($response)['error']);
     }
 }


### PR DESCRIPTION
Follow-up to the merged **#3637** (mobile SSO bridge). #3637's maintainer-sweep raised a batch of hardening items *after* its last commit that never got a follow-up before it merged — this PR addresses them.

## What #3637 already handled (for context)
peek→validate→consume rework, POST-only (405), validate-user-before-mint, `code_challenge` required + S256 format check, `safeUser()` field allow-list, cache-backed codes (no migration). Those stand.

## What this PR adds
| # | #3637 review item | Fix |
|---|---|---|
| 1 | **Token lifetime/scope/revocation** ("the biggest open question") | `AccessTokenRepository::createToken()` gains an optional `expiresAt`; the `mobile-sso` bearer is minted with a **30-day TTL** (`TOKEN_TTL_DAYS`) instead of non-expiring. Scope stays `['*']` (the app is a full API client, same as the password-login token); TTL + `deleteToken()` provide expiry + revocation. **Backward-compatible** — existing callers (default `null`) are unchanged. |
| 2 | **No rate limit** on the public exchange | Per-IP throttle (`MAX_ATTEMPTS_PER_MINUTE = 10`) via the `RateLimiter` facade → **429 + Retry-After**, before the code store is touched. |
| 3 | **Secrets accepted from the query string** | `code` + `code_verifier` are read from the **POST body only** (`->post()`), never the merged params bag — a `?code=…` in the URL is ignored (URLs land in access logs). |
| 4 | **Non-atomic consume (peek→consume race)** | `OidcMobileCode::consumeCode()` now returns `bool` via atomic `Cache::pull`; `exchange()` mints **only when it actually burned the code**, so two concurrent exchanges of one single-use code can't both mint. |

## Tests
`MobileTest` → **9 tests / 33 assertions**. New: secrets-in-query-ignored, rate-limit-429, lost-consume-race; the valid-exchange test now asserts the minted token carries an **expiry** (not non-expiring). `AuthCheckTest` (public route) green. Pint clean on touched files.

## Not in this PR (still maintainer confirm items from #3637)
- **Session survival across the provider round-trip** — needs a live-provider run (can't be unit-tested; the flow silently falls back to `/dashboard/home` if `oidc.mobile*` session keys are lost).
- **Multi-node cache** — the codes use the default cache store; a per-node file store misses on multi-node. Documented in `OidcMobileCode`'s class doc; a startup warning could be a further follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
