### PR TITLE
feat(oidc): gate the mobile OIDC bridge behind AdvancedAuth

### DIFF
--- a/app/Domain/Oidc/Controllers/Login.php
+++ b/app/Domain/Oidc/Controllers/Login.php
@@ -7,20 +7,24 @@ use Illuminate\Support\Facades\Log;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Domain\Oidc\Services\Oidc as OidcService;
+use Leantime\Domain\Plugins\Services\Plugins;
 use Symfony\Component\HttpFoundation\Response;
 
 class Login extends Controller
 {
     private OidcService $oidc;
 
+    private Plugins $plugins;
+
     /**
      * Initializes dependencies.
      *
      * @throws GuzzleException
      */
-    public function init(OidcService $oidc): void
+    public function init(OidcService $oidc, Plugins $plugins): void
     {
         $this->oidc = $oidc;
+        $this->plugins = $plugins;
     }
 
     /**
@@ -39,6 +43,13 @@ class Login extends Controller
             $mobile = ! empty($params['mobile']);
             $redirectUri = is_string($params['redirect_uri'] ?? null) ? $params['redirect_uri'] : '';
             $codeChallenge = is_string($params['code_challenge'] ?? null) ? $params['code_challenge'] : '';
+
+            // The mobile-brokered branch is an AdvancedAuth capability. Without the
+            // plugin, ignore the mobile params and fall back to normal web login —
+            // the mint endpoint refuses too, so no mobile session can be brokered.
+            if ($mobile && ! $this->plugins->isEnabled('AdvancedAuth')) {
+                return Frontcontroller::redirect(BASE_URL.'/auth/login');
+            }
 
             // Mobile flow requires a PKCE challenge — otherwise the callback
             // would mint a code whose exchange can never succeed (pkceMatches

--- a/app/Domain/Oidc/Controllers/Mobile.php
+++ b/app/Domain/Oidc/Controllers/Mobile.php
@@ -7,6 +7,7 @@ use Leantime\Core\Controller\Controller;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
 use Leantime\Domain\Oidc\Services\OidcMobileCode;
+use Leantime\Domain\Plugins\Services\Plugins;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,16 +37,20 @@ class Mobile extends Controller
 
     private IncomingRequest $request;
 
+    private Plugins $plugins;
+
     public function init(
         OidcMobileCode $codes,
         AccessTokenRepository $tokens,
         UserRepository $userRepo,
-        IncomingRequest $request
+        IncomingRequest $request,
+        Plugins $plugins
     ): void {
         $this->codes = $codes;
         $this->tokens = $tokens;
         $this->userRepo = $userRepo;
         $this->request = $request;
+        $this->plugins = $plugins;
     }
 
     /**
@@ -57,6 +62,16 @@ class Mobile extends Controller
      */
     public function exchange(array $params): Response
     {
+        // Mobile auth is an AdvancedAuth capability. The OIDC bridge lives in core,
+        // so — unlike getToken, which lives in the plugin and is gated by absence —
+        // it must ask explicitly whether AdvancedAuth is installed before minting.
+        // Without it, treat the endpoint as nonexistent (404) so an unlicensed
+        // instance reveals nothing. This is the enforcement boundary: even a direct
+        // caller that never touched /status is refused here.
+        if (! $this->plugins->isEnabled('AdvancedAuth')) {
+            return new JsonResponse(['error' => 'not_found'], 404);
+        }
+
         // Frontcontroller resolves methods by URL segment regardless of verb;
         // enforce POST here so `?code=...&code_verifier=...` on a GET is
         // rejected before we touch the code store.

--- a/app/Domain/Status/Controllers/Index.php
+++ b/app/Domain/Status/Controllers/Index.php
@@ -6,6 +6,7 @@ use Leantime\Core\Configuration\AppSettings;
 use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Controller\Controller;
 use Leantime\Core\Http\IncomingRequest;
+use Leantime\Domain\Plugins\Services\Plugins;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -43,14 +44,18 @@ class Index extends Controller
 
     private IncomingRequest $request;
 
+    private Plugins $plugins;
+
     /**
-     * init - inject config, app settings, and the incoming request.
+     * init - inject config, app settings, the incoming request, and the plugin
+     * service (used to gate mobile-auth advertising on AdvancedAuth).
      */
-    public function init(Environment $config, AppSettings $appSettings, IncomingRequest $request): void
+    public function init(Environment $config, AppSettings $appSettings, IncomingRequest $request, Plugins $plugins): void
     {
         $this->config = $config;
         $this->appSettings = $appSettings;
         $this->request = $request;
+        $this->plugins = $plugins;
     }
 
     /**
@@ -64,17 +69,25 @@ class Index extends Controller
         $oidcEnabled = (bool) $this->config->oidcEnable;
         $ldapEnabled = $this->config->useLdap === true && extension_loaded('ldap');
 
+        // Mobile auth is an AdvancedAuth capability — the mobile connection points
+        // (getToken, and the OIDC mint bridge) require the plugin. Only advertise
+        // mobile OIDC when AdvancedAuth is installed, so a core-only instance never
+        // offers a login the mint endpoint (Oidc\Controllers\Mobile) would refuse.
+        // NOTE: Cloud is assumed to ship AdvancedAuth, so this predicate covers it;
+        // confirm before release.
+        $mobileGate = $this->plugins->isEnabled('AdvancedAuth');
+
         // password is always available; ldap/oidc only when configured.
         $authMethods = ['password'];
         if ($ldapEnabled) {
             $authMethods[] = 'ldap';
         }
-        if ($oidcEnabled) {
+        if ($oidcEnabled && $mobileGate) {
             $authMethods[] = 'oidc';
         }
 
         $payload = [
-            'mobileAuthEnabled' => true,
+            'mobileAuthEnabled' => $mobileGate,
             'instanceName' => (string) ($this->config->sitename ?: 'Leantime'),
             'version' => $this->appSettings->appVersion,
             'minAppVersion' => null,
@@ -82,10 +95,11 @@ class Index extends Controller
             'ssoProviders' => [],
         ];
 
-        if ($oidcEnabled) {
-            // Generic-OIDC login initiation URL (core). The app opens this in the
-            // system auth browser; the mobile branch is triggered by its own query
-            // params (see Oidc\Controllers\Login).
+        if ($oidcEnabled && $mobileGate) {
+            // Generic-OIDC login initiation URL — advertised for mobile only when
+            // AdvancedAuth is installed. The app opens this in the system auth
+            // browser; the mobile branch is triggered by its own query params
+            // (see Oidc\Controllers\Login).
             $payload['oidcLoginUrl'] = $this->request->getSchemeAndHttpHost().'/oidc/login';
         }
 

--- a/tests/Unit/app/Domain/Oidc/Controllers/MobileTest.php
+++ b/tests/Unit/app/Domain/Oidc/Controllers/MobileTest.php
@@ -12,6 +12,7 @@ use Leantime\Core\UI\Template;
 use Leantime\Domain\Auth\Repositories\AccessTokenRepository;
 use Leantime\Domain\Oidc\Controllers\Mobile;
 use Leantime\Domain\Oidc\Services\OidcMobileCode;
+use Leantime\Domain\Plugins\Services\Plugins;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
 
 /**
@@ -46,6 +47,13 @@ class MobileTest extends \Unit\TestCase
         $this->app->instance(OidcMobileCode::class, $this->codes);
         $this->app->instance(AccessTokenRepository::class, $this->tokens);
         $this->app->instance(UserRepository::class, $this->userRepo);
+
+        // Mobile SSO is gated on AdvancedAuth (see Mobile::exchange). Mock the
+        // plugin as installed so these exchange-contract tests run past the gate;
+        // the gate itself is verified live e2e (AdvancedAuth off -> 404).
+        $plugins = $this->createMock(Plugins::class);
+        $plugins->method('isEnabled')->willReturn(true);
+        $this->app->instance(Plugins::class, $plugins);
 
         // Back the RateLimiter facade with a fresh in-memory store so throttle
         // state is deterministic and isolated per test.

--- a/tests/Unit/app/Domain/Status/Controllers/IndexTest.php
+++ b/tests/Unit/app/Domain/Status/Controllers/IndexTest.php
@@ -11,6 +11,7 @@ use Leantime\Core\Configuration\Environment;
 use Leantime\Core\Http\IncomingRequest;
 use Leantime\Core\Language;
 use Leantime\Core\UI\Template;
+use Leantime\Domain\Plugins\Services\Plugins;
 use Leantime\Domain\Status\Controllers\Index;
 
 /**
@@ -47,6 +48,13 @@ class IndexTest extends \Unit\TestCase
         $this->app->instance(IncomingRequest::class, $request);
         $this->app->instance(Environment::class, $env);
         $this->app->instance(AppSettings::class, new AppSettings);
+
+        // Mobile-auth advertising is gated on AdvancedAuth; mock it installed so
+        // these contract tests cover a mobile-capable instance. The gate itself
+        // is verified live e2e (AdvancedAuth off -> mobile OIDC not advertised).
+        $plugins = $this->createMock(Plugins::class);
+        $plugins->method('isEnabled')->willReturn(true);
+        $this->app->instance(Plugins::class, $plugins);
 
         return new Index($request, $this->createMock(Template::class), $this->createMock(Language::class));
     }


### PR DESCRIPTION
## What
Gate the mobile OIDC SSO bridge behind AdvancedAuth.

## Why
The OIDC mobile bridge — `POST /oidc/mobile/exchange` + the `mobile=1` branch of `/oidc/login`, advertised via `/status` — lives in **core** and minted a 30-day mobile bearer token **without checking AdvancedAuth**. Every other mobile connection point (`getToken`, …) is gated by living inside the AdvancedAuth plugin; the OIDC bridge is the only mobile auth path that landed in core, so it must ask explicitly. Today, any instance with OIDC configured can grant mobile access with no AdvancedAuth.

The bridge is currently on `master` in **no release tag**, so this closes it before it ships.

## Change
Same predicate — `Plugins::isEnabled('AdvancedAuth')` — at three layers:

| Layer | File | Behavior without AdvancedAuth |
|---|---|---|
| Discovery | `Status/Controllers/Index` (`/status`) | `mobileAuthEnabled:false`, no `oidc` in `authMethods`, no `oidcLoginUrl` (drops the hardcoded `true`) |
| Initiation | `Oidc/Controllers/Login` (`/oidc/login?mobile=1`) | mobile branch falls back to `/auth/login` |
| **Mint** | `Oidc/Controllers/Mobile::exchange` (`POST /oidc/mobile/exchange`) | **404** — the enforcement boundary; a direct caller is refused even without hitting `/status` |

Web/desktop OIDC is untouched — all guards are on the mobile path only.

## Verified
Core instance, AdvancedAuth toggled via `zp_plugins.enabled`:
- **off** → `/status` hides `oidc` + `mobileAuthEnabled:false`; `POST /oidc/mobile/exchange` → `404`; `/oidc/login?mobile=1` → `303 /auth/login`
- **on** → `oidc` advertised; `/oidc/login?mobile=1` → `302` to provider (full SSO flow works end-to-end)

## Notes / to confirm
- **Cloud:** predicate is "AdvancedAuth installed" (`isEnabled` reads `zp_plugins`, DB-driven, matching how core detects plugins elsewhere). This assumes Cloud ships AdvancedAuth so `isEnabled` is `true` there — please confirm before release.
- **Optional follow-up (architectural):** the clean parts of the bridge (`Oidc/Controllers/Mobile`, `Oidc/Services/OidcMobileCode`, the `oidc.mobile` allowlist entry) could be relocated *into* AdvancedAuth so the capability is gated by absence rather than an explicit check — matching `getToken`. `app/Plugins` is a submodule, so that's a separate-repo change; the mint gate here already closes the hole regardless of where the code physically lives. The mobile branches threaded through `Oidc/Services/Oidc` (buildLoginUrl / callback OTC mint) would move with it.
- **No mobile app changes** — the app already keys the SSO button off `/status`, so an unlicensed instance simply never offers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtfhjPwUEEHJb4Jf7714eR
