### PR TITLE
feat(canvas): CanvasItemUpdated event (phase-2 propagation foundation)

### DIFF
--- a/app/Domain/Blueprints/Events/CanvasItemUpdated.php
+++ b/app/Domain/Blueprints/Events/CanvasItemUpdated.php
@@ -27,7 +27,7 @@ final class CanvasItemUpdated implements LeantimeEvent
     /**
      * @param  int  $canvasItemId  The updated canvas item id.
      * @param  array<int, string>  $changedFields  Best-effort names of the fields possibly
-     *                                              written (see class doc); not authoritative.
+     *                                             written (see class doc); not authoritative.
      * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
      *                                   pass __FUNCTION__ — used to rebuild the historical string
      *                                   name for legacy string-based listeners.

--- a/app/Domain/Blueprints/Events/CanvasItemUpdated.php
+++ b/app/Domain/Blueprints/Events/CanvasItemUpdated.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Leantime\Domain\Blueprints\Events;
+
+use Leantime\Core\Events\Concerns\InteractsWithEvents;
+use Leantime\Core\Events\Contracts\LeantimeEvent;
+
+/**
+ * Fired after a canvas item was updated — for ANY canvas type (goal, idea,
+ * wiki, logic model, …), since all canvas items share the zp_canvas_items
+ * table and the same update chokepoints.
+ *
+ * The event is deliberately generic: consumers that only care about a specific
+ * canvas (e.g. the strategy Logic Model, which propagates edits down to the
+ * work it generated) resolve the item's canvas and filter themselves.
+ * `changedFields` is best-effort — precise for patches (the patched keys),
+ * over-inclusive for full updates — so listeners should still no-op when the
+ * field they mirror is unchanged.
+ */
+final class CanvasItemUpdated implements LeantimeEvent
+{
+    use InteractsWithEvents;
+
+    /**
+     * @param  int  $canvasItemId  The updated canvas item id.
+     * @param  array<int, string>  $changedFields  Best-effort names of the fields written.
+     * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
+     *                                   pass __FUNCTION__ — used to rebuild the historical string
+     *                                   name for legacy string-based listeners.
+     */
+    public function __construct(
+        public readonly int $canvasItemId,
+        public readonly array $changedFields = [],
+        private readonly ?string $legacyHook = null,
+    ) {}
+
+    /**
+     * The exact historical string name of the emitting site. Remove with the migration window.
+     *
+     * @return array<int, string>
+     */
+    public function legacyHooks(): array
+    {
+        if ($this->legacyHook === null) {
+            return [];
+        }
+
+        return ['leantime.domain.blueprints.services.blueprints.'.$this->legacyHook.'.canvas_item_updated'];
+    }
+}

--- a/app/Domain/Blueprints/Events/CanvasItemUpdated.php
+++ b/app/Domain/Blueprints/Events/CanvasItemUpdated.php
@@ -13,9 +13,12 @@ use Leantime\Core\Events\Contracts\LeantimeEvent;
  * The event is deliberately generic: consumers that only care about a specific
  * canvas (e.g. the strategy Logic Model, which propagates edits down to the
  * work it generated) resolve the item's canvas and filter themselves.
- * `changedFields` is best-effort — precise for patches (the patched keys),
- * over-inclusive for full updates — so listeners should still no-op when the
- * field they mirror is unchanged.
+ * `changedFields` is best-effort and never authoritative: for patches it is
+ * the set of allow-listed keys that were written (which can include a key set
+ * to the value it already held), and for full updates it is over-inclusive
+ * (every mirrored column). Either way it says "possibly touched", not
+ * "definitely changed", so listeners must still no-op when the field they
+ * mirror is actually unchanged.
  */
 final class CanvasItemUpdated implements LeantimeEvent
 {
@@ -23,7 +26,8 @@ final class CanvasItemUpdated implements LeantimeEvent
 
     /**
      * @param  int  $canvasItemId  The updated canvas item id.
-     * @param  array<int, string>  $changedFields  Best-effort names of the fields written.
+     * @param  array<int, string>  $changedFields  Best-effort names of the fields possibly
+     *                                              written (see class doc); not authoritative.
      * @param  string|null  $legacyHook  TEMPORARY (migration window): the emitting method name —
      *                                   pass __FUNCTION__ — used to rebuild the historical string
      *                                   name for legacy string-based listeners.

--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -11,6 +11,7 @@ use Leantime\Core\Auth\Permissions\RequiresPermission;
 use Leantime\Core\Domains\BaseService;
 use Leantime\Core\Exceptions\AuthorizationException;
 use Leantime\Core\Language as LanguageCore;
+use Leantime\Domain\Blueprints\Events\CanvasItemUpdated;
 use Leantime\Domain\Blueprints\Models\CanvasTemplate;
 use Leantime\Domain\Blueprints\Permissions\BlueprintsPermissions;
 use Leantime\Domain\Blueprints\Repositories\Blueprints as BlueprintsRepository;
@@ -166,6 +167,12 @@ class Blueprints extends BaseService
         $this->authorize(BlueprintsPermissions::EDIT, $projectId);
 
         $this->blueprintsRepo->editCanvasItem($values);
+
+        CanvasItemUpdated::dispatch(
+            canvasItemId: $itemId,
+            changedFields: array_map('strval', array_keys($values)),
+            legacyHook: __FUNCTION__,
+        );
     }
 
     /**
@@ -187,7 +194,17 @@ class Blueprints extends BaseService
         }
         $this->authorize(BlueprintsPermissions::EDIT, $projectId);
 
-        return $this->blueprintsRepo->patchCanvasItem($id, $params);
+        $patched = $this->blueprintsRepo->patchCanvasItem($id, $params);
+
+        if ($patched) {
+            CanvasItemUpdated::dispatch(
+                canvasItemId: $id,
+                changedFields: array_map('strval', array_keys($params)),
+                legacyHook: __FUNCTION__,
+            );
+        }
+
+        return $patched;
     }
 
     /**

--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -170,9 +170,26 @@ class Blueprints extends BaseService
 
         CanvasItemUpdated::dispatch(
             canvasItemId: $itemId,
-            changedFields: array_map('strval', array_keys($values)),
+            changedFields: $this->fieldNames($values),
             legacyHook: __FUNCTION__,
         );
+    }
+
+    /**
+     * Extract the canvas-item field names from a controller payload for the
+     * CanvasItemUpdated event, dropping the transport/identifier keys (id,
+     * itemId, canvasId, changeItem, routing params) that ride along in the
+     * payload but are not columns — so `changedFields` reads as field names,
+     * not request plumbing.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<int, string>
+     */
+    private function fieldNames(array $payload): array
+    {
+        $transportKeys = ['id', 'itemId', 'canvasId', 'changeItem', 'action', 'module'];
+
+        return array_values(array_diff(array_map('strval', array_keys($payload)), $transportKeys));
     }
 
     /**
@@ -199,7 +216,7 @@ class Blueprints extends BaseService
         if ($patched) {
             CanvasItemUpdated::dispatch(
                 canvasItemId: $id,
-                changedFields: array_map('strval', array_keys($params)),
+                changedFields: $this->fieldNames($params),
                 legacyHook: __FUNCTION__,
             );
         }


### PR DESCRIPTION
Foundation for **phase 2** (Logic Model edits flow down to the work they generated). Adds a generic, class-based **`CanvasItemUpdated`** event fired from the Blueprints service update chokepoints (`updateCanvasItem` + `patchCanvasItem`, the latter only when it actually wrote) — so it covers every canvas-item edit path, for any canvas type.

- Carries `canvasItemId` + best-effort `changedFields` (the written keys — precise for patches, over-inclusive for full updates, so listeners still no-op when their mirrored field is unchanged) + the `legacyHooks()` migration shim. Mirrors the existing `Tickets/Events` pattern.
- **Deliberately generic** — it doesn't know strategy vs project vs idea. The upcoming StrategyPro listener filters to **strategy** logic-model items (`isStrategyLogicModelCanvas`) and walks their `GeneratedFrom` edges to push the change down; a project-level logic model hits the event and no-ops.

No consumer yet (the listener lives in the plugin repo, stacked on this). Verified: dispatch reaches a registered listener. Lint + Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)