### PR TITLE
feat(status): public /status discovery endpoint — advertise auth methods for mobile SSO

### DIFF
--- a/app/Core/Middleware/AuthCheck.php
+++ b/app/Core/Middleware/AuthCheck.php
@@ -37,6 +37,8 @@ class AuthCheck
         'oidc.login',
         'oidc.callback',
         'oidc.mobile',
+        'status',
+        'status.index',
         'cron.run',
         'auth.callback',
         'auth.redirect',

--- a/app/Domain/Status/Controllers/Index.php
+++ b/app/Domain/Status/Controllers/Index.php
@@ -30,12 +30,22 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Index extends Controller
 {
+    /**
+     * Keys that must NEVER appear in the unauthenticated response, even if a
+     * publicStatus filter (or a future edit) adds them — a recon-risk inventory.
+     * Stripped after the filter runs, as defense in depth.
+     */
+    private const SENSITIVE_KEYS = ['plugins', 'pluginVersions', 'installedPlugins', 'dbVersion', 'db_version'];
+
     private Environment $config;
 
     private AppSettings $appSettings;
 
     private IncomingRequest $request;
 
+    /**
+     * init - inject config, app settings, and the incoming request.
+     */
     public function init(Environment $config, AppSettings $appSettings, IncomingRequest $request): void
     {
         $this->config = $config;
@@ -43,6 +53,12 @@ class Index extends Controller
         $this->request = $request;
     }
 
+    /**
+     * Return the public discovery payload: enabled auth methods, the OIDC login
+     * URL (when enabled), instance name, core version, and min app version — the
+     * safe unauthenticated tier only. Never plugin inventory / versions / db
+     * version (see the class-level security note).
+     */
     public function get(array $params): Response
     {
         $oidcEnabled = (bool) $this->config->oidcEnable;
@@ -78,6 +94,14 @@ class Index extends Controller
         // core knowing about them. Filter handlers MUST preserve the public-safe
         // contract — never add secrets, plugin inventory, or versions here.
         $payload = self::dispatchFilter('publicStatus', $payload, ['request' => $this->request]);
+
+        // Defense in depth: this endpoint is unauthenticated, so strip any
+        // known-sensitive keys a misbehaving filter (or a future edit) might have
+        // added. The recon-risk inventory must NEVER reach an unauthenticated
+        // caller, even if a plugin gets the contract wrong.
+        foreach (self::SENSITIVE_KEYS as $sensitive) {
+            unset($payload[$sensitive]);
+        }
 
         return new JsonResponse($payload);
     }

--- a/app/Domain/Status/Controllers/Index.php
+++ b/app/Domain/Status/Controllers/Index.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Leantime\Domain\Status\Controllers;
+
+use Leantime\Core\Configuration\AppSettings;
+use Leantime\Core\Configuration\Environment;
+use Leantime\Core\Controller\Controller;
+use Leantime\Core\Http\IncomingRequest;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Public, unauthenticated instance status / discovery endpoint — GET /status.
+ *
+ * The mobile app calls this at connect time to discover which login methods the
+ * instance offers (password / ldap / oidc), so it can show the right affordances
+ * — notably the OIDC "Sign in with SSO" redirect, which stays dormant in the app
+ * until a backend advertises it here. See the mobile client's
+ * connectionService::fetchPublicStatus and
+ * docs/backend-mobile-auth-bridge-plan.md for the contract.
+ *
+ * SECURITY — this endpoint is UNAUTHENTICATED, so it returns ONLY the safe,
+ * minimal tier: auth methods, the core version + instance name, provider labels,
+ * and the min app version. It deliberately does NOT list installed plugins,
+ * plugin versions, or the db version — an unauthenticated inventory of those is a
+ * recon gift (CVE matching). Those stay behind auth (the authenticated
+ * mobileStatus). Keep any `publicStatus` filter additions to this safe tier.
+ *
+ * Route 'status.index' is allow-listed public in AuthCheck.
+ */
+class Index extends Controller
+{
+    private Environment $config;
+
+    private AppSettings $appSettings;
+
+    private IncomingRequest $request;
+
+    public function init(Environment $config, AppSettings $appSettings, IncomingRequest $request): void
+    {
+        $this->config = $config;
+        $this->appSettings = $appSettings;
+        $this->request = $request;
+    }
+
+    public function get(array $params): Response
+    {
+        $oidcEnabled = (bool) $this->config->oidcEnable;
+        $ldapEnabled = $this->config->useLdap === true && extension_loaded('ldap');
+
+        // password is always available; ldap/oidc only when configured.
+        $authMethods = ['password'];
+        if ($ldapEnabled) {
+            $authMethods[] = 'ldap';
+        }
+        if ($oidcEnabled) {
+            $authMethods[] = 'oidc';
+        }
+
+        $payload = [
+            'mobileAuthEnabled' => true,
+            'instanceName' => (string) ($this->config->sitename ?: 'Leantime'),
+            'version' => $this->appSettings->appVersion,
+            'minAppVersion' => null,
+            'authMethods' => $authMethods,
+            'ssoProviders' => [],
+        ];
+
+        if ($oidcEnabled) {
+            // Generic-OIDC login initiation URL (core). The app opens this in the
+            // system auth browser; the mobile branch is triggered by its own query
+            // params (see Oidc\Controllers\Login).
+            $payload['oidcLoginUrl'] = $this->request->getSchemeAndHttpHost().'/oidc/login';
+        }
+
+        // AdvancedAuth (or other plugins) can append named SSO providers to the
+        // PUBLIC-safe payload (labels + login URLs only) via this filter, without
+        // core knowing about them. Filter handlers MUST preserve the public-safe
+        // contract — never add secrets, plugin inventory, or versions here.
+        $payload = self::dispatchFilter('publicStatus', $payload, ['request' => $this->request]);
+
+        return new JsonResponse($payload);
+    }
+}

--- a/tests/Unit/app/Core/Middleware/AuthCheckTest.php
+++ b/tests/Unit/app/Core/Middleware/AuthCheckTest.php
@@ -105,4 +105,14 @@ class AuthCheckTest extends \Unit\TestCase
         // Negative control: an oidc sub-route that is NOT allow-listed stays private.
         $this->assertFalse($authCheck->isPublicController('oidc.settings.save'));
     }
+
+    public function test_status_discovery_is_a_public_route(): void
+    {
+        $authCheck = $this->make(AuthCheck::class);
+
+        // The mobile app hits /status unauthenticated at connect time to discover
+        // login methods, so the route must be public.
+        $this->assertTrue($authCheck->isPublicController('status.index'));
+        $this->assertTrue($authCheck->isPublicController('status'));
+    }
 }

--- a/tests/Unit/app/Domain/Status/Controllers/IndexTest.php
+++ b/tests/Unit/app/Domain/Status/Controllers/IndexTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\app\Domain\Status\Controllers;
+
+use Leantime\Core\Application;
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
+use Leantime\Core\Bootstrap\LoadConfig;
+use Leantime\Core\Bootstrap\SetRequestForConsole;
+use Leantime\Core\Configuration\AppSettings;
+use Leantime\Core\Configuration\Environment;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Core\Language;
+use Leantime\Core\UI\Template;
+use Leantime\Domain\Status\Controllers\Index;
+
+/**
+ * Unit tests for the public /status discovery endpoint.
+ *
+ * Pins the contract the mobile app relies on (authMethods + oidcLoginUrl drive
+ * whether the SSO button appears) AND the security tier: the unauthenticated
+ * response must NEVER leak a plugin/version inventory.
+ */
+class IndexTest extends \Unit\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app = new Application(APP_ROOT);
+        $this->app->bootstrapWith([LoadConfig::class, SetRequestForConsole::class]);
+        $this->app->boot();
+        $this->app['view'] = $this->createMock(\Illuminate\View\Factory::class);
+        $this->app['session'] = $this->createMock(\Illuminate\Session\SessionManager::class);
+        $this->app->instance(PermissionEnforcer::class, $this->createMock(PermissionEnforcer::class));
+    }
+
+    private function makeController(array $overrides): Index
+    {
+        // Environment's constructor overwrites known config keys with
+        // env-resolved defaults, so set the values AFTER construction.
+        $env = new Environment;
+        $env->set('oidcEnable', $overrides['oidcEnable'] ?? false);
+        $env->set('useLdap', $overrides['useLdap'] ?? false);
+        $env->set('sitename', $overrides['sitename'] ?? 'Leantime');
+
+        $request = IncomingRequest::create('https://demo.leantime.io/status', 'GET');
+        $this->app->instance(IncomingRequest::class, $request);
+        $this->app->instance(Environment::class, $env);
+        $this->app->instance(AppSettings::class, new AppSettings);
+
+        return new Index($request, $this->createMock(Template::class), $this->createMock(Language::class));
+    }
+
+    private function bodyOf($response): array
+    {
+        return json_decode($response->getContent(), true);
+    }
+
+    public function test_password_only_when_no_sso_configured(): void
+    {
+        $response = $this->makeController(['oidcEnable' => false, 'useLdap' => false, 'sitename' => 'Acme'])->get([]);
+        $body = $this->bodyOf($response);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['password'], $body['authMethods']);
+        $this->assertArrayNotHasKey('oidcLoginUrl', $body);
+        $this->assertSame('Acme', $body['instanceName']);
+        $this->assertTrue($body['mobileAuthEnabled']);
+    }
+
+    public function test_oidc_enabled_advertises_oidc_and_login_url(): void
+    {
+        $response = $this->makeController(['oidcEnable' => true, 'useLdap' => false, 'sitename' => 'Acme'])->get([]);
+        $body = $this->bodyOf($response);
+
+        $this->assertContains('oidc', $body['authMethods']);
+        $this->assertSame('https://demo.leantime.io/oidc/login', $body['oidcLoginUrl']);
+    }
+
+    public function test_response_never_leaks_a_plugin_or_version_inventory(): void
+    {
+        // The unauthenticated tier must not become a recon gift.
+        $response = $this->makeController(['oidcEnable' => true, 'useLdap' => false])->get([]);
+        $body = $this->bodyOf($response);
+
+        $this->assertArrayNotHasKey('plugins', $body);
+        $this->assertArrayNotHasKey('dbVersion', $body);
+        $this->assertArrayHasKey('version', $body);
+    }
+}


### PR DESCRIPTION
The discovery half of the mobile OIDC bridge (**#3637**). Answers **Q5** in `docs/backend-mobile-auth-bridge-plan.md` ("build the general status endpoint in core with auth-tiered disclosure").

## Why
The mobile app calls **`GET /status`** (unauthenticated) at connect time to discover which login methods an instance offers, so it shows the right affordances — most importantly the OIDC **"Sign in with SSO"** flow. That flow ships **gated**: the button stays dormant until a backend advertises OIDC here. Without this endpoint, SSO never appears even when the bridge (#3637) is deployed. (Mobile side: `connectionService::fetchPublicStatus`.)

## What
New `app/Domain/Status/Controllers/Index.php` — `GET /status` returns the **safe public tier**:
```jsonc
{
  "mobileAuthEnabled": true,
  "instanceName": "…",            // config sitename
  "version": "3.9.8",             // AppSettings::appVersion
  "minAppVersion": null,
  "authMethods": ["password", "oidc"],   // password always; ldap/oidc when configured
  "oidcLoginUrl": "https://host/oidc/login",  // only when OIDC enabled
  "ssoProviders": []              // AdvancedAuth appends via the 'publicStatus' filter
}
```
- `AuthCheck`: `status` / `status.index` allow-listed public.
- **Security — the whole point of the auth tiering:** this is unauthenticated, so it deliberately **omits plugin inventory / plugin versions / dbVersion**. An unauthenticated inventory of those is a recon gift (CVE matching) — the plan doc flags this as "probably why a full public status endpoint wasn't built." Those stay behind auth (the existing authenticated mobileStatus). Plugins extend the public payload only via the `publicStatus` filter, which must preserve the safe contract.

## Tests
`IndexTest` (3): password-only when no SSO configured, OIDC advertised + `oidcLoginUrl` when enabled, and **never leaks a plugin/version inventory**. `AuthCheckTest`: `/status` is a public route. Pint clean.

## Note for review
- `authMethods` reads `config->oidcEnable` / `config->useLdap` (mirrors `Auth\Controllers\Login` + `Auth\Services\Auth`).
- `ssoProviders` is empty in core by design; AdvancedAuth's provider labels + login URLs come through the `publicStatus` filter (keeps core provider-agnostic — Q1 in the plan doc).

Follow-up to #3637 / #3662 / #3663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
