### PR TITLE
perf(reports): batch capacity analyzer ticket reads into one query

### DIFF
--- a/app/Domain/Reports/Services/CapacityAnalyzer.php
+++ b/app/Domain/Reports/Services/CapacityAnalyzer.php
@@ -85,6 +85,10 @@ final class CapacityAnalyzer
         $out = [];
         $weeksInPeriod = $this->weeksBetween($period->from, $period->to);
 
+        // Resolve the set of projects we'll actually analyze first (respecting
+        // the reportable-only skip below), then pull every project's tickets in
+        // ONE query instead of one round-trip per project.
+        $idsToAnalyze = [];
         foreach ($projectIds as $pid) {
             $pid = (int) $pid;
 
@@ -96,14 +100,17 @@ final class CapacityAnalyzer
                 continue;
             }
 
-            $rawTickets = $this->ticketsRepo->getAllByProjectId($pid) ?: [];
+            $idsToAnalyze[] = $pid;
+        }
+
+        $ticketsByProject = $this->ticketsRepo->getAllByProjectIds($idsToAnalyze);
+
+        foreach ($idsToAnalyze as $pid) {
+            $rawTickets = $ticketsByProject[$pid] ?? [];
 
             // Normalize — the repo hydrates rows into Tickets model objects; we
             // want plain array rows for uniform key access downstream.
-            $tickets = array_map(
-                fn ($t) => is_object($t) ? (array) $t : (array) $t,
-                $rawTickets,
-            );
+            $tickets = array_map(static fn ($t) => (array) $t, $rawTickets);
 
             // Filter to open tickets only — DONE work doesn't need capacity. DONE is
             // resolved per project from the status labels (custom statuses can mark

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -933,6 +933,82 @@ class Tickets
         return $tickets;
     }
 
+    /**
+     * Batched sibling of getAllByProjectId(): fetch every ticket for a SET of
+     * projects in a single query, grouped by project id. Callers that would
+     * otherwise loop getAllByProjectId() once per project (e.g. the capacity
+     * analyzer building a plan report) use this to collapse N round-trips into
+     * one. Returns the same hydrated Tickets models, keyed by projectId; every
+     * requested project is present (empty array when it has no tickets) so the
+     * caller can index without existence checks.
+     *
+     * @param  int[]  $projectIds
+     * @return array<int, array<int, \Leantime\Domain\Tickets\Models\Tickets>> projectId => Tickets[]
+     */
+    public function getAllByProjectIds(array $projectIds): array
+    {
+        $projectIds = array_values(array_unique(array_map('intval', $projectIds)));
+        if ($projectIds === []) {
+            return [];
+        }
+
+        $results = $this->connection->table('zp_tickets')
+            ->select([
+                'zp_tickets.id',
+                'zp_tickets.headline',
+                'zp_tickets.description',
+                'zp_tickets.date',
+                'zp_tickets.dateToFinish',
+                'zp_tickets.projectId',
+                'zp_tickets.priority',
+                'zp_tickets.status',
+                'zp_tickets.sprint',
+                'zp_tickets.storypoints',
+                'zp_tickets.hourRemaining',
+                'zp_tickets.acceptanceCriteria',
+                'zp_tickets.outcomeImpact',
+                'zp_tickets.userId',
+                'zp_tickets.editorId',
+                'zp_tickets.planHours',
+                'zp_tickets.tags',
+                'zp_tickets.url',
+                'zp_tickets.editFrom',
+                'zp_tickets.editTo',
+                'zp_tickets.dependingTicketId',
+                'zp_tickets.milestoneid',
+                'zp_projects.name as projectName',
+                'zp_clients.name as clientName',
+                'zp_user.firstname as userFirstname',
+                'zp_user.lastname as userLastname',
+                't3.firstname as editorFirstname',
+                't3.lastname as editorLastname',
+            ])
+            ->selectRaw("CASE WHEN zp_tickets.type <> '' THEN zp_tickets.type ELSE 'task' END AS type")
+            ->leftJoin('zp_projects', 'zp_tickets.projectId', '=', 'zp_projects.id')
+            ->leftJoin('zp_clients', 'zp_projects.clientId', '=', 'zp_clients.id')
+            ->leftJoin('zp_user', 'zp_tickets.userId', '=', 'zp_user.id')
+            ->leftJoin('zp_user as t3', function ($join) {
+                $join->on('zp_tickets.editorId', '=', $this->connection->raw($this->dbHelper->castAs($this->dbHelper->wrapColumn('t3.id'), 'text')));
+            })
+            ->whereIn('zp_tickets.projectId', $projectIds)
+            ->get();
+
+        // Pre-seed every requested project so a project with no tickets maps to
+        // [] rather than a missing key.
+        $grouped = array_fill_keys($projectIds, []);
+        foreach ($results as $row) {
+            $ticket = new \Leantime\Domain\Tickets\Models\Tickets;
+            foreach ((array) $row as $key => $value) {
+                if (property_exists($ticket, $key)) {
+                    $ticket->$key = $value;
+                }
+            }
+            $grouped[(int) $row->projectId][] = $ticket;
+        }
+
+        return $grouped;
+    }
+
     public function getTags($projectId): false|array
     {
         $results = $this->connection->table('zp_tickets')

--- a/tests/Unit/app/Domain/Reports/Services/CapacityAnalyzerTest.php
+++ b/tests/Unit/app/Domain/Reports/Services/CapacityAnalyzerTest.php
@@ -77,9 +77,11 @@ class CapacityAnalyzerTest extends TestCase
     /**
      * @param  array<int, array<string, mixed>>  $tickets
      */
-    private function withTickets(array $tickets): void
+    private function withTickets(array $tickets, int $projectId = 10): void
     {
-        $this->ticketsRepo->method('getAllByProjectId')->willReturn($tickets);
+        // The analyzer batches its ticket reads into one getAllByProjectIds()
+        // call keyed by projectId; the single-project cases here all use id 10.
+        $this->ticketsRepo->method('getAllByProjectIds')->willReturn([$projectId => $tickets]);
     }
 
     private function summaryWithWeeklyAllocation(int $projectId, float $weeklyHours, int $people = 1): ResourceSummary
@@ -194,6 +196,64 @@ class CapacityAnalyzerTest extends TestCase
         $rows = $this->analyzer->analyzeProjects([10], $this->oneWeekPeriod(), ResourceSummary::empty([10]), [10 => 'P']);
 
         $this->assertSame([], $rows);
+    }
+
+    /**
+     * The N+1 guard: tickets for every analyzed project are pulled in a SINGLE
+     * getAllByProjectIds() call, not one getAllByProjectId() per project. This
+     * pins the batching so a future refactor can't quietly reintroduce the
+     * per-project round-trip.
+     */
+    public function test_tickets_are_fetched_in_one_batched_call_for_all_projects(): void
+    {
+        $this->ticketsRepo->expects($this->once())
+            ->method('getAllByProjectIds')
+            ->with($this->equalTo([10, 20, 30]))
+            ->willReturn([
+                10 => [['id' => 1, 'status' => 3, 'planHours' => 10.0, 'storypoints' => 0]],
+                20 => [['id' => 2, 'status' => 3, 'planHours' => 20.0, 'storypoints' => 0]],
+                30 => [['id' => 3, 'status' => 3, 'planHours' => 30.0, 'storypoints' => 0]],
+            ]);
+
+        $summary = new ResourceSummary(
+            [10, 20, 30],
+            [new PersonAllocation(
+                itemId: 1, userId: 1, displayName: 'P', capacity: 40.0,
+                allocations: [10 => 10.0, 20 => 10.0, 30 => 10.0],
+            )],
+            [], [], 40.0, 30.0, 0.0, 0.0,
+        );
+
+        $rows = $this->analyzer->analyzeProjects(
+            [10, 20, 30],
+            $this->oneWeekPeriod(),
+            $summary,
+            [10 => 'A', 20 => 'B', 30 => 'C'],
+        );
+
+        $this->assertSame([10, 20, 30], array_keys($rows));
+        $this->assertEqualsWithDelta(10.0, $rows[10]['budgetedHours'], 0.001);
+        $this->assertEqualsWithDelta(30.0, $rows[30]['budgetedHours'], 0.001);
+    }
+
+    /**
+     * Only the reportable projects (those present in $projectNames) reach the
+     * batched fetch — the skip that used to sit inside the per-project loop now
+     * shapes the single WHERE IN, so we don't over-fetch container projects.
+     */
+    public function test_only_reportable_projects_are_batched(): void
+    {
+        $this->ticketsRepo->expects($this->once())
+            ->method('getAllByProjectIds')
+            ->with($this->equalTo([10])) // 20 is not in $projectNames → excluded
+            ->willReturn([10 => [['id' => 1, 'status' => 3, 'planHours' => 10.0, 'storypoints' => 0]]]);
+
+        $this->analyzer->analyzeProjects(
+            [10, 20],
+            $this->oneWeekPeriod(),
+            $this->summaryWithWeeklyAllocation(10, 20.0),
+            [10 => 'A'], // 20 omitted on purpose
+        );
     }
 
     // ─── Program rollup: supply is capacity, not booked hours ────────


### PR DESCRIPTION
## What

`CapacityAnalyzer::analyzeProjects()` looped `getAllByProjectId()` **once per project**, so a plan/strategy capacity report issued **N ticket-fetch round-trips** (one per project in the plan) on every render. This collapses that into a single query.

## Change
- **New** `Tickets::getAllByProjectIds(array $projectIds)` — batched sibling of `getAllByProjectId()`. Same select / joins / model hydration, but `WHERE projectId IN (...)`, returning tickets grouped by `projectId` with an empty `[]` for projects that have no tickets (predictable key set).
- `analyzeProjects()` resolves the reportable project set first, then fetches all their tickets in one call and indexes into the loop. The reportable-only skip now shapes the single `WHERE IN`, so program/container projects aren't over-fetched.
- Simplified a dead-branch normalization ternary the new precise return type exposed.

No behavior change — same rows, same numbers; only the query count drops from N to 1.

## Tests
- Repointed the existing `withTickets()` mock to the batched method (all existing assertions unchanged).
- Added `test_tickets_are_fetched_in_one_batched_call_for_all_projects` — pins the single batched call across 3 projects so the per-project round-trip can't quietly return.
- Added `test_only_reportable_projects_are_batched` — pins that non-reportable projects stay out of the `WHERE IN`.
- Full suite: 19 tests green. PHPStan clean, Pint clean.

## Scope
Standalone off `master`. Part of the resource/capacity optimization pass; independent of the goal-milestone lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)