### PR TITLE
fix(blueprints): green the import() unit tests merged red in #3656

### DIFF
--- a/app/Domain/Blueprints/Services/Blueprints.php
+++ b/app/Domain/Blueprints/Services/Blueprints.php
@@ -484,7 +484,6 @@ class Blueprints extends BaseService
         }
 
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $users = app()->make(UserRepository::class);
 
         // Validate the file path and extension to prevent SSRF and Local File
         // Inclusion. Reject URL wrappers (http://, ftp://, etc.), restrict
@@ -553,6 +552,11 @@ class Blueprints extends BaseService
         }
 
         $elementNodeList = $dataNodeList->item(0)->getElementsByTagName('element');
+
+        // Resolve the user repository only now that the path is validated and the
+        // XML has parsed — it hits the database, so we must not touch it for an
+        // import we would have rejected on path/extension grounds.
+        $users = app()->make(UserRepository::class);
 
         foreach ($elementNodeList as $elementNode) {
             if (! $elementNode->hasAttribute('key')) {

--- a/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
+++ b/tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php
@@ -693,8 +693,10 @@ class BlueprintsServiceTest extends TestCase
         $expectedId = 42;
         $repo = $this->make(BlueprintsRepository::class, [
             'existCanvas' => fn () => false,
-            'addCanvas' => fn () => $expectedId,
-            'addCanvasItem' => fn () => 1,
+            // addCanvas() / addCanvasItem() are typed false|string; import() casts
+            // the canvas id to int.
+            'addCanvas' => fn () => (string) $expectedId,
+            'addCanvasItem' => fn () => '1',
         ]);
         $service = $this->securedService($repo, $this->allowingPermissions());
 
@@ -714,8 +716,8 @@ class BlueprintsServiceTest extends TestCase
             <item>
                 <author firstname="A" lastname="B"/>
                 <description>Test item</description>
-                <status>status_draft</status>
-                <relates>relates_none</relates>
+                <status key="status_draft">status_draft</status>
+                <relates key="relates_none">relates_none</relates>
                 <data>none</data>
                 <conclusion>none</conclusion>
                 <assumptions>none</assumptions>


### PR DESCRIPTION
## Why

#3656 (SSRF/LFI hardening of `Blueprints::import()`) merged with its own unit suite red — `Tests: 795, Errors: 5, Failures: 1`, all in `BlueprintsServiceTest`. Master's `unit` check is red as a result. This restores it.

Two independent defects came in with that PR:

### 1. `import()` resolved the DB-backed `UserRepository` before validating the path (5 errors)
`import()` called `app()->make(UserRepository::class)` at the very top of the method — before the SSRF/LFI path-validation guards. In the unit environment (no DB) the five *rejection* tests errored with `str_ends_with(): array given` from the database manager **before they ever reached the code under test**. It's also wasteful in production: we hit the DB for imports we were about to reject on path/extension grounds.

**Fix:** move the `UserRepository` resolution down to just before the element loop that actually uses it. Pure ordering change; no behaviour difference on the happy path — and now the guards fail closed without touching the database.

### 2. The happy-path test fixture never parsed (1 failure)
`test_import_accepts_xml_file_in_allowed_temp_dir` used `<status>…</status>` / `<relates>…</relates>` without the `key` attribute that `import()` requires, so the parse bailed to `false`; and the repo stubs returned `int` where `addCanvas()`/`addCanvasItem()` are typed `false|string`, tripping the mock's return-type contract.

**Fix (test-only):** give `<status>`/`<relates>` a `key` attribute and return strings from the stubs so the happy path reaches its assertion.

## Verification
- `vendor/bin/codecept run Unit tests/Unit/app/Domain/Blueprints/Services/BlueprintsServiceTest.php` → **OK (30 tests, 61 assertions)**
- Full `codecept run Unit` → **795 tests, 1981 assertions, 0 errors, 0 failures** (8 skipped), up from 5 errors + 1 failure.
- `vendor/bin/pint` → clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)