### PR TITLE
feat(resources): period-aware actuals window on the ResourcesGateway contract

### DIFF
--- a/app/Core/Resources/Contracts/ResourcesGateway.php
+++ b/app/Core/Resources/Contracts/ResourcesGateway.php
@@ -32,12 +32,13 @@ interface ResourcesGateway
      * @param  array<int>  $projectIds  Projects to aggregate over. May include
      *                                  the program row itself and its children,
      *                                  or a hand-picked subset for a report.
-     * @param  string|null  $actualsFrom  Start of the logged-hours window (Y-m-d,
-     *                                    DB timezone). Null = provider default
-     *                                    (current week).
+     * @param  string|null  $actualsFrom  Start of the logged-hours window
+     *                                    (Y-m-d, UTC — DB datetimes are stored
+     *                                    in UTC; do not pass user-local dates).
+     *                                    Null = provider default (current week).
      * @param  string|null  $actualsTo  End of the logged-hours window (Y-m-d,
-     *                                  inclusive). Pass the report period so
-     *                                  actuals line up with what's reported on.
+     *                                  UTC, inclusive). Pass the report period
+     *                                  so actuals line up with what's reported on.
      * @return ResourceSummary Empty summary if none of the projects have
      *                         resources authored.
      */

--- a/app/Core/Resources/Contracts/ResourcesGateway.php
+++ b/app/Core/Resources/Contracts/ResourcesGateway.php
@@ -32,10 +32,16 @@ interface ResourcesGateway
      * @param  array<int>  $projectIds  Projects to aggregate over. May include
      *                                  the program row itself and its children,
      *                                  or a hand-picked subset for a report.
+     * @param  string|null  $actualsFrom  Start of the logged-hours window (Y-m-d,
+     *                                    DB timezone). Null = provider default
+     *                                    (current week).
+     * @param  string|null  $actualsTo  End of the logged-hours window (Y-m-d,
+     *                                  inclusive). Pass the report period so
+     *                                  actuals line up with what's reported on.
      * @return ResourceSummary Empty summary if none of the projects have
      *                         resources authored.
      */
-    public function getForProjects(array $projectIds): ResourceSummary;
+    public function getForProjects(array $projectIds, ?string $actualsFrom = null, ?string $actualsTo = null): ResourceSummary;
 
     /**
      * Aggregate resources for a program and its child projects.

--- a/tests/Unit/app/Core/Resources/Services/ResourcesRegistryTest.php
+++ b/tests/Unit/app/Core/Resources/Services/ResourcesRegistryTest.php
@@ -87,7 +87,7 @@ class ResourcesRegistryTest extends TestCase
     {
         return new class implements ResourcesGateway
         {
-            public function getForProjects(array $projectIds): ResourceSummary
+            public function getForProjects(array $projectIds, ?string $actualsFrom = null, ?string $actualsTo = null): ResourceSummary
             {
                 return ResourceSummary::empty($projectIds);
             }
@@ -103,7 +103,7 @@ class ResourcesRegistryTest extends TestCase
     {
         return new class implements ResourcesGateway
         {
-            public function getForProjects(array $projectIds): ResourceSummary
+            public function getForProjects(array $projectIds, ?string $actualsFrom = null, ?string $actualsTo = null): ResourceSummary
             {
                 return ResourceSummary::empty($projectIds);
             }


### PR DESCRIPTION
## What & why

Declares the optional `actualsFrom` / `actualsTo` (Y-m-d) parameters on `ResourcesGateway::getForProjects` — the logged-hours window. The single implementor (PgmPro `ResourceStructureService`, shipped in plugins #83) already accepts exactly this signature; the contract just never caught up.

This unblocks the plugins companion PR, which makes the strategy report pass its period as the actuals window — fixing the long-standing "actuals reflect the current week regardless of the reported period" seam bug (stranded commit `7ebf18ca`, see `Docs/PR-FORENSICS-ANALYSIS.md`).

## Merge order
This contract PR merges **first**; the plugins caller PR follows.

PHPStan clean; no behavior change on its own (params optional, defaults preserve today's behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85
