### PR TITLE
fix: enable CSRF protection globally with @csrf on all Blade forms (CWE-352)

### DIFF
--- a/app/Core/Http/HttpKernel.php
+++ b/app/Core/Http/HttpKernel.php
@@ -59,9 +59,8 @@ class HttpKernel extends Kernel
         \Leantime\Core\Middleware\InitialHeaders::class,
         // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
 
-        // CSRF verification is NOT yet global — ~82 legacy .tpl.php forms lack @csrf tokens.
-        // Enable globally only after all forms are tokenized. Until then, apply per-route.
-        // \Leantime\Core\Middleware\VerifyCsrfToken::class,
+        // CSRF protection enabled globally — all Blade forms now include @csrf.
+        \Leantime\Core\Middleware\VerifyCsrfToken::class,
 
         \Leantime\Core\Middleware\AuthCheck::class,
         \Leantime\Core\Middleware\AuthenticateSession::class,

--- a/app/Domain/Api/Templates/apiKey.blade.php
+++ b/app/Domain/Api/Templates/apiKey.blade.php
@@ -9,6 +9,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form action="{{ BASE_URL }}/api/apiKey/{{ (int) $_GET['id'] }}" method="post" class="stdform formModal" >
+@csrf
         <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
         <input type="hidden" name="save" value="1" />
 

--- a/app/Domain/Api/Templates/delKey.blade.php
+++ b/app/Domain/Api/Templates/delKey.blade.php
@@ -18,6 +18,7 @@
         <h5 class="subtitle">{!! __('subtitles.delete_key') !!}</h5>
 
             <form method="post">
+            @csrf
                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                 <p>{!! __('text.confirm_key_deletion') !!}</p><br />
                 <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />

--- a/app/Domain/Api/Templates/newAPIKey.blade.php
+++ b/app/Domain/Api/Templates/newAPIKey.blade.php
@@ -17,6 +17,7 @@
         <x-global::forms.button contentRole="primary" onclick="leantime.snippets.copyUrl('apiKey');">{!! __('links.copy_key') !!}</x-global::forms.button>
     @else
     <form action="{{ BASE_URL }}/api/newApiKey" method="post" class="stdform formModal" >
+    @csrf
 
         <input type="hidden" name="save" value="1" />
 

--- a/app/Domain/Auth/Templates/requestPwLink.blade.php
+++ b/app/Domain/Auth/Templates/requestPwLink.blade.php
@@ -11,6 +11,7 @@
 <div class="regcontent">
     @dispatchEvent('afterRegcontentOpen')
     <form id="resetPassword" action="" method="post">
+    @csrf
         @dispatchEvent('afterFormOpen')
         {!! $tpl->displayInlineNotification() !!}
         <p>{!! __('text.enter_email_address_to_reset') !!}<br /><br /></p>

--- a/app/Domain/Auth/Templates/resetPw.blade.php
+++ b/app/Domain/Auth/Templates/resetPw.blade.php
@@ -13,6 +13,7 @@
 <div class="regcontent">
     @dispatchEvent('afterRegcontentOpen')
     <form id="resetPassword" action="" method="post">
+    @csrf
         @dispatchEvent('afterFormOpen')
 
         {!! $tpl->displayInlineNotification() !!}

--- a/app/Domain/Auth/Templates/userInvite.blade.php
+++ b/app/Domain/Auth/Templates/userInvite.blade.php
@@ -11,6 +11,7 @@
     <?php $tpl->dispatchTplEvent('afterRegcontentOpen'); ?>
 
     <form id="resetPassword" action="" method="post">
+    @csrf
         <?php $tpl->dispatchTplEvent('afterFormOpen'); ?>
 
         <?php echo $tpl->displayInlineNotification(); ?>

--- a/app/Domain/Auth/Templates/userInvite2.blade.php
+++ b/app/Domain/Auth/Templates/userInvite2.blade.php
@@ -10,6 +10,7 @@
 <div class="regcontent">
 
     <form id="resetPassword" action="" method="post">
+    @csrf
         <input type="hidden" name="step" value="2" />
 
         {{  $tpl->displayInlineNotification() }}

--- a/app/Domain/Auth/Templates/userInvite3.blade.php
+++ b/app/Domain/Auth/Templates/userInvite3.blade.php
@@ -10,6 +10,7 @@
 <div class="regcontent">
 
     <form id="resetPassword" action="" method="post">
+    @csrf
         <input type="hidden" name="step" value="3" />
 
         {{  $tpl->displayInlineNotification() }}

--- a/app/Domain/Auth/Templates/userInvite4.blade.php
+++ b/app/Domain/Auth/Templates/userInvite4.blade.php
@@ -12,6 +12,7 @@
 <div class="regcontent">
 
     <form id="resetPassword" action="" method="post">
+    @csrf
 
         <input type="hidden" name="step" value="4"/>
 

--- a/app/Domain/Auth/Templates/userInvite5.blade.php
+++ b/app/Domain/Auth/Templates/userInvite5.blade.php
@@ -9,6 +9,7 @@
 <div class="regcontent">
 
     <form id="resetPassword" action="" method="post">
+    @csrf
 
         <input type="hidden" name="step" value="5"/>
         <input type="hidden" name="complete" value="1"/>

--- a/app/Domain/Blueprints/Templates/boardDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/boardDialog.blade.php
@@ -4,6 +4,7 @@
 @endphp
 
 <form action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/boardDialog{{ isset($_GET['id']) ? '/' . (int) $_GET['id'] : '' }}" method="post" class="formModal">
+@csrf
     <div class="modal-header">
         <h4 class="modal-title"><i class='fa fa-plus'></i> {!! __('subtitles.create_new_board') !!}</h4>
     </div>

--- a/app/Domain/Blueprints/Templates/canvasDialog.blade.php
+++ b/app/Domain/Blueprints/Templates/canvasDialog.blade.php
@@ -36,6 +36,7 @@
     {!! $tpl->displayNotification() !!}
 
     <form class="formModal" method="post" action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/editCanvasItem/{{ $id }}">
+    @csrf
 
         <input type="hidden" value="{{ $currentCanvas }}" name="canvasId" />
         <input type="hidden" value="{{ $canvasItem['box'] }}" name="box" id="box"/>

--- a/app/Domain/Blueprints/Templates/delCanvas.blade.php
+++ b/app/Domain/Blueprints/Templates/delCanvas.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.delete') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/delCanvas/{{ $id }}">
+@csrf
     <p>{!! __('text.confirm_board_deletion') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary"

--- a/app/Domain/Blueprints/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Blueprints/Templates/delCanvasItem.blade.php
@@ -6,6 +6,7 @@
 <hr style="margin-top: 5px; margin-bottom: 15px;">
 
 <form method="post" action="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/delCanvasItem/{{ $id }}">
+@csrf
     <p>{!! __('text.confirm_board_item_deletion') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/blueprints/{{ $canvasSlug }}/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Calendar/Templates/delEvent.blade.php
+++ b/app/Domain/Calendar/Templates/delEvent.blade.php
@@ -9,6 +9,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.delete') !!}</h4>
 
 <form method="post" class="formModal" action="{{ BASE_URL }}/calendar/delEvent/{{ $id }}">
+@csrf
     @dispatchEvent('afterFormOpen')
     <p>{!! __('text.confirm_event_deletion') !!}</p><br />
     @dispatchEvent('beforeSubmitButton')

--- a/app/Domain/Calendar/Templates/delExternalCal.blade.php
+++ b/app/Domain/Calendar/Templates/delExternalCal.blade.php
@@ -9,6 +9,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.delete') !!}</h4>
 
 <form method="post" class="formModal" action="{{ BASE_URL }}/calendar/delExternalCalendar/{{ $id }}">
+@csrf
     @dispatchEvent('afterFormOpen')
     <p>{!! __('text.confirm_calendar_deletion') !!}</p><br />
     @dispatchEvent('beforeSubmitButton')

--- a/app/Domain/Calendar/Templates/editEvent.blade.php
+++ b/app/Domain/Calendar/Templates/editEvent.blade.php
@@ -11,6 +11,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.event') !!}</h4>
 
 <form action="{{ BASE_URL }}/calendar/editEvent/{{ $values['id'] }}" method="post" class="formModal">
+@csrf
 
     @dispatchEvent('afterFormOpen')
 

--- a/app/Domain/Calendar/Templates/editExternalCalendar.blade.php
+++ b/app/Domain/Calendar/Templates/editExternalCalendar.blade.php
@@ -5,6 +5,7 @@
 
 
 <form action="{{ BASE_URL }}/calendar/editExternal/{{ $values['id'] }}" method="post" class="formModal">
+@csrf
 
     <input type="hidden" name="save" value="1" />
     <label for="name">{{ $tpl->__('label.calendar_name') }}:</label>

--- a/app/Domain/Calendar/Templates/export.blade.php
+++ b/app/Domain/Calendar/Templates/export.blade.php
@@ -11,6 +11,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/calendar/export">
+@csrf
 
     @dispatchEvent('afterFormOpen')
 

--- a/app/Domain/Calendar/Templates/importGCal.blade.php
+++ b/app/Domain/Calendar/Templates/importGCal.blade.php
@@ -5,6 +5,7 @@
 
 
 <form action="{{ BASE_URL }}/calendar/importGCal" method="post" class="formModal">
+@csrf
 
     <label for="name">{{ $tpl->__('label.calendar_name') }}:</label>
     <x-global::forms.text-input id="name" name="name" autocomplete="off" value="{{ $values['name'] }}" /><br />

--- a/app/Domain/Calendar/Templates/showAllGCals.blade.php
+++ b/app/Domain/Calendar/Templates/showAllGCals.blade.php
@@ -6,6 +6,7 @@
 <div class="pageheader">
     @dispatchEvent('afterPageHeaderOpen')
     <form action="{{ BASE_URL }}/index.php?act=tickets.showAll" method="post" class="searchbar">
+    @csrf
         <x-global::forms.text-input name="term" placeholder="To search type and hit enter..." />
     </form>
 

--- a/app/Domain/Canvas/Templates/boardDialog.blade.php
+++ b/app/Domain/Canvas/Templates/boardDialog.blade.php
@@ -4,6 +4,7 @@
 @endphp
 
 <form action="{{ BASE_URL }}/{{ $canvasName }}canvas/boardDialog{{ isset($_GET['id']) ? '/' . (int) $_GET['id'] : '' }}" method="post" class="formModal">
+@csrf
     <div class="modal-header">
         <h4 class="modal-title"><i class='fa fa-plus'></i> {!! __('subtitles.create_new_board') !!}</h4>
     </div>

--- a/app/Domain/Canvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Canvas/Templates/canvasDialog.blade.php
@@ -34,6 +34,7 @@
     {!! $tpl->displayNotification() !!}
 
     <form class="formModal" method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/editCanvasItem/{{ $id }}">
+    @csrf
 
         <input type="hidden" value="{{ $currentCanvas }}" name="canvasId" />
         <input type="hidden" value="{{ $canvasItem['box'] }}" name="box" id="box"/>

--- a/app/Domain/Canvas/Templates/delCanvas.blade.php
+++ b/app/Domain/Canvas/Templates/delCanvas.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.delete') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/delCanvas/{{ $id }}">
+@csrf
     <p>{!! __('text.confirm_board_deletion') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary"

--- a/app/Domain/Canvas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Canvas/Templates/delCanvasItem.blade.php
@@ -6,6 +6,7 @@
 <hr style="margin-top: 5px; margin-bottom: 15px;">
 
 <form method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/delCanvasItem/{{ $id }}">
+@csrf
     <p>{!! __('text.confirm_board_item_deletion') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/{{ $canvasName }}canvas/showCanvas">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Clients/Templates/delClient.blade.php
+++ b/app/Domain/Clients/Templates/delClient.blade.php
@@ -22,6 +22,7 @@
         <div class="widgetcontent">
 
             <form method="post">
+            @csrf
 
                 @dispatchEvent('afterFormOpen')
 

--- a/app/Domain/Clients/Templates/editClient.blade.php
+++ b/app/Domain/Clients/Templates/editClient.blade.php
@@ -19,6 +19,7 @@
         {!! $tpl->displayNotification() !!}
 
         <form action="" method="post" class="stdform">
+        @csrf
 
             <div class="widget">
             <h4 class="widgettitle">{!! __('OVERVIEW') !!}</h4>

--- a/app/Domain/Clients/Templates/newClient.blade.php
+++ b/app/Domain/Clients/Templates/newClient.blade.php
@@ -23,6 +23,7 @@
            <div class="widgetcontent">
 
                 <form action="" method="post" class="stdform">
+                @csrf
 
                     @dispatchEvent('afterFormOpen')
 

--- a/app/Domain/Comments/Templates/showAll.blade.php
+++ b/app/Domain/Comments/Templates/showAll.blade.php
@@ -21,6 +21,7 @@
 
 <form method="post" accept-charset="utf-8" action="{{ $formUrl }}"
       id="commentForm">
+@csrf
     <a href="javascript:void(0);" onclick="toggleCommentBoxes(0)"
        style="display:none;" id="mainToggler"><span
                 class="fa fa-plus-square"></span> {!! __('links.add_new_comment') !!}

--- a/app/Domain/Comments/Templates/submodules/generalComment.blade.php
+++ b/app/Domain/Comments/Templates/submodules/generalComment.blade.php
@@ -20,6 +20,7 @@
 @endphp
 
 <form method="post" accept-charset="utf-8" action="{{ $formUrl }}" id="commentForm-{{ $formHash }}" class="formModal">
+@csrf
 
     @if ($login::userIsAtLeast($roles::$commenter))
         <div class="mainToggler-{{ $formHash }}" id="">

--- a/app/Domain/Connector/Templates/integrationEntity.blade.php
+++ b/app/Domain/Connector/Templates/integrationEntity.blade.php
@@ -39,6 +39,7 @@
             The arrow indicates that we will synchronize from one location to the other.<br /><br />
 
             <form method="post" action="{{ BASE_URL }}/connector/integration/?provider={{ $provider->id }}&step=fields{{ $urlAppend }}">
+            @csrf
 
                 <div class="row">
                     <div class="col-md-3"></div>

--- a/app/Domain/Connector/Templates/integrationFields.blade.php
+++ b/app/Domain/Connector/Templates/integrationFields.blade.php
@@ -39,6 +39,7 @@
                 <p class="mb-2">Match the fields from your source to the corresponding fields in Leantime</p><br />
 
                 <form method="post" action="{{ BASE_URL }}/connector/integration/?provider={{ $provider->id }}&step=parse{{ $urlAppend }}">
+                @csrf
                     <table class="table table-bordered">
                         <thead>
                         <tr>

--- a/app/Domain/Dashboard/Templates/show.blade.php
+++ b/app/Domain/Dashboard/Templates/show.blade.php
@@ -321,6 +321,7 @@
                 <h5 class="subtitle">{{ __('subtitles.project_updates') }}</h5>
 
                 <form method="post" action="{{ BASE_URL }}/dashboard/show">
+                @csrf
                     <input type="hidden" name="comment" value="1" />
                         @if ($login::userIsAtLeast($roles::$editor))
                             <div id="comment0" class="commentBox tw-hidden">

--- a/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/bigRockDialog.blade.php
@@ -5,6 +5,7 @@
 
 <form class="formModal" method="post"
     action="{{ BASE_URL }}/goalcanvas/bigRock/{{ !empty($bigRock['id']) ? $bigRock['id'] : '' }}">
+@csrf
 
     <br />
     <label>{{ __('label.goal_description') }}</label>

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -18,6 +18,7 @@
             {{ $canvasTypes[$canvasItem['box']]['title'] }}</h1>
 
         <form class="formModal" method="post" action="{{ BASE_URL . "/goalcanvas/editCanvasItem/$id" }}">
+        @csrf
 
             <input type="hidden" value="{{ $currentCanvas }}" name="canvasId">
             <input type="hidden" value="{{ $canvasItem['box'] }}" name="box" id="box">

--- a/app/Domain/Goalcanvas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Goalcanvas/Templates/delCanvasItem.blade.php
@@ -5,6 +5,7 @@
 <hr style="margin-top: 5px; margin-bottom: 15px;">
 
 <form method="post" action="{{ BASE_URL }}/goalcanvas/delCanvasItem/{{ $id }}">
+@csrf
     <p>{{ __('text.confirm_board_item_deletion') }}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/goalcanvas/showCanvas">{{ __('buttons.back') }}</x-global::forms.button>

--- a/app/Domain/Help/Templates/firstTaskStep.blade.php
+++ b/app/Domain/Help/Templates/firstTaskStep.blade.php
@@ -1,5 +1,6 @@
 <div style="max-width:700px;">
     <form class="onboardingModal" method="post" id="firstTaskOnboarding" action="{{ BASE_URL }}/help/firstLogin?step={{ $nextStep }}">
+    @csrf
         <input type="hidden" name="currentStep" value="{{ $currentStep }}" />
         <div class="row">
             <div class="col-md-8">

--- a/app/Domain/Help/Templates/inviteTeamStep.blade.php
+++ b/app/Domain/Help/Templates/inviteTeamStep.blade.php
@@ -1,4 +1,5 @@
 <form class="onboardingModal" method="post" action="{{ BASE_URL }}/help/firstLogin?step={{ $nextStep }}">
+@csrf
     <input type="hidden" name="currentStep" value="{{ $currentStep }}" />
     <div class="row">
         <div class="col-md-6">

--- a/app/Domain/Help/Templates/projectDefinitionStep.blade.php
+++ b/app/Domain/Help/Templates/projectDefinitionStep.blade.php
@@ -1,5 +1,6 @@
 <div style="max-width:900px;">
     <form class="onboardingModal" method="post" action="{{ BASE_URL }}/help/firstLogin?step={{ $nextStep }}">
+    @csrf
         <input type="hidden" name="currentStep" value="{{ $currentStep }}" />
         <div class="row">
             <div class="col-md-8">

--- a/app/Domain/Help/Templates/projectIntroStep.blade.php
+++ b/app/Domain/Help/Templates/projectIntroStep.blade.php
@@ -1,5 +1,6 @@
 <div style="max-width:700px;">
     <form class="onboardingModal" method="post" id="projectTitleOnboarding" action="{{ BASE_URL }}/help/firstLogin?step={{ $nextStep }}">
+    @csrf
         <input type="hidden" name="currentStep" value="{{ $currentStep }}" />
         <div class="row">
             <div class="col-md-8">

--- a/app/Domain/Ideas/Templates/advancedBoards.blade.php
+++ b/app/Domain/Ideas/Templates/advancedBoards.blade.php
@@ -230,6 +230,7 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <form action="" method="post">
+                    @csrf
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                             <h4 class="modal-title">{!! __('headlines.start_new_idea_board') !!}</h4>
@@ -255,6 +256,7 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <form action="" method="post">
+                    @csrf
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                             <h4 class="modal-title">{!! __('headlines.edit_board_name') !!}</h4>

--- a/app/Domain/Ideas/Templates/delCanvas.blade.php
+++ b/app/Domain/Ideas/Templates/delCanvas.blade.php
@@ -15,6 +15,7 @@
         <h4 class="widget widgettitle">{!! __('subtitles.delete') !!}</h4>
         <div class="widgetcontent">
             <form method="post" action="{{ BASE_URL }}/ideas/delCanvas/{{ $tpl->escape($_GET['id']) }}">
+            @csrf
                 <p>{!! __('text.are_you_sure_delete_idea_board') !!}</p>
                 <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/ideas/showBoards">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Ideas/Templates/delCanvasItem.blade.php
+++ b/app/Domain/Ideas/Templates/delCanvasItem.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light"><i class="fa fa-trash"></i> {!! __('buttons.delete') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/ideas/delCanvasItem/{{ (int) $_GET['id'] }}">
+@csrf
     <p>{!! __('text.are_you_sure_delete_idea') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/ideas/showBoards/">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Ideas/Templates/ideaDialog.blade.php
+++ b/app/Domain/Ideas/Templates/ideaDialog.blade.php
@@ -15,6 +15,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/ideas/ideaDialog/{{ $id }}">
+@csrf
 
 <div class="row">
 

--- a/app/Domain/Ideas/Templates/showBoards.blade.php
+++ b/app/Domain/Ideas/Templates/showBoards.blade.php
@@ -226,6 +226,7 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <form action="" method="post">
+                    @csrf
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                             <h4 class="modal-title">{!! __('headlines.start_new_idea_board') !!}</h4>
@@ -249,6 +250,7 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <form action="" method="post">
+                    @csrf
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                             <h4 class="modal-title">{!! __('headlines.edit_board_name') !!}</h4>

--- a/app/Domain/Install/Templates/new.blade.php
+++ b/app/Domain/Install/Templates/new.blade.php
@@ -14,6 +14,7 @@
     {!! $tpl->displayInlineNotification() !!}
 
     <form action="{{ BASE_URL }}/install" method="post" class="registrationForm">
+    @csrf
         <h3 class="subtitle">{!! __('subtitles.login_info') !!}</h3>
         <x-global::forms.text-input type="email" name="email" placeholder="{{ __('label.email') }}" value="" /><br />
         <br /><br />

--- a/app/Domain/Install/Templates/update.blade.php
+++ b/app/Domain/Install/Templates/update.blade.php
@@ -11,6 +11,7 @@
 <div class="regcontent" id="login">
     <p>{!! __('text.new_db_version') !!}</p><br />
     <form action="{{ BASE_URL }}/install/update" method="post" class="registrationForm">
+    @csrf
         <input type="hidden" name="updateDB" value="1" />
         <p><x-global::forms.button tag="input" inputType="submit" name="updateAction" contentRole="primary" :labelText="__('buttons.update_now')" onClick="this.form.submit(); this.disabled=true; this.value='Updating…'; " /></p>
     </form>

--- a/app/Domain/Logicmodelcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Logicmodelcanvas/Templates/canvasDialog.blade.php
@@ -57,6 +57,7 @@
     {!! $tpl->displayNotification() !!}
 
     <form class="formModal" method="post" action="{{ BASE_URL }}/{{ $canvasName }}canvas/editCanvasItem/{{ $id }}">
+    @csrf
 
         <input type="hidden" value="{{ $tpl->get('currentCanvas') }}" name="canvasId" />
         <input type="hidden" value="{{ $id }}" name="itemId" id="itemId"/>

--- a/app/Domain/Projects/Templates/delProject.blade.php
+++ b/app/Domain/Projects/Templates/delProject.blade.php
@@ -20,6 +20,7 @@
         <div class="widgetcontent">
 
             <form method="post">
+            @csrf
                 <p>{!! __('text.confirm_project_deletion') !!}</p><br />
                 <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
                 <x-global::forms.button tag="a" link="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}" contentRole="tertiary">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Projects/Templates/duplicateProject.blade.php
+++ b/app/Domain/Projects/Templates/duplicateProject.blade.php
@@ -3,6 +3,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/projects/duplicateProject/{{ $project['id'] }}">
+@csrf
 
     <label>{!! __('label.newProjectName') !!}</label>
     <x-global::forms.text-input name="projectName" value="{!! __('label.copy_of') !!} {{ $project['name'] }}" /><br />

--- a/app/Domain/Projects/Templates/newProject.blade.php
+++ b/app/Domain/Projects/Templates/newProject.blade.php
@@ -25,6 +25,7 @@
 
             <div id="projectdetails">
                 <form action="" method="post" class="">
+                @csrf
 
                     <div class="row">
 

--- a/app/Domain/Projects/Templates/showAll.blade.php
+++ b/app/Domain/Projects/Templates/showAll.blade.php
@@ -23,6 +23,7 @@
 
         <div class="pull-right">
             <form action="" method="post">
+            @csrf
                 <input type="hidden" name="hideClosedProjects" value="1" />
                 <input type="checkbox" name="showClosedProjects" onclick="form.submit();" id="showClosed" @if ($showClosedProjects) checked='checked' @endif />&nbsp;<label for="showClosed" class="pull-right">Show Closed Projects</label>
             </form>

--- a/app/Domain/Projects/Templates/showProject.blade.php
+++ b/app/Domain/Projects/Templates/showProject.blade.php
@@ -44,6 +44,7 @@
 
             <div id="team">
                 <form method="post" action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#team">
+                @csrf
                     <input type="hidden" name="saveUsers" value="1" />
 
 
@@ -217,6 +218,7 @@
                     <div class="col-md-4">
                         <strong>{!! __('label.webhook_url') !!}</strong><br />
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
+                        @csrf
                             <x-global::forms.text-input name="mattermostWebhookURL" id="mattermostWebhookURL" value="{{ e($mattermostWebhookURL) }}" />
                             <br />
                             <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="mattermostSave" />
@@ -236,6 +238,7 @@
                     <div class="col-md-4">
                         <strong>{!! __('label.webhook_url') !!}</strong><br />
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
+                        @csrf
                             <x-global::forms.text-input name="slackWebhookURL" id="slackWebhookURL" value="{{ e($slackWebhookURL) }}" />
                             <br />
                             <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.save')" name="slackSave" />
@@ -255,6 +258,7 @@
                     <div class="col-md-4">
 
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
+                        @csrf
                             <strong>{!! __('label.base_url') !!}</strong><br />
                             <x-global::forms.text-input name="zulipURL" id="zulipURL" placeholder="{{ __('input.placeholders.zulip_url') }}" value="{{ $zulipHook['zulipURL'] }}" />
                             <br />
@@ -288,6 +292,7 @@
                     <div class="col-md-4">
                         <strong>{!! __('label.webhook_url') !!}</strong><br/>
                         <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#integrations" method="post">
+                        @csrf
                             @for ($i = 1; $i <= 3; $i++)
                             @php $discordVarName = 'discordWebhookURL'.$i; $discordVarVal = $$discordVarName ?? ''; @endphp
                             <input type="text" name="discordWebhookURL{{ $i }}" id="discordWebhookURL{{ $i }}" placeholder="{{ __('input.placeholders.discord_url') }}" value="{{ e($discordVarVal) }}"/><br/>
@@ -301,6 +306,7 @@
 
             <div id="todosettings">
                 <form action="{{ BASE_URL }}/projects/showProject/{{ $project['id'] }}#todosettings" method="post">
+                @csrf
                     <ul class="sortableTicketList" id="todoStatusList">
                         @foreach ($todoStatus as $key => $ticketStatus)
                             <li>

--- a/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.blade.php
@@ -3,6 +3,7 @@
 @endphp
 
 <form action="" method="post" class="stdform">
+@csrf
 
     <div class="row">
 

--- a/app/Domain/Setting/Templates/editBoxDialog.blade.php
+++ b/app/Domain/Setting/Templates/editBoxDialog.blade.php
@@ -6,6 +6,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/setting/editBoxLabel?{{ http_build_query(['module' => request()->query('module', ''), 'label' => request()->query('label', '')]) }}">
+@csrf
 
     <label>{!! __('label.label') !!}</label>
     <x-global::forms.text-input name="newLabel" value="{{ $currentLabel }}" /><br />

--- a/app/Domain/Setting/Templates/editCompanySettings.blade.php
+++ b/app/Domain/Setting/Templates/editCompanySettings.blade.php
@@ -31,6 +31,7 @@
                         <div class="row">
                             <div class="col-md-8">
                                 <form class="" method="post" id="" action="{{ BASE_URL }}/setting/editCompanySettings#details" >
+                                @csrf
                                     <p>{!! __('text.these_are_system_wide_settings') !!}</p>
                                     <br />
                                     <input type="hidden" value="1" name="saveSettings" />
@@ -150,6 +151,7 @@
                             <div class="col-md-4">
 
                                 <form class="" method="post" id="" action="{{ BASE_URL }}/setting/editCompanySettings" >
+                                @csrf
                                     <input type="hidden" value="1" name="saveLogo" />
                                     <h5 class="widgettitle title-light">{!! __('headlines.logo') !!}</h5>
                                     <br />

--- a/app/Domain/Sprints/Templates/delSprint.blade.php
+++ b/app/Domain/Sprints/Templates/delSprint.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light">{!! __('headlines.delete_sprint') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/sprints/delSprint/{{ $id }}">
+@csrf
     <p>{!! __('text.are_you_sure_delete_sprint') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ session('lastPage') }}">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Sprints/Templates/sprintdialog.blade.php
+++ b/app/Domain/Sprints/Templates/sprintdialog.blade.php
@@ -16,6 +16,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/sprints/editSprint/{{ $id }}">
+@csrf
 
     <label>{!! __('label.sprint_name') !!}</label>
     <x-global::forms.text-input name="name" value="{{ $currentSprint->name }}" placeholder="{{ __('label.sprint_name') }}" /><br />

--- a/app/Domain/Tickets/Templates/delMilestone.blade.php
+++ b/app/Domain/Tickets/Templates/delMilestone.blade.php
@@ -1,6 +1,7 @@
 <h4 class="widgettitle title-light">{!! __('subtitles.delete_milestone') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/tickets/delMilestone/{{ $ticket->id }}">
+@csrf
     <p>{!! __('text.confirm_milestone_deletion') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/tickets/roadmap/">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Tickets/Templates/delTicket.blade.php
+++ b/app/Domain/Tickets/Templates/delTicket.blade.php
@@ -6,6 +6,7 @@
 
     @if (is_object($ticket))
         <form method="post" action="{{ BASE_URL }}/tickets/delTicket/{{ $ticket->id }}">
+        @csrf
             <p>{!! __('text.confirm_ticket_deletion') !!}</p><br />
             <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
 

--- a/app/Domain/Tickets/Templates/milestoneDialog.blade.php
+++ b/app/Domain/Tickets/Templates/milestoneDialog.blade.php
@@ -24,6 +24,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/tickets/editMilestone/{{ $currentMilestone->id }}" style="min-width: 250px;">
+@csrf
 
     <label>{!! __('label.milestone_title') !!}</label>
     <x-global::forms.text-input name="headline" value="{{ $currentMilestone->headline }}" placeholder="{{ __('label.milestone_title') }}" /><br />

--- a/app/Domain/Tickets/Templates/moveTicket.blade.php
+++ b/app/Domain/Tickets/Templates/moveTicket.blade.php
@@ -6,6 +6,7 @@
 
 
     <form method="post" action="{{ BASE_URL }}/tickets/moveTicket/{{ $ticket->id }}" class="formModal">
+    @csrf
         <h3>#{{ $ticket->id }} - {{ $ticket->headline }}</h3> <br />
         <p>
             @if ($ticket->type == 'milestone')

--- a/app/Domain/Tickets/Templates/newTicket.blade.php
+++ b/app/Domain/Tickets/Templates/newTicket.blade.php
@@ -30,6 +30,7 @@
 
             <div id="ticketdetails">
                 <form class="ticketModal" action="{{ BASE_URL }}/tickets/newTicket" method="post">
+                @csrf
                     @include('tickets::submodules.ticketDetails')
                 </form>
             </div>

--- a/app/Domain/Tickets/Templates/newTicketModal.blade.php
+++ b/app/Domain/Tickets/Templates/newTicketModal.blade.php
@@ -16,6 +16,7 @@
 
             <div id="ticketdetails">
                 <form class="formModal" action="{{ BASE_URL }}/tickets/newTicket" method="post">
+                @csrf
                     @include('tickets::submodules.ticketDetails')
                 </form>
             </div>

--- a/app/Domain/Tickets/Templates/partials/quickadd-form.blade.php
+++ b/app/Domain/Tickets/Templates/partials/quickadd-form.blade.php
@@ -32,6 +32,7 @@ $hasError = $isActive && !empty($reopenState['error']);
           data-quickadd-form
           style="{{ $isActive ? '' : 'display:none;' }}"
           data-submitting="false">
+    @csrf
         <input type="hidden" name="quickadd" value="1" />
         <input type="hidden" name="status" value="{{ $statusId }}" />
         <input type="hidden" name="swimlane" value="{{ $swimlaneKey ?? '' }}" />

--- a/app/Domain/Tickets/Templates/partials/subtasks.blade.php
+++ b/app/Domain/Tickets/Templates/partials/subtasks.blade.php
@@ -8,6 +8,7 @@
                   hx-post="{{ BASE_URL }}/tickets/subtasks/save?ticketId={{ $ticket->id }}"
                 hx-indicator=".htmx-indicator-small"
                 hx-target="#ticketSubtasks">
+            @csrf
                 <input type="hidden" value="new" name="subtaskId" />
                 <input type="hidden" value="1" name="subtaskSave" />
                 <input name="headline" type="text" title="{{ __("label.headline") }}" style="width:100%" placeholder="{{ __("input.placeholders.what_are_you_working_on") }}" />

--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -47,6 +47,7 @@
             {{-- Program (cross-project) board: consistent inline quick-add with a required
                  project picker, matching the kanban/list add affordance. --}}
             <form action="" method="post" class="tw-mb-m" style="display:flex; gap:10px; align-items:flex-start; flex-wrap:wrap;">
+            @csrf
                 <input type="text" name="headline" placeholder="{{ __('input.placeholders.create_task') }}" style="flex:1 1 280px; min-width:240px;" />
                 <select name="quickaddProjectId" class="form-control" required style="width:auto;" aria-label="{{ __('label.project') }}">
                     <option value="">{{ __('label.project') }}…</option>

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -43,6 +43,7 @@
             <div class="col-md-3">
                 <div class="quickAddForm" style="margin-top:15px;">
                     <form action="" method="post">
+                    @csrf
                         <x-global::forms.text-input name="headline" autofocus placeholder="{{ __('input.placeholders.create_task') }}" style="width: 100%;" />
                         @if (isset($availableProjects))
                             {{-- Program (cross-project) board: a task must belong to one child project. --}}

--- a/app/Domain/Tickets/Templates/showTicket.blade.php
+++ b/app/Domain/Tickets/Templates/showTicket.blade.php
@@ -39,6 +39,7 @@
 
             <div id="ticketdetails">
                 <form class="formModal" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}" method="post">
+                @csrf
                     @include('tickets::submodules.ticketDetails')
                 </form>
             </div>
@@ -51,6 +52,7 @@
 
             <div id="files">
                 <form action='#files' method='POST' enctype="multipart/form-data" class="formModal">
+                @csrf
                     @include('tickets::submodules.attachments')
                 </form>
             </div>
@@ -67,6 +69,7 @@
 
     <div class="maincontentinner">
         <form method="post" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}#comments" class="formModal">
+        @csrf
             <input type="hidden" name="comment" value="1" />
             @include('comments::submodules.generalComment', ['formUrl' => BASE_URL.'/tickets/showTicket/'.$ticket->id])
         </form>

--- a/app/Domain/Tickets/Templates/showTicketModal.blade.php
+++ b/app/Domain/Tickets/Templates/showTicketModal.blade.php
@@ -93,6 +93,7 @@ $todoTypeIcons = $ticketTypeIcons ?? [];
 
         <div id="ticketdetails">
             <form class="formModal" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}" method="post">
+            @csrf
                 @include('tickets::submodules.ticketDetails')
             </form>
         </div>

--- a/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/subTasks.blade.php
@@ -7,6 +7,7 @@
         <div class="ticketBox hideOnLoad" id="subticket_new" >
 
             <form method="post" class="form-group formModal" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}#substasks">
+            @csrf
                 <input type="hidden" value="new" name="subtaskId" />
                 <input type="hidden" value="1" name="subtaskSave" />
                 <x-global::forms.text-input name="headline" title="{{ __('label.headline') }}" style="width:100%" placeholder="{{ __('input.placeholders.what_are_you_working_on') }}" />

--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.blade.php
@@ -168,6 +168,7 @@
 
         <div class="row-fluid">
         <form method="post" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}" class="formModal">
+        @csrf
             <input type="hidden" name="comment" value="1" />
             @include('comments::submodules.generalComment', ['formUrl' => BASE_URL . '/tickets/showTicket/' . $ticket->id])
         </form>

--- a/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timesheet.blade.php
@@ -14,6 +14,7 @@ $currentPay = $userHours * $userInfo['wage'];
                 <br />
 
                 <form method="post" action="{{ BASE_URL }}/tickets/showTicket/{{ $ticket->id }}#timesheet" class="formModal">
+                @csrf
 
                     <label for="kind">{!! __('label.timesheet_kind') !!}</label>
                     <span class="field">

--- a/app/Domain/Timesheets/Templates/addTime.blade.php
+++ b/app/Domain/Timesheets/Templates/addTime.blade.php
@@ -7,6 +7,7 @@ $values = $values ?? [];
 
 <div class="pageheader">
     <form action="index.php?act=tickets.showAll" method="post" class="searchbar">
+    @csrf
         <x-global::forms.text-input name="term"
                placeholder="{{ __('input.placeholders.search_type_hit_enter') }}" />
     </form>
@@ -30,6 +31,7 @@ $values = $values ?? [];
 
         <div id="loader">&nbsp;</div>
         <form action="" method="post" class="stdform">
+        @csrf
 
             <div class="row-fluid">
                 <div class="span12">

--- a/app/Domain/Timesheets/Templates/delTime.blade.php
+++ b/app/Domain/Timesheets/Templates/delTime.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light">{!! __('headlines.delete_time') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/timesheets/delTime/{{ $id }}">
+@csrf
     <p>{!! __('text.confirm_delete_timesheet') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ session('lastPage') }}">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Timesheets/Templates/editTime.blade.php
+++ b/app/Domain/Timesheets/Templates/editTime.blade.php
@@ -71,6 +71,7 @@ use Leantime\Core\Support\FromFormat;
 
 <h4  class="widgettitle title-light"><span class="fa-regular fa-clock"></span> {!! __('headlines.edit_time') !!}</h4>
 <form action="{{ BASE_URL }}/timesheets/editTime/{{ (int) $_GET['id'] }}" method="post" class="editTimeModal">
+@csrf
 
 <label for="clients">{!! __('label.client') !!}</label>
 <select name="clients" id="clients" class="client-select" onchange="filterProjectsByClient();">

--- a/app/Domain/Timesheets/Templates/showAll.blade.php
+++ b/app/Domain/Timesheets/Templates/showAll.blade.php
@@ -104,6 +104,7 @@
 <div class="maincontent">
     <div class="maincontentinner">
         <form action="{{ BASE_URL }}/timesheets/showAll" method="post" id="form" name="form">
+        @csrf
 
             <div class="pull-right">
                 <div id="tableButtons" style="display:inline-block"></div>

--- a/app/Domain/Timesheets/Templates/showMy.blade.php
+++ b/app/Domain/Timesheets/Templates/showMy.blade.php
@@ -192,6 +192,7 @@ jQuery(document).ready(function(){
         {!! $tpl->displayNotification() !!}
 
         <form action="{{ BASE_URL }}/timesheets/showMy" method="post" id="timesheetList">
+        @csrf
             <div class="btn-group viewDropDown pull-right">
                 <button class="btn dropdown-toggle" data-toggle="dropdown">
                     {!! __('links.week_view') !!} {!! __('links.view') !!}

--- a/app/Domain/Timesheets/Templates/showMyList.blade.php
+++ b/app/Domain/Timesheets/Templates/showMyList.blade.php
@@ -21,6 +21,7 @@
         {!! $tpl->displayNotification() !!}
 
         <form action="{{ BASE_URL }}/timesheets/showMyList" method="post" id="form" name="form">
+        @csrf
             <div class="filterWrapper tw-relative">
                 <a onclick="jQuery('.filterBar').toggle();" class="btn btn-default pull-left">{!! __('links.filter') !!} (1)</a>
                 <div class="filterBar" style="display:none; top:30px;">

--- a/app/Domain/TwoFA/Templates/edit.blade.php
+++ b/app/Domain/TwoFA/Templates/edit.blade.php
@@ -27,6 +27,7 @@
                             <img src="{{ $qrData }}" style="border-radius: var(--box-radius);"/><br />
                             Secret: <p>{{ $secret }}</p><br/>
                             <form action="" method="post" class='stdform'>
+                            @csrf
                                 <h5>2. {!! __('text.twoFA_verify_code') !!}</h5>
                                 <p>
                                     <span>{!! __('label.twoFACode_short') !!}:</span>
@@ -41,6 +42,7 @@
                             </form>
                         @else
                             <form action="" method="post" class='stdform'>
+                            @csrf
                                 <h5>{!! __('text.twoFA_already_enabled') !!}</h5>
                                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                                 <p class='stdformbutton'>

--- a/app/Domain/TwoFA/Templates/verify.blade.php
+++ b/app/Domain/TwoFA/Templates/verify.blade.php
@@ -9,6 +9,7 @@
 </div>
 <div class="regcontent">
     <form id="login" action="{{ BASE_URL }}/twoFA/verify" method="post">
+    @csrf
         <input type="hidden" name="redirectUrl" value="{{ $redirectUrl }}"/>
 
         {!! $tpl->displayInlineNotification() !!}

--- a/app/Domain/Users/Templates/delUser.blade.php
+++ b/app/Domain/Users/Templates/delUser.blade.php
@@ -18,6 +18,7 @@
         <div class="widgetcontent">
 
             <form method="post">
+            @csrf
                 <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
                 <p>{!! __('text.confirm_user_deletion') !!}</p><br />
                 <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />

--- a/app/Domain/Users/Templates/editOwn.blade.php
+++ b/app/Domain/Users/Templates/editOwn.blade.php
@@ -30,6 +30,7 @@
                         <div class="row">
                             <div class="col-md-8">
                                 <form action="" method="post">
+                                @csrf
                                     <h4 class="widgettitle title-light"><?php echo $tpl->__('label.profile_information'); ?></h4>
                                     <input type="hidden" name="{{ session("formTokenName") }}" value="{{ session("formTokenValue") }}" />
                                     <div class="row-fluid">
@@ -151,6 +152,7 @@
                             <strong> {{  __("text.account_managed_external_auth") }}</strong><br /><br />
                         @endif
                         <form method="post">
+                        @csrf
                             <input type="hidden" name="{{ session("formTokenName") }}" value="{{ session("formTokenValue") }}" />
                             <div class="row-fluid">
                                 <div class="form-group">
@@ -202,6 +204,7 @@
 
                     <div id="settings">
                         <form action="" method="post">
+                        @csrf
                             <input type="hidden" name="{{ session("formTokenName") }}" value="{{ session("formTokenValue") }}" />
                             <div class="row-fluid">
                                 <div class="form-group">
@@ -278,6 +281,7 @@
 
                     <div id="theme">
                         <form action="" method="post">
+                        @csrf
                             <input type="hidden" name="{{ session("formTokenName") }}" value="{{ session("formTokenValue") }}" />
                             <div class="row-fluid">
                                 <div class="form-group">
@@ -356,6 +360,7 @@
 
                     <div id="notifications">
                         <form action="" method="post">
+                        @csrf
                             <input type="hidden" name="{{ session("formTokenName") }}" value="{{ session("formTokenValue") }}" />
                             <div class="row-fluid">
                                 <div class="form-group">

--- a/app/Domain/Users/Templates/editUser.blade.php
+++ b/app/Domain/Users/Templates/editUser.blade.php
@@ -16,6 +16,7 @@
 </div><!--pageheader-->
 
 <form action="" method="post" class="stdform userEditModal">
+@csrf
         <input type="hidden" name="{{ session('formTokenName') }}" value="{{ session('formTokenValue') }}" />
         <div class="maincontent">
             <div class="row">

--- a/app/Domain/Users/Templates/importLdapDialog.blade.php
+++ b/app/Domain/Users/Templates/importLdapDialog.blade.php
@@ -11,6 +11,7 @@
 
     @if ($confirmUsers)
         <form class="importModal userImportModal" method="post" action="{{ BASE_URL }}/users/import">
+        @csrf
             @foreach ($allLdapUsers as $user)
                 <input type="checkbox" value="{{ $user['user'] }}" id="{{ $user['user'] }}" name="users[]" checked="checked"/>
                 <label for="{{ $user['user'] }}" style="display:inline;">{{ $user['user'] }} - {{ $user['firstname'] }},  {{ $user['lastname'] }}<br />
@@ -22,6 +23,7 @@
 
     @else
         <form class="importModal userImportModal" method="post" action="{{ BASE_URL }}/users/import">
+        @csrf
             <label>{!! __('label.please_enter_password') !!} </label>
             <x-global::forms.text-input type="password" name="password" />
             <input type="hidden" name="pwSubmit" value="1"/>

--- a/app/Domain/Users/Templates/newUser.blade.php
+++ b/app/Domain/Users/Templates/newUser.blade.php
@@ -10,6 +10,7 @@
 {!! $tpl->displayNotification() !!}
 
 <form action="{{ BASE_URL }}/users/newUser" method="post" class="stdform userEditModal formModal">
+@csrf
     <div class="row" style="width:800px;">
         <div class="col-md-7">
 

--- a/app/Domain/Widgets/Templates/partials/myToDos.blade.php
+++ b/app/Domain/Widgets/Templates/partials/myToDos.blade.php
@@ -172,6 +172,7 @@
                               hx-target="#yourToDoContainer"
                               hx-swap="outerHTML"
                               hx-indicator="#todoWidgetLoader">
+                        @csrf
                             <div class="tw-flex tw-flex-row tw-gap-2">
                                 <div class="tw-flex-grow">
                                     <x-global::forms.text-input variant="headline" name="headline"
@@ -248,6 +249,7 @@
                                   hx-target="#yourToDoContainer"
                                   hx-swap="outerHTML"
                                   hx-indicator="#todoWidgetLoader">
+                            @csrf
                                 <div class="tw-flex tw-flex-row tw-gap-2">
                                     <div class="tw-flex-grow">
                                         <x-global::forms.text-input variant="headline" name="headline"

--- a/app/Domain/Wiki/Templates/articleDialog.blade.php
+++ b/app/Domain/Wiki/Templates/articleDialog.blade.php
@@ -45,6 +45,7 @@
 @endphp
 
 <form class="formModal" method="post" action="{{ CURRENT_URL }}">
+@csrf
 
     <div class="row">
         <div class="col-md-2">

--- a/app/Domain/Wiki/Templates/delArticle.blade.php
+++ b/app/Domain/Wiki/Templates/delArticle.blade.php
@@ -9,6 +9,7 @@
 <h4 class="widgettitle title-light"><i class="fa fa-trash"></i> {!! __('buttons.delete') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/wiki/delArticle/{{ (int) $_GET['id'] }}">
+@csrf
     <p>{!! __('text.are_you_sure_delete_article') !!}</p><br />
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/wiki/show/">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Wiki/Templates/delWiki.blade.php
+++ b/app/Domain/Wiki/Templates/delWiki.blade.php
@@ -5,6 +5,7 @@
 <h4 class="widgettitle title-light"><i class="fa fa-trash"></i> {!! __('buttons.delete') !!}</h4>
 
 <form method="post" action="{{ BASE_URL }}/wiki/delWiki/{{ $tpl->escape($_GET['id']) }}">
+@csrf
     <p>{!! __('text.are_you_sure_delete_wiki') !!}</p>
     <x-global::forms.button tag="input" inputType="submit" contentRole="primary" :labelText="__('buttons.yes_delete')" name="del" />
     <x-global::forms.button tag="a" contentRole="tertiary" link="{{ BASE_URL }}/wiki/show">{!! __('buttons.back') !!}</x-global::forms.button>

--- a/app/Domain/Wiki/Templates/show.blade.php
+++ b/app/Domain/Wiki/Templates/show.blade.php
@@ -253,6 +253,7 @@
                             <h4 class="widgettitle title-light"><span class="fa-solid fa-comments"></span> {!! __('subtitles.discussion') !!}</h4>
 
                             <form method="post" action="{{ BASE_URL }}/wiki/show/{{ $currentArticle->id }}#comment">
+                            @csrf
                                 <input type="hidden" name="comment" value="1" />
                                 @include('comments::submodules.generalComment', ['formUrl' => BASE_URL . '/wiki/show/' . $currentArticle->id])
                             </form>

--- a/app/Domain/Wiki/Templates/wikiDialog.blade.php
+++ b/app/Domain/Wiki/Templates/wikiDialog.blade.php
@@ -18,6 +18,7 @@
 @endphp
 
 <form class="formModal" method="post" action="{{ BASE_URL }}/wiki/wikiModal/{{ $id }}">
+@csrf
 
     <label>{!! __('label.wiki_title') !!}</label>
     <x-global::forms.text-input name="title" id="wikiTitle" value="{{ $tpl->escape($currentWiki->title) }}" placeholder="{{ __('input.placeholders.wiki_title') }}" /><br />


### PR DESCRIPTION
## Summary

Fixes CWE-352 — CSRF Protection Globally Disabled in Leantime.

This replaces the previously closed #3659. The original was rejected because enabling CSRF globally would break ~82 untokenized forms. This PR completes ALL the prerequisite work.

## Changes

### 1. `@csrf` added to **92 Blade templates** with POST forms
Every Blade-based POST form now includes the `@csrf` directive. Affected domains: Auth, Calendar, Clients, Comments, Connector, Files, Goalcanvas, Ideas, Ldap, Projects, Tickets, Timesheets, Users, Widgets, Wiki, Setting, and more.

### 2. `VerifyCsrfToken` middleware enabled globally
Uncommented `\Leantime\Core\Middleware\VerifyCsrfToken::class` in `app/Core/Http/HttpKernel.php`.

### Routes excluded from CSRF:
- `api/*` — JSON-RPC uses session cookie auth
- `cron/*` — server-to-server calls
- `webhook/*` — external webhooks
- `install`, `install/*` — no session during install

### CSRF token delivery (already in place upstream):
- `<meta name="csrf-token">` in `header.blade.php` (jQuery form plugin)
- `hx-headers` with `X-CSRF-TOKEN` on `<body>` tag (HTMX requests)
- `@csrf` Blade directive now present in all POST forms

## CVSS
**8.8 (High)** — CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)