### PR TITLE
style(reverse-wizard): rw-guide-sub class for muted guide sub-paragraphs

### DIFF
--- a/public/assets/css/components/reverse-wizard.css
+++ b/public/assets/css/components/reverse-wizard.css
@@ -639,9 +639,9 @@ body.reverse-intercept-open .lmCanvas-stages, body.reverse-intercept-open .lm-st
 }
 
 .rev-wiz .rw-guide .rw-guide-sub {
-    margin-top: 8px;
-    color: var(--rw-muted);
-    font-size: 12.5px;
+    margin-top:8px;
+    color:var(--rw-muted);
+    font-size:12.5px;
 }
 
 .rev-wiz .rw-guide .rw-guide-lbl {

--- a/public/assets/css/components/reverse-wizard.css
+++ b/public/assets/css/components/reverse-wizard.css
@@ -638,6 +638,12 @@ body.reverse-intercept-open .lmCanvas-stages, body.reverse-intercept-open .lm-st
     margin:0 0 14px;
 }
 
+.rev-wiz .rw-guide .rw-guide-sub {
+    margin-top: 8px;
+    color: var(--rw-muted);
+    font-size: 12.5px;
+}
+
 .rev-wiz .rw-guide .rw-guide-lbl {
     display:block;
     font-size:11px;


### PR DESCRIPTION
Two-line companion to the plugins stage-copy re-land: the per-stage guide blocks use a muted secondary paragraph; this gives it a proper class (`.rw-guide-sub`) so no inline styles return to the templates.

**Merge before the plugins PR** (which references the class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85
