### PR TITLE
feat(css): body.lt-doc-page — one document-page mode for doc-shell pages

### DIFF
--- a/public/assets/css/components/structure.css
+++ b/public/assets/css/components/structure.css
@@ -592,3 +592,30 @@ body {
 .announcementBanner:before {
 
 }
+
+/* ── Document-page mode ──────────────────────────────────────────────
+   body.lt-doc-page: for pages whose content card renders its OWN doc-shell
+   header (the stakeholder reports' .rd-hdr — see report-deck.css). The shared
+   teal pageheader collapses (kept in the DOM so its lifecycle hooks still
+   fire) and the content shell goes flush/transparent so the document card IS
+   the page. ONE implementation for every doc-shell page — never re-create
+   this per page in a template. Specificity (body + class) outranks the plain
+   .pageheader/.maincontentinner base rules, so no !important is needed.
+   (RA's body.ra-page-active predates this mode and should converge onto it
+   in the tab-component rollout follow-ups.) */
+body.lt-doc-page .pageheader {
+    display: none;
+}
+body.lt-doc-page .maincontent {
+    margin-top: 0;
+    padding-top: 14px;
+}
+body.lt-doc-page .maincontentinner {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}


### PR DESCRIPTION
## What & why

Review feedback on plugins #88 (Marcel): the pageheader-collapse CSS lived **duplicated in two report blades behind `!important`**. This is the unified core implementation — `body.lt-doc-page`, one document-page mode for every page whose content card renders its own doc-shell header (the stakeholder reports' `.rd-hdr`).

- `body + class` specificity outranks the base `.pageheader`/`.maincontentinner` rules → **zero `!important`**
- pageheader stays in the DOM (lifecycle hooks fire), just collapsed; content shell goes flush/transparent
- one implementation, valid for all current and future doc-shell pages; RA's `body.ra-page-active` predates it and converges here in the rollout follow-ups

## Merge order
This merges **before** plugins #88 (whose latest commit strips the blade CSS and stamps this class).

Bundle builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85
