### PR TITLE
fix(help): readonly users can't complete first-login onboarding (Fixes #3683)

### DIFF
--- a/app/Domain/Help/Services/FirstTaskStep.php
+++ b/app/Domain/Help/Services/FirstTaskStep.php
@@ -3,9 +3,11 @@
 namespace Leantime\Domain\Help\Services;
 
 use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Domain\Help\Contracts\OnboardingSteps;
 use Leantime\Domain\Setting\Repositories\Setting;
 use Leantime\Domain\Tickets\Services\Tickets;
+use Throwable;
 
 class FirstTaskStep implements OnboardingSteps
 {
@@ -50,14 +52,34 @@ class FirstTaskStep implements OnboardingSteps
     /**
      * Handle the given parameters.
      *
+     * Persisting the firstLoginCompleted flag MUST NOT depend on the optional
+     * first-task creation succeeding. Users without TicketsPermissions::CREATE
+     * (e.g. the readonly role) would otherwise have quickAddTicket() throw a
+     * permission error before the flag was ever written, trapping them in an
+     * infinite onboarding modal loop (see GH #3683). The ticket creation is a
+     * best-effort convenience; the completion flag is the load-bearing write.
+     *
      * @param  array  $params  The parameters passed to the handle method.
      * @return bool Returns true on success.
      */
     public function handle($params): bool
     {
+        $headline = isset($params['headline']) && is_string($params['headline'])
+            ? trim($params['headline'])
+            : '';
 
-        if (isset($params['headline'])) {
-            $this->ticketService->quickAddTicket(['headline' => $params['headline']]);
+        if ($headline !== '') {
+            try {
+                $this->ticketService->quickAddTicket(['headline' => $headline]);
+            } catch (AuthorizationException $e) {
+                // Expected: the readonly role has no TicketsPermissions::CREATE. This is
+                // a normal outcome, not an incident, so it is not reported — otherwise
+                // every readonly first login would look like a recurring error to ops.
+            } catch (Throwable $e) {
+                // Anything else is genuinely unexpected and worth surfacing, but it
+                // still must not block the completion flag write below.
+                report($e);
+            }
         }
 
         $this->settingsRepo->saveSetting('user.'.session()->get('userdata.id', -1).'.firstLoginCompleted', true);

--- a/tests/Unit/app/Domain/Help/Services/FirstTaskStepTest.php
+++ b/tests/Unit/app/Domain/Help/Services/FirstTaskStepTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Unit\app\Domain\Help\Services;
+
+use Leantime\Core\Exceptions\AuthorizationException;
+use Leantime\Domain\Help\Services\FirstTaskStep;
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Leantime\Domain\Tickets\Services\Tickets as TicketService;
+use RuntimeException;
+use Unit\TestCase;
+
+/**
+ * Regression tests for the first-login onboarding dead-end in GH #3683.
+ *
+ * Readonly users have no TicketsPermissions::CREATE, so quickAddTicket() throws an
+ * AuthorizationException. That used to happen before the firstLoginCompleted flag was
+ * written, leaving the onboarding modal re-rendering forever with no way out. The flag
+ * write is the invariant here; the first task is only a convenience.
+ */
+class FirstTaskStepTest extends TestCase
+{
+    use \Codeception\Test\Feature\Stub;
+
+    /** Captures every saveSetting() call as [key, value]. */
+    private array $savedSettings = [];
+
+    /** Captures every headline quickAddTicket() was called with. */
+    private array $createdHeadlines = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        session(['userdata.id' => 1]);
+
+        $this->savedSettings = [];
+        $this->createdHeadlines = [];
+    }
+
+    /**
+     * Builds the step with a spying Setting repo and a Tickets service that either
+     * records the headline or throws the given exception.
+     */
+    private function makeStep(?\Throwable $ticketFailure = null): FirstTaskStep
+    {
+        $settingsRepo = $this->make(SettingRepository::class, [
+            'saveSetting' => function ($key, $value) {
+                $this->savedSettings[] = [$key, $value];
+
+                return true;
+            },
+        ]);
+
+        $ticketService = $this->make(TicketService::class, [
+            'quickAddTicket' => function ($params) use ($ticketFailure) {
+                if ($ticketFailure !== null) {
+                    throw $ticketFailure;
+                }
+
+                $this->createdHeadlines[] = $params['headline'];
+
+                return 1;
+            },
+        ]);
+
+        return new FirstTaskStep($settingsRepo, $ticketService);
+    }
+
+    /** The flag write, asserted as "written exactly once with true". */
+    private function assertOnboardingCompleted(): void
+    {
+        $this->assertSame(
+            [['user.1.firstLoginCompleted', true]],
+            $this->savedSettings,
+            'firstLoginCompleted must be persisted exactly once, regardless of ticket creation'
+        );
+    }
+
+    public function test_readonly_user_completes_onboarding_when_ticket_creation_is_denied(): void
+    {
+        $result = $this->makeStep(new AuthorizationException)->handle(['headline' => 'Water the plants']);
+
+        $this->assertTrue($result, 'handle() must report success even when the user cannot create tickets');
+        $this->assertOnboardingCompleted();
+        $this->assertSame([], $this->createdHeadlines);
+    }
+
+    public function test_unexpected_ticket_failure_still_completes_onboarding(): void
+    {
+        $result = $this->makeStep(new RuntimeException('database went away'))->handle(['headline' => 'Water the plants']);
+
+        $this->assertTrue($result);
+        $this->assertOnboardingCompleted();
+    }
+
+    public function test_permitted_user_creates_the_first_task_and_completes_onboarding(): void
+    {
+        $result = $this->makeStep()->handle(['headline' => 'Water the plants']);
+
+        $this->assertTrue($result);
+        $this->assertSame(['Water the plants'], $this->createdHeadlines);
+        $this->assertOnboardingCompleted();
+    }
+
+    public function test_headline_is_trimmed_before_the_task_is_created(): void
+    {
+        $this->makeStep()->handle(['headline' => '  Water the plants  ']);
+
+        $this->assertSame(['Water the plants'], $this->createdHeadlines);
+    }
+
+    /**
+     * A blank, whitespace-only, missing or non-string headline must not create an empty
+     * task — but must still complete onboarding.
+     *
+     * @dataProvider blankHeadlineProvider
+     */
+    public function test_blank_headline_skips_task_creation_but_completes_onboarding(array $params): void
+    {
+        $result = $this->makeStep()->handle($params);
+
+        $this->assertTrue($result);
+        $this->assertSame([], $this->createdHeadlines, 'No task should be created for a blank headline');
+        $this->assertOnboardingCompleted();
+    }
+
+    public static function blankHeadlineProvider(): array
+    {
+        return [
+            'empty string' => [['headline' => '']],
+            'whitespace only' => [['headline' => "  \t "]],
+            'missing key' => [[]],
+            'null' => [['headline' => null]],
+            'array (malformed POST)' => [['headline' => ['nope']]],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **#3683** — readonly users (role level 5) are trapped in an infinite first-login onboarding modal loop.

`FirstTaskStep::handle()` called the permission-guarded `Tickets::quickAddTicket()` **before** writing the `firstLoginCompleted` flag. Readonly users lack `TicketsPermissions::CREATE`, so the `POST /help/firstLogin?step=end` threw a 403 before the flag was ever persisted — and `Helpermodal` kept `isFirstLogin` true on every render, re-showing the modal indefinitely with no escape short of a manual DB insert.

Reported and root-caused by @christiansteier (thank you — the trace was spot-on, incl. the observation that readonly is the de-facto default in the Add-User dialog).

## Root cause

`app/Domain/Help/Services/FirstTaskStep.php` — the completion flag write was coupled to the optional first-task creation:

- `quickAddTicket()` calls `$this->authorize(TicketsPermissions::CREATE, ...)` (`app/Domain/Tickets/Services/Tickets.php:1939`) and throws `AuthorizationException`.
- readonly role = `['scope' => 'project', 'verbs' => ['view']]` → 403 on the POST.
- `saveSetting('user.<id>.firstLoginCompleted', true)` on the next line never runs.

## Change

Single production file: `app/Domain/Help/Services/FirstTaskStep.php`.

**1. Decouple the two writes.** The first task is a best-effort convenience; onboarding completion is the invariant. The catch is split so an expected readonly denial doesn't read as a recurring incident in the logs, while a genuinely unexpected failure is still surfaced:

```php
if ($headline !== '') {
    try {
        $this->ticketService->quickAddTicket(['headline' => $headline]);
    } catch (AuthorizationException $e) {
        // Expected: the readonly role has no TicketsPermissions::CREATE. This is
        // a normal outcome, not an incident, so it is not reported.
    } catch (Throwable $e) {
        // Anything else is genuinely unexpected and worth surfacing, but it
        // still must not block the completion flag write below.
        report($e);
    }
}

$this->settingsRepo->saveSetting('user.'.$id.'.firstLoginCompleted', true);
```

**2. Guard the headline.** `trim()` + `is_string()`, so a blank or malformed submission skips creation instead of creating an empty task. `is_string()` rather than a `(string)` cast is deliberate — `$params` comes off `$_POST`, so `headline[]=x` arrives as an array and a cast would be fatal.

## Test plan

- [x] `pint --test --config .pint/pint.json` — PASS, 750 files
- [x] `phpstan analyse -c .phpstan/phpstan.neon` — no errors
- [x] `php -l app/Domain/Help/Services/FirstTaskStep.php`
- [x] Full unit suite — `codecept run Unit`: 798 tests, 1996 assertions, 8 pre-existing skips
- [x] **Regression test added:** `tests/Unit/app/Domain/Help/Services/FirstTaskStepTest.php` (9 tests / 24 assertions)
  - readonly: `quickAddTicket()` throws `AuthorizationException` → `handle()` returns `true`, doesn't throw, `saveSetting('user.1.firstLoginCompleted', true)` called exactly once
  - unexpected `RuntimeException` → same guarantee
  - permitted user → task created **and** flag written (happy path unregressed)
  - headline guard: empty / whitespace-only / missing / `null` / array
  - verified the test bites: 6 of 9 cases fail against the unpatched `master` version

## Acceptance checklist
1. [x] Readonly first-login completes; `firstLoginCompleted` written; modal doesn't loop.
2. [x] Editor/manager first-login still creates the first task + completes onboarding.
3. [x] CI green (Pint + PHPStan + `php -l` + unit) with the readonly regression test.

## Notes

- Rebased onto `master` @ `c9ae5a83` — picks up #3679, clearing an unrelated npm-audit red.
- Commit re-authored to `marcel@leantime.io` (the original non-GitHub `maintainer-bot@leantime.io` identity is what left `license/cla` pending).
- @christiansteier's complementary finding — `NewUser::getDefaultValues()` returns `'role' => ''`, no `<option>` matches, and `5 => 'readonly'` is first in `Roles::getRoles()`, so the browser silently preselects readonly — is the reason this dead-end gets hit in practice, but the default-role choice is a product decision. **Follow-up PR, not this one.**
