### PR TITLE
fix(reports): stakeholder deck no longer 500s when the caller omits projectId

### DIFF
--- a/app/Domain/Reports/Templates/partials/stakeholder/deck.blade.php
+++ b/app/Domain/Reports/Templates/partials/stakeholder/deck.blade.php
@@ -244,7 +244,7 @@
 
                 {{-- ═══ Page 3 — Resources & Coverage ═════════════════ --}}
                 <div class="rd-page">
-                    @include('reports::partials.stakeholder.page-resources', compact('logicModel', 'hasLM', 'resourceSummary', 'report', 'scope', 'capacityAnalysis', 'programMeta', 'programChildMap', 'capacityByProgram', 'projectId'))
+                    @include('reports::partials.stakeholder.page-resources', compact('logicModel', 'hasLM', 'resourceSummary', 'report', 'scope', 'capacityAnalysis', 'programMeta', 'programChildMap', 'capacityByProgram') + ['projectId' => $projectId ?? null])
                 </div>
 
                 {{-- ═══ Page 4 — Impact Journey ═══════════════════════ --}}


### PR DESCRIPTION
## What & why

`deck.blade.php:247` passes `projectId` through `compact()`, but the variable is optional everywhere else in the file (`$projectId ?? 0` at line 132, `! empty($projectId ?? null)` at line 152) — and **neither plugin report template passes it**. `compact()` warns on undefined variables, and the exception handler converts that to a thrown `ErrorException` mid-render, so **both stakeholder report pages 500 at program scope** as pinned.

One line: pass it explicitly with a null default, matching the file's own optional-variable convention.

Confirmed in the wild (program report screenshot: `compact(): Undefined variable $projectId`); flagged in `Docs/PR-FORENSICS-ANALYSIS.md` §5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85
