### PR TITLE
design(chrome): pageheader is a glass card (app-wide header modernization)

### DIFF
--- a/public/assets/css/components/structure.css
+++ b/public/assets/css/components/structure.css
@@ -441,19 +441,30 @@ body {
     /*background:var(--header-bg-color);*/
 }
 
+/* Pageheader is a glass card matching the content card below it, floating on
+   the app's gradient background (which lives on .rightpanel, untouched). The
+   old design used a 150px invisible cushion + a -95px content overlap to make
+   the header float transparently on the gradient; that's replaced by a proper
+   boxed header. Applied globally so every page's header is consistent. */
 .pageheader {
-    padding: 0px 15px;
-    padding-bottom:150px;
-    height:60px;
-    line-height:60px;
+    padding: 14px 20px;
+    height: auto;
+    line-height: 1.3;
     position: relative;
+    background: var(--glass-background);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: var(--glass-border);
+    border-radius: var(--box-radius);
+    box-shadow: var(--large-shadow);
+    margin-bottom: 10px;
 }
 
 .maincontent {
     float: left;
     width: 100%;
     padding: 10px 15px;
-    margin-top:-95px;
+    margin-top: 0;
     position:relative;
     z-index:5;
 }

--- a/public/assets/css/components/structure.css
+++ b/public/assets/css/components/structure.css
@@ -437,7 +437,7 @@ body {
     z-index: 15;
     width: 100%;
     box-shadow: var(--large-shadow);
-    backdrop-filter: var(--glass-blur)
+    backdrop-filter: var(--glass-blur);
     /*background:var(--header-bg-color);*/
 }
 
@@ -457,7 +457,10 @@ body {
     border: var(--glass-border);
     border-radius: var(--box-radius);
     box-shadow: var(--large-shadow);
-    margin-bottom: 10px;
+    /* Inset the header card horizontally to match .maincontent's 15px side
+       padding, so it lines up with the content card below (both are siblings
+       inside .primaryContent, which has no horizontal padding of its own). */
+    margin: 0 15px 10px;
 }
 
 .maincontent {

--- a/public/assets/css/components/style.default.css
+++ b/public/assets/css/components/style.default.css
@@ -649,19 +649,20 @@ body.loginpage {
     height:30px;
     font-size:16px;
     padding: 0px;
-    color: var(--main-titles-color);
+    /* Dark on the white/glass header card (was white on the gradient). */
+    color: var(--primary-font-color);
     border-width: 2px;
     border-style: solid;
-    border-color:var(--main-titles-color);
+    border-color: var(--primary-font-color);
     display: inline-block;
     -moz-border-radius: 30px;
     -webkit-border-radius: 30px;
     border-radius: 30px;
     float: left;
     text-align: center;
-    margin-right:5px;
+    margin-right:10px;
     line-height:26px;
-    margin-top:15px;
+    margin-top:0;
 }
 
 

--- a/public/assets/css/components/style.default.css
+++ b/public/assets/css/components/style.default.css
@@ -631,12 +631,14 @@ body.loginpage {
 
 .pageheader .padding-top {
     padding-top:0px;
-    line-height:60px;
+    /* Header is now an auto-height card; inherit its 1.3 line-height instead of
+       the old fixed 60px that pinned the title to the removed 60px header. */
+    line-height:normal;
 }
 
 .pageheader .headerCTA {
     float:right;
-    line-height:60px;
+    line-height:normal;
     color:var(--main-action-color);
 }
 

--- a/public/assets/css/components/text-styles.css
+++ b/public/assets/css/components/text-styles.css
@@ -116,12 +116,14 @@ a .label.feature-label:after {
 
 .pagetitle h1 {
     font-size: var(--font-size-xl);
-    color: var(--main-titles-color);
-    line-height:60px;
+    /* Dark text now that the header is a white/glass card (was white on the
+       gradient). --primary-font-color adapts in dark mode. */
+    color: var(--primary-font-color);
+    line-height: 1.2;
 }
 
 .pagetitle h1 a {
-    color: var(--main-titles-color);
+    color: var(--primary-font-color);
     text-decoration:underline;
 }
 

--- a/public/assets/css/components/text-styles.css
+++ b/public/assets/css/components/text-styles.css
@@ -120,6 +120,9 @@ a .label.feature-label:after {
        gradient). --primary-font-color adapts in dark mode. */
     color: var(--primary-font-color);
     line-height: 1.2;
+    /* Reset the Bootstrap default h1 margin (0.67em 0); the auto-height header
+       card owns the vertical rhythm via its own padding. */
+    margin: 0;
 }
 
 .pagetitle h1 a {
@@ -131,6 +134,9 @@ a .label.feature-label:after {
     text-transform: uppercase;
     font-size: var(--font-size-xs);
     color: var(--secondary-font-color);
+    /* Reset the Bootstrap default heading margin so the subtitle sits tight
+       under the title inside the auto-height header card. */
+    margin: 0;
 }
 
 .maincontentinner .subtitle,


### PR DESCRIPTION
**PR 1 of the chrome-modernization plan.** Targets `master` so Copilot reviews the app-wide foundation. Standalone-releasable — modernizes every page's header on its own.

### What changes
The page header stops being transparent text floating on the gradient background and becomes a **glass card** matching the content card below it.

The old design leaned on a 150px invisible padding cushion on `.pageheader` + a `-95px` `.maincontent` overlap so the title floated on the gradient. This replaces that with a real boxed header (`var(--glass-background)`, `border-radius`, shadow, padding; `.maincontent margin-top: 0`). **The gradient itself — on `.rightpanel::before` — is untouched** and still shows around the cards.

Header text flips white → dark to read on the light card: `.pagetitle h1` and `.pageicon` move from `--main-titles-color` (#fff) to `--primary-font-color`. Both are **tokens, so dark mode adapts automatically**. The `--main-titles-color` token is unchanged, so its other consumers (menu, etc.) are unaffected. Login/registration keep their look via the more-specific `.regpanelinner .pageheader` rules.

### Why this way
Per Marcel: update the *shared* pageheader CSS once → app-wide consistency, one source of truth, **no per-page overrides or scoped body-class hacks**. Because the pageheader is `icon + {{ $slot }}`, pages then just pass richer slot content (breadcrumb, subject-switcher) into the modernized header — that's PR 2/3, not this.

### Validation (live, cache-busted)
| Page | Result |
|---|---|
| To-Dos (`/tickets/showKanban`) | white glass box · dark readable title · existing "To-Dos // All To-Dos ▾" switcher sits cleanly inside · no h-scroll |
| Dashboard | white box · dark "Strategy" title · no h-scroll · left menu intact |

### Follow-up before merge (honest)
Broader page sweep (Settings, project views), **dark mode**, and **mobile** (`mobile.css` has its own `.pagetitle h1`). Plugin pages (RA, reports) validate once they rebase onto this.

### Note on build artifacts
Only source CSS is committed (`structure.css`, `text-styles.css`, `style.default.css`). The compiled `dist/css/main.*.min.css` is gitignored and built on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85