### PR TITLE
feat(goals): edge model for goal↔milestone links (PR 1 — foundation + migration)

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.9.8';
 
-    public string $dbVersion = '3.5.23';
+    public string $dbVersion = '3.5.24';
 }

--- a/app/Core/Support/EntityRelationshipEnum.php
+++ b/app/Core/Support/EntityRelationshipEnum.php
@@ -27,8 +27,9 @@ enum EntityRelationshipEnum: string
     /**
      * Represents a "tracked by" relationship: a goal is tracked/measured by a
      * milestone. Direction convention: entityA = goal (GoalItem),
-     * entityB = milestone (Ticket). Replaces the legacy single
-     * zp_canvas_items.milestoneId column so a goal can hold many milestones.
+     * entityB = milestone (Ticket). The edge-based successor to the legacy
+     * single zp_canvas_items.milestoneId column (which is retained during the
+     * transition) so a goal can hold many milestones.
      */
     case TrackedBy = 'tracked_by';
 }

--- a/app/Core/Support/EntityRelationshipEnum.php
+++ b/app/Core/Support/EntityRelationshipEnum.php
@@ -23,4 +23,12 @@ enum EntityRelationshipEnum: string
      * Represents a "maps to" relationship (cross-structure element mapping).
      */
     case MapsTo = 'maps_to';
+
+    /**
+     * Represents a "tracked by" relationship: a goal is tracked/measured by a
+     * milestone. Direction convention: entityA = goal (GoalItem),
+     * entityB = milestone (Ticket). Replaces the legacy single
+     * zp_canvas_items.milestoneId column so a goal can hold many milestones.
+     */
+    case TrackedBy = 'tracked_by';
 }

--- a/app/Core/Support/EntityRelationshipEnum.php
+++ b/app/Core/Support/EntityRelationshipEnum.php
@@ -25,11 +25,13 @@ enum EntityRelationshipEnum: string
     case MapsTo = 'maps_to';
 
     /**
-     * Represents a "tracked by" relationship: a goal is tracked/measured by a
-     * milestone. Direction convention: entityA = goal (GoalItem),
-     * entityB = milestone (Ticket). The edge-based successor to the legacy
-     * single zp_canvas_items.milestoneId column (which is retained during the
-     * transition) so a goal can hold many milestones.
+     * Associates a goal with a milestone for informational display only — the
+     * milestone(s) are rendered as a list on the goal; they do NOT drive goal
+     * progress (progress stays metric-defined from the goal's own values).
+     * Direction convention: entityA = goal (GoalItem), entityB = milestone
+     * (Ticket). The edge-based successor to the legacy single
+     * zp_canvas_items.milestoneId column (retained during the transition) so a
+     * goal can hold many milestones.
      */
     case TrackedBy = 'tracked_by';
 }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 use Leantime\Core\Configuration\AppSettings as AppSettingCore;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Core\Support\EntityRelationshipEnum;
 use Leantime\Domain\Install\Services\SchemaBuilder;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Setting\Repositories\Setting;
@@ -2971,6 +2972,118 @@ class Install
             Log::error('Migration 30523: '.$e->getMessage());
 
             return ['Migration 30523 failed: '.$e->getMessage()];
+        }
+
+        return true;
+    }
+
+    /**
+     * update_sql_30524 — database update for v3.5.24.
+     *
+     * Backfills the legacy single goal→milestone link (the varchar
+     * `zp_canvas_items.milestoneId` column, `box='goal'`) into many-to-many
+     * edges on the core `zp_entity_relationship` graph, so a goal can be
+     * tracked by any number of milestones. Each edge:
+     *   entityA = goal canvas item (GoalItem), entityB = milestone (Ticket),
+     *   relationship = 'tracked_by'.
+     *
+     * The `milestoneId` column is intentionally KEPT here — readers are cut
+     * over incrementally and a later migration drops it once nothing reads it.
+     *
+     * Written with the query builder (not raw REGEXP/CAST) so it is portable
+     * across MySQL/Postgres/MSSQL, and idempotent: junk values (empty, '0',
+     * non-numeric, deleted-milestone) are skipped and already-migrated pairs
+     * are not duplicated on re-run.
+     */
+    public function update_sql_30524(): bool|array
+    {
+        try {
+            if (! Schema::hasTable('zp_canvas_items') || ! Schema::hasTable('zp_entity_relationship')) {
+                return true;
+            }
+
+            $goals = \Illuminate\Support\Facades\DB::table('zp_canvas_items')
+                ->where('box', 'goal')
+                ->whereNotNull('milestoneId')
+                ->where('milestoneId', '<>', '')
+                ->where('milestoneId', '<>', '0')
+                ->select('id', 'milestoneId', 'author')
+                ->get();
+
+            if ($goals->isEmpty()) {
+                return true;
+            }
+
+            // Numeric-only candidate (goal, milestone) pairs.
+            $pairs = [];
+            $milestoneIds = [];
+            foreach ($goals as $g) {
+                $raw = (string) $g->milestoneId;
+                if (! ctype_digit($raw)) {
+                    continue;
+                }
+                $mid = (int) $raw;
+                if ($mid <= 0) {
+                    continue;
+                }
+                $pairs[] = ['goalId' => (int) $g->id, 'milestoneId' => $mid, 'author' => (int) ($g->author ?? 0)];
+                $milestoneIds[$mid] = true;
+            }
+
+            if ($pairs === []) {
+                return true;
+            }
+
+            // Pre-fetch existing milestones (drop edges to deleted tickets)
+            // and existing tracked_by edges (dedup) — O(1) lookups, no N+1.
+            $liveTickets = array_flip(array_map(
+                'intval',
+                \Illuminate\Support\Facades\DB::table('zp_tickets')
+                    ->whereIn('id', array_keys($milestoneIds))
+                    ->pluck('id')
+                    ->all()
+            ));
+
+            $existingEdges = [];
+            foreach (
+                \Illuminate\Support\Facades\DB::table('zp_entity_relationship')
+                    ->where('relationship', EntityRelationshipEnum::TrackedBy->value)
+                    ->where('entityAType', 'GoalItem')
+                    ->where('entityBType', 'Ticket')
+                    ->select('entityA', 'entityB')
+                    ->get() as $e
+            ) {
+                $existingEdges[(int) $e->entityA.':'.(int) $e->entityB] = true;
+            }
+
+            $now = date('Y-m-d H:i:s');
+            $rows = [];
+            foreach ($pairs as $p) {
+                if (! isset($liveTickets[$p['milestoneId']])) {
+                    continue;
+                }
+                if (isset($existingEdges[$p['goalId'].':'.$p['milestoneId']])) {
+                    continue;
+                }
+                $rows[] = [
+                    'entityA' => $p['goalId'],
+                    'entityAType' => 'GoalItem',
+                    'entityB' => $p['milestoneId'],
+                    'entityBType' => 'Ticket',
+                    'relationship' => EntityRelationshipEnum::TrackedBy->value,
+                    'createdOn' => $now,
+                    'createdBy' => $p['author'],
+                    'meta' => json_encode(['source' => 'milestoneId_migration']),
+                ];
+            }
+
+            foreach (array_chunk($rows, 200) as $chunk) {
+                \Illuminate\Support\Facades\DB::table('zp_entity_relationship')->insert($chunk);
+            }
+        } catch (\Exception $e) {
+            Log::error('Migration 30524: '.$e->getMessage());
+
+            return ['Migration 30524 failed: '.$e->getMessage()];
         }
 
         return true;

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -96,6 +97,7 @@ class Install
         30521,
         30522,
         30523,
+        30524,
     ];
 
     /**
@@ -2998,88 +3000,95 @@ class Install
     public function update_sql_30524(): bool|array
     {
         try {
-            if (! Schema::hasTable('zp_canvas_items') || ! Schema::hasTable('zp_entity_relationship')) {
+            if (! Schema::hasTable('zp_canvas_items')
+                || ! Schema::hasTable('zp_entity_relationship')
+                || ! Schema::hasTable('zp_tickets')) {
                 return true;
             }
 
-            $goals = \Illuminate\Support\Facades\DB::table('zp_canvas_items')
+            $now = date('Y-m-d H:i:s');
+
+            // Chunk the goal rows so a very large zp_canvas_items never loads
+            // into memory at once. Each chunk resolves its own live-milestone
+            // and existing-edge sets, scoped to the chunk's ids (no full-table
+            // scan), then batch-inserts.
+            DB::table('zp_canvas_items')
                 ->where('box', 'goal')
                 ->whereNotNull('milestoneId')
                 ->where('milestoneId', '<>', '')
                 ->where('milestoneId', '<>', '0')
-                ->select('id', 'milestoneId', 'author')
-                ->get();
+                ->orderBy('id')
+                ->chunkById(500, function ($goals) use ($now): void {
+                    // Numeric-only (goal, milestone) pairs. milestoneId is a
+                    // varchar, so trim before the digit check.
+                    $pairs = [];
+                    $milestoneIds = [];
+                    foreach ($goals as $g) {
+                        $raw = trim((string) $g->milestoneId);
+                        if (! ctype_digit($raw)) {
+                            continue;
+                        }
+                        $mid = (int) $raw;
+                        if ($mid <= 0) {
+                            continue;
+                        }
+                        $pairs[] = ['goalId' => (int) $g->id, 'milestoneId' => $mid, 'author' => $g->author];
+                        $milestoneIds[$mid] = true;
+                    }
 
-            if ($goals->isEmpty()) {
-                return true;
-            }
+                    if ($pairs === []) {
+                        return;
+                    }
 
-            // Numeric-only candidate (goal, milestone) pairs.
-            $pairs = [];
-            $milestoneIds = [];
-            foreach ($goals as $g) {
-                $raw = (string) $g->milestoneId;
-                if (! ctype_digit($raw)) {
-                    continue;
-                }
-                $mid = (int) $raw;
-                if ($mid <= 0) {
-                    continue;
-                }
-                $pairs[] = ['goalId' => (int) $g->id, 'milestoneId' => $mid, 'author' => (int) ($g->author ?? 0)];
-                $milestoneIds[$mid] = true;
-            }
+                    $goalIds = array_values(array_unique(array_map(static fn ($p) => $p['goalId'], $pairs)));
 
-            if ($pairs === []) {
-                return true;
-            }
+                    // Drop edges to deleted milestones + dedup existing edges,
+                    // both scoped to this chunk's ids — O(1) lookups, no N+1.
+                    $liveTickets = array_flip(array_map(
+                        'intval',
+                        DB::table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->pluck('id')->all()
+                    ));
 
-            // Pre-fetch existing milestones (drop edges to deleted tickets)
-            // and existing tracked_by edges (dedup) — O(1) lookups, no N+1.
-            $liveTickets = array_flip(array_map(
-                'intval',
-                \Illuminate\Support\Facades\DB::table('zp_tickets')
-                    ->whereIn('id', array_keys($milestoneIds))
-                    ->pluck('id')
-                    ->all()
-            ));
+                    $existingEdges = [];
+                    foreach (
+                        DB::table('zp_entity_relationship')
+                            ->where('relationship', EntityRelationshipEnum::TrackedBy->value)
+                            ->where('entityAType', 'GoalItem')
+                            ->where('entityBType', 'Ticket')
+                            ->whereIn('entityA', $goalIds)
+                            ->select('entityA', 'entityB')
+                            ->get() as $e
+                    ) {
+                        $existingEdges[(int) $e->entityA.':'.(int) $e->entityB] = true;
+                    }
 
-            $existingEdges = [];
-            foreach (
-                \Illuminate\Support\Facades\DB::table('zp_entity_relationship')
-                    ->where('relationship', EntityRelationshipEnum::TrackedBy->value)
-                    ->where('entityAType', 'GoalItem')
-                    ->where('entityBType', 'Ticket')
-                    ->select('entityA', 'entityB')
-                    ->get() as $e
-            ) {
-                $existingEdges[(int) $e->entityA.':'.(int) $e->entityB] = true;
-            }
+                    $rows = [];
+                    foreach ($pairs as $p) {
+                        if (! isset($liveTickets[$p['milestoneId']])) {
+                            continue;
+                        }
+                        if (isset($existingEdges[$p['goalId'].':'.$p['milestoneId']])) {
+                            continue;
+                        }
+                        // Unknown author stays NULL ("unknown"), not 0 — 0 would
+                        // read as a real user id in downstream joins/filters.
+                        $author = (int) ($p['author'] ?? 0);
+                        $rows[] = [
+                            'entityA' => $p['goalId'],
+                            'entityAType' => 'GoalItem',
+                            'entityB' => $p['milestoneId'],
+                            'entityBType' => 'Ticket',
+                            'relationship' => EntityRelationshipEnum::TrackedBy->value,
+                            'createdOn' => $now,
+                            'createdBy' => $author > 0 ? $author : null,
+                            'meta' => json_encode(['source' => 'milestoneId_migration']),
+                        ];
+                    }
 
-            $now = date('Y-m-d H:i:s');
-            $rows = [];
-            foreach ($pairs as $p) {
-                if (! isset($liveTickets[$p['milestoneId']])) {
-                    continue;
-                }
-                if (isset($existingEdges[$p['goalId'].':'.$p['milestoneId']])) {
-                    continue;
-                }
-                $rows[] = [
-                    'entityA' => $p['goalId'],
-                    'entityAType' => 'GoalItem',
-                    'entityB' => $p['milestoneId'],
-                    'entityBType' => 'Ticket',
-                    'relationship' => EntityRelationshipEnum::TrackedBy->value,
-                    'createdOn' => $now,
-                    'createdBy' => $p['author'],
-                    'meta' => json_encode(['source' => 'milestoneId_migration']),
-                ];
-            }
-
-            foreach (array_chunk($rows, 200) as $chunk) {
-                \Illuminate\Support\Facades\DB::table('zp_entity_relationship')->insert($chunk);
-            }
+                    foreach (array_chunk($rows, 200) as $insertChunk) {
+                        DB::table('zp_entity_relationship')->insert($insertChunk);
+                    }
+                });
         } catch (\Exception $e) {
             Log::error('Migration 30524: '.$e->getMessage());
 

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3006,13 +3006,17 @@ class Install
                 return true;
             }
 
-            $now = date('Y-m-d H:i:s');
+            // UTC — DB datetimes are stored in UTC; date() would use the
+            // server timezone and write a skewed createdOn.
+            $now = gmdate('Y-m-d H:i:s');
 
             // Chunk the goal rows so a very large zp_canvas_items never loads
             // into memory at once. Each chunk resolves its own live-milestone
             // and existing-edge sets, scoped to the chunk's ids (no full-table
-            // scan), then batch-inserts.
-            DB::table('zp_canvas_items')
+            // scan), then batch-inserts. Uses the installer's selected
+            // $this->connection (not the global DB facade), which may point at
+            // a temp/target install connection.
+            $this->connection->table('zp_canvas_items')
                 ->where('box', 'goal')
                 ->whereNotNull('milestoneId')
                 ->where('milestoneId', '<>', '')
@@ -3046,12 +3050,12 @@ class Install
                     // both scoped to this chunk's ids — O(1) lookups, no N+1.
                     $liveTickets = array_flip(array_map(
                         'intval',
-                        DB::table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->pluck('id')->all()
+                        $this->connection->table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->pluck('id')->all()
                     ));
 
                     $existingEdges = [];
                     foreach (
-                        DB::table('zp_entity_relationship')
+                        $this->connection->table('zp_entity_relationship')
                             ->where('relationship', EntityRelationshipEnum::TrackedBy->value)
                             ->where('entityAType', 'GoalItem')
                             ->where('entityBType', 'Ticket')
@@ -3086,11 +3090,12 @@ class Install
                     }
 
                     foreach (array_chunk($rows, 200) as $insertChunk) {
-                        DB::table('zp_entity_relationship')->insert($insertChunk);
+                        $this->connection->table('zp_entity_relationship')->insert($insertChunk);
                     }
                 });
         } catch (\Exception $e) {
-            Log::error('Migration 30524: '.$e->getMessage());
+            Log::error('Migration 30524 failed: '.$e->getMessage());
+            Log::error($e);
 
             return ['Migration 30524 failed: '.$e->getMessage()];
         }

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3058,7 +3058,10 @@ class Install
                     // both scoped to this chunk's ids — O(1) lookups, no N+1.
                     $liveTickets = array_flip(array_map(
                         'intval',
-                        $this->connection->table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->pluck('id')->all()
+                        $this->connection->table('zp_tickets')
+                            ->whereIn('id', array_keys($milestoneIds))
+                            ->where('type', 'milestone')
+                            ->pluck('id')->all()
                     ));
 
                     $existingEdges = [];
@@ -3071,7 +3074,7 @@ class Install
                             ->select('entityA', 'entityB')
                             ->get() as $e
                     ) {
-                        $existingEdges[(int) $e->entityA.':'.(int) $e->entityB] = true;
+                        $existingEdges[((int) $e->entityA).':'.((int) $e->entityB)] = true;
                     }
 
                     $rows = [];

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3003,7 +3003,12 @@ class Install
             // facade, which checks the default connection) so the existence
             // check matches the connection the migration queries actually run
             // against (may be a temp/target install connection).
-            $schema = $this->connection->getSchemaBuilder();
+            // DatabaseManager always resolves a concrete Connection here; the
+            // property is typed to the interface, which doesn't declare the
+            // schema-builder accessor, so narrow it for static analysis.
+            /** @var \Illuminate\Database\Connection $connection */
+            $connection = $this->connection;
+            $schema = $connection->getSchemaBuilder();
             if (! $schema->hasTable('zp_canvas_items')
                 || ! $schema->hasTable('zp_entity_relationship')
                 || ! $schema->hasTable('zp_tickets')

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -2999,9 +2999,14 @@ class Install
     public function update_sql_30524(): bool|array
     {
         try {
-            if (! Schema::hasTable('zp_canvas_items')
-                || ! Schema::hasTable('zp_entity_relationship')
-                || ! Schema::hasTable('zp_tickets')) {
+            // Guard on the installer's own connection (not the global Schema
+            // facade, which checks the default connection) so the existence
+            // check matches the connection the migration queries actually run
+            // against (may be a temp/target install connection).
+            $schema = $this->connection->getSchemaBuilder();
+            if (! $schema->hasTable('zp_canvas_items')
+                || ! $schema->hasTable('zp_entity_relationship')
+                || ! $schema->hasTable('zp_tickets')) {
                 return true;
             }
 

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3006,7 +3006,8 @@ class Install
             $schema = $this->connection->getSchemaBuilder();
             if (! $schema->hasTable('zp_canvas_items')
                 || ! $schema->hasTable('zp_entity_relationship')
-                || ! $schema->hasTable('zp_tickets')) {
+                || ! $schema->hasTable('zp_tickets')
+                || ! $schema->hasColumn('zp_canvas_items', 'milestoneId')) {
                 return true;
             }
 
@@ -3025,6 +3026,9 @@ class Install
                 ->whereNotNull('milestoneId')
                 ->where('milestoneId', '<>', '')
                 ->where('milestoneId', '<>', '0')
+                // Only the columns this migration reads — never the heavy
+                // description/data text columns. id is required for chunkById.
+                ->select('id', 'milestoneId', 'author')
                 ->orderBy('id')
                 ->chunkById(500, function ($goals) use ($now): void {
                     // Numeric-only (goal, milestone) pairs. milestoneId is a

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -7,7 +7,6 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;

--- a/tests/Unit/app/Domain/Install/UpdateSql30524Test.php
+++ b/tests/Unit/app/Domain/Install/UpdateSql30524Test.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Unit\app\Domain\Install;
+
+use Illuminate\Database\ConnectionInterface;
+use Leantime\Domain\Install\Repositories\Install;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Unit\TestCase;
+
+/**
+ * Regression tests for migration update_sql_30524 (#3686) — the load-bearing
+ * backfill that copies each goal's legacy zp_canvas_items.milestoneId into a
+ * `tracked_by` edge on zp_entity_relationship. A mis-backfill silently corrupts
+ * goal↔milestone links for every existing install (and it already had a
+ * near-miss: it shipped unregistered in $dbUpdates once), so its behavior is
+ * pinned here with a faked connection — no DB.
+ *
+ * Covers: correct edge direction, junk/non-numeric skipped, deleted /
+ * non-milestone tickets skipped, NULL author for unknown, idempotent re-run
+ * (existing edge not duplicated), and the table-guard no-op.
+ */
+class UpdateSql30524Test extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * Run update_sql_30524 against a fully-faked connection.
+     *
+     * @param  array<int, object>  $canvasGoals  rows shaped {id, milestoneId, author}
+     * @param  int[]  $liveMilestoneIds  ticket ids that are live milestones
+     * @param  array<int, array{0:int,1:int}>  $existingEdges  [goalId, milestoneId] pairs already linked
+     * @return array{result: mixed, inserted: array<int, array<string, mixed>>}
+     */
+    private function runMigration(array $canvasGoals, array $liveMilestoneIds, array $existingEdges, bool $tablesExist = true): array
+    {
+        $inserted = [];
+        $capture = function ($rows) use (&$inserted): void {
+            foreach ($rows as $row) {
+                $inserted[] = $row;
+            }
+        };
+
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasTable')->andReturn($tablesExist);
+        $schema->shouldReceive('hasColumn')->andReturn($tablesExist);
+
+        $conn = Mockery::mock(ConnectionInterface::class);
+        $conn->shouldReceive('getSchemaBuilder')->andReturn($schema);
+        $conn->shouldReceive('table')->andReturnUsing(
+            fn () => $this->fakeBuilder($canvasGoals, $liveMilestoneIds, $existingEdges, $capture)
+        );
+
+        $install = (new \ReflectionClass(Install::class))->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(Install::class, 'connection');
+        $prop->setAccessible(true);
+        $prop->setValue($install, $conn);
+
+        return ['result' => $install->update_sql_30524(), 'inserted' => $inserted];
+    }
+
+    /**
+     * One fake builder serves all three tables — the migration uses a distinct
+     * terminal on each (chunkById on zp_canvas_items, pluck on zp_tickets,
+     * get/insert on zp_entity_relationship), so there is no cross-talk.
+     */
+    private function fakeBuilder(array $canvasGoals, array $liveMilestoneIds, array $existingEdges, callable $capture): object
+    {
+        return new class($canvasGoals, $liveMilestoneIds, $existingEdges, $capture)
+        {
+            public function __construct(
+                private array $canvasGoals,
+                private array $liveMilestoneIds,
+                private array $existingEdges,
+                private $capture
+            ) {}
+
+            public function where(...$a): static
+            {
+                return $this;
+            }
+
+            public function whereNotNull(...$a): static
+            {
+                return $this;
+            }
+
+            public function whereIn(...$a): static
+            {
+                return $this;
+            }
+
+            public function select(...$a): static
+            {
+                return $this;
+            }
+
+            public function orderBy(...$a): static
+            {
+                return $this;
+            }
+
+            public function chunkById($count, $callback): bool
+            {
+                $callback(collect($this->canvasGoals));
+
+                return true;
+            }
+
+            public function pluck($column)
+            {
+                return collect($this->liveMilestoneIds);
+            }
+
+            public function get($columns = ['*'])
+            {
+                return collect(array_map(
+                    fn ($e) => (object) ['entityA' => $e[0], 'entityB' => $e[1]],
+                    $this->existingEdges
+                ));
+            }
+
+            public function insert($rows): bool
+            {
+                ($this->capture)($rows);
+
+                return true;
+            }
+        };
+    }
+
+    private function goal(int $id, ?string $milestoneId, ?int $author): object
+    {
+        return (object) ['id' => $id, 'milestoneId' => $milestoneId, 'author' => $author];
+    }
+
+    public function test_backfills_a_tracked_by_edge_in_the_correct_direction(): void
+    {
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(5, '42', 7)],
+            liveMilestoneIds: [42],
+            existingEdges: [],
+        );
+
+        $this->assertTrue($out['result']);
+        $this->assertCount(1, $out['inserted']);
+        $edge = $out['inserted'][0];
+        $this->assertSame(5, $edge['entityA']);
+        $this->assertSame('GoalItem', $edge['entityAType']);
+        $this->assertSame(42, $edge['entityB']);
+        $this->assertSame('Ticket', $edge['entityBType']);
+        $this->assertSame('tracked_by', $edge['relationship']);
+        $this->assertSame(7, $edge['createdBy']);
+    }
+
+    public function test_skips_junk_and_non_numeric_milestone_ids(): void
+    {
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(6, 'abc', 1), $this->goal(7, '   ', 1), $this->goal(8, '4x', 1)],
+            liveMilestoneIds: [42],
+            existingEdges: [],
+        );
+
+        $this->assertSame([], $out['inserted'], 'non-numeric milestoneId values are skipped');
+    }
+
+    public function test_skips_deleted_or_non_milestone_tickets(): void
+    {
+        // Goal points at ticket 99, which is not in the live-milestone set
+        // (deleted, or demoted to a task).
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(9, '99', 1)],
+            liveMilestoneIds: [],
+            existingEdges: [],
+        );
+
+        $this->assertSame([], $out['inserted'], 'a milestone that is not live is not backfilled');
+    }
+
+    public function test_is_idempotent_when_the_edge_already_exists(): void
+    {
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(5, '42', 7)],
+            liveMilestoneIds: [42],
+            existingEdges: [[5, 42]],
+        );
+
+        $this->assertSame([], $out['inserted'], 'a re-run does not duplicate an existing edge');
+    }
+
+    public function test_unknown_author_is_stored_as_null_not_zero(): void
+    {
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(9, '42', null)],
+            liveMilestoneIds: [42],
+            existingEdges: [],
+        );
+
+        $this->assertCount(1, $out['inserted']);
+        $this->assertNull($out['inserted'][0]['createdBy'], 'unknown author stays NULL, never 0');
+    }
+
+    public function test_is_a_no_op_when_the_required_tables_are_absent(): void
+    {
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(5, '42', 7)],
+            liveMilestoneIds: [42],
+            existingEdges: [],
+            tablesExist: false,
+        );
+
+        $this->assertTrue($out['result']);
+        $this->assertSame([], $out['inserted'], 'missing schema short-circuits before any write');
+    }
+}


### PR DESCRIPTION
First of a phased refactor: the goal→milestone link is a single `zp_canvas_items.milestoneId` varchar column (single-select) — this moves it to **many-to-many edges** on the core `zp_entity_relationship` graph so a goal can be tracked by any number of milestones. Approved by Marcel; his clarification: **goal progress stays metric-defined** — milestones just render as a *list* below the goal (today capped at one).

## This PR (foundation only — no reader/writer changes, fully backward compatible)
- **`EntityRelationshipEnum::TrackedBy`** (`tracked_by`). Direction: `entityA = goal (GoalItem)`, `entityB = milestone (Ticket)`. New case rather than reusing `GeneratedFrom`/`MapsTo` (StrategyPro's wizard filters on those — reuse would hide goals from its candidate lists).
- **`update_sql_30524`** — backfills every `box='goal'` row's `milestoneId` into a `tracked_by` edge. Query-builder based (portable across MySQL/Postgres/MSSQL), idempotent, junk-guarded (skips empty/`'0'`/non-numeric and edges to deleted milestones). The `milestoneId` column is **kept**; a later migration drops it once readers are ported.
- Bump `dbVersion` 3.5.23 → 3.5.24.

## Verification
Live-DB run of the migration: 5/5 — creates the exact edge, source-tags it (`meta.source=milestoneId_migration`), idempotent on re-run, no dupes. `php -l` + Pint clean.

## Phasing (separate PRs)
2. cut readers (`getGoalsByMilestone`, reports, Tickets bridge, MCP) + writers to edges
3. multi-select UI
4. drop the `milestoneId` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)