### PR TITLE
fix(blueprints): repair unit suite broken by import() path validation (#3656)

### DIFF
--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -484,7 +484,6 @@ class Blueprints extends BaseService
         }
 
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $users = app()->make(UserRepository::class);
 
         // Validate the file path and extension to prevent SSRF and Local File
         // Inclusion. Reject URL wrappers (http://, ftp://, etc.), restrict
@@ -553,6 +552,11 @@ class Blueprints extends BaseService
         }
 
         $elementNodeList = $dataNodeList->item(0)->getElementsByTagName('element');
+
+        // Resolved here rather than at the top of the method: it is only needed to map
+        // item authors below, so a rejected path or malformed document never pays for
+        // building a database-backed repository.
+        $users = app()->make(UserRepository::class);
 
         foreach ($elementNodeList as $elementNode) {
             if (! $elementNode->hasAttribute('key')) {

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
@@ -691,10 +691,12 @@ class BlueprintsServiceTest extends TestCase
         // The repository is stubbed so the import completes and returns a
         // known canvas id, proving that path validation did NOT block it.
         $expectedId = 42;
+        // addCanvas()/addCanvasItem() are declared `false|string` (insertGetId), so the
+        // stubs must return strings — import() casts the id to int on the way out.
         $repo = $this->make(BlueprintsRepository::class, [
             'existCanvas' => fn () => false,
-            'addCanvas' => fn () => $expectedId,
-            'addCanvasItem' => fn () => 1,
+            'addCanvas' => fn () => (string) $expectedId,
+            'addCanvasItem' => fn () => '1',
         ]);
         $service = $this->securedService($repo, $this->allowingPermissions());
 
@@ -705,6 +707,9 @@ class BlueprintsServiceTest extends TestCase
         ]);
         app()->instance(UserRepository::class, $usersStub);
 
+        // Mirrors what BlueprintsExport::buildXml() actually emits — in particular
+        // status/relates carry their value in a `key` attribute, which is what
+        // import() reads. Element text there is silently dropped.
         $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <canvas key="leancanvas">
@@ -712,17 +717,13 @@ class BlueprintsServiceTest extends TestCase
     <content>
         <element key="problem">
             <item>
-                <author firstname="A" lastname="B"/>
+                <author id="1" firstname="A" lastname="B"/>
                 <description>Test item</description>
-                <status>status_draft</status>
-                <relates>relates_none</relates>
+                <status key="status_draft" />
+                <relates key="relates_none" />
+                <assumptions>none</assumptions>
                 <data>none</data>
                 <conclusion>none</conclusion>
-                <assumptions>none</assumptions>
-                <priority>low</priority>
-                <progress>0</progress>
-                <duedate></duedate>
-                <tags></tags>
             </item>
         </element>
     </content>


### PR DESCRIPTION
## Summary

The `unit` job has been red on `master` since #3656 merged (`73c0fe2c`) — **5 errors + 1 failure** in `BlueprintsServiceTest`. Every PR opened since inherits the red suite, because PR CI runs against a merge commit with the master tip. This restores it.

Master's own run for `73c0fe2c`: [failure](https://github.com/Leantime/leantime/actions/runs/30171245853). The run immediately before it (`c9ae5a83`) was green.

The security behaviour #3656 added is **unchanged** — all six import path-validation tests still pass, and now for the right reason rather than erroring out before they assert anything.

## Two causes

### 1. `import()` resolved a DB repository before validating anything

```php
$dom = new DOMDocument('1.0', 'UTF-8');
$users = app()->make(UserRepository::class);   // <- before any path check

$resolvedPath = realpath($filename);
...
```

`Unit\TestCase::setUp()` disables the database (`database.default => []`), so `DatabaseManager` threw:

```
[TypeError] str_ends_with(): Argument #1 ($haystack) must be of type string, array given
  Illuminate/Support/Str.php:394
  Illuminate/Database/DatabaseManager.php:179
```

…for all five rejection tests — none of which should ever reach the database, since they assert the path is refused. `$users` is only used to map item authors, so it's now resolved immediately before that loop. A rejected path or a malformed document no longer pays for constructing it.

### 2. The happy-path fixture XML didn't match the real export format

`import()` reads status/relates from a `key` **attribute**:

```php
if (! $statusNodeList->item(0)->hasAttribute('key')) {
    return false;
}
```

…which is what `BlueprintsExport::buildXml()` emits (`<status key="…" />`). The fixture put the value in element text instead, so parsing bailed and `import()` returned `false` — `Failed asserting that false is identical to 42`. The fixture now mirrors the real export shape.

Also: the repo stubs returned `int`, but `addCanvas()`/`addCanvasItem()` are declared `false|string` (they wrap `insertGetId`). They now return strings; `import()` casts to `int` on the way out, so the `assertSame(42, …)` assertion is unchanged.

## Test plan

- [x] `codecept run Unit` — **795 tests, 1981 assertions, 8 pre-existing skips, green** (was 5 errors + 1 failure)
- [x] `BlueprintsServiceTest` alone — 30 tests, 61 assertions, green
- [x] `pint --test --config .pint/pint.json` — PASS, 749 files
- [x] `phpstan analyse -c .phpstan/phpstan.neon` — no errors

## Note

`NPM Security Audit` is separately red on master (transitive `eslint → minimatch → brace-expansion`, needs an eslint major bump) and is out of scope here.
