### PR TITLE
docs: rescue the full Docs/ knowledge base from stash

### DIFF
--- a/Docs/00-IMPLEMENTATION-GUIDE.md
+++ b/Docs/00-IMPLEMENTATION-GUIDE.md
@@ -1,0 +1,116 @@
+# Logic Model Canvas — Implementation Guide
+
+## Overview
+
+The Logic Model Canvas is a new board type in Leantime that provides a five-stage causal chain view for program planning. It ships in **three phases** that must be built sequentially. Each phase produces a working, shippable product.
+
+## Reference Prototype
+
+The definitive visual reference is `logic-model-v11.html`. It includes both core and plugin modes toggled by header buttons. Use it as the source of truth for spacing, colors, transitions, and hierarchy.
+
+---
+
+## Phase 1: Core Board
+
+**Goal:** A functional logic model canvas that ships free with Leantime. Users can create a board, add items to five fixed stages, set hypothesis statuses, and navigate between stages.
+
+**Files:** `01-CORE.md`
+
+**Depends on:** Existing Leantime canvas board architecture (Lean Canvas, Value Canvas, SWOT). Extend the same base patterns — same card component, same modal system, same comment/attachment infrastructure.
+
+**Definition of Done:**
+- [ ] New board type selectable from project board menu
+- [ ] Five fixed stages render with correct colors, icons, titles, subtitles
+- [ ] Click-to-focus stage interaction with pricing-page visual hierarchy
+- [ ] Item cards display with title, description, hypothesis status dropdown, comments, attachments, avatar
+- [ ] Inactive stages show compact dot + title rows
+- [ ] Count badge on stage headers (visible on hover only)
+- [ ] Logic model selector dropdown (create, switch between models)
+- [ ] Print button (browser native)
+- [ ] Card modal opens on item click with edit capabilities
+- [ ] Stage titles, colors, order are locked (not editable)
+
+**Do NOT build in Phase 1:**
+- Theory of change narrative
+- Health badges
+- Progress bars
+- Status pills / priority indicators
+- Project links
+- Item-level progress indicators
+- Export PNG/PDF
+- Board templates
+- AI copilot
+- Activity log
+
+---
+
+## Phase 2: Strategy Plugin
+
+**Goal:** The paid plugin layer that adds strategic intelligence, validation workflows, system integration, and advanced export.
+
+**Files:** `02-PLUGIN.md`
+
+**Depends on:** Phase 1 complete. Plugin features render conditionally when the Strategy Plugin is active. The board must function fully without the plugin.
+
+**Definition of Done:**
+- [ ] Plugin detection — all plugin features hidden when plugin is not active
+- [ ] Theory of change narrative strip above columns
+- [ ] Stage health badges (top-right corner, with hover popover)
+- [ ] Progress bars on stage headers (validation completeness)
+- [ ] Status pills on item cards (Validated / In Progress / Draft / etc.)
+- [ ] Priority indicators (border color override: high = red, medium = amber)
+- [ ] Project link integration (folder icon + name on card footer)
+- [ ] Item-level progress indicators (current/target with bar)
+- [ ] Export dropdown (PNG, PDF, Print)
+- [ ] Board templates (5 framework options)
+- [ ] Snapshot versioning (save/restore point-in-time)
+- [ ] Empty board narrative template (fill-in-the-blank)
+
+**Do NOT build in Phase 2:**
+- AI copilot
+- Activity log (build the data capture, but UI is Phase 3)
+
+**Important:** Phase 2 should capture activity log DATA from the start (every status change, item edit, etc.) even though the activity log UI ships in Phase 3. This ensures the copilot has history to work with on launch.
+
+---
+
+## Phase 3: AI Copilot
+
+**Goal:** The AI assistant layer that analyzes the logic model, identifies gaps, and provides an activity audit trail.
+
+**Files:** `03-COPILOT.md`
+
+**Depends on:** Phase 2 complete (needs health badges, progress bars, and activity log data).
+
+**Definition of Done:**
+- [ ] Floating trigger button (bottom-right, with notification dot)
+- [ ] Hover preview card showing most relevant insight
+- [ ] Side panel with chat interface
+- [ ] Activity Log tab in copilot panel (audit trail of all changes)
+- [ ] AI can analyze model state and identify gaps
+- [ ] AI can reference activity history in conversation
+- [ ] Suggested actions: walk through, gap analysis, fill gaps, refine narrative
+- [ ] Notification system for proactive insights
+
+---
+
+## File Structure
+
+```
+00-IMPLEMENTATION-GUIDE.md    ← You are here
+01-CORE.md                    ← Phase 1: Core board specification
+02-PLUGIN.md                  ← Phase 2: Strategy plugin specification
+03-COPILOT.md                 ← Phase 3: AI copilot specification
+04-DATA-MODEL.md              ← Shared data model (all phases)
+05-VISUAL-REFERENCE.md        ← Design system, colors, spacing, transitions
+06-CARD-MODAL.md              ← Card detail modal specification (Phase 2 design)
+```
+
+## Conventions
+
+- **Core features** are always visible. They do not check for plugin state.
+- **Plugin features** check for plugin activation before rendering. Use the same conditional pattern as other Leantime plugins.
+- **Copilot features** are a sub-module of the plugin. They require both plugin activation AND AI service configuration.
+- Stage colors, titles, and order are constants defined once and referenced everywhere. Never hardcode them inline.
+- The hypothesis status system is CORE, not plugin. Status pills (the visual badges on cards) are plugin, but the status dropdown and status data are core.
+- All activity logging (data capture) begins in Phase 2 even though the UI ships in Phase 3.

--- a/Docs/01-CORE.md
+++ b/Docs/01-CORE.md
@@ -1,0 +1,245 @@
+# Phase 1: Core Board
+
+## Summary
+
+The core logic model canvas is a new board type that ships free with Leantime. It provides a five-stage causal chain — Inputs, Activities, Outputs, Outcomes, Impact — with a visual hierarchy that emphasizes one active stage while keeping the full chain visible.
+
+---
+
+## 1. Board Type Registration
+
+Register "Logic Model" as a new board type alongside existing canvas boards (Lean Canvas, Value Canvas, SWOT). It should appear in the project board menu and follow the same creation flow.
+
+A project can have multiple logic models. Each is an independent board with its own items and state.
+
+---
+
+## 2. The Five Stages
+
+Stages are **fixed** in core. Titles, subtitles, icons, colors, and order cannot be changed by the user.
+
+| # | Stage | Subtitle | Icon | Primary Color | Background Tint |
+|---|-------|----------|------|---------------|-----------------|
+| 1 | Inputs | Resources we invest | `arrow-right-to-bracket` | `#4A85B5` | `#EDF3F8` |
+| 2 | Activities | What we do | `gears` | `#3E937A` | `#ECF6F2` |
+| 3 | Outputs | What we produce | `boxes-stacked` | `#C09035` | `#FBF5EA` |
+| 4 | Outcomes | Changes we expect | `chart-line` | `#8E6AAD` | `#F2EDF8` |
+| 5 | Impact | Ultimate change | `bullseye` | `#2D7D5E` | `#EAF5F0` |
+
+Icons listed are FontAwesome references from the prototype. Use Leantime's icon system equivalents in production.
+
+---
+
+## 3. Visual Hierarchy — Pricing Page Pattern
+
+This is NOT a kanban board. One stage is always "active" (focused), and the others are receded.
+
+### Active Stage
+- `transform: scale(1)`
+- Full opacity (1.0)
+- Elevated shadow (`0 14px 48px rgba(0,0,0,0.13)`)
+- Background: gradient from stage tint color at top fading to white at ~80px
+- Header: 3px colored bottom border (stage color)
+- Items: fully expanded cards with title, description, footer
+- "Current Focus" pill flag above the stage (-11px from top)
+- Add item link visible at bottom
+
+### Inactive Stage
+- `transform: scale(0.955)`
+- Reduced opacity (0.5)
+- Subtle shadow (`0 1px 3px rgba(0,0,0,0.04)`)
+- Background: white, no gradient
+- Header: 2px light border bottom
+- Items: compact rows — status dot (8px circle) + title only
+- No flag, no add link
+- Cursor: pointer (entire stage is clickable)
+
+### Inactive Stage on Hover
+- Opacity rises to 0.78
+- Scale rises to 0.97
+- Shadow increases to medium
+- This creates a "peek before you click" interaction
+
+### Transition
+- Duration: 350ms
+- Easing: `cubic-bezier(0.25, 0.46, 0.45, 0.94)`
+- Only one stage is active at a time
+
+---
+
+## 4. Stage Header
+
+Each stage header is a centered column layout containing:
+
+1. **Icon** — 36px rounded square (active) / 28px (inactive). Active: filled with stage color, white icon. Inactive: stage tint background, stage color icon.
+2. **Title row** — Stage name (16px bold active / 12px semibold inactive) + count badge
+3. **Subtitle** — (11px secondary color active / 10px tertiary inactive)
+
+### Count Badge
+- Small circle in stage color showing number of items
+- **Hidden by default, visible on hover only** (same pattern as kanban)
+- Active: 20px circle, 10px font
+- Inactive: 16px circle, 9px font
+- Positioned inline after the title text
+
+### Header Border
+- Active: 3px bottom border in stage color
+- Inactive: 2px bottom border in light gray (`#eef0f2`)
+
+---
+
+## 5. Stage Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  [Tab: Q1 Youth Literacy ▾]                          [Print] [+ Add] │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  ┌─Stage─┐  ┌─Stage─┐  ┌─Stage─┐  ┌─Stage─┐  ┌─Stage─┐            │
+│  │ACTIVE │  │ inact │  │ inact │  │ inact │  │ inact │            │
+│  │       │  │       │  │       │  │       │  │       │            │
+│  │ Cards │  │ Dots  │  │ Dots  │  │ Dots  │  │ Dots  │            │
+│  │ Full  │  │ Only  │  │ Only  │  │ Only  │  │ Only  │            │
+│  │       │  │       │  │       │  │       │  │       │            │
+│  │+ Add  │  └───────┘  └───────┘  └───────┘  └───────┘            │
+│  └───────┘                                                          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- Flow container: `display: flex; align-items: flex-start; gap: 10px`
+- Each stage: `flex: 1 1 0; min-width: 0`
+- Stages naturally size to content height (active stage is taller)
+
+---
+
+## 6. Item Cards
+
+### Expanded Card (Active Stage)
+
+```
+┌───────────────────────────────┐
+│▌ $250K annual budget          │  ← 3px left border in stage color
+│▌ Federal Title I funding...   │  ← Description: 11px, secondary color
+│▌                              │
+│▌ [In Review ▾]  💬 3  📎 1  (GF)│  ← Footer row
+└───────────────────────────────┘
+```
+
+- Padding: 8px 10px
+- Border-left: 3px solid (stage color)
+- Title: 13px, bold
+- Description: 11px, secondary color (`#5e6e7d`), single line
+- Footer: hypothesis status dropdown + comment count + attachment count + assignee avatar
+- Gap between cards: 8px
+- Border-radius: 5px
+- Hover: subtle background tint (`rgba(0,0,0,0.02)`)
+
+### Compact Row (Inactive Stage)
+
+```
+● $250K annual budget
+● 1 Director, 3 Specialists...
+● 500+ age-appropriate books
+```
+
+- Status dot: 8px circle, colored by hypothesis status
+- Title: 11px, medium weight, secondary color
+- No description, no footer, no left border
+- Padding: 5px 8px
+
+### Card Pattern Alignment
+
+The expanded card matches Leantime's existing canvas board cards (Project Value Board, Lean Canvas). It uses the same elements: bold title in accent color, description text, status dropdown pill, comment icon, attachment icon, assignee avatar, and three-dot menu.
+
+---
+
+## 7. Hypothesis Status System
+
+Every item is a hypothesis. The status tracks its validation state. **This is a core feature.**
+
+| Status | Color | Dot Color | Meaning |
+|--------|-------|-----------|---------|
+| Draft | Blue `#1B75BB` | `#cccccc` (muted) | Not yet examined |
+| In Review | Orange `#F0A030` | `#1B75BB` (blue) | Being tested |
+| Validated: Valid | Green `#75BB1B` | `#75BB1B` (green) | Evidence confirms |
+| On Hold | Red `#BB1B25` | `#BB1B25` (red) | Paused or blocked |
+| Validated: Invalid | Red `#BB1B25` | `#BB1B25` (red) | Evidence disproves |
+
+### Status Dropdown
+- Displays as a clickable pill on the card (matching existing value canvas pattern)
+- Click opens dropdown with all five options, each with their color
+- Default for new items: Draft
+
+---
+
+## 8. Logic Model Selector
+
+### Tab Structure
+Top bar shows a button with the current model name + dropdown chevron. Follows the same pattern as Leantime's wiki/docs selector (`Docs // Default ▾`).
+
+### Dropdown Content
+```
+┌─────────────────────────┐
+│ Q1 Youth Literacy    ✓  │  ← Active (bold, accent color)
+│ Summer Pilot            │
+│─────────────────────────│
+│ + Create new logic model│
+└─────────────────────────┘
+```
+
+Just model names. No sub-views, no wiki pages. Click to switch. "+ Create new logic model" at the bottom.
+
+---
+
+## 9. Top Bar Actions
+
+### Core Mode
+- **Print** button — triggers `window.print()` (browser native)
+- **+ Add** button — opens item creation modal for the active stage
+
+---
+
+## 10. Card Modal
+
+Clicking an item card opens the detail modal (same modal system as existing canvas cards).
+
+### Core Modal Sections
+
+1. **Header** — Editable title, stage label (colored pill, read-only), hypothesis status dropdown, three-dot menu (edit, delete)
+2. **Description** — Rich text editor, markdown supported
+3. **Comments** — Threaded discussion (existing Leantime comment system)
+4. **Attachments** — File uploads
+5. **Meta** — Assignee selector, created date, last modified
+
+### Behavior
+- Modal opens as slide-over or center modal (match existing pattern)
+- Changes save on blur or explicit save button (match existing pattern)
+- Status changes in modal update the card immediately
+
+---
+
+## 11. Responsive Behavior
+
+| Breakpoint | Layout |
+|------------|--------|
+| > 1100px | Five columns side by side |
+| 600–1100px | Columns wrap to 2 per row (`flex-wrap: wrap`) |
+| < 600px | Single column stack, active stage first |
+
+---
+
+## 12. Keyboard Navigation
+
+- **Tab** — move focus between stages
+- **Enter / Space** — activate focused stage
+- **Arrow Up/Down** — navigate items within active stage
+- **Enter** on item — open card modal
+- **Escape** — close modal
+
+---
+
+## 13. ARIA Labels
+
+- Stage: `"Inputs stage, 4 items, Current focus"` / `"Activities stage, 3 items"`
+- Item: `"Item: $250K annual budget, Status: Validated Valid"`
+- Status dropdown: `"Hypothesis status: In Review, click to change"`

--- a/Docs/02-PLUGIN.md
+++ b/Docs/02-PLUGIN.md
@@ -1,0 +1,294 @@
+# Phase 2: Strategy Plugin
+
+## Summary
+
+The Strategy Plugin adds strategic intelligence, validation workflows, system integration, and advanced features to the logic model canvas. All plugin features render conditionally — the board must function fully without the plugin active.
+
+**Prerequisite:** Phase 1 (Core Board) must be complete.
+
+---
+
+## 1. Plugin Detection Pattern
+
+All plugin features check for plugin activation before rendering. Use the same conditional pattern as other Leantime plugins. In the prototype, this is represented by the `.plugin` CSS class on the workspace container.
+
+```
+if (plugin is NOT active):
+    render core board only
+if (plugin IS active):
+    render core board + all plugin enhancements
+```
+
+---
+
+## 2. Theory of Change Narrative
+
+### Position
+Horizontal bar above the stage columns, below the top bar. 24px margin between narrative and columns.
+
+### Visual Treatment
+- Background: white
+- Left border: 3px solid `#00aa64` (accent green)
+- Border radius: 8px
+- Padding: 12px 20px
+- Shadow: subtle (`0 1px 3px rgba(0,0,0,0.04)`)
+
+### Content Format
+```
+**Theory of Change:** If we invest [Inputs text] and deliver [Activities text],
+we produce [Outputs text], leading to [Outcomes text], ultimately creating [Impact text].
+```
+
+Each bracketed section uses the corresponding stage color:
+- Inputs text: `#4A85B5`
+- Activities text: `#3E937A`
+- Outputs text: `#C09035`
+- Outcomes text: `#8E6AAD`
+- Impact text: `#2D7D5E`
+
+Content is generated from item titles within each stage. AI can help refine.
+
+### Empty Board Template
+When a logic model has no items, the narrative becomes a fill-in-the-blank template:
+
+> If we invest in *[inputs here]* and deliver on *[these activities]*, then we can produce *[these outputs]* because they will lead to *[these outcomes]* and make *[this impact]*.
+
+Italicized placeholder text in each bracket. Teaches the framework while inviting participation.
+
+---
+
+## 3. Stage Health Badges
+
+### Purpose
+Indicate the quality of the causal connection BETWEEN stages (not within a stage). The badge on "Inputs" describes whether the assumption that inputs lead to activities is sound.
+
+### Position
+Top-right corner of the stage header, absolutely positioned (8px from top, 8px from right).
+
+### Size
+24px circle with 10px icon. Border: 1.5px solid in matching color.
+
+### States
+
+| State | Icon | Background | Text Color | Border | Meaning |
+|-------|------|------------|------------|--------|---------|
+| Strong | check | `#EAF5E8` | `#5a9e4f` | `#c8e0c2` | Assumptions validated |
+| Warning | exclamation | `#FEF4E4` | `#c08a2e` | `#edd9ad` | Some assumptions untested |
+| Gap | exclamation | `#FDEAEB` | `#BB1B25` | `#edb5b9` | Critical assumptions unvalidated |
+
+### Hover Behavior
+- Scale to 1.15x
+- Shadow increases
+- Popover appears below the badge
+
+### Popover Content
+```
+┌─────────────────────────────┐
+│ INPUTS → ACTIVITIES         │  ← 9px uppercase label
+│                             │
+│ Funding stable. Qualified   │  ← Assumption text
+│ volunteers available.       │
+│                             │
+│ [Medium Risk]               │  ← Risk level tag (colored)
+│                             │
+│ Volunteer recruitment       │  ← Notes (10px, tertiary)
+│ challenging in Q3           │
+└─────────────────────────────┘
+```
+
+### No Badge on Impact
+Impact (stage 5) has no health badge — there is no next stage to connect to.
+
+### Data
+Health badges are manually set by users through a settings interface or inline edit. The AI copilot (Phase 3) can suggest health status changes.
+
+---
+
+## 4. Progress Bars
+
+### Definition
+The progress bar = percentage of items with status **"Validated: Valid"** within the stage.
+
+### Calculation
+```
+progress = (items with status "validated_valid") / (total items in stage) × 100%
+```
+
+Only "Validated: Valid" counts. Draft, In Review, On Hold, Validated: Invalid = 0%.
+
+### Visual Treatment
+- Height: 4px
+- Position: below subtitle in stage header, full width with 16px horizontal padding
+- Fill color: stage primary color
+- Track color: `#eef0f2` (light gray)
+- Border radius: 2px
+- Fill transition: 500ms ease
+
+### Opacity by State
+- Active stage: full opacity (1.0)
+- Inactive stage: 30% opacity (ambient, not competing)
+
+### Hover Tooltip
+On hover, show: `"2 of 4 items validated"` (or equivalent count).
+
+---
+
+## 5. Card Enhancements
+
+### Status Pills
+Visual badges on expanded cards showing the hypothesis status in a small colored pill. These are a visual enhancement of the core status — the data is already there from Phase 1, the pills add visual prominence.
+
+| Pill | Color | Background |
+|------|-------|------------|
+| Validated | White text | `#75BB1B` green |
+| In Progress | White text | `#1B75BB` blue |
+| Draft | White text | `#aaaaaa` gray |
+| High (priority) | White text | `#BB1B25` red |
+
+Pills appear in the card footer, before the project link.
+
+### Priority Indicators
+Items can have a priority level (High, Medium, or none). In plugin mode, priority overrides the left border color on expanded cards:
+- High priority: `#BB1B25` (red) instead of stage color
+- Medium priority: `#fdab3d` (amber) instead of stage color
+- No priority: stage color (default)
+
+### Project Links
+Items can link to Leantime projects. On the card footer, this shows as:
+```
+📁 Project Name
+```
+- Icon: folder (7px)
+- Text: 10px, truncated with ellipsis at 150px max-width
+- Background: 7% tint of accent color
+- Color: accent blue (`#00456e`)
+- Click: navigates to the linked project
+- Only visible in plugin mode on active stage cards
+
+### Item-Level Progress Indicators
+For quantifiable items, a mini progress bar appears below the description:
+```
+87/120                    ████████░░░░  72%
+```
+- Current value / target value on the left
+- 3px bar in the middle
+- Percentage on the right (bold, accent green)
+- Only visible in plugin mode on active stage cards
+
+---
+
+## 6. Export Dropdown
+
+Replace the core Print button with an Export button (in plugin mode only).
+
+### Dropdown
+```
+┌─────────────────────┐
+│ 🖼  Export as PNG    │
+│ 📄 Export as PDF    │
+│ 🖨  Print           │
+└─────────────────────┘
+```
+
+- PNG: high-resolution image capture of the full board
+- PDF: formatted document with layout optimization
+- Print: browser native print dialog
+
+Core mode continues to show only the Print button.
+
+---
+
+## 7. Board Templates
+
+Templates change stage titles, subtitles, and narrative template while keeping the five-stage structure.
+
+### Available Templates
+
+| Template | Stage 1 | Stage 2 | Stage 3 | Stage 4 | Stage 5 |
+|----------|---------|---------|---------|---------|---------|
+| **Standard Logic Model** (default) | Inputs | Activities | Outputs | Outcomes | Impact |
+| Theory of Change | Problem | Root Causes | Interventions | Outcomes | Long-term Change |
+| Results Framework | Resources | Processes | Deliverables | Results | Goals |
+| Impact Pathway | Needs | Strategies | Milestones | Changes | Vision |
+| Program Logic | Investments | Actions | Products | Effects | Impact |
+
+### Subtitles per Template
+Each template defines its own subtitle text for each stage. Define these as constants.
+
+### Selection
+- Selected during logic model creation
+- Can be changed in model settings
+- Changing template updates titles and subtitles but does NOT delete or move items
+
+---
+
+## 8. Snapshot Versioning
+
+### Purpose
+Save point-in-time snapshots of the logic model for grant reporting, board meetings, or milestone documentation.
+
+### Behavior
+- Manual save: user clicks "Save Snapshot" from model settings or export menu
+- Snapshot captures: all items, all statuses, all health badges, progress bar state, narrative text
+- Snapshots are read-only historical records
+- Users can view and compare past snapshots
+
+---
+
+## 9. Activity Log Data Capture
+
+**CRITICAL:** Begin capturing activity log data in Phase 2, even though the UI ships in Phase 3.
+
+### Events to Capture
+
+| Event | Data |
+|-------|------|
+| Item created | item_id, stage, title, created_by, timestamp |
+| Item edited | item_id, field_changed, old_value, new_value, edited_by, timestamp |
+| Item deleted | item_id, stage, title, deleted_by, timestamp |
+| Status changed | item_id, old_status, new_status, changed_by, timestamp |
+| Priority changed | item_id, old_priority, new_priority, changed_by, timestamp |
+| Project linked | item_id, project_id, linked_by, timestamp |
+| Project unlinked | item_id, project_id, unlinked_by, timestamp |
+| Health badge changed | from_stage, old_health, new_health, changed_by, timestamp |
+| Snapshot saved | snapshot_id, saved_by, timestamp |
+| Template changed | old_template, new_template, changed_by, timestamp |
+
+Store as JSON detail in the activity_log table (see `04-DATA-MODEL.md`).
+
+---
+
+## 10. Plugin Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| Board template | Select (5 options) | Standard Logic Model | Framework template |
+| Stakeholder visibility | Select | Project team | Who can view/edit |
+| Notification preferences | Multi-select | Email on red | Alert triggers |
+| Auto-link suggestions | Toggle | On | Suggest project links by title match |
+| Validation workflow | Toggle | Off | Require sign-off for status transitions |
+| Snapshot mode | Select | Manual | When to auto-save snapshots |
+| Default assignee per stage | User select × 5 | Creator | Auto-assign new items |
+
+---
+
+## 11. Card Modal Additions (Plugin)
+
+When plugin is active, the card modal (from Phase 1) gains additional sections:
+
+### Evidence & Assumptions
+- Section for attaching evidence supporting or contradicting the hypothesis
+- Links to documents, data, research
+- Feeds into health badge system
+
+### Project Links
+- Search and link Leantime projects
+- Shows entity type (milestone, KPI, goal) in the modal — simplified to folder icon on the board card
+
+### Progress Indicator
+- For quantifiable items: current value, target value, unit
+- Visual bar showing progress toward target
+
+### Priority Selector
+- High / Medium / None
+- Affects card border color on the board

--- a/Docs/03-COPILOT.md
+++ b/Docs/03-COPILOT.md
@@ -1,0 +1,222 @@
+# Phase 3: AI Copilot
+
+## Summary
+
+The AI copilot is a conversational assistant embedded in the logic model canvas that analyzes model state, identifies gaps, provides strategic suggestions, and surfaces an activity audit trail. It lives in a side panel triggered by a floating button.
+
+**Prerequisite:** Phase 2 (Strategy Plugin) must be complete, including activity log data capture.
+
+---
+
+## 1. Trigger Button
+
+### Position
+Fixed position, bottom-right corner (20px from edges). Always visible when plugin is active.
+
+### Visual
+- Size: 44px × 44px
+- Border radius: 12px
+- Background: gradient from `#00456e` to `#00aa64`
+- Icon: sparkle/AI icon, white, 16px
+- Shadow: `0 8px 32px rgba(0,0,0,0.10)`
+
+### Notification Dot
+- Position: top-right corner of button (-2px offset)
+- Size: 10px circle
+- Color: `#BB1B25` (red) with 2px white border
+- Visible when AI has a proactive suggestion
+
+### Hover Preview
+On hover, a dark tooltip card appears above the button showing the most relevant AI insight:
+
+```
+┌─────────────────────────────────┐
+│ Your Outputs → Outcomes link    │  ← Bold, white
+│ has a gap                       │
+│                                 │
+│ No measurement plan defined yet │  ← 11px, muted
+│                                 │
+│ ✓ Walk me through this          │  ← Quick action options
+│ ✓ What needs attention?         │
+│ ✓ Help me fill gaps             │
+└─────────────────────────────────┘
+```
+
+- Background: `#1e2b38` (dark primary)
+- Width: 240px
+- Arrow pointing down to the button
+
+---
+
+## 2. Side Panel
+
+### Opening
+Click the trigger button to open. Panel slides in from the right.
+
+### Layout
+- Width: 360px (or 30% of viewport, whichever is larger, max 440px)
+- Height: full viewport
+- Background: white
+- Shadow: left edge shadow
+- Z-index above the board but below modals
+
+### Tabs
+Two tabs at the top of the panel:
+
+| Tab | Purpose |
+|-----|---------|
+| **Chat** | Conversational AI interface |
+| **Activity** | Chronological audit trail |
+
+---
+
+## 3. Chat Tab
+
+### Interface
+Standard chat interface:
+- Message history (scrollable)
+- Text input at bottom with send button
+- AI responses in styled bubbles
+- User messages in simpler bubbles
+
+### AI Capabilities
+
+The copilot can:
+
+1. **Analyze model state** — "What's the current state of my logic model?"
+2. **Identify gaps** — "What needs attention?" / surfaces health badge issues
+3. **Suggest items** — "What inputs am I missing?" / suggests based on activities
+4. **Validate assumptions** — "Is my theory of change sound?"
+5. **Refine narrative** — "Help me rewrite my theory of change"
+6. **Reference history** — "What changed last week?" / uses activity log
+7. **Compare snapshots** — "How has the model evolved since January?"
+8. **Guided walkthrough** — "Walk me through this view" / stage-by-stage tour
+
+### Suggested Actions
+When the panel first opens (or on a fresh conversation), show quick-action buttons:
+
+- Walk me through this view
+- What needs attention?
+- Help me fill gaps
+- Refine my narrative
+
+These seed the conversation with common starting points.
+
+### Context Awareness
+The AI always has access to:
+- All items across all stages (titles, descriptions, statuses)
+- Health badge states and assumption text
+- Progress bar percentages
+- Activity log history
+- Current template type
+- Narrative text
+
+---
+
+## 4. Activity Tab
+
+### Purpose
+Chronological audit trail of every change to the logic model. This is the UI for the activity log data captured in Phase 2.
+
+### Entry Format
+```
+┌─────────────────────────────────────┐
+│ GF changed status                    │
+│ "$250K annual budget"                │
+│ Draft → Validated: Valid             │
+│ 2 hours ago                          │
+├─────────────────────────────────────┤
+│ MJ added item                        │
+│ "1 Director, 3 Specialists..."       │
+│ Added to Inputs                      │
+│ Yesterday at 3:42 PM                 │
+├─────────────────────────────────────┤
+│ TS linked project                    │
+│ "1-on-1 tutoring 3x per week"       │
+│ Linked to "Tutoring Program"         │
+│ Feb 10 at 10:15 AM                   │
+└─────────────────────────────────────┘
+```
+
+### Entry Elements
+- **Avatar + name** — who made the change
+- **Action** — what happened (changed status, added item, linked project, etc.)
+- **Item context** — which item was affected (title, truncated)
+- **Detail** — specific change (old → new for status changes, stage name for additions)
+- **Timestamp** — relative ("2 hours ago") or absolute ("Feb 10 at 10:15 AM")
+
+### Filtering
+- Filter by action type (status changes, additions, edits, links)
+- Filter by user
+- Filter by stage
+- Date range selector
+
+### Versioning Integration
+Snapshots appear in the activity log as milestone markers:
+```
+┌─────────────────────────────────────┐
+│ 📸 Snapshot saved                    │
+│ "Q1 Board Meeting Version"           │
+│ by GF — Feb 8 at 9:00 AM            │
+│ [View Snapshot]                      │
+└─────────────────────────────────────┘
+```
+
+---
+
+## 5. Notification System
+
+### Proactive Insights
+The AI periodically analyzes the model and generates insights. When a new insight is available:
+1. Red notification dot appears on the trigger button
+2. Hover preview shows the insight
+3. Clicking the button opens the chat with the insight as the first message
+
+### Insight Triggers
+
+| Trigger | Example Insight |
+|---------|----------------|
+| Health badge at "Gap" | "Your Outputs → Outcomes connection has a gap. No measurement plan defined." |
+| Stage has 0 validated items | "None of your Activities have been validated yet. Consider reviewing evidence." |
+| Item stuck in Draft > 14 days | "3 items in Outcomes have been in Draft for over 2 weeks." |
+| Progress bar regression | "Inputs progress dropped from 75% to 50% after a status change." |
+| Imbalanced stages | "You have 6 Inputs but only 1 Impact item. Consider whether your impact is fully defined." |
+
+### Notification Behavior
+- Only one insight at a time (most relevant)
+- Dismissable (clicking the button clears the dot)
+- Does not interrupt workflow — passive notification only
+- Frequency cap: max 1 new insight per session
+
+---
+
+## 6. Technical Requirements
+
+### AI Service
+- Requires AI service configuration (API key, model selection)
+- Copilot features hidden if AI service is not configured
+- Graceful degradation: activity log tab works without AI service, chat tab shows "Configure AI to enable" message
+
+### Context Window
+The copilot sends the full model state as context with each message:
+- All items (id, title, description, status, stage, priority)
+- Health badges (from_stage, status, assumption_text)
+- Progress percentages per stage
+- Recent activity log entries (last 50)
+- Current template type
+- Narrative text
+
+### Performance
+- Chat responses should stream (token by token)
+- Activity log should paginate (load 20 entries at a time, load more on scroll)
+- Insight generation runs asynchronously, not blocking the board
+
+---
+
+## 7. ARIA Labels
+
+- Trigger button: `"AI Copilot, 1 new suggestion"`
+- Panel: `"AI Copilot panel"`
+- Chat tab: `"Chat with AI assistant"`
+- Activity tab: `"Activity log, 47 entries"`
+- Activity entry: `"GF changed status of $250K annual budget from Draft to Validated Valid, 2 hours ago"`

--- a/Docs/04-DATA-MODEL.md
+++ b/Docs/04-DATA-MODEL.md
@@ -1,0 +1,206 @@
+# Data Model
+
+## Overview
+
+Data model for the Logic Model Canvas. Tables are organized by phase — Phase 1 tables are required for core functionality, Phase 2 tables are added when the Strategy Plugin is active.
+
+---
+
+## Phase 1 Tables
+
+### logic_models
+
+The top-level entity. One project can have multiple logic models.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| project_id | int (FK) | — | References projects table |
+| name | varchar(255) | — | User-defined model name |
+| template_type | varchar(50) | 'standard' | Phase 2: template selection |
+| active_stage | int | 1 | Currently focused stage (1-5) |
+| created_at | datetime | now | |
+| updated_at | datetime | now | |
+| created_by | int (FK) | — | References users table |
+
+### logic_model_items
+
+Individual items within a stage. Each is a hypothesis.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| logic_model_id | int (FK) | — | References logic_models |
+| stage | int | — | 1-5 (Inputs through Impact) |
+| title | varchar(500) | — | Item hypothesis title |
+| description | text | null | Rich text description |
+| hypothesis_status | varchar(30) | 'draft' | draft, in_review, validated_valid, on_hold, validated_invalid |
+| sort_order | int | 0 | Order within the stage |
+| assigned_to | int (FK) | null | References users table |
+| created_at | datetime | now | |
+| updated_at | datetime | now | |
+| created_by | int (FK) | — | References users table |
+
+### logic_model_item_comments
+
+Reuse Leantime's existing comment system. Link comments to items via the standard module/entity pattern:
+- Module: `logic_model_item`
+- Entity ID: `item.id`
+
+### logic_model_item_attachments
+
+Reuse Leantime's existing attachment/file system. Link files to items via the standard module/entity pattern.
+
+---
+
+## Phase 2 Tables (Plugin)
+
+### logic_model_health
+
+Connection quality between stages. One record per connection (max 4 per model: 1→2, 2→3, 3→4, 4→5).
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| logic_model_id | int (FK) | — | References logic_models |
+| from_stage | int | — | 1-4 (no health badge on stage 5) |
+| health_status | varchar(20) | 'warning' | ok, warning, risk |
+| assumption_text | text | null | Description of assumptions |
+| risk_level | varchar(20) | null | For display in popover |
+| evidence_notes | text | null | Supporting evidence or gaps |
+| updated_at | datetime | now | |
+| updated_by | int (FK) | — | References users table |
+
+### logic_model_item_progress
+
+Quantifiable progress tracking on individual items.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| item_id | int (FK) | — | References logic_model_items |
+| current_value | decimal | 0 | Current measured value |
+| target_value | decimal | — | Goal value |
+| unit | varchar(50) | null | "students", "hours", "%" etc. |
+| updated_at | datetime | now | |
+
+### logic_model_item_priority
+
+Item priority for border color override.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| item_id | int (FK, PK) | — | References logic_model_items |
+| priority | varchar(20) | null | null, 'medium', 'high' |
+
+**Alternative:** Add `priority` column directly to `logic_model_items` table instead of a separate table.
+
+### logic_model_project_links
+
+Links between items and Leantime projects/milestones/goals.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| item_id | int (FK) | — | References logic_model_items |
+| linked_entity_type | varchar(50) | — | 'project', 'milestone', 'goal' |
+| linked_entity_id | int | — | ID of the linked entity |
+| created_at | datetime | now | |
+| created_by | int (FK) | — | References users table |
+
+### logic_model_snapshots
+
+Point-in-time snapshots of the entire model.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| logic_model_id | int (FK) | — | References logic_models |
+| name | varchar(255) | null | User-defined snapshot name |
+| snapshot_data | json/text | — | Full serialized model state |
+| created_at | datetime | now | |
+| created_by | int (FK) | — | References users table |
+
+### logic_model_activity_log
+
+Audit trail for all changes. Begin populating in Phase 2 even though UI ships in Phase 3.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | int (PK) | auto | |
+| logic_model_id | int (FK) | — | References logic_models |
+| item_id | int (FK) | null | Null for model-level events |
+| action_type | varchar(50) | — | See action types below |
+| action_detail | json/text | — | Structured change data |
+| user_id | int (FK) | — | Who made the change |
+| created_at | datetime | now | |
+
+**Action Types:**
+- `item_created`
+- `item_edited`
+- `item_deleted`
+- `status_changed`
+- `priority_changed`
+- `project_linked`
+- `project_unlinked`
+- `health_changed`
+- `snapshot_saved`
+- `template_changed`
+- `model_created`
+- `model_renamed`
+
+**action_detail Example (status_changed):**
+```json
+{
+  "field": "hypothesis_status",
+  "old_value": "draft",
+  "new_value": "validated_valid",
+  "item_title": "$250K annual budget"
+}
+```
+
+---
+
+## Indexes
+
+### Phase 1
+- `logic_models`: index on `project_id`
+- `logic_model_items`: index on `logic_model_id, stage`, index on `logic_model_id, sort_order`
+
+### Phase 2
+- `logic_model_health`: unique index on `logic_model_id, from_stage`
+- `logic_model_project_links`: index on `item_id`, index on `linked_entity_type, linked_entity_id`
+- `logic_model_activity_log`: index on `logic_model_id, created_at DESC`, index on `item_id`
+- `logic_model_snapshots`: index on `logic_model_id, created_at DESC`
+
+---
+
+## Stage Constants
+
+Define these once, reference everywhere:
+
+```php
+const STAGES = [
+    1 => ['key' => 'inputs',     'title' => 'Inputs',     'subtitle' => 'Resources we invest',  'icon' => 'arrow-right-to-bracket', 'color' => '#4A85B5', 'bg' => '#EDF3F8'],
+    2 => ['key' => 'activities',  'title' => 'Activities',  'subtitle' => 'What we do',           'icon' => 'gears',                  'color' => '#3E937A', 'bg' => '#ECF6F2'],
+    3 => ['key' => 'outputs',     'title' => 'Outputs',     'subtitle' => 'What we produce',      'icon' => 'boxes-stacked',          'color' => '#C09035', 'bg' => '#FBF5EA'],
+    4 => ['key' => 'outcomes',    'title' => 'Outcomes',    'subtitle' => 'Changes we expect',    'icon' => 'chart-line',             'color' => '#8E6AAD', 'bg' => '#F2EDF8'],
+    5 => ['key' => 'impact',      'title' => 'Impact',      'subtitle' => 'Ultimate change',      'icon' => 'bullseye',               'color' => '#2D7D5E', 'bg' => '#EAF5F0'],
+];
+
+const TEMPLATES = [
+    'standard'  => ['Inputs', 'Activities', 'Outputs', 'Outcomes', 'Impact'],
+    'toc'       => ['Problem', 'Root Causes', 'Interventions', 'Outcomes', 'Long-term Change'],
+    'results'   => ['Resources', 'Processes', 'Deliverables', 'Results', 'Goals'],
+    'pathway'   => ['Needs', 'Strategies', 'Milestones', 'Changes', 'Vision'],
+    'program'   => ['Investments', 'Actions', 'Products', 'Effects', 'Impact'],
+];
+
+const HYPOTHESIS_STATUSES = [
+    'draft'              => ['label' => 'Draft',              'color' => '#1B75BB'],
+    'in_review'          => ['label' => 'In Review',          'color' => '#F0A030'],
+    'validated_valid'    => ['label' => 'Validated: Valid',    'color' => '#75BB1B'],
+    'on_hold'            => ['label' => 'On Hold',            'color' => '#BB1B25'],
+    'validated_invalid'  => ['label' => 'Validated: Invalid',  'color' => '#BB1B25'],
+];
+```

--- a/Docs/05-VISUAL-REFERENCE.md
+++ b/Docs/05-VISUAL-REFERENCE.md
@@ -1,0 +1,186 @@
+# Visual Reference & Design System
+
+## Overview
+
+This document defines the visual constants, spacing rules, and transition behaviors for the Logic Model Canvas. The definitive source of truth is the v11 HTML prototype (`logic-model-v11.html`).
+
+---
+
+## 1. Color Palette
+
+### Brand Colors
+| Name | Value | Usage |
+|------|-------|-------|
+| Accent Primary | `#00456e` | Header, buttons, links |
+| Accent Secondary | `#00aa64` | Positive indicators, narrative border |
+
+### Text Colors
+| Name | Value | Usage |
+|------|-------|-------|
+| Primary | `#1e2b38` | Headings, titles |
+| Secondary | `#5e6e7d` | Body text, descriptions |
+| Tertiary | `#9aa7b4` | Metadata, timestamps |
+| Muted | `#c3ccd4` | Disabled, inactive elements |
+
+### Surface Colors
+| Name | Value | Usage |
+|------|-------|-------|
+| Background | `#f3f4f6` | Page background |
+| Surface | `#ffffff` | Cards, panels |
+| Border | `#e2e6ea` | Active borders |
+| Border Light | `#eef0f2` | Subtle dividers |
+
+### Stage Colors
+| Stage | Primary | Background Tint |
+|-------|---------|-----------------|
+| 1 - Inputs | `#4A85B5` | `#EDF3F8` |
+| 2 - Activities | `#3E937A` | `#ECF6F2` |
+| 3 - Outputs | `#C09035` | `#FBF5EA` |
+| 4 - Outcomes | `#8E6AAD` | `#F2EDF8` |
+| 5 - Impact | `#2D7D5E` | `#EAF5F0` |
+
+### Status Colors
+| Status | Color |
+|--------|-------|
+| Draft | `#1B75BB` |
+| In Review | `#F0A030` |
+| Validated: Valid | `#75BB1B` |
+| On Hold | `#BB1B25` |
+| Validated: Invalid | `#BB1B25` |
+
+### Health Badge Colors
+| State | Background | Icon/Text | Border |
+|-------|------------|-----------|--------|
+| Strong | `#EAF5E8` | `#5a9e4f` | `#c8e0c2` |
+| Warning | `#FEF4E4` | `#c08a2e` | `#edd9ad` |
+| Gap | `#FDEAEB` | `#BB1B25` | `#edb5b9` |
+
+---
+
+## 2. Border Radii
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| r | 12px | Stage cards, panels |
+| r-sm | 8px | Inner cards, dropdowns, narrative |
+| r-xs | 5px | Item cards, pills |
+| pill | 20px | Buttons, badges, count circles |
+
+---
+
+## 3. Shadows
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| sh-sm | `0 1px 3px rgba(0,0,0,0.04)` | Inactive stages, tabs |
+| sh-md | `0 4px 16px rgba(0,0,0,0.07)` | Hover states |
+| sh-lg | `0 8px 32px rgba(0,0,0,0.10)` | AI trigger, elevated elements |
+| sh-xl | `0 14px 48px rgba(0,0,0,0.13)` | Active stage, dropdowns |
+
+---
+
+## 4. Typography
+
+| Element | Size | Weight | Color |
+|---------|------|--------|-------|
+| Stage title (active) | 16px | 700 (bold) | Primary |
+| Stage title (inactive) | 12px | 600 (semibold) | Primary |
+| Stage subtitle (active) | 11px | 400 | Secondary |
+| Stage subtitle (inactive) | 10px | 400 | Tertiary |
+| Item title | 13px | 600 (semibold) | Primary |
+| Item description | 11px | 400 | Secondary |
+| Compact item title | 11px | 500 (medium) | Secondary |
+| Pill text | 9px | 600 (semibold) | White |
+| Metadata | 10px | 400 | Tertiary |
+| Count badge | 10px (active), 9px (inactive) | 700 | White |
+
+Font stack: `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`
+
+---
+
+## 5. Spacing
+
+| Context | Value |
+|---------|-------|
+| Gap between stage columns | 10px |
+| Gap between item cards | 8px |
+| Stage body padding (top, from header) | 14px |
+| Stage body padding (sides) | 10px |
+| Stage header padding (top, active) | 24px |
+| Stage header padding (top, inactive) | 20px |
+| Narrative to columns margin | 24px |
+| Item card padding | 8px 10px |
+| Compact item padding | 5px 8px |
+| Progress bar horizontal padding | 16px |
+| Max workspace width | 1480px |
+| Workspace side padding | 16px |
+
+---
+
+## 6. Transitions
+
+| Element | Duration | Easing | Properties |
+|---------|----------|--------|------------|
+| Stage focus change | 350ms | `cubic-bezier(0.25, 0.46, 0.45, 0.94)` | transform, opacity, box-shadow, background |
+| Stage hover | 150-200ms | ease | opacity, transform, box-shadow |
+| Progress bar fill | 500ms | ease | width |
+| Count badge appear | 300ms | ease | opacity |
+| Health badge hover | 200ms | ease | transform, box-shadow |
+| Item hover | 150ms | ease | background |
+
+---
+
+## 7. Active vs. Inactive Stage Properties
+
+| Property | Active | Inactive | Hover (inactive) |
+|----------|--------|----------|-------------------|
+| Scale | 1.0 | 0.955 | 0.97 |
+| Opacity | 1.0 | 0.5 | 0.78 |
+| Shadow | sh-xl | sh-sm | sh-md |
+| Background | Gradient (tint → white) | White | White |
+| Header border | 3px, stage color | 2px, border-light | 2px, border-light |
+| Icon size | 36px | 28px | 28px |
+| Icon style | Filled (stage color bg, white icon) | Tint (tint bg, stage color icon) | Tint |
+| Items | Expanded cards | Compact dot + title | Compact dot + title |
+| Focus flag | Visible | Hidden | Hidden |
+| Add button | Visible | Hidden | Hidden |
+| Z-index | 10 | 1 | 1 |
+
+---
+
+## 8. Responsive Breakpoints
+
+| Breakpoint | Behavior |
+|------------|----------|
+| > 1100px | Five columns, `flex: 1 1 0`, side by side |
+| 600–1100px | `flex-wrap: wrap`, stages become `flex: 1 1 calc(50% - 4px)`, 2 per row |
+| < 600px | Single column stack, active stage appears first |
+
+---
+
+## 9. Entry Animation
+
+Stages animate in on page load:
+```css
+@keyframes enter {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.stage { animation: enter 350ms ease both; }
+```
+
+Each stage can be staggered with `animation-delay` for a cascade effect.
+
+---
+
+## 10. Status Dot Colors (Compact View)
+
+| Status | Dot Color |
+|--------|-----------|
+| Draft | `#c3ccd4` (muted) |
+| In Review | `#1B75BB` (blue) |
+| Validated: Valid | `#75BB1B` (green) |
+| On Hold | `#BB1B25` (red) |
+| Validated: Invalid | `#BB1B25` (red) |
+
+Dots are 8px circles with `border-radius: 50%`, positioned inline before the title text with 5px right margin.

--- a/Docs/06-CARD-MODAL.md
+++ b/Docs/06-CARD-MODAL.md
@@ -1,0 +1,184 @@
+# Card Modal & Detail View
+
+## Status
+
+**Phase 1:** Core modal sections defined and ready for implementation.
+**Phase 2:** Plugin modal additions defined. Detailed interaction design for evidence, project links, and progress to be finalized during Phase 2 development.
+
+---
+
+## 1. Opening Behavior
+
+- Click an item card on the board → modal opens
+- Use Leantime's existing modal/slide-over system
+- Modal should not close the active stage or change board state
+
+---
+
+## 2. Core Modal Layout (Phase 1)
+
+```
+┌─────────────────────────────────────────────────┐
+│  ✕                                               │
+│                                                   │
+│  ┌─ Stage pill ─┐   ┌─ Status dropdown ──┐  ⋯  │
+│  │ Inputs       │   │ In Review ▾        │      │
+│  └──────────────┘   └────────────────────┘      │
+│                                                   │
+│  Title (editable)                                │
+│  ─────────────────────────────────────           │
+│  $250K annual budget                             │
+│                                                   │
+│  Description                                     │
+│  ─────────────────────────────────────           │
+│  Federal Title I funding for after-school        │
+│  programming across 3 community centers.         │
+│  [Rich text editor]                              │
+│                                                   │
+│  ─────────────────────────────────────           │
+│  Assigned to: [GF ▾]     Created: Feb 1, 2026   │
+│                                                   │
+│  ─── Comments ─────────────────────────          │
+│  GF: Budget confirmed by finance team.           │
+│  MJ: Need to verify carry-over amount.           │
+│  [Add comment...]                                │
+│                                                   │
+│  ─── Attachments ──────────────────────          │
+│  📎 Budget_Approval_2026.pdf                     │
+│  [Add attachment]                                │
+│                                                   │
+└─────────────────────────────────────────────────┘
+```
+
+### Sections
+
+1. **Header bar**
+   - Stage label: colored pill (read-only), shows which stage this item belongs to
+   - Hypothesis status: clickable dropdown pill (same as board card)
+   - Three-dot menu: Edit title, Move to different stage, Delete item
+   - Close button (✕)
+
+2. **Title**
+   - Editable inline (click to edit)
+   - 18-20px, bold
+   - Auto-saves on blur
+
+3. **Description**
+   - Rich text editor (match Leantime's existing editor)
+   - Markdown supported
+   - Auto-saves or explicit save button (match existing pattern)
+
+4. **Meta row**
+   - Assignee selector (dropdown of project team members)
+   - Created date (read-only)
+   - Last modified date (read-only)
+
+5. **Comments**
+   - Threaded discussion
+   - Uses Leantime's existing comment system
+   - Module: `logic_model_item`, entity: item ID
+
+6. **Attachments**
+   - File upload area
+   - Uses Leantime's existing attachment system
+   - Module: `logic_model_item`, entity: item ID
+
+---
+
+## 3. Plugin Modal Additions (Phase 2)
+
+When the Strategy Plugin is active, additional sections appear in the modal:
+
+### Evidence & Assumptions
+Position: below description, above meta row.
+
+```
+│  ─── Evidence & Assumptions ───────────          │
+│                                                   │
+│  📄 Title I Grant Approval Letter                │
+│     Uploaded Feb 1 — confirms $250K              │
+│                                                   │
+│  🔗 District Budget Dashboard                    │
+│     External link — shows allocation              │
+│                                                   │
+│  [+ Add evidence]                                │
+│                                                   │
+│  Assumptions:                                    │
+│  "Federal funding continues at current levels    │
+│   through FY2027"                                │
+│  Risk: Medium                                    │
+```
+
+- List of evidence items (documents, links, notes)
+- Each with a title and brief description
+- Assumption text (feeds into health badges)
+- Risk level tag
+
+### Project Links
+Position: below evidence section.
+
+```
+│  ─── Linked Projects ─────────────────           │
+│                                                   │
+│  📁 Secure Funding Q1                            │
+│     Milestone · 3 tasks · 67% complete           │
+│     [View project →]                             │
+│                                                   │
+│  [🔍 Link a project...]                          │
+```
+
+- Shows linked projects with entity type detail (milestone, KPI, goal)
+- Click to navigate to the project
+- Search interface to link new projects
+- On the board card, this simplifies to just `📁 Project Name`
+
+### Progress Indicator
+Position: below title (for quantifiable items only).
+
+```
+│  Progress                                        │
+│  87 / 120 students         ████████░░░░  72%    │
+│  [Edit target]                                   │
+```
+
+- Current value (editable)
+- Target value (editable)
+- Unit label
+- Visual bar
+- Only shown when item has a target value defined
+
+### Priority Selector
+Position: in the header bar or meta row.
+
+```
+│  Priority: [High ▾]                              │
+```
+
+- Options: None, Medium, High
+- Affects border color on the board card
+
+---
+
+## 4. Move Item Between Stages
+
+From the three-dot menu → "Move to..." → dropdown shows all five stages → select target stage → item moves immediately.
+
+The item retains its status, description, comments, and attachments when moved. Sort order is set to the end of the target stage.
+
+---
+
+## 5. Delete Item
+
+From the three-dot menu → "Delete" → confirmation dialog → item removed.
+
+Deletion is logged in the activity log (Phase 2).
+
+---
+
+## 6. Keyboard Shortcuts (Modal)
+
+| Key | Action |
+|-----|--------|
+| Escape | Close modal |
+| Tab | Move between sections |
+| Cmd/Ctrl + Enter | Save and close |

--- a/Docs/07-leantime-core-WORKSTRUCTURE.md
+++ b/Docs/07-leantime-core-WORKSTRUCTURE.md
@@ -1,0 +1,707 @@
+# WorkStructure Core + Content-to-Work Wizard
+
+**Product Requirements Document**
+
+| Field | Value |
+|---|---|
+| Product | Leantime |
+| Feature | WorkStructure Core + Content-to-Work Wizard |
+| Version | 3.0 |
+| Date | February 20, 2026 |
+| Author | Gloria Folaron |
+| Status | Draft |
+| Core Domain | `app/Domain/WorkStructure/` |
+| Plugin Layer | StrategyPro, Copilot, future plugins |
+| Prerequisites | Phase 1: Core Logic Model Board |
+
+---
+
+## 1. Overview
+
+### 1.1 Problem Statement
+
+Leantime users define strategy through boards (Logic Model Canvas, Ideas Board, Goal Canvas) and need to translate that thinking into actionable work. Today this requires manual re-entry. But beyond the creation problem, there is no standard way for any part of Leantime to describe a bundle of work — its milestones, tasks, goals, relationships, and context — in a portable, normalized format. Every feature that needs to create, read, or present work structures reinvents its own approach.
+
+### 1.2 Solution
+
+Two layers:
+
+**Layer 1 — WorkStructure (Core Domain):** A normalized interchange format for describing work and a generator service for creating Leantime entities from it. This lives in core and provides anchor points that any plugin can hook into.
+
+**Layer 2 — Plugin Implementations:** Source adapters (Logic Model, Ideas, Goals), wizard UIs, Copilot flows, and view renderers. Each plugin produces or consumes WorkStructures through the core anchor.
+
+### 1.3 The Anchor Metaphor
+
+WorkStructure is a tow truck anchor in core. Plugins hook into it and build on top. The anchor does not know about Logic Models, Ideas, Copilot, or stakeholder dashboards. It only knows the shape of work and how to create it or describe it.
+
+> **Core provides the hitch point. Plugins bring the vehicle.**
+>
+> Write direction: any adapter → WorkStructure → WorkGenerator → creates entities.
+> Read direction: existing project → WorkStructure → any renderer → presents work.
+> Same shape, opposite flow. One interchange format serves all directions.
+
+### 1.4 Design Principles
+
+- **Core is thin.** WorkStructure defines the contract and provides the generator. No UI, no board-specific logic, no wizard steps.
+- **Plugins are thick.** All board-specific adapters, wizard flows, Copilot conversations, and view renderers live in plugins.
+- **Canvas is source of truth.** Adapters read from boards; they never maintain parallel data models.
+- **Two entry points, one outcome.** Manual fill and Copilot guided flow both produce WorkStructures that feed the same generator.
+- **Bidirectional by design.** WorkStructure supports both writing new work and reading existing work, enabling creation and presentation through the same format.
+
+### 1.5 Relationship to Existing PRDs
+
+This document extends the Logic Model Canvas PRD (Docs/00 through 06). It covers the core WorkStructure domain and the first plugin implementation (StrategyPro wizard). It does not duplicate the core board spec, plugin features, or Copilot conversation design.
+
+---
+
+## 2. Core Domain: WorkStructure
+
+### 2.1 Domain Location
+
+The WorkStructure domain lives at `app/Domain/WorkStructure/` alongside the existing 56 domain modules. It follows the standard Leantime domain structure: Services, Models, Repositories, Contracts.
+
+```
+app/Domain/WorkStructure/
+├── Contracts/
+│   └── WorkStructureAdapter.php       # Interface for source adapters
+├── Models/
+│   ├── WorkStructure.php              # The normalized work bundle
+│   ├── ProposedMilestone.php
+│   ├── ProposedTask.php
+│   ├── ProposedGoal.php
+│   ├── ProposedResource.php
+│   ├── SourceMeta.php
+│   ├── RoutingDecision.php
+│   └── EntityLink.php
+├── Services/
+│   ├── WorkGenerator.php              # Write direction: WorkStructure → entities
+│   ├── WorkStructureReader.php        # Read direction: entities → WorkStructure
+│   └── AdapterRegistry.php            # Discovers registered adapters
+├── Repositories/
+│   └── EntityLinkRepository.php       # Generic entity link storage
+├── Events/
+│   ├── WorkStructureCreated.php
+│   ├── WorkGenerationStarted.php
+│   ├── WorkGenerationCompleted.php
+│   ├── WorkGenerationFailed.php
+│   ├── EntityLinked.php
+│   ├── EntityUnlinked.php
+│   └── WorkStructureRead.php
+└── register.php
+```
+
+### 2.2 The WorkStructure Contract
+
+WorkStructure is a normalized data object that describes a proposed or existing bundle of work. It is the interface between producers (adapters, project readers) and consumers (generators, renderers).
+
+#### WorkStructure Shape
+
+| Property | Type | Purpose |
+|---|---|---|
+| id | string\|null | Null for proposed work, populated for existing work reads |
+| title | string | Project or work bundle name |
+| objective | string | Strategic objective / north star description |
+| source | SourceMeta | Where this structure came from (board type, board ID, adapter) |
+| routing | RoutingDecision | What kind of entity to create (project, program, strategy, in-place) |
+| milestones | ProposedMilestone[] | Proposed or existing milestones |
+| tasks | ProposedTask[] | Proposed or existing tasks, each referencing a parent milestone |
+| goals | ProposedGoal[] | Proposed or existing goals with metric definitions |
+| resources | ProposedResource[] | Dependencies, budget items, team requirements |
+| links | EntityLink[] | Bidirectional links between source items and work entities |
+| metadata | array | Extensible key-value pairs for plugin-specific data |
+
+#### SourceMeta
+
+| Property | Type | Purpose |
+|---|---|---|
+| boardType | string | Canvas type identifier (e.g., 'logicmodel', 'ideas', 'goalcanvas') |
+| boardId | int | The specific board instance ID |
+| adapterClass | string | Fully qualified class name of the adapter that produced this |
+| generatedAt | datetime\|null | When this structure was produced |
+| generatedBy | int\|null | User who triggered production |
+
+#### RoutingDecision
+
+| Property | Type | Purpose |
+|---|---|---|
+| type | enum | Values: `in_place`, `project`, `program`, `strategy` |
+| parentId | int\|null | Parent entity ID (project, program, or strategy to nest under) |
+| projectId | int\|null | Existing project ID for `in_place` routing |
+
+#### Sub-object Field Mapping
+
+Each sub-object (ProposedMilestone, ProposedTask, ProposedGoal, ProposedResource) carries the fields needed for entity creation, plus a `sourceItemId` that traces back to the originating board item. Field shapes map to existing Leantime service method parameters (`Tickets::quickAddMilestone`, `Tickets::quickAddTicket`, `Goalcanvas::createGoal`).
+
+### 2.3 WorkStructureAdapter Interface
+
+The core domain defines an interface that any plugin can implement to produce WorkStructures from board data:
+
+```php
+interface WorkStructureAdapter
+{
+    /** Board type identifier (e.g., 'logicmodel', 'ideas') */
+    public function getSourceType(): string;
+
+    /** Can this board produce a meaningful WorkStructure? */
+    public function canAdapt(int $boardId): bool;
+
+    /** Evaluate what's populated vs. missing */
+    public function assessCompleteness(int $boardId): CompletenessReport;
+
+    /** Read the board and produce a normalized WorkStructure */
+    public function adapt(int $boardId): WorkStructure;
+}
+```
+
+Plugins register their adapters through Leantime's event system. The core domain maintains a registry of available adapters via `AdapterRegistry`, allowing any part of the system to discover what boards can produce WorkStructures.
+
+### 2.4 WorkGenerator Service
+
+Takes a WorkStructure and creates Leantime entities. Thin orchestration over existing services:
+
+| Method | What It Does | Services Called |
+|---|---|---|
+| `generate(WorkStructure)` | Full generation: creates all entities | Orchestrates all methods below in order |
+| `createProject(WorkStructure)` | Creates the project entity | `Projects::addProject()` |
+| `createMilestones(projectId, Milestone[])` | Creates milestones under the project | `Tickets::quickAddMilestone()` |
+| `createTasks(projectId, Task[])` | Creates tasks under their milestones | `Tickets::quickAddTicket()` |
+| `createGoals(projectId, Goal[])` | Creates a goal board and goals | `Goalcanvas::createGoalboard()`, `createGoal()` |
+| `recordLinks(EntityLink[])` | Records source-to-entity links | Inserts into entity links table |
+
+The `generate()` method respects the routing decision: `in_place` skips project creation and uses the existing project ID; `project`, `program`, and `strategy` create the appropriate entity type in `zp_projects` with the correct `type` and `parent` fields.
+
+### 2.5 WorkStructureReader Service
+
+The reverse operation: reads existing Leantime entities and produces a WorkStructure. This enables the read direction — any renderer can consume the same format.
+
+| Method | What It Does | Sources |
+|---|---|---|
+| `fromProject(projectId)` | Reads a full project into a WorkStructure | Project, its milestones, tasks, goals, links |
+| `fromMilestone(milestoneId)` | Reads a single milestone scope | Milestone, its tasks, related goals |
+| `fromProgram(programId)` | Reads a program with child projects | Program entity, child projects via parent FK |
+
+This is the anchor for view-only plugins, stakeholder dashboards, reporting tools, and any feature that needs to present work status without knowing the internal entity model.
+
+### 2.6 Entity Links Table
+
+The core domain owns a generic entity linking table that tracks bidirectional connections between source items and work entities:
+
+| Field | Type | Purpose |
+|---|---|---|
+| id | int (PK) | Auto-increment |
+| source_type | varchar(50) | Source system: 'logicmodel', 'ideas', 'goalcanvas', etc. |
+| source_item_id | int | ID in the source system |
+| target_entity_type | varchar(50) | Leantime entity: 'project', 'milestone', 'ticket', 'goal' |
+| target_entity_id | int | ID of the Leantime entity |
+| link_type | varchar(30) | Relationship: 'generated_from', 'maps_to', 'tracks' |
+| created_by | int (FK) | User who created the link |
+| created_at | datetime | Timestamp |
+
+> **Why Entity Links Live in Core**
+>
+> Entity links are not Logic Model–specific. An Ideas board item linked to a task, a Goal canvas goal linked to a milestone, a stakeholder view linked to a project — these all need the same table. Putting it in core means every plugin uses the same linking mechanism, and queries like "show me everything linked to this milestone" work across all source types.
+
+---
+
+## 3. Core Events
+
+The WorkStructure domain dispatches class-based events (following the migration direction documented in CLAUDE.md) that any plugin can listen to:
+
+| Event Class | When Fired | Payload |
+|---|---|---|
+| WorkStructureCreated | An adapter produces a new WorkStructure | WorkStructure, source info, user |
+| WorkGenerationStarted | `generate()` is called | WorkStructure, routing decision, user |
+| WorkGenerationCompleted | All entities successfully created | WorkStructure with populated entity IDs, user |
+| WorkGenerationFailed | Entity creation failed | WorkStructure, error details, partial results |
+| EntityLinked | A source-to-entity link is recorded | Link details |
+| EntityUnlinked | A link is removed | Link details |
+| WorkStructureRead | `fromProject`/`fromMilestone`/`fromProgram` called | WorkStructure, reader context |
+
+These events are the hook points for plugins. StrategyPro listens to `WorkGenerationCompleted` to record activity log entries. Copilot listens to `WorkStructureCreated` to log conversation context alongside the structure. A future analytics plugin could listen to `WorkStructureRead` to track stakeholder dashboard views.
+
+---
+
+## 4. Strategy Plugin: Logic Model Wizard
+
+The first consumer of the core WorkStructure domain. Lives entirely in `app/Plugins/StrategyPro/`.
+
+### 4.1 Entry Points
+
+**Entry Point A: Manual Fill, Then Generate.** User fills out the Logic Model Canvas through the standard board UI. When ready, they click "Create Work from Canvas" in the board toolbar (visible when Strategy Plugin is active). This launches the translation wizard with canvas data pre-loaded.
+
+**Entry Point B: Copilot Guided Flow (Phase 3).** The Copilot walks the user through filling the canvas conversationally, then suggests creating work. Both paths produce the same WorkStructure through the Logic Model adapter.
+
+### 4.2 Logic Model Source Adapter
+
+The StrategyPro plugin registers a `LogicModelAdapter` that implements the core `WorkStructureAdapter` interface:
+
+| Canvas Stage | WorkStructure Property | Mapping |
+|---|---|---|
+| Impact (Stage 5) | `objective` | Item title → strategic objective / project description |
+| Outcomes (Stage 4) | `goals[]` | Each item → goal with metrics (startValue, endValue, metricType) |
+| Activities (Stage 2) | `milestones[]` | Each item → milestone with timeframe mapping |
+| Outputs (Stage 3) | `tasks[]` | Each item → task, grouped under parent Activity's milestone |
+| Inputs (Stage 1) | `resources[]` | Items → resource notes, budget entries, team requirements |
+
+The adapter's `assessCompleteness()` method evaluates which stages have items and returns a report that drives wizard weight (see 4.4).
+
+### 4.3 Translation Wizard (4 Steps)
+
+**Step 1 — Scope Confirmation:** Shows Activities mapped as proposed milestones. User can reorder, group/split activities, set timeframes, or remove items.
+
+**Step 2 — Deliverables & Tasks:** For each confirmed milestone, shows associated Outputs as proposed tasks. User can add, edit, remove tasks, assign owners, flag dependencies.
+
+**Step 3 — Success Criteria:** Maps Outcomes to goals on the Goalcanvas. User confirms goal-to-milestone links, sets metric types and targets, adds qualitative definitions.
+
+**Step 4 — Review & Generate:** Tree view of the complete proposed structure. Includes routing decision. One-click "Generate" calls `WorkGenerator.generate()` with the confirmed WorkStructure.
+
+### 4.4 Adaptive Wizard Weight
+
+| Canvas State | Wizard Behavior | Duration |
+|---|---|---|
+| Rich (4–5 stages, multiple items) | Single review screen, expandable sections | 30–60 seconds |
+| Moderate (2–3 stages) | Full 4-step flow, pre-filled where data exists | 2–4 minutes |
+| Sparse (0–1 stages) | Extended flow with prompts for missing data | 5–10 minutes |
+| Lightweight escape | Skip wizard, create minimal project shell | Instant |
+
+### 4.5 Routing Decision
+
+Before generation, the wizard asks what kind of work to create:
+
+| Option | Entity Type | Plugin Required | zp_projects Fields |
+|---|---|---|---|
+| Work in current project | `in_place` | None | Uses `session('currentProject')` |
+| Its own project | `project` | None | `type='project'`, optional parent |
+| A program | `program` | PgmPro | `type='program'`, parent=strategy |
+| A strategic initiative | `strategy` | StrategyPro | `type='strategy'`, auto-creates focus areas |
+
+Options 3 and 4 only appear when their plugins are active. The routing decision is stored in the WorkStructure's `RoutingDecision` and passed to the core `WorkGenerator`.
+
+### 4.6 Living Link
+
+After generation, StrategyPro maintains bidirectional connections through the core entity links table.
+
+**Forward (Canvas → Work):** Canvas items show a linked entity indicator (folder icon + name in card footer). Card modal shows full link details. Click navigates to the linked project, milestone, or goal.
+
+**Backward (Work → Canvas):** Project dashboard shows "Strategy Source" link to the Logic Model. Milestone detail shows originating Activity item. Goal detail shows originating Outcome item.
+
+**Change Detection:** When canvas items with linked entities are modified, StrategyPro fires a notification: "Your Logic Model has changed. Activity X is linked to Milestone Y. Review impact?" Links to a diff view. User can update entities, dismiss, or unlink.
+
+**Regeneration:** For major canvas changes, user can re-run the wizard. It detects existing links and offers three paths: update existing entities, add new for new canvas items, or archive and replace.
+
+---
+
+## 5. Wizard Component Architecture
+
+The wizard UI is built with Blade components and HTMX, targeting the architecture direction documented in CLAUDE.md: components for reusable entities, HTMX for async loading, Blade for all new templates.
+
+### 5.1 Plugin File Structure
+
+```
+app/Plugins/StrategyPro/
+├── Hxcontrollers/
+│   └── Wizard/
+│       ├── Start.php                  # Launches wizard, runs adapter
+│       ├── ScopeStep.php              # Step 1: milestone confirmation
+│       ├── DeliverablesStep.php       # Step 2: task mapping
+│       ├── CriteriaStep.php           # Step 3: goal mapping
+│       ├── ReviewStep.php             # Step 4: review + generate
+│       └── Routing.php                # Routing decision handler
+├── Templates/
+│   ├── components/
+│   │   ├── wizard-shell.blade.php     # Outer wizard frame + progress
+│   │   ├── wizard-step.blade.php      # Step wrapper with nav
+│   │   ├── milestone-row.blade.php    # Draggable milestone item
+│   │   ├── task-row.blade.php         # Task item within milestone
+│   │   ├── goal-row.blade.php         # Goal mapping row
+│   │   ├── resource-note.blade.php    # Resource/dependency item
+│   │   ├── entity-tree.blade.php      # Review tree view
+│   │   ├── routing-picker.blade.php   # Routing decision selector
+│   │   ├── completeness-badge.blade.php # Canvas readiness indicator
+│   │   └── entity-link-badge.blade.php  # Linked entity indicator for cards
+│   └── partials/
+│       ├── wizard-scope.blade.php     # Step 1 content
+│       ├── wizard-deliverables.blade.php # Step 2 content
+│       ├── wizard-criteria.blade.php  # Step 3 content
+│       └── wizard-review.blade.php    # Step 4 content
+├── Services/
+│   ├── LogicModelAdapter.php          # Implements WorkStructureAdapter
+│   └── WizardStateService.php         # Cache-based wizard state
+├── Events/
+│   └── Htmx/
+│       └── HtmxWizardEvents.php       # HTMX event enum
+└── register.php
+```
+
+### 5.2 Composing from Shared Components
+
+The wizard composes from existing `app/Views/Templates/components/` rather than reinventing UI primitives:
+
+| Shared Component | Usage in Wizard |
+|---|---|
+| `<x-global::elements.card>` | Wraps each wizard step content area, uses `header` and `actions` slots for step title and nav buttons |
+| `<x-global::selectable>` | Routing decision picker (radio-style selection cards for "What kind of work is this?") |
+| `<x-global::progress>` | Wizard step progress bar (value=currentStep, max=totalSteps) |
+| `<x-global::elements.button-group>` | Step navigation (Back / Next / Generate) |
+| `<x-global::button>` | Primary and secondary actions within steps |
+| `<x-global::accordion>` | Collapsed milestone sections in the review step |
+| `<x-global::forms.select>` | Milestone timeframe pickers, assignee dropdowns |
+| `<x-global::forms.input>` | Inline editing of milestone/task titles |
+| `<x-global::forms.checkbox>` | Item selection for what to include in generation |
+| `<x-global::elements.empty-state>` | Shown when a stage has no items to map |
+| `<x-global::elements.status-indicator>` | Canvas completeness per stage |
+| `<x-global::loader>` | Generation in-progress state |
+| `<x-global::feedback.alert>` | Validation messages, sparse canvas warnings |
+| `<x-global::avatar>` | Assignee display in task rows |
+| `<x-global::stageflow.card>` | Reused in review step to show the canvas source alongside proposed work |
+| `<x-global::stageflow.item>` | Individual canvas items shown as source context |
+| `<x-global::badge>` | Entity type labels (milestone, task, goal) in the review tree |
+
+### 5.3 Plugin-Specific Components
+
+Components that are wizard-specific and live in the StrategyPro plugin:
+
+#### `<x-strategypro::wizard-shell>`
+
+The outer frame. Renders the progress bar, step indicators, and the HTMX target container where step partials swap in.
+
+```html
+@props(['currentStep' => 1, 'totalSteps' => 4, 'boardId' => null])
+
+<div class="tw:max-w-4xl tw:mx-auto tw:py-8" id="wizardFrame">
+    {{-- Progress --}}
+    <x-global::progress :value="$currentStep" :max="$totalSteps" size="sm" />
+
+    {{-- Step indicators --}}
+    <div class="tw:flex tw:justify-between tw:mt-4 tw:mb-8">
+        @foreach(['Scope', 'Deliverables', 'Success Criteria', 'Review'] as $i => $label)
+            <span class="tw:text-sm {{ $currentStep > $i + 1 ? 'tw:text-success' : ($currentStep == $i + 1 ? 'tw:font-bold' : 'tw:text-base-300') }}">
+                {{ $label }}
+            </span>
+        @endforeach
+    </div>
+
+    {{-- Step content swaps here via HTMX --}}
+    <div id="wizardStep">
+        {{ $slot }}
+    </div>
+</div>
+```
+
+#### `<x-strategypro::wizard-step>`
+
+Wraps individual step content with consistent navigation.
+
+```html
+@props([
+    'step' => 1,
+    'totalSteps' => 4,
+    'boardId' => null,
+    'title' => '',
+    'subtitle' => '',
+    'prevUrl' => null,
+    'nextUrl' => null,
+])
+
+<x-global::elements.card :title="$title">
+    <x-slot name="header">
+        <div>
+            <h2 class="tw:card-title">{{ $title }}</h2>
+            @if($subtitle)
+                <p class="tw:text-sm tw:text-base-content/60">{{ $subtitle }}</p>
+            @endif
+        </div>
+    </x-slot>
+
+    {{ $slot }}
+
+    <x-slot name="actions">
+        <x-global::elements.button-group>
+            @if($prevUrl)
+                <x-global::button
+                    hx-get="{{ $prevUrl }}"
+                    hx-target="#wizardStep"
+                    type="secondary">Back</x-global::button>
+            @endif
+            @if($nextUrl)
+                <x-global::button
+                    hx-get="{{ $nextUrl }}"
+                    hx-target="#wizardStep"
+                    hx-include="#wizardStep"
+                    type="primary">{{ $step == $totalSteps ? 'Generate' : 'Next' }}</x-global::button>
+            @endif
+        </x-global::elements.button-group>
+    </x-slot>
+</x-global::elements.card>
+```
+
+#### `<x-strategypro::milestone-row>`
+
+A draggable milestone item within Step 1, showing the Activity source and editable fields.
+
+#### `<x-strategypro::task-row>`
+
+A task item within Step 2, nested under its parent milestone, with inline edit and assignee picker.
+
+#### `<x-strategypro::goal-row>`
+
+A goal mapping row in Step 3, linking an Outcome to metric fields.
+
+#### `<x-strategypro::routing-picker>`
+
+Composes `<x-global::selectable>` cards for the routing decision. Only shows plugin-gated options when those plugins are active.
+
+```html
+<div class="tw:grid tw:grid-cols-2 tw:gap-4">
+    <x-global::selectable name="routingType" value="in_place" id="route-inplace"
+        :selected="$default === 'in_place' ? 'true' : 'false'">
+        <x-slot name="label">Work in current project</x-slot>
+        Add milestones and tasks to {{ $currentProjectName }}
+    </x-global::selectable>
+
+    <x-global::selectable name="routingType" value="project" id="route-project"
+        :selected="$default === 'project' ? 'true' : 'false'">
+        <x-slot name="label">Its own project</x-slot>
+        Create a new project for this work
+    </x-global::selectable>
+
+    @if($hasPgmPro)
+    <x-global::selectable name="routingType" value="program" id="route-program">
+        <x-slot name="label">A program</x-slot>
+        Span multiple projects under a program
+    </x-global::selectable>
+    @endif
+
+    @if($hasStrategyPro)
+    <x-global::selectable name="routingType" value="strategy" id="route-strategy">
+        <x-slot name="label">A strategic initiative</x-slot>
+        Create a strategy with focus area boards
+    </x-global::selectable>
+    @endif
+</div>
+```
+
+#### `<x-strategypro::entity-tree>`
+
+Review step tree view. Composes `<x-global::accordion>`, `<x-global::badge>`, and the milestone/task/goal row components to show the full proposed structure.
+
+#### `<x-strategypro::entity-link-badge>`
+
+Small indicator for canvas item cards showing that a work entity was generated from this item. Used on the Logic Model board after generation.
+
+### 5.4 HTMX Patterns
+
+Following the patterns documented in CLAUDE.md:
+
+**Step progression:** Each step is an HxController that renders its partial. Navigation uses `hx-get` targeting `#wizardStep` to swap content without full page reload.
+
+```
+/hx/strategypro/wizard/start/{boardId}       → Runs adapter, launches shell
+/hx/strategypro/wizard/scopeStep/{boardId}    → Step 1 partial
+/hx/strategypro/wizard/deliverablesStep/{boardId} → Step 2 partial
+/hx/strategypro/wizard/criteriaStep/{boardId}  → Step 3 partial
+/hx/strategypro/wizard/reviewStep/{boardId}    → Step 4 partial
+/hx/strategypro/wizard/routing/{boardId}       → Routing decision handler
+```
+
+**Cross-component events:** Define as enum for type safety:
+
+```php
+enum HtmxWizardEvents: string
+{
+    case STEP_CHANGED = 'wizard_step_changed';
+    case STRUCTURE_UPDATED = 'wizard_structure_updated';
+    case GENERATION_COMPLETE = 'wizard_generation_complete';
+}
+```
+
+**State management:** Wizard state is cached per user via `WizardStateService`:
+
+- `wizard.{userId}.logicmodel.{boardId}.structure` — the in-progress WorkStructure
+- `wizard.{userId}.logicmodel.{boardId}.step` — current step number
+- `wizard.{userId}.logicmodel.{boardId}.routing` — routing decision
+
+State persists across step navigations and is cleared on completion or cancellation.
+
+**Lazy loading within steps:** For the review tree, milestones load collapsed and expand via `hx-trigger="click"` to load their tasks and goals. This keeps the review step fast even for large canvas boards.
+
+**Generation feedback:** The Generate button uses `hx-post` with `hx-indicator` pointing to a `<x-global::loader>`. On success, the `GENERATION_COMPLETE` event triggers a redirect to the newly created project.
+
+### 5.5 CSS Approach
+
+Following CLAUDE.md guidance: Tailwind 3.4.x with `tw:` prefix for new work. Use CSS custom properties (design tokens) for colors and spacing rather than hardcoded values. No new Bootstrap dependencies.
+
+Wizard-specific styles are minimal since components compose from shared UI:
+
+- Step transition animations (Tailwind `tw:transition-all`)
+- Drag handle styling for milestone reordering (integrates with existing nestedSortable if needed, or lightweight HTML5 drag-and-drop)
+- Review tree indentation (Tailwind margin utilities)
+
+---
+
+## 6. Copilot Plugin: Guided Flow
+
+Ships in Phase 3. The Copilot plugin adds guided canvas population on top of the same WorkStructure pipeline.
+
+### 6.1 Pre-Flow Routing Question
+
+Before starting, the Copilot asks a single question to determine direction:
+
+> **"Let's build out your strategy. Where do you want to start?"**
+>
+> 1. **I know what I want to achieve** (Impact/Outcomes backward)
+> 2. **I know what I have to work with** (Inputs forward)
+> 3. **I have a specific project in mind** (Activities outward)
+> 4. **I'm not sure yet — just ask me questions** (outcome-backward default)
+
+Default direction is outcome-backward. This aligns with how non-profit, education, and government organizations think about program design: start with the change you want to see.
+
+Each selection routes to the same conversation but sequences questions differently. The canvas fills identically regardless of direction.
+
+### 6.2 Conversation Pattern
+
+For each stage the Copilot addresses:
+
+1. Ask an open-ended question appropriate to the stage
+2. Parse the response into candidate canvas items
+3. Show what it will add to the canvas, ask for confirmation
+4. Write confirmed items to the canvas via the standard API
+5. Brief reflection/summary before the next stage
+
+| Stage | Example Prompt | Output |
+|---|---|---|
+| Impact | "What's the ultimate change you want to create?" | Single item: strategic north star |
+| Outcomes | "What measurable changes would tell you this is working?" | 2–4 items with indicators |
+| Activities | "What programs or activities will drive those outcomes?" | 3–6 work packages |
+| Outputs | "For each activity, what will you produce or deliver?" | Grouped deliverables |
+| Inputs | "What resources, funding, or people do you need?" | Resource inventory |
+
+### 6.3 Handoff to Wizard
+
+When the canvas is sufficiently populated, the Copilot suggests: "Your Logic Model looks ready. Want me to help create your project structure?" On confirmation, it triggers the StrategyPro wizard with the same Logic Model adapter producing the same WorkStructure. The Copilot adds its conversation context to the WorkStructure's metadata for activity logging.
+
+### 6.4 Enmotiv Integration (Future)
+
+When enmotiv profiles are available, the pre-flow routing question can be pre-answered based on profile type. The routing selection is behavioral data that validates against profiles even before integration ships.
+
+---
+
+## 7. Future Consumers
+
+The core WorkStructure domain supports plugins beyond the initial StrategyPro wizard. Each hooks into the same anchors.
+
+### 7.1 Ideas Board (Write Direction)
+
+A future Ideas adapter produces WorkStructures from approved ideas. Before the full wizard, a triage step determines scope:
+
+- **Single task:** skip wizard, direct create via WorkGenerator
+- **Milestone with deliverables:** lightweight 1–2 step wizard
+- **Its own project:** full wizard with routing
+- **Program or strategic:** routes to program/strategy creation (plugin-gated)
+
+### 7.2 Goal Canvas (Write Direction)
+
+A Goal Canvas adapter maps goals to milestones or projects, preserving KPI tracking and parent/child goal relationships through the WorkStructure format.
+
+### 7.3 Stakeholder View Plugin (Read Direction)
+
+A stakeholder view plugin uses `WorkStructureReader` to read an existing project into a WorkStructure, then renders it through a read-only template for external audiences.
+
+- **No authentication required.** External users see a generated view, not the Leantime app.
+- **Strategy language, not PM jargon.** Because WorkStructure carries entity links back to canvas items, progress can display in Logic Model terms: "Activity: Community Outreach — 3 of 4 deliverables completed" instead of "Milestone 72% complete."
+- **Multiple audiences.** Grant funders see progress against the Logic Model. Board members see the strategic dashboard. Partner organizations see shared milestones.
+- **Same data, different lens.** The WorkStructure is identical; only the renderer changes.
+
+### 7.4 Reporting & Export (Read Direction)
+
+Any reporting or export tool can consume a WorkStructure to generate grant reports, board presentations, or compliance documentation. The format is the same regardless of what's consuming it.
+
+### 7.5 API / Integration (Both Directions)
+
+WorkStructure could serve as the payload format for an API endpoint that accepts work structures from external systems (write) or exposes Leantime project status to external consumers (read). Not planned for initial implementation but the architecture supports it naturally.
+
+---
+
+## 8. Implementation Phasing
+
+### Phase 1: Core Domain (ships with Logic Model Phase 2)
+
+Build the anchor points in core. These are deliberately thin.
+
+- WorkStructure model class with all sub-objects
+- `WorkStructureAdapter` interface
+- `WorkGenerator` service (orchestrates existing project/milestone/task/goal services)
+- `WorkStructureReader` service (reads existing entities into WorkStructure)
+- Entity links table and repository (generic, not Logic Model–specific)
+- Core events (class-based): `WorkStructureCreated`, `WorkGenerationStarted`, `WorkGenerationCompleted`, `WorkGenerationFailed`, `EntityLinked`, `EntityUnlinked`, `WorkStructureRead`
+- `AdapterRegistry` (plugins register adapters via events)
+
+### Phase 2: StrategyPro Wizard (ships with Logic Model Phase 2)
+
+First plugin to hook into the core anchors.
+
+- `LogicModelAdapter` implementing `WorkStructureAdapter`
+- Blade component library: `wizard-shell`, `wizard-step`, `milestone-row`, `task-row`, `goal-row`, `routing-picker`, `entity-tree`, `entity-link-badge`, `completeness-badge`
+- 4-step wizard with HTMX step controllers
+- Composition from shared components (`card`, `selectable`, `progress`, `button-group`, `accordion`, `forms/*`, `empty-state`, `badge`, `avatar`)
+- Routing decision UI
+- "Create Work from Canvas" toolbar action
+- Entity linking from canvas items to generated work
+- Living Link: forward and backward navigation
+- Activity log data capture
+
+### Phase 3: Living Link + Copilot
+
+- Change detection on canvas items with linked entities
+- Notification system for strategy changes
+- Diff view and regeneration flow (update / add / replace)
+- Copilot guided canvas population flow
+- Pre-flow routing question and conversational stage population
+- Copilot-to-wizard handoff
+
+### Phase 4: Framework Extension
+
+- Ideas Board source adapter and triage flow
+- Goal Canvas source adapter
+- Stakeholder View plugin (read direction, external audiences)
+- Template system for pre-populated canvas examples
+- Enmotiv profile-driven flow direction
+
+---
+
+## 9. Telemetry & Activity Logging
+
+### 9.1 Activity Log
+
+All wizard interactions are captured via core events. StrategyPro listens to `WorkGenerationCompleted` and related events to write to the `logic_model_activity_log` table (data capture starts Phase 2, per existing PRD):
+
+- Wizard started: source board, items selected, routing decision
+- Step progression and time per step
+- Items confirmed, modified, added, or removed during wizard
+- Entities created with IDs
+- Wizard cancellation and drop-off point
+
+### 9.2 Product Metrics
+
+- Starting point selection distribution (outcome-backward vs. input-forward vs. middle-out)
+- Canvas completeness at wizard trigger
+- Step completion time and drop-off rates
+- Revision patterns (how often users go back)
+- Living link engagement (how often users act on change notifications)
+- Read direction usage (stakeholder view access frequency, audience types)
+
+---
+
+## 10. Open Questions
+
+| # | Question | Impact | Status |
+|---|---|---|---|
+| 1 | Should WorkStructure support nesting (a program WorkStructure containing child project WorkStructures)? | Read direction complexity for programs/strategies | Open |
+| 2 | How should the reader handle cases where entities were independently modified after generation? | Living Link reliability, staleness detection | Open |
+| 3 | Should the Copilot flow support mid-conversation canvas editing (user switches to manual while Copilot is active)? | Copilot state management complexity | Open |
+| 4 | What's the right granularity for Inputs mapping? Budget items vs. resource notes vs. team assignments are different entity types. | Mapping completeness | Open |
+| 5 | Should the stakeholder view plugin use WorkStructure snapshots (point-in-time) or live reads? | Performance vs. freshness tradeoff | Open |
+| 6 | How does the wizard interact with existing project content? Merge, append, or choice? | UX for in-place routing | Open |
+| 7 | Should WorkStructure carry status/progress data, or is that derived at read time from entity state? | WorkStructure scope, caching strategy | Open |
+| 8 | Is there a "Copilot Lite" or free-tier AI path for canvas-to-work that doesn't require the full Copilot plugin? | Business model, open-source AI plugin scope | Open |
+| 9 | Should any new shared components (e.g., a generic `wizard-step` or `step-progress`) be promoted to `app/Views/Templates/components/` for reuse by future wizards? | Component library growth strategy | Open |

--- a/Docs/08-leantime-core-WORKSTRUCTURE-PROMPT.md
+++ b/Docs/08-leantime-core-WORKSTRUCTURE-PROMPT.md
@@ -1,0 +1,1111 @@
+# WorkStructure Core + Content-to-Work Wizard — Implementation Prompt
+
+## For Claude Code Execution
+
+**Project:** Logic Model Canvas — Phase 2: Strategy Plugin
+**Scope:** Core WorkStructure domain + StrategyPro wizard for Logic Model → work generation
+**Depends on:** Phase 1 Core Board complete, existing canvas board architecture, existing service layer
+**Risk Level:** MEDIUM (new core domain + new plugin feature, no existing code changes)
+**Generated:** February 20, 2026
+
+---
+
+## Pre-Read Documents
+
+```
+Read these documents in order before starting:
+1. CLAUDE.md — Architecture overview, domain patterns, HTMX patterns, component system
+2. Docs/00-IMPLEMENTATION-GUIDE.md — Logic Model phasing overview
+3. Docs/01-CORE.md — Phase 1 core board spec (what's already built)
+4. Docs/02-PLUGIN.md — Phase 2 plugin spec (what's shipping alongside this)
+5. Docs/04-DATA-MODEL.md — Existing data model (canvas tables, item structure)
+6. Docs/07-WORKSTRUCTURE.md — Full PRD for this feature (architecture, contracts, components)
+```
+
+---
+
+## What This Is
+
+Two deliverables that ship together:
+
+1. **WorkStructure Core Domain** (`app/Domain/WorkStructure/`) — A normalized interchange format for describing work (milestones, tasks, goals, relationships) and services for creating entities from it or reading existing entities into it. This is the anchor that any plugin hooks into.
+
+2. **StrategyPro Wizard** (`app/Plugins/StrategyPro/`) — The first plugin consumer. Reads a Logic Model Canvas, produces a WorkStructure, walks the user through a 4-step confirmation wizard, and generates Leantime work entities.
+
+---
+
+## CRITICAL CONSTRAINTS
+
+```
+- DO NOT modify existing service classes (Projects, Tickets, Goalcanvas). Call their existing public methods.
+- DO NOT modify existing canvas board code. The adapter READS from the Logic Model; it does not change it.
+- DO NOT create .tpl.php files. All new templates are Blade (.blade.php).
+- DO NOT add jQuery dependencies. Use HTMX for async, vanilla JS only for interactivity.
+- DO compose from existing shared components in app/Views/Templates/components/.
+- DO use class-based events (not string-based) for all new events.
+- DO use the tw: prefix for all Tailwind classes (required by Leantime's Tailwind config).
+- DO use CSS custom properties (--accent1, --primary-color, etc.) not hardcoded colors.
+- DO follow the HxController pattern from CLAUDE.md for all HTMX controllers.
+- DO use DI via init() method in HxControllers, NOT __construct().
+- Tables use zp_ prefix (e.g., zp_entity_links).
+- All new Blade components use @props for their interface.
+- Test each step in browser before proceeding to next.
+```
+
+---
+
+## Deliverable 1: WorkStructure Core Domain
+
+### 1.1 Create Domain Directory Structure
+
+```
+app/Domain/WorkStructure/
+├── Contracts/
+│   └── WorkStructureAdapter.php
+├── Models/
+│   ├── WorkStructure.php
+│   ├── ProposedMilestone.php
+│   ├── ProposedTask.php
+│   ├── ProposedGoal.php
+│   ├── ProposedResource.php
+│   ├── SourceMeta.php
+│   ├── RoutingDecision.php
+│   ├── EntityLink.php
+│   └── CompletenessReport.php
+├── Services/
+│   ├── WorkGenerator.php
+│   ├── WorkStructureReader.php
+│   └── AdapterRegistry.php
+├── Repositories/
+│   └── EntityLinkRepository.php
+├── Events/
+│   ├── WorkStructureCreated.php
+│   ├── WorkGenerationStarted.php
+│   ├── WorkGenerationCompleted.php
+│   ├── WorkGenerationFailed.php
+│   ├── EntityLinked.php
+│   ├── EntityUnlinked.php
+│   └── WorkStructureRead.php
+└── register.php
+```
+
+### 1.2 Models
+
+**`WorkStructure.php`** — The normalized work bundle:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class WorkStructure
+{
+    public ?string $id = null;
+    public string $title = '';
+    public string $objective = '';
+    public SourceMeta $source;
+    public RoutingDecision $routing;
+    /** @var ProposedMilestone[] */
+    public array $milestones = [];
+    /** @var ProposedTask[] */
+    public array $tasks = [];
+    /** @var ProposedGoal[] */
+    public array $goals = [];
+    /** @var ProposedResource[] */
+    public array $resources = [];
+    /** @var EntityLink[] */
+    public array $links = [];
+    public array $metadata = [];
+
+    public function __construct()
+    {
+        $this->source = new SourceMeta();
+        $this->routing = new RoutingDecision();
+    }
+}
+```
+
+**`SourceMeta.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class SourceMeta
+{
+    public string $boardType = '';
+    public int $boardId = 0;
+    public string $adapterClass = '';
+    public ?\DateTime $generatedAt = null;
+    public ?int $generatedBy = null;
+}
+```
+
+**`RoutingDecision.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class RoutingDecision
+{
+    /** @var 'in_place'|'project'|'program'|'strategy' */
+    public string $type = 'project';
+    public ?int $parentId = null;
+    public ?int $projectId = null;
+}
+```
+
+**`ProposedMilestone.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class ProposedMilestone
+{
+    public ?string $tempId = null;       // Temporary ID for task grouping before generation
+    public ?int $entityId = null;        // Populated after generation
+    public string $title = '';
+    public string $description = '';
+    public ?string $startDate = null;    // Y-m-d format
+    public ?string $endDate = null;      // Y-m-d format
+    public ?int $sortIndex = 0;
+    public ?int $sourceItemId = null;    // Canvas item ID this came from
+    public array $metadata = [];
+}
+```
+
+**`ProposedTask.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class ProposedTask
+{
+    public ?string $tempId = null;
+    public ?int $entityId = null;
+    public string $title = '';
+    public string $description = '';
+    public ?string $milestoneTempId = null;  // Links to ProposedMilestone::tempId
+    public ?int $milestoneEntityId = null;
+    public ?string $dateToFinish = null;
+    public ?int $editorId = null;            // Assigned user
+    public ?int $sortIndex = 0;
+    public ?int $sourceItemId = null;
+    public array $metadata = [];
+}
+```
+
+**`ProposedGoal.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class ProposedGoal
+{
+    public ?string $tempId = null;
+    public ?int $entityId = null;
+    public string $title = '';
+    public string $description = '';
+    public ?string $metricType = null;       // 'numeric', 'percentage', 'currency', 'qualitative'
+    public mixed $startValue = null;
+    public mixed $endValue = null;
+    public ?string $milestoneTempId = null;   // Optional link to a milestone
+    public ?int $sortIndex = 0;
+    public ?int $sourceItemId = null;
+    public array $metadata = [];
+}
+```
+
+**`ProposedResource.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class ProposedResource
+{
+    public string $title = '';
+    public string $type = '';                // 'budget', 'team', 'dependency', 'note'
+    public string $description = '';
+    public ?float $amount = null;
+    public ?int $sourceItemId = null;
+    public array $metadata = [];
+}
+```
+
+**`EntityLink.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class EntityLink
+{
+    public ?int $id = null;
+    public string $sourceType = '';          // 'logicmodel', 'ideas', 'goalcanvas'
+    public int $sourceItemId = 0;
+    public string $targetEntityType = '';    // 'project', 'milestone', 'ticket', 'goal'
+    public int $targetEntityId = 0;
+    public string $linkType = 'generated_from';  // 'generated_from', 'maps_to', 'tracks'
+    public ?int $createdBy = null;
+    public ?string $createdAt = null;
+}
+```
+
+**`CompletenessReport.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Models;
+
+class CompletenessReport
+{
+    /** @var array<string, int> Stage name => item count */
+    public array $stageCounts = [];
+    public int $totalItems = 0;
+    public int $populatedStages = 0;
+    public int $totalStages = 0;
+
+    /** @var 'rich'|'moderate'|'sparse'|'empty' */
+    public string $level = 'empty';
+
+    /** @var string[] Human-readable notes about what's missing */
+    public array $gaps = [];
+}
+```
+
+### 1.3 Contracts
+
+**`WorkStructureAdapter.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Contracts;
+
+use Leantime\Domain\WorkStructure\Models\WorkStructure;
+use Leantime\Domain\WorkStructure\Models\CompletenessReport;
+
+interface WorkStructureAdapter
+{
+    /** Board type identifier (e.g., 'logicmodel', 'ideas') */
+    public function getSourceType(): string;
+
+    /** Can this board produce a meaningful WorkStructure? */
+    public function canAdapt(int $boardId): bool;
+
+    /** Evaluate what's populated vs. missing */
+    public function assessCompleteness(int $boardId): CompletenessReport;
+
+    /** Read the board and produce a normalized WorkStructure */
+    public function adapt(int $boardId): WorkStructure;
+}
+```
+
+### 1.4 Services
+
+**`AdapterRegistry.php`** — Discovers registered adapters:
+
+```php
+namespace Leantime\Domain\WorkStructure\Services;
+
+use Leantime\Domain\WorkStructure\Contracts\WorkStructureAdapter;
+
+class AdapterRegistry
+{
+    /** @var WorkStructureAdapter[] */
+    private array $adapters = [];
+
+    public function register(WorkStructureAdapter $adapter): void
+    {
+        $this->adapters[$adapter->getSourceType()] = $adapter;
+    }
+
+    public function get(string $sourceType): ?WorkStructureAdapter
+    {
+        return $this->adapters[$sourceType] ?? null;
+    }
+
+    /** @return WorkStructureAdapter[] */
+    public function all(): array
+    {
+        return $this->adapters;
+    }
+
+    public function has(string $sourceType): bool
+    {
+        return isset($this->adapters[$sourceType]);
+    }
+}
+```
+
+**`WorkGenerator.php`** — Write direction: WorkStructure → Leantime entities:
+
+```php
+namespace Leantime\Domain\WorkStructure\Services;
+
+use Leantime\Core\Events\DispatchesEvents;
+use Leantime\Domain\Projects\Services\Projects as ProjectsService;
+use Leantime\Domain\Tickets\Services\Tickets as TicketsService;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvasService;
+use Leantime\Domain\WorkStructure\Models\WorkStructure;
+use Leantime\Domain\WorkStructure\Models\EntityLink;
+use Leantime\Domain\WorkStructure\Events\WorkGenerationStarted;
+use Leantime\Domain\WorkStructure\Events\WorkGenerationCompleted;
+use Leantime\Domain\WorkStructure\Events\WorkGenerationFailed;
+use Leantime\Domain\WorkStructure\Repositories\EntityLinkRepository;
+
+class WorkGenerator
+{
+    use DispatchesEvents;
+
+    public function __construct(
+        private ProjectsService $projectsService,
+        private TicketsService $ticketsService,
+        private GoalcanvasService $goalcanvasService,
+        private EntityLinkRepository $entityLinkRepository,
+    ) {}
+
+    /**
+     * Generate all Leantime entities from a WorkStructure.
+     * Respects the routing decision for entity type.
+     */
+    public function generate(WorkStructure $structure): WorkStructure
+    {
+        // Dispatch started event
+        // See CLAUDE.md for class-based event pattern: new event class, dispatch via event()
+        event(new WorkGenerationStarted($structure));
+
+        try {
+            $projectId = $this->resolveProjectId($structure);
+
+            // Create milestones, mapping tempId → entityId
+            $milestoneMap = $this->createMilestones($projectId, $structure->milestones);
+
+            // Create tasks, resolving milestone references
+            $this->createTasks($projectId, $structure->tasks, $milestoneMap);
+
+            // Create goals
+            $this->createGoals($projectId, $structure->goals, $milestoneMap);
+
+            // Record entity links
+            $this->recordLinks($structure);
+
+            event(new WorkGenerationCompleted($structure));
+
+            return $structure;
+
+        } catch (\Throwable $e) {
+            event(new WorkGenerationFailed($structure, $e));
+            throw $e;
+        }
+    }
+
+    private function resolveProjectId(WorkStructure $structure): int
+    {
+        if ($structure->routing->type === 'in_place') {
+            return $structure->routing->projectId;
+        }
+
+        // Create new project via existing service
+        // Projects::addProject() expects an array with 'name', 'details', 'clientId', 'type', 'parent'
+        $projectValues = [
+            'name' => $structure->title,
+            'details' => $structure->objective,
+            'clientId' => '', // inherits from session
+            'type' => $structure->routing->type === 'strategy' ? 'strategy'
+                     : ($structure->routing->type === 'program' ? 'program' : 'project'),
+            'parent' => $structure->routing->parentId,
+        ];
+
+        $projectId = $this->projectsService->addProject($projectValues);
+        $structure->routing->projectId = $projectId;
+
+        return $projectId;
+    }
+
+    /**
+     * @return array<string, int> Map of tempId → entityId
+     */
+    private function createMilestones(int $projectId, array &$milestones): array
+    {
+        $map = [];
+
+        foreach ($milestones as $milestone) {
+            // Tickets::quickAddMilestone expects: headline, projectId, editFrom, editTo
+            $values = [
+                'headline' => $milestone->title,
+                'description' => $milestone->description,
+                'projectId' => $projectId,
+                'editFrom' => $milestone->startDate ?? '',
+                'editTo' => $milestone->endDate ?? '',
+                'sortIndex' => $milestone->sortIndex,
+            ];
+
+            $entityId = $this->ticketsService->quickAddMilestone($values);
+            $milestone->entityId = $entityId;
+
+            if ($milestone->tempId) {
+                $map[$milestone->tempId] = $entityId;
+            }
+        }
+
+        return $map;
+    }
+
+    private function createTasks(int $projectId, array &$tasks, array $milestoneMap): void
+    {
+        foreach ($tasks as $task) {
+            $milestoneId = null;
+            if ($task->milestoneTempId && isset($milestoneMap[$task->milestoneTempId])) {
+                $milestoneId = $milestoneMap[$task->milestoneTempId];
+            } elseif ($task->milestoneEntityId) {
+                $milestoneId = $task->milestoneEntityId;
+            }
+
+            // Tickets::quickAddTicket expects: headline, projectId, description, milestoneId, editorId, dateToFinish
+            $values = [
+                'headline' => $task->title,
+                'description' => $task->description,
+                'projectId' => $projectId,
+                'milestoneid' => $milestoneId,
+                'editorId' => $task->editorId ?? '',
+                'dateToFinish' => $task->dateToFinish ?? '',
+                'sortindex' => $task->sortIndex,
+            ];
+
+            $entityId = $this->ticketsService->quickAddTicket($values);
+            $task->entityId = $entityId;
+        }
+    }
+
+    private function createGoals(int $projectId, array &$goals, array $milestoneMap): void
+    {
+        if (empty($goals)) {
+            return;
+        }
+
+        // Create a goal board for this project
+        $goalBoardId = $this->goalcanvasService->createGoalboard([
+            'title' => 'Goals: ' . '',
+            'projectId' => $projectId,
+        ]);
+
+        foreach ($goals as $goal) {
+            $values = [
+                'title' => $goal->title,
+                'description' => $goal->description,
+                'canvasId' => $goalBoardId,
+                'metricType' => $goal->metricType ?? 'qualitative',
+                'startValue' => $goal->startValue,
+                'endValue' => $goal->endValue,
+                'sortindex' => $goal->sortIndex,
+            ];
+
+            $entityId = $this->goalcanvasService->createGoal($values);
+            $goal->entityId = $entityId;
+        }
+    }
+
+    private function recordLinks(WorkStructure $structure): void
+    {
+        $links = [];
+
+        // Link milestones to source items
+        foreach ($structure->milestones as $m) {
+            if ($m->sourceItemId && $m->entityId) {
+                $links[] = $this->buildLink($structure, $m->sourceItemId, 'milestone', $m->entityId);
+            }
+        }
+
+        // Link tasks to source items
+        foreach ($structure->tasks as $t) {
+            if ($t->sourceItemId && $t->entityId) {
+                $links[] = $this->buildLink($structure, $t->sourceItemId, 'ticket', $t->entityId);
+            }
+        }
+
+        // Link goals to source items
+        foreach ($structure->goals as $g) {
+            if ($g->sourceItemId && $g->entityId) {
+                $links[] = $this->buildLink($structure, $g->sourceItemId, 'goal', $g->entityId);
+            }
+        }
+
+        foreach ($links as $link) {
+            $this->entityLinkRepository->create($link);
+            $structure->links[] = $link;
+        }
+    }
+
+    private function buildLink(WorkStructure $structure, int $sourceItemId, string $targetType, int $targetId): EntityLink
+    {
+        $link = new EntityLink();
+        $link->sourceType = $structure->source->boardType;
+        $link->sourceItemId = $sourceItemId;
+        $link->targetEntityType = $targetType;
+        $link->targetEntityId = $targetId;
+        $link->linkType = 'generated_from';
+        $link->createdBy = $structure->source->generatedBy;
+        return $link;
+    }
+}
+```
+
+**`WorkStructureReader.php`** — Read direction: existing entities → WorkStructure:
+
+```php
+namespace Leantime\Domain\WorkStructure\Services;
+
+use Leantime\Domain\Projects\Services\Projects as ProjectsService;
+use Leantime\Domain\Tickets\Services\Tickets as TicketsService;
+use Leantime\Domain\Goalcanvas\Services\Goalcanvas as GoalcanvasService;
+use Leantime\Domain\WorkStructure\Models\WorkStructure;
+use Leantime\Domain\WorkStructure\Models\ProposedMilestone;
+use Leantime\Domain\WorkStructure\Models\ProposedTask;
+use Leantime\Domain\WorkStructure\Models\ProposedGoal;
+use Leantime\Domain\WorkStructure\Models\SourceMeta;
+use Leantime\Domain\WorkStructure\Models\RoutingDecision;
+use Leantime\Domain\WorkStructure\Repositories\EntityLinkRepository;
+use Leantime\Domain\WorkStructure\Events\WorkStructureRead;
+
+class WorkStructureReader
+{
+    public function __construct(
+        private ProjectsService $projectsService,
+        private TicketsService $ticketsService,
+        private GoalcanvasService $goalcanvasService,
+        private EntityLinkRepository $entityLinkRepository,
+    ) {}
+
+    /**
+     * Read a full project into a WorkStructure.
+     */
+    public function fromProject(int $projectId): WorkStructure
+    {
+        $project = $this->projectsService->getProject($projectId);
+
+        $structure = new WorkStructure();
+        $structure->id = (string) $projectId;
+        $structure->title = $project['name'] ?? '';
+        $structure->objective = $project['details'] ?? '';
+
+        $structure->routing = new RoutingDecision();
+        $structure->routing->type = 'in_place';
+        $structure->routing->projectId = $projectId;
+
+        // Read milestones
+        $milestones = $this->ticketsService->getAllMilestones(['sprint' => '', 'type' => 'milestone', 'currentProject' => $projectId]);
+        foreach ($milestones as $m) {
+            $pm = new ProposedMilestone();
+            $pm->entityId = (int) $m['id'];
+            $pm->title = $m['headline'] ?? '';
+            $pm->description = $m['description'] ?? '';
+            $pm->startDate = $m['editFrom'] ?? null;
+            $pm->endDate = $m['editTo'] ?? null;
+            $pm->sortIndex = (int) ($m['sortindex'] ?? 0);
+            $structure->milestones[] = $pm;
+        }
+
+        // Read tasks
+        $tickets = $this->ticketsService->getAll(['sprint' => '', 'type' => 'task', 'currentProject' => $projectId]);
+        foreach ($tickets as $t) {
+            $pt = new ProposedTask();
+            $pt->entityId = (int) $t['id'];
+            $pt->title = $t['headline'] ?? '';
+            $pt->description = $t['description'] ?? '';
+            $pt->milestoneEntityId = !empty($t['milestoneid']) ? (int) $t['milestoneid'] : null;
+            $pt->editorId = !empty($t['editorId']) ? (int) $t['editorId'] : null;
+            $pt->dateToFinish = $t['dateToFinish'] ?? null;
+            $pt->sortIndex = (int) ($t['sortindex'] ?? 0);
+            $structure->tasks[] = $pt;
+        }
+
+        // Read entity links
+        $structure->links = $this->entityLinkRepository->getByProject($projectId);
+
+        event(new WorkStructureRead($structure));
+
+        return $structure;
+    }
+}
+```
+
+**Note to Claude Code:** The `fromProject` method above is a starting scaffold. The exact method signatures for `getAll`, `getAllMilestones`, `getProject` etc. should be verified against the actual service classes before implementation. Check `app/Domain/Tickets/Services/Tickets.php` and `app/Domain/Projects/Services/Projects.php` for actual parameter names and return types.
+
+### 1.5 Repository
+
+**`EntityLinkRepository.php`**:
+
+```php
+namespace Leantime\Domain\WorkStructure\Repositories;
+
+use Leantime\Core\Db\Repository;
+use Leantime\Domain\WorkStructure\Models\EntityLink;
+
+class EntityLinkRepository extends Repository
+{
+    /**
+     * Create entity links table if it doesn't exist.
+     * Call this from install/migration.
+     */
+    public function createTable(): void
+    {
+        // Use SchemaBuilder for database-agnostic table creation
+        // Table: zp_entity_links
+        // Columns: id (PK auto), source_type varchar(50), source_item_id int,
+        //          target_entity_type varchar(50), target_entity_id int,
+        //          link_type varchar(30) default 'generated_from',
+        //          created_by int, created_at datetime
+        // Indexes: (source_type, source_item_id), (target_entity_type, target_entity_id)
+    }
+
+    public function create(EntityLink $link): int
+    {
+        // INSERT into zp_entity_links
+        // Return inserted ID
+    }
+
+    public function delete(int $id): void
+    {
+        // DELETE from zp_entity_links WHERE id = :id
+    }
+
+    /**
+     * Get all links for a given source item.
+     * @return EntityLink[]
+     */
+    public function getBySource(string $sourceType, int $sourceItemId): array
+    {
+        // SELECT * FROM zp_entity_links WHERE source_type = :type AND source_item_id = :id
+    }
+
+    /**
+     * Get all links pointing to a given entity.
+     * @return EntityLink[]
+     */
+    public function getByTarget(string $targetType, int $targetId): array
+    {
+        // SELECT * FROM zp_entity_links WHERE target_entity_type = :type AND target_entity_id = :id
+    }
+
+    /**
+     * Get all links for entities within a project.
+     * Joins against zp_tickets and zp_canvas_items to find project-scoped links.
+     * @return EntityLink[]
+     */
+    public function getByProject(int $projectId): array
+    {
+        // Complex query — join zp_entity_links against target entity tables
+        // to find all links where target entities belong to given project
+    }
+}
+```
+
+**Note to Claude Code:** Implement the repository methods following the existing repository pattern in the codebase. Check `app/Domain/Tickets/Repositories/Tickets.php` for the query style (`$this->db->`, prepared statements, etc.). Use `dbcall()` wrapper for event dispatching around SQL execution.
+
+### 1.6 Events
+
+Create class-based events following the pattern in `app/Domain/Files/Events/FileUploaded.php` (the one existing class-based event):
+
+```php
+namespace Leantime\Domain\WorkStructure\Events;
+
+class WorkGenerationStarted
+{
+    public function __construct(
+        public readonly \Leantime\Domain\WorkStructure\Models\WorkStructure $structure,
+    ) {}
+}
+```
+
+Create the same pattern for all 7 events listed in section 1.1. Each event class takes the relevant payload as constructor arguments with `public readonly` properties.
+
+### 1.7 Register File
+
+**`register.php`** — Register the adapter registry listener:
+
+```php
+use Leantime\Core\Events\EventDispatcher;
+use Leantime\Domain\WorkStructure\Services\AdapterRegistry;
+
+// Listen for adapter registrations from plugins
+EventDispatcher::add_event_listener(
+    'leantime.domain.workstructure.services.adapterregistry.register',
+    function ($params) {
+        // Plugins dispatch this event with their adapter instance
+    }
+);
+```
+
+**Note to Claude Code:** The exact registration pattern depends on how plugins currently register themselves. Check `app/Domain/Plugins/Services/Registration.php` and existing plugin `register.php` files for the pattern. The AdapterRegistry should be resolvable via `app()->make(AdapterRegistry::class)` so plugins can register adapters in their own `register.php`.
+
+### 1.8 Database Migration
+
+Create the `zp_entity_links` table. Follow the installation pattern used by other domains:
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | INT | PRIMARY KEY, AUTO_INCREMENT |
+| source_type | VARCHAR(50) | NOT NULL |
+| source_item_id | INT | NOT NULL |
+| target_entity_type | VARCHAR(50) | NOT NULL |
+| target_entity_id | INT | NOT NULL |
+| link_type | VARCHAR(30) | NOT NULL, DEFAULT 'generated_from' |
+| created_by | INT | NULL |
+| created_at | DATETIME | NOT NULL, DEFAULT CURRENT_TIMESTAMP |
+
+Indexes:
+- `idx_entity_links_source` on `(source_type, source_item_id)`
+- `idx_entity_links_target` on `(target_entity_type, target_entity_id)`
+
+**Note to Claude Code:** Check how the Logic Model canvas tables were created in Phase 1. Follow the same migration/installation pattern (SchemaBuilder, version check, etc.).
+
+### Validation Checklist — Core Domain
+- [ ] All model classes instantiate without errors
+- [ ] `WorkStructureAdapter` interface is implementable (create a test stub)
+- [ ] `AdapterRegistry` can register, retrieve, and list adapters
+- [ ] `EntityLinkRepository` can CRUD entity links
+- [ ] `WorkGenerator` can create a project with milestones, tasks, and goals from a WorkStructure (test with hardcoded WorkStructure)
+- [ ] `WorkStructureReader::fromProject()` returns a populated WorkStructure for an existing project
+- [ ] All 7 events fire at the correct points
+- [ ] `zp_entity_links` table creates successfully on fresh install
+
+---
+
+## Deliverable 2: StrategyPro Logic Model Wizard
+
+### 2.1 Plugin File Structure
+
+Add these files to the existing StrategyPro plugin:
+
+```
+app/Plugins/StrategyPro/
+├── Hxcontrollers/
+│   └── Wizard/
+│       ├── Start.php
+│       ├── ScopeStep.php
+│       ├── DeliverablesStep.php
+│       ├── CriteriaStep.php
+│       ├── ReviewStep.php
+│       └── Routing.php
+├── Templates/
+│   ├── components/
+│   │   ├── wizard-shell.blade.php
+│   │   ├── wizard-step.blade.php
+│   │   ├── milestone-row.blade.php
+│   │   ├── task-row.blade.php
+│   │   ├── goal-row.blade.php
+│   │   ├── resource-note.blade.php
+│   │   ├── entity-tree.blade.php
+│   │   ├── routing-picker.blade.php
+│   │   ├── completeness-badge.blade.php
+│   │   └── entity-link-badge.blade.php
+│   └── partials/
+│       ├── wizard-scope.blade.php
+│       ├── wizard-deliverables.blade.php
+│       ├── wizard-criteria.blade.php
+│       └── wizard-review.blade.php
+├── Services/
+│   ├── LogicModelAdapter.php
+│   └── WizardStateService.php
+├── Events/
+│   └── Htmx/
+│       └── HtmxWizardEvents.php
+└── register.php                          ← UPDATE existing file
+```
+
+### 2.2 LogicModelAdapter
+
+Implements `WorkStructureAdapter`. Reads from the Logic Model canvas tables and maps stages to WorkStructure properties:
+
+| Canvas Stage | DB Source | WorkStructure Target | Mapping Logic |
+|---|---|---|---|
+| Impact (stage 5) | `zp_canvas_items` where `box = 'box5'` | `$structure->objective` | First item's title → objective. Additional items → metadata. |
+| Outcomes (stage 4) | `zp_canvas_items` where `box = 'box4'` | `$structure->goals[]` | Each item → ProposedGoal. Use item description for metric details. |
+| Activities (stage 2) | `zp_canvas_items` where `box = 'box2'` | `$structure->milestones[]` | Each item → ProposedMilestone. tempId = 'ms-' + item ID. |
+| Outputs (stage 3) | `zp_canvas_items` where `box = 'box3'` | `$structure->tasks[]` | Each item → ProposedTask. Use `relates_to` field to link to parent Activity's milestone. |
+| Inputs (stage 1) | `zp_canvas_items` where `box = 'box1'` | `$structure->resources[]` | Each item → ProposedResource. Infer type from content. |
+
+**Note to Claude Code:** Check the actual Logic Model canvas table structure from `Docs/04-DATA-MODEL.md` and the Phase 1 implementation. The box names, field names, and relationships may differ. The `relates_to` field for Output→Activity relationships is a key mapping; verify how parent-child relationships are stored on the canvas.
+
+**`assessCompleteness()`** logic:
+
+```
+Rich (4-5 stages with items) → level = 'rich'
+Moderate (2-3 stages) → level = 'moderate'
+Sparse (0-1 stages) → level = 'sparse'
+Empty (0 items) → level = 'empty'
+```
+
+Gaps array populated with messages like "No outcomes defined — goals won't be created" or "No activities — milestones won't be created."
+
+### 2.3 WizardStateService
+
+Cache-based state management. Keys follow pattern: `wizard.{userId}.logicmodel.{boardId}.{key}`
+
+```php
+namespace Leantime\Plugins\StrategyPro\Services;
+
+class WizardStateService
+{
+    public function __construct(private \Illuminate\Contracts\Cache\Repository $cache) {}
+
+    public function getStructure(int $userId, int $boardId): ?WorkStructure
+    {
+        return $this->cache->get("wizard.{$userId}.logicmodel.{$boardId}.structure");
+    }
+
+    public function saveStructure(int $userId, int $boardId, WorkStructure $structure): void
+    {
+        $this->cache->put("wizard.{$userId}.logicmodel.{$boardId}.structure", $structure, 3600);
+    }
+
+    public function getStep(int $userId, int $boardId): int
+    {
+        return $this->cache->get("wizard.{$userId}.logicmodel.{$boardId}.step", 1);
+    }
+
+    public function saveStep(int $userId, int $boardId, int $step): void
+    {
+        $this->cache->put("wizard.{$userId}.logicmodel.{$boardId}.step", $step, 3600);
+    }
+
+    public function clear(int $userId, int $boardId): void
+    {
+        $this->cache->forget("wizard.{$userId}.logicmodel.{$boardId}.structure");
+        $this->cache->forget("wizard.{$userId}.logicmodel.{$boardId}.step");
+    }
+}
+```
+
+### 2.4 HTMX Event Enum
+
+```php
+namespace Leantime\Plugins\StrategyPro\Events\Htmx;
+
+enum HtmxWizardEvents: string
+{
+    case STEP_CHANGED = 'wizard_step_changed';
+    case STRUCTURE_UPDATED = 'wizard_structure_updated';
+    case GENERATION_COMPLETE = 'wizard_generation_complete';
+}
+```
+
+### 2.5 HxControllers
+
+Each wizard step is an HxController. Follow the pattern from CLAUDE.md:
+
+**`Wizard/Start.php`** — Entry point. Runs the adapter, stores initial structure, renders wizard shell:
+
+```php
+namespace Leantime\Plugins\StrategyPro\Hxcontrollers\Wizard;
+
+use Leantime\Core\Controller\HtmxController;
+use Leantime\Plugins\StrategyPro\Services\LogicModelAdapter;
+use Leantime\Plugins\StrategyPro\Services\WizardStateService;
+
+class Start extends HtmxController
+{
+    protected static string $view = 'strategypro::partials.wizard-scope';
+
+    private LogicModelAdapter $adapter;
+    private WizardStateService $stateService;
+
+    public function init(LogicModelAdapter $adapter, WizardStateService $stateService): void
+    {
+        $this->adapter = $adapter;
+        $this->stateService = $stateService;
+    }
+
+    public function get(array $params): void
+    {
+        $boardId = (int) ($params['id'] ?? 0);
+        $userId = session('userdata.id');
+
+        // Run adapter
+        $structure = $this->adapter->adapt($boardId);
+        $completeness = $this->adapter->assessCompleteness($boardId);
+
+        // Store in cache
+        $this->stateService->saveStructure($userId, $boardId, $structure);
+        $this->stateService->saveStep($userId, $boardId, 1);
+
+        $this->tpl->assign('structure', $structure);
+        $this->tpl->assign('completeness', $completeness);
+        $this->tpl->assign('boardId', $boardId);
+        $this->tpl->assign('currentStep', 1);
+    }
+}
+```
+
+**`Wizard/ScopeStep.php`** — Step 1: milestone confirmation. POST saves milestone edits, GET renders step.
+
+**`Wizard/DeliverablesStep.php`** — Step 2: task mapping under milestones.
+
+**`Wizard/CriteriaStep.php`** — Step 3: goal mapping from outcomes.
+
+**`Wizard/ReviewStep.php`** — Step 4: review tree + generate button. POST triggers WorkGenerator.
+
+**`Wizard/Routing.php`** — Handles routing decision selection. Returns inline in Step 4 or as a standalone step for lightweight paths.
+
+**Note to Claude Code:** Each HxController follows this exact pattern:
+- Extends `HtmxController`
+- Static `$view` points to a Blade partial in `strategypro::partials.*`
+- DI via `init()`, NOT `__construct()`
+- `get()` loads data and assigns template vars
+- POST actions (save step data) use a semantic method name, update cached state, and set HTMX events via `$this->setHTMXEvent()`
+
+### 2.6 Blade Components
+
+Build these components composing from existing shared components. Reference the inventory in `app/Views/Templates/components/`:
+
+**Components that compose from shared UI (see 07-WORKSTRUCTURE.md Section 5.2 for full mapping):**
+
+| Plugin Component | Composes From |
+|---|---|
+| `wizard-shell` | `<x-global::progress>` for step bar |
+| `wizard-step` | `<x-global::elements.card>` with header/actions slots, `<x-global::elements.button-group>` for nav |
+| `milestone-row` | `<x-global::forms.input>` for title edit, `<x-global::forms.date>` for timeframe |
+| `task-row` | `<x-global::forms.input>`, `<x-global::forms.select>` for assignee, `<x-global::avatar>` |
+| `goal-row` | `<x-global::forms.input>`, `<x-global::forms.select>` for metric type |
+| `routing-picker` | `<x-global::selectable>` cards in a grid |
+| `entity-tree` | `<x-global::accordion>` for milestone groups, `<x-global::badge>` for entity types |
+| `completeness-badge` | `<x-global::elements.status-indicator>` |
+| `entity-link-badge` | `<x-global::badge>` with link icon |
+| `resource-note` | `<x-global::elements.card compact>` |
+
+**Example markup patterns are in 07-WORKSTRUCTURE.md Section 5.3.** Follow those exactly.
+
+### 2.7 Step Partials
+
+Each partial is the content that swaps into `#wizardStep` via HTMX:
+
+**`wizard-scope.blade.php`** (Step 1):
+- Renders `<x-strategypro::wizard-step step="1">` wrapping a list of `<x-strategypro::milestone-row>` components
+- Each row shows: Activity title (editable), description (expandable), start/end date pickers, drag handle for reorder, checkbox to include/exclude
+- HTMX: `hx-get="/hx/strategypro/wizard/deliverablesStep/{{ $boardId }}"` on Next button, targeting `#wizardStep`
+- POST data: milestone order, title edits, date changes, include/exclude state
+
+**`wizard-deliverables.blade.php`** (Step 2):
+- Groups tasks under their parent milestones
+- Each milestone section is an `<x-global::accordion>` item
+- Inside: list of `<x-strategypro::task-row>` components
+- "Add task" button per milestone section
+- HTMX: Back goes to Step 1, Next goes to Step 3
+
+**`wizard-criteria.blade.php`** (Step 3):
+- List of `<x-strategypro::goal-row>` components
+- Each row: Outcome title (read-only source), goal title (editable), metric type dropdown, start/end value inputs
+- Optional: link goal to a specific milestone
+- HTMX: Back to Step 2, Next to Step 4
+
+**`wizard-review.blade.php`** (Step 4):
+- `<x-strategypro::routing-picker>` at the top
+- `<x-strategypro::entity-tree>` showing the full proposed structure
+- Generate button with `hx-post`, `hx-indicator` for loading state
+- On success: `HtmxWizardEvents::GENERATION_COMPLETE` triggers redirect to new project
+
+### 2.8 Toolbar Action
+
+Add a "Create Work from Canvas" button to the Logic Model board toolbar. This is a toolbar action that only appears when StrategyPro plugin is active.
+
+**Note to Claude Code:** Check how existing plugin toolbar actions are added. Look at the register.php patterns and menu filter hooks. The button should:
+- Only appear on Logic Model board pages
+- Only appear when StrategyPro is active
+- Link to `/hx/strategypro/wizard/start/{boardId}` (opens in modal or navigates)
+- Show a `<x-strategypro::completeness-badge>` indicating canvas readiness
+
+### 2.9 Entity Link Display
+
+After generation, canvas item cards should show an `<x-strategypro::entity-link-badge>` in their footer. This requires hooking into the canvas card rendering.
+
+**Note to Claude Code:** Check how the Logic Model canvas card template renders items. It likely extends the base Canvas card component. Add a filter or event hook that appends the entity link badge when links exist for that item. Query `EntityLinkRepository::getBySource('logicmodel', $itemId)` to check for links.
+
+### 2.10 Register Adapter
+
+Update StrategyPro's `register.php` to register the LogicModelAdapter with the core AdapterRegistry:
+
+```php
+// In StrategyPro register.php
+use Leantime\Domain\WorkStructure\Services\AdapterRegistry;
+use Leantime\Plugins\StrategyPro\Services\LogicModelAdapter;
+
+// Register adapter when WorkStructure domain is available
+EventDispatcher::add_event_listener(
+    'leantime.core.middleware.loadplugins.handle.plugins_loaded',
+    function () {
+        $registry = app()->make(AdapterRegistry::class);
+        $adapter = app()->make(LogicModelAdapter::class);
+        $registry->register($adapter);
+    }
+);
+```
+
+**Note to Claude Code:** Verify the correct event name for plugin loading. Check existing plugin register.php files for the pattern.
+
+### Validation Checklist — Wizard
+- [ ] LogicModelAdapter reads a populated Logic Model and produces a valid WorkStructure
+- [ ] `assessCompleteness()` correctly reports rich/moderate/sparse/empty states
+- [ ] "Create Work from Canvas" button appears on Logic Model board when StrategyPro is active
+- [ ] Button does NOT appear when StrategyPro is inactive
+- [ ] Clicking button launches wizard with Step 1 showing milestones from Activities
+- [ ] Step 1: Can reorder milestones, edit titles, set dates, exclude items
+- [ ] Step 1 → Step 2: tasks appear grouped under their parent milestones
+- [ ] Step 2: Can add/remove tasks, edit titles, assign users
+- [ ] Step 2 → Step 3: goals appear with Outcome source context
+- [ ] Step 3: Can set metric types, target values, link goals to milestones
+- [ ] Step 3 → Step 4: review tree shows complete proposed structure
+- [ ] Step 4: routing picker shows correct options based on active plugins
+- [ ] Step 4: Generate button creates project with milestones, tasks, and goals
+- [ ] Entity links are recorded in zp_entity_links after generation
+- [ ] Canvas item cards show entity link badges after generation
+- [ ] Wizard state persists when navigating back/forward between steps
+- [ ] Wizard state clears on completion or cancellation
+- [ ] Wizard handles sparse canvas gracefully (shows gaps, allows proceeding with partial data)
+- [ ] Wizard handles empty canvas (shows message, offers lightweight escape)
+- [ ] All HTMX step transitions work without full page reload
+- [ ] Loading indicator shows during generation
+- [ ] After generation, user is navigated to the new project
+
+---
+
+## Execution Order
+
+```
+1. Core domain models          [0.5 day]   — All model classes
+2. Entity links table          [0.5 day]   — Migration + repository
+3. WorkGenerator service       [1 day]     — Write direction, test with hardcoded data
+4. WorkStructureReader service [0.5 day]   — Read direction
+5. Core events                 [0.5 day]   — All 7 event classes
+6. AdapterRegistry             [0.5 day]   — Registration mechanism
+7. LogicModelAdapter           [1 day]     — Canvas → WorkStructure mapping
+8. WizardStateService          [0.5 day]   — Cache-based state
+9. Blade components            [2 days]    — All 10 plugin components
+10. HxControllers + partials   [2 days]    — All 6 controllers + 4 step partials
+11. Toolbar action             [0.5 day]   — Button + completeness badge
+12. Entity link display        [0.5 day]   — Badge on canvas cards
+13. Adapter registration       [0.5 day]   — register.php hookup
+14. Integration testing        [1 day]     — Full flow: canvas → wizard → generated project
+```
+
+**Total: ~10-11 days**
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Canvas table structure differs from assumed box naming | MEDIUM | HIGH | Verify against actual Phase 1 implementation before writing adapter |
+| Service method signatures don't match assumed params | MEDIUM | HIGH | Check actual Tickets, Projects, Goalcanvas service methods |
+| Plugin register.php event timing issues | LOW | MEDIUM | Test adapter registration fires after plugin load |
+| Cache serialization of WorkStructure objects | LOW | MEDIUM | Ensure all model properties are serializable (no closures, no resource handles) |
+| HTMX step swapping breaks form state | MEDIUM | MEDIUM | Cache all step data server-side, don't rely on client form state |
+| Existing shared components missing features | LOW | MEDIUM | Extend with slots/props rather than forking |
+| Entity link queries slow on large projects | LOW | LOW | Indexes on both source and target columns |
+
+---
+
+## What This Document Does NOT Cover
+
+- Living Link change detection and notifications (Phase 3)
+- Copilot guided flow and canvas population (Phase 3)
+- Diff view and regeneration flow (Phase 3)
+- Ideas Board or Goal Canvas adapters (Phase 4)
+- Stakeholder View plugin (Phase 4)
+- Template system for pre-populated canvases (Phase 4)
+- WorkStructure nesting for programs (open question)
+- Business model decisions (free/bundled/premium)

--- a/Docs/09-leantime-workstructure-ADDENDUM-MAPPING-CORRECTION.md
+++ b/Docs/09-leantime-workstructure-ADDENDUM-MAPPING-CORRECTION.md
@@ -1,0 +1,146 @@
+# 09-ADDENDUM-MAPPING-CORRECTION.md
+
+## Addendum: Canvas-to-Entity Mapping Correction
+
+**Applies to:** `07-WORKSTRUCTURE.md` (Section 4.2) and `08-WORKSTRUCTURE-PROMPT.md` (Section 2.2)
+**Date:** February 20, 2026
+**Trigger:** Review of populated Logic Model board with real workforce development data
+**Status:** APPROVED — supersedes mapping tables in referenced documents
+
+---
+
+## What Changed
+
+The original PRD mapped Activities → Milestones and Outputs → Tasks. This was backwards. Review of a real populated board (DOL WIOA workforce development program) revealed that the natural mapping follows the Logic Model's bottom-up causal chain.
+
+---
+
+## Corrected Mapping
+
+| Canvas Stage | What It Means | Leantime Entity | Example from Real Board |
+|---|---|---|---|
+| **Inputs** (Stage 1) | What I have to work with | Resources / dependencies / notes | "DOL WIOA grant funding", "Case management staff" |
+| **Activities** (Stage 2) | What I'll do every day | **Tasks (to-dos)** | "Skills assessment and IEP creation", "Job placement and retention coaching" |
+| **Outputs** (Stage 3) | How I know I'm on track | **Milestones (delivery markers)** | "200 participants enrolled annually", "150 credentials earned" |
+| **Outcomes** (Stage 4) | The results of that work | Goals (Goalcanvas) | "75% credential attainment rate", "80% retention at 6 months" |
+| **Impact** (Stage 5) | How it changes the world | Project objective / strategy description | "Increase economic self-sufficiency", "Reduce unemployment in target communities" |
+
+### Previous (Incorrect) Mapping
+
+| Canvas Stage | Was Mapped To | Why It Was Wrong |
+|---|---|---|
+| Activities (Stage 2) | Milestones | Activities are things people *do*. "Skills assessment and IEP creation" is a task, not a milestone. |
+| Outputs (Stage 3) | Tasks | Outputs are what activities *produce*. "200 participants enrolled" is a delivery target — a milestone you hit or miss. |
+
+---
+
+## Impact on Documents
+
+### 07-WORKSTRUCTURE.md — Section 4.2 (Logic Model Source Adapter)
+
+**Replace the mapping table with:**
+
+| Canvas Stage | WorkStructure Property | Mapping |
+|---|---|---|
+| Impact (Stage 5) | `objective` | Item title → strategic objective / project description |
+| Outcomes (Stage 4) | `goals[]` | Each item → ProposedGoal with metrics (startValue, endValue, metricType) |
+| Outputs (Stage 3) | `milestones[]` | Each item → ProposedMilestone. These are delivery markers the team works toward. |
+| Activities (Stage 2) | `tasks[]` | Each item → ProposedTask, grouped under parent Output's milestone via canvas relationships. |
+| Inputs (Stage 1) | `resources[]` | Items → resource notes, budget entries, team requirements |
+
+### 08-WORKSTRUCTURE-PROMPT.md — Section 2.2 (LogicModelAdapter)
+
+**Replace the mapping table with:**
+
+| Canvas Stage | DB Source | WorkStructure Target | Mapping Logic |
+|---|---|---|---|
+| Impact (stage 5) | `zp_canvas_items` where `box = 'box5'` | `$structure->objective` | First item's title → objective. Additional items → metadata. |
+| Outcomes (stage 4) | `zp_canvas_items` where `box = 'box4'` | `$structure->goals[]` | Each item → ProposedGoal. Use item description for metric details. |
+| Outputs (stage 3) | `zp_canvas_items` where `box = 'box3'` | `$structure->milestones[]` | Each item → ProposedMilestone. tempId = 'ms-' + item ID. |
+| Activities (stage 2) | `zp_canvas_items` where `box = 'box2'` | `$structure->tasks[]` | Each item → ProposedTask. Use `relates_to` field to link to parent Output's milestone. |
+| Inputs (stage 1) | `zp_canvas_items` where `box = 'box1'` | `$structure->resources[]` | Each item → ProposedResource. Infer type from content. |
+
+### 08-WORKSTRUCTURE-PROMPT.md — Section 2.5 (HxControllers)
+
+**Step 1 (ScopeStep)** now shows Outputs as proposed milestones, not Activities.
+
+**Step 2 (DeliverablesStep)** now shows Activities as proposed tasks grouped under their parent Output milestones.
+
+### 08-WORKSTRUCTURE-PROMPT.md — Section 2.7 (Step Partials)
+
+**Replace `wizard-scope.blade.php` description with:**
+
+Step 1 shows **Outputs** mapped as proposed milestones. Each row: Output title (editable), description (expandable), start/end date pickers, checkbox to include/exclude. These are the delivery markers the team works toward.
+
+**Replace `wizard-deliverables.blade.php` description with:**
+
+Step 2 shows **Activities** mapped as proposed tasks, grouped under their parent Output milestone. Each milestone section is an accordion. Inside: list of task rows from Activities. "Add task" button per section for tasks not yet on the canvas.
+
+---
+
+## Impact on Wizard UX
+
+### Task-to-Milestone Grouping
+
+The grouping of tasks under milestones comes from the **Output → Activity relationship** on the canvas. Specifically:
+
+- If an Activity's `relates_to` field points to an Output, the resulting task is grouped under that Output's milestone.
+- If an Activity has no `relates_to`, it becomes an ungrouped task. The wizard should prompt the user to assign it to a milestone.
+
+**Note to Claude Code:** Verify how the canvas stores relationships between items across stages. The `relates_to` field, parent-child relationships, or a separate relationship table — check the Phase 1 implementation for the actual mechanism.
+
+### Adaptive Weight Implications
+
+For a **rich** board (like the workforce development example), the wizard flow changes:
+
+- Stage 1 has 3 Outputs → 3 proposed milestones. Almost no editing needed.
+- Stage 2 has 3 Activities → 3 proposed tasks. User confirms grouping under milestones.
+- Stage 3 has 3 Outcomes → 3 proposed goals. Confirm metric types.
+- This should collapse to a **single review screen** since the data is clean.
+
+For a **sparse** board (e.g., only Activities filled in):
+
+- No Outputs → no milestones to create. Wizard asks: "What deliverables would tell you these activities are working?"
+- This is where the extended prompts kick in to fill gaps.
+
+---
+
+## The Bottom-Up Mental Model
+
+The Logic Model reads as a bottom-up causal chain that maps directly to Leantime's work hierarchy:
+
+```
+Inputs       → "Here's what I have"           → Resources / dependencies
+Activities   → "Here's what I'll do"           → Tasks (to-dos)
+Outputs      → "Here's how I know I'm on track" → Milestones (delivery markers)
+Outcomes     → "Here's the results of that work" → Goals (measurable targets)
+Impact       → "Here's how it changes the world" → Project objective / strategy
+```
+
+This also clarifies the Copilot routing question:
+
+| Starting Point | Direction | Who Thinks This Way |
+|---|---|---|
+| Inputs forward (bottom up) | "I have these resources, what can I do?" | Scarcity-driven, constrained orgs |
+| Impact backward (top down) | "Here's the change I want, what would it take?" | Vision-driven, strategic planning |
+| Activities outward (middle out) | "I know what we do, help me frame it" | Existing programs documenting retroactively |
+
+All three fill the same board. The wizard reads the same board. The entities come out identical.
+
+---
+
+## No Other Changes
+
+Everything else in the PRD and prompt doc remains correct:
+
+- WorkStructure core domain architecture — unchanged
+- WorkGenerator service — unchanged (it creates milestones and tasks; only the source of each changes)
+- WorkStructureReader — unchanged
+- Entity links — unchanged
+- Events — unchanged
+- Component architecture — unchanged
+- Blade component list — unchanged
+- Execution order — unchanged
+- Risk register — unchanged
+
+The only delta is which canvas stage maps to which entity type in the LogicModelAdapter.

--- a/Docs/10-LEANTIME-UTD-WORKSTRUCTURE-ARCHITECTURE.md
+++ b/Docs/10-LEANTIME-UTD-WORKSTRUCTURE-ARCHITECTURE.md
@@ -1,0 +1,328 @@
+# 10-ADDENDUM-WORKSTRUCTURE-ARCHITECTURE.md
+
+## Addendum: WorkStructure as Schema Definition Layer
+
+**Applies to:** `07-WORKSTRUCTURE.md` (Section 2), `08-WORKSTRUCTURE-PROMPT.md` (Deliverable 1)
+**Date:** February 21, 2026
+**Trigger:** Architecture review — WorkStructure was specced as a data container holding domain-specific models. It should be a schema definition layer that describes structures, element types, and relationships without holding instance data.
+**Status:** APPROVED — supersedes all core domain specs in referenced documents
+
+---
+
+## What Changed
+
+The original spec defined WorkStructure as a normalized data object containing `ProposedMilestone`, `ProposedTask`, `ProposedGoal`, etc. This violated DDD by pulling domain-specific models into the WorkStructure domain and conflated the structure definition with instance data.
+
+**WorkStructure is a schema, not a container.** It defines what types of elements exist, how they relate to each other, and how one structure maps to another. It does not hold individual milestones, tasks, or goals. Those stay in their own domain tables (`zp_tickets`, `zp_canvas_items`, `zp_goal_canvas_items`). WorkStructure describes the *shape* — like a UML diagram describes tables without containing rows.
+
+---
+
+## Core Concepts
+
+### WorkStructure
+
+A named, reusable definition of how work is organized. Examples:
+
+- **"Project"** — the current Leantime hierarchy: milestones contain tasks, goals measure milestones
+- **"Logic Model"** — five stages (input → activity → output → outcome → impact) with causal relationships
+- **"Simple Project"** — tasks only, no milestones
+- **"Program"** — projects grouped under a program with shared resources
+
+Each is a different organizational opinion. The system ships with a few. Plugins can register more.
+
+### Element Definition
+
+A type of thing that can exist within a structure. WorkStructure doesn't know what a "milestone" is — it knows that the "Project" structure has an element definition called "milestone" with certain metadata, a reference to a state machine (future), and a class/domain reference for entity realization.
+
+### Relationship Definition
+
+How element types relate to each other within a structure. Directional. "task belongs_to milestone" and "milestone measures goal" are relationship definitions within the "Project" structure.
+
+### Cross-Structure Mapping
+
+How element types in one structure correspond to element types in another. This is what makes the wizard possible: "Logic Model output ↔ Project milestone" means when you generate work from a Logic Model, outputs become milestones. The mapping is a relationship between structures, not between instances.
+
+---
+
+## How It Works — Logic Model Wizard Example
+
+```
+1. User fills out Logic Model Canvas (data in zp_canvas_items)
+
+2. User clicks "Create Work from Canvas"
+
+3. Wizard reads the Logic Model WorkStructure definition:
+   - It has element types: input, activity, output, outcome, impact
+   - It has relationships: input→activity, activity→output, etc.
+
+4. Wizard reads the cross-structure mapping:
+   - Logic Model "output" ↔ Project "milestone"
+   - Logic Model "activity" ↔ Project "task"  
+   - Logic Model "outcome" ↔ Project "goal"
+   - Logic Model "impact" ↔ Project (the structure itself)
+
+5. Wizard presents canvas items mapped to their target types:
+   - "200 participants enrolled" (output) → will become a milestone
+   - "Skills assessment" (activity) → will become a task
+   - User confirms/edits
+
+6. Generator creates entities in their native domain tables:
+   - Milestone → zp_tickets (via Tickets service)
+   - Task → zp_tickets (via Tickets service)
+   - Goal → zp_goal_canvas_items (via Goalcanvas service)
+
+7. Entity relationships recorded in zp_entityrelations:
+   - canvas_item_42 → ticket_108 (generated_from)
+   - canvas_item_37 → ticket_115 (generated_from)
+```
+
+WorkStructure never held the data. It defined the shape that told the wizard how to map and the generator what to create.
+
+---
+
+## Data Model
+
+### zp_work_structures
+
+The structure definitions themselves.
+
+| Column | Type | Purpose |
+|---|---|---|
+| id | INT (PK) | Auto-increment |
+| title | VARCHAR(255) | Human name: "Project", "Logic Model", "Program" |
+| description | TEXT | What this structure represents |
+| type | VARCHAR(50) | Classifier: 'system', 'plugin', 'custom' |
+| created_by | INT NULL | NULL for system-defined structures |
+| meta | JSON NULL | Extensible metadata |
+| created_at | DATETIME | Timestamp |
+| modified_at | DATETIME | Timestamp |
+
+**Ships with:**
+- "Project" (system) — codifies current milestone/task/goal hierarchy
+- "Logic Model" (plugin, registered by StrategyPro) — five-stage causal chain
+
+### zp_work_structure_elements
+
+Element type definitions within a structure. Not instances — definitions.
+
+| Column | Type | Purpose |
+|---|---|---|
+| id | INT (PK) | Auto-increment |
+| structure_id | INT (FK) | Which structure this element type belongs to |
+| type_key | VARCHAR(50) | Identifier: 'milestone', 'task', 'activity', 'output', etc. |
+| label | VARCHAR(100) | Human display name |
+| description | TEXT NULL | What this element type represents in this structure |
+| domain_reference | VARCHAR(255) NULL | Class or domain that realizes this type (e.g., 'Leantime\\Domain\\Tickets') |
+| sort_order | INT | Display/hierarchy order within the structure |
+| meta | JSON NULL | Extensible: icon, color, default fields, state machine ref (future) |
+| created_at | DATETIME | Timestamp |
+
+**Example rows for "Project" structure:**
+
+| structure_id | type_key | label | domain_reference | sort_order |
+|---|---|---|---|---|
+| 1 | milestone | Milestone | Leantime\Domain\Tickets | 1 |
+| 1 | task | Task | Leantime\Domain\Tickets | 2 |
+| 1 | goal | Goal | Leantime\Domain\Goalcanvas | 3 |
+
+**Example rows for "Logic Model" structure:**
+
+| structure_id | type_key | label | domain_reference | sort_order |
+|---|---|---|---|---|
+| 2 | input | Input | Leantime\Domain\Logicmodelcanvas | 1 |
+| 2 | activity | Activity | Leantime\Domain\Logicmodelcanvas | 2 |
+| 2 | output | Output | Leantime\Domain\Logicmodelcanvas | 3 |
+| 2 | outcome | Outcome | Leantime\Domain\Logicmodelcanvas | 4 |
+| 2 | impact | Impact | Leantime\Domain\Logicmodelcanvas | 5 |
+
+### zp_work_structure_relationships
+
+How element types relate within a structure.
+
+| Column | Type | Purpose |
+|---|---|---|
+| id | INT (PK) | Auto-increment |
+| structure_id | INT (FK) | Which structure this relationship belongs to |
+| from_element_id | INT (FK) | Source element definition |
+| to_element_id | INT (FK) | Target element definition |
+| relationship_type | VARCHAR(50) | 'belongs_to', 'produces', 'measures', 'funds', 'leads_to', etc. |
+| description | TEXT NULL | Human description of this relationship |
+| meta | JSON NULL | Extensible |
+
+**Example rows for "Project":**
+
+| from (type_key) | to (type_key) | relationship_type |
+|---|---|---|
+| task | milestone | belongs_to |
+| milestone | goal | measures |
+
+**Example rows for "Logic Model":**
+
+| from (type_key) | to (type_key) | relationship_type |
+|---|---|---|
+| input | activity | enables |
+| activity | output | produces |
+| output | outcome | leads_to |
+| outcome | impact | contributes_to |
+
+### zp_work_structure_mappings
+
+Cross-structure element type mappings. This is what powers the wizard's translation.
+
+| Column | Type | Purpose |
+|---|---|---|
+| id | INT (PK) | Auto-increment |
+| source_structure_id | INT (FK) | Source structure (e.g., Logic Model) |
+| source_element_id | INT (FK) | Source element definition (e.g., "output") |
+| target_structure_id | INT (FK) | Target structure (e.g., Project) |
+| target_element_id | INT (FK) | Target element definition (e.g., "milestone") |
+| mapping_type | VARCHAR(50) | 'equivalent', 'generates', 'informs' |
+| meta | JSON NULL | Extensible |
+
+**Example rows:**
+
+| source structure | source element | target structure | target element | mapping_type |
+|---|---|---|---|---|
+| Logic Model | impact | Project | (structure itself) | generates |
+| Logic Model | output | Project | milestone | generates |
+| Logic Model | activity | Project | task | generates |
+| Logic Model | outcome | Project | goal | generates |
+
+### Instance-Level Relationships
+
+When the wizard actually creates work from a canvas, the **instance-level** connections (canvas item #42 generated ticket #108) are recorded in the **existing `zp_entityrelations` table**. No new table needed.
+
+**Note to Claude Code:** Review the existing Entityrelations domain (`app/Domain/Entityrelations/`). Understand its table structure, relationship types, and service methods. Build on it. If it needs enhancement (e.g., a `generated_from` relationship type or a `source_context` metadata field), extend it rather than creating a parallel linking system.
+
+---
+
+## Domain Structure
+
+### Revised File Layout
+
+```
+app/Domain/WorkStructure/
+├── Models/
+│   ├── WorkStructure.php              # Structure definition
+│   ├── ElementDefinition.php          # Element type within a structure
+│   ├── RelationshipDefinition.php     # How element types relate
+│   └── StructureMapping.php           # Cross-structure element mapping
+├── Services/
+│   ├── WorkStructureService.php       # CRUD for structures and definitions
+│   ├── StructureRegistry.php          # Plugins register structures + elements
+│   └── MappingService.php             # Cross-structure mapping queries
+├── Repositories/
+│   └── WorkStructureRepository.php    # All table access
+├── Events/
+│   ├── StructureRegistered.php        # A new structure was registered
+│   ├── ElementTypeRegistered.php      # A new element type was added
+│   └── MappingCreated.php             # A cross-structure mapping was defined
+└── register.php                       # Registers "Project" as system structure
+```
+
+### What's Gone
+
+These models from the original spec are **removed** — they were domain-specific:
+
+- ~~ProposedMilestone.php~~ → Tickets domain concern
+- ~~ProposedTask.php~~ → Tickets domain concern
+- ~~ProposedGoal.php~~ → Goalcanvas domain concern
+- ~~ProposedResource.php~~ → future ResourceStructure concern
+- ~~SourceMeta.php~~ → adapter concern (stays in plugin)
+- ~~RoutingDecision.php~~ → wizard concern (stays in plugin)
+- ~~EntityLink.php~~ → use existing Entityrelations domain
+- ~~CompletenessReport.php~~ → adapter concern (stays in plugin)
+- ~~WorkGenerator.php~~ → moves to plugin (see below)
+- ~~WorkStructureReader.php~~ → moves to plugin (see below)
+- ~~EntityLinkRepository.php~~ → use existing Entityrelations
+- ~~zp_entity_links table~~ → use existing zp_entityrelations
+
+### What Moves to StrategyPro Plugin
+
+The WorkGenerator and WorkStructureReader were doing domain-specific entity creation (calling `Tickets::quickAddMilestone()`, `Goalcanvas::createGoal()`). That logic belongs in the plugin, not core. Core defines the structure; the plugin knows how to realize elements as domain entities.
+
+```
+app/Plugins/StrategyPro/
+├── Services/
+│   ├── LogicModelAdapter.php          # Reads canvas, uses mappings to propose work
+│   ├── WorkGenerator.php              # Creates domain entities from mapped elements
+│   ├── WizardStateService.php         # Cache-based wizard state
+│   └── (CompletenessReport, RoutingDecision, SourceMeta as needed)
+```
+
+The generator reads the cross-structure mapping (Logic Model → Project), iterates the canvas items, and for each mapped element type, calls the appropriate domain service. It records instance-level relationships in `zp_entityrelations`.
+
+---
+
+## Impact on Other Documents
+
+### 07-WORKSTRUCTURE.md
+
+**Section 2 (Core Domain):** Replace entirely with the architecture described in this addendum. The core domain is a schema definition layer with four tables and a registry, not a data container with typed models.
+
+**Section 3 (Events):** Replace the entity-level events (WorkGenerationStarted, etc.) with structure-level events (StructureRegistered, ElementTypeRegistered, MappingCreated). Generation events move to the plugin.
+
+**Sections 4-9:** Mostly unchanged. The wizard, components, Copilot, future consumers, phasing, and telemetry all work the same way. They just interact with WorkStructure as a definition layer rather than a data container.
+
+### 08-WORKSTRUCTURE-PROMPT.md
+
+**Deliverable 1:** Rewrite to create the four tables, four models, three services, and system "Project" structure registration.
+
+**Deliverable 2:** Mostly unchanged. The LogicModelAdapter now reads structure mappings to know output→milestone. The WorkGenerator moves from core to plugin. The wizard UX is identical.
+
+### 09-ADDENDUM-MAPPING-CORRECTION.md
+
+Still valid. The corrected mapping (Activities→Tasks, Outputs→Milestones) is now expressed as rows in `zp_work_structure_mappings` rather than as code in the adapter. Same mapping, different storage.
+
+---
+
+## What Ships First (Minimum Viable)
+
+1. **Four tables:** `zp_work_structures`, `zp_work_structure_elements`, `zp_work_structure_relationships`, `zp_work_structure_mappings`
+
+2. **Four models:** `WorkStructure`, `ElementDefinition`, `RelationshipDefinition`, `StructureMapping`
+
+3. **Core services:** `WorkStructureService` (CRUD), `StructureRegistry` (plugin registration), `MappingService` (cross-structure queries)
+
+4. **System structure:** "Project" registered in `register.php` with element types: milestone, task, goal and their relationships
+
+5. **Plugin structure:** "Logic Model" registered by StrategyPro with element types: input, activity, output, outcome, impact and their relationships plus cross-structure mappings to Project
+
+6. **Instance relationships:** Use existing `zp_entityrelations` for canvas-item-to-entity links after generation
+
+### Deferred
+
+- State machine definitions per element type (future)
+- Custom user-defined structures (future)
+- Dynamic MCP/JSON-RPC tool generation from registered element types (future)
+- ResourceStructure as a parallel core definition (future, see separate spec)
+- API query patterns for LLM navigation (future)
+
+---
+
+## Caching Considerations
+
+WorkStructure definitions are read-heavy, write-rare. Structure definitions, element types, relationships, and mappings should be cached aggressively:
+
+- Cache all structures + their element definitions on first load
+- Invalidate on structure registration (rare — only happens when plugins activate)
+- Instance-level queries (entityrelations) follow existing caching patterns
+
+**Note to Claude Code:** Use Laravel cache (file or Redis depending on config). Check how other domains handle caching — look for `Cache::remember()` patterns in existing services. Structure definitions are perfect candidates for `Cache::rememberForever()` with manual invalidation on registration events.
+
+---
+
+## API/MCP Future Direction (Not Built Now, But Design For It)
+
+When element types are registered with `domain_reference` and metadata including descriptions, the system has enough information to dynamically generate API tools:
+
+```
+Element type "milestone" registered by Tickets domain
+→ Auto-generate: get_all_milestones, create_milestone, update_milestone
+→ Tool description pulled from ElementDefinition.description
+→ Parameters inferred from domain service method signatures
+```
+
+This means installing a plugin that registers new element types automatically expands the API surface. An LLM querying Leantime via MCP sees `get_all_activities` appear when StrategyPro is activated, without anyone writing a new MCP tool definition.
+
+**Design implication:** Element definitions should carry enough metadata (description, domain_reference, and eventually parameter schemas) to support this future auto-generation. The `meta` JSON column on `zp_work_structure_elements` is where this lives.

--- a/Docs/11-ADDENDUM-RESOURCE-DECISIONS.md
+++ b/Docs/11-ADDENDUM-RESOURCE-DECISIONS.md
@@ -1,0 +1,165 @@
+# 11-ADDENDUM-RESOURCE-DECISIONS.md
+
+## Addendum: Resource Management Boundaries & Plugin Decisions
+
+**Applies to:** `07-WORKSTRUCTURE.md`, `08-WORKSTRUCTURE-PROMPT.md`, `10-ADDENDUM-WORKSTRUCTURE-ARCHITECTURE.md`
+**Date:** February 21, 2026
+**Trigger:** Discussion of where resource management lives, program-level work creation, and future adaptive capacity
+**Status:** APPROVED
+
+---
+
+## Decisions
+
+### 1. ResourceStructure is a Core Data Layer
+
+ResourceStructure follows the same pattern as WorkStructure: a thin core domain that stores the data (allocation tables, models, basic query service). It does not contain management UI or business logic. Any plugin or view can read from it.
+
+```
+app/Domain/ResourceStructure/
+├── Models/
+├── Services/
+├── Repositories/
+└── register.php
+```
+
+Deferred to PgmPro redesign. Not built with the initial WorkStructure delivery.
+
+### 2. Resource Management Lives in PgmPro
+
+There is no separate ResourceManagement plugin. PgmPro owns the resource management experience — allocation UI, budget tracking, people assignment across projects. It writes to ResourceStructure core tables.
+
+Rationale: Resource allocation is inherently a program-level decision. A program manager allocating budget and people across child projects IS program management. Separating it into its own plugin creates an orphan with no natural home.
+
+### 3. Program View: Aggregate Read + Resource Write
+
+The program-level view has two modes:
+
+**Read-only aggregation** of work data from child entities:
+- Goals (from Goalcanvas, linked via entityrelations)
+- Project status (from child projects)
+- Timeline (milestones rolled up from child projects)
+- Source link back to originating canvas (Logic Model or other)
+
+**Read-write resource management** (the program manager's workspace):
+- Allocate people to child projects
+- Set budget envelopes per project
+- Track allocation vs. actuals (hours, budget)
+
+Without the resource features, the program view is a curated read-only dashboard. Resource management upgrades it to an actual workspace.
+
+### 4. Routing-Dependent Mapping
+
+When the wizard creates work, the canvas-to-entity mapping changes based on the routing decision:
+
+| Canvas Stage | → Single Project | → Program |
+|---|---|---|
+| Impact | Project description | Program description |
+| Outcomes | Goals | Goals (program-level) |
+| Outputs | Milestones | Goals (program-level KPIs) |
+| Activities | Tasks | Projects (one per activity) |
+| Inputs | Resource notes | Resource allocations (when resource features ship) |
+
+This means the wizard must ask routing BEFORE presenting the mapping. Routing moves from Step 4 to Step 1 in the wizard flow.
+
+**Note to Claude Code:** The wizard step order in `08-WORKSTRUCTURE-PROMPT.md` Section 2.5 changes. Routing selection is now the first interaction. The scope/deliverables/criteria steps that follow adapt their labels and grouping based on whether the user chose project or program routing.
+
+### 5. Logic Model Canvas Appears at Both Levels
+
+**StrategyPro plugin** provides the Logic Model Canvas board type. It can be used at:
+
+- **Strategy level:** Planning and framing (the primary creation context)
+- **Program level:** As the source canvas linked to the program. Not embedded or duplicated — the program view links back to it and shows live status indicators on canvas items based on entityrelations to child project data.
+
+---
+
+## Plugin Boundary Summary
+
+### StrategyPro (Strategy Management)
+
+**Owns:**
+- Logic Model Canvas board type
+- Work creation wizard (canvas → project or program)
+- Cross-structure mappings (Logic Model → Project, Logic Model → Program)
+- Living Link (bidirectional canvas ↔ work navigation)
+- Future: additional canvas types, board templates, stakeholder views
+
+**Does not own:**
+- Resource management (PgmPro)
+- Program dashboard aggregation (PgmPro)
+- Personal capacity management (future ACM)
+
+### PgmPro (Program Management)
+
+**Owns:**
+- Program dashboard (aggregate view of child projects, goals, timelines)
+- Resource management UI (people allocation, budget envelopes, capacity tracking)
+- Writes to ResourceStructure core tables
+- Program-level goal surfacing (reads goals linked via entityrelations)
+
+**Ships in phases:**
+1. Aggregate read-only dashboard + basic resource data inputs (fast follow to WorkStructure)
+2. Full resource allocation and tracking features
+3. Allocation vs. actuals reporting
+
+**Does not own:**
+- Logic Model Canvas (StrategyPro)
+- Work creation wizard (StrategyPro)
+- Personal capacity or individual workload (future ACM)
+
+### Future: Adaptive Capacity Management (ACM)
+
+**Concept:** Personal capacity management that goes beyond simple hour allocation. Helps the user manage their day-to-day energy, focus, and workload based on:
+
+- Motivational profile and energy patterns (enmotiv integration)
+- Mental/emotional capacity signals
+- External biometric sources (Apple Health, Oura)
+- Motivational overlap — alignment between assigned work and what energizes the user
+
+**Reads from:**
+- ResourceStructure (what's been allocated to this user)
+- WorkStructure (what work exists and its state)
+- Timesheets (actual hours logged)
+- enmotiv (motivational profile, behavioral patterns)
+- External APIs (health/biometric data)
+
+**Does not duplicate:**
+- Program-level resource allocation (that's PgmPro)
+- Project-level task assignment (that's existing Tickets domain)
+
+ACM is the personal companion layer. PgmPro allocates resources top-down. ACM helps the individual manage their capacity bottom-up. They read from the same data but serve different users with different questions.
+
+---
+
+## Data Flow Summary
+
+```
+StrategyPro                    PgmPro                      ACM (future)
+  │                              │                             │
+  │ Creates work from            │ Allocates resources         │ Manages personal
+  │ canvas via wizard            │ across projects             │ capacity & energy
+  │                              │                             │
+  ▼                              ▼                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                          CORE                                       │
+│                                                                     │
+│  WorkStructure          ResourceStructure        Entityrelations    │
+│  (structure schemas)    (allocation tables)      (instance links)   │
+│                                                                     │
+│  Tickets    Goalcanvas    Projects    Timesheets    Users           │
+│  (tasks,    (goals)       (projects,  (hours)       (people)       │
+│  milestones)              programs)                                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## No Other Changes
+
+The WorkStructure core domain architecture (addendum 10), the mapping correction (addendum 09), and the wizard component/UX spec (08) remain valid. This addendum adds:
+
+- Routing-dependent mapping table
+- Wizard step reorder (routing first)
+- PgmPro as the resource management home
+- ACM as the future personal capacity layer
+- Plugin boundary definitions

--- a/Docs/12-RESOURCE-ALLOCATION.md
+++ b/Docs/12-RESOURCE-ALLOCATION.md
@@ -1,0 +1,633 @@
+# Resource Allocation View — PgmPro Plugin
+
+**Product Requirements Document**
+
+| Field | Value |
+|---|---|
+| Product | Leantime |
+| Feature | Resource Allocation View (PgmPro) |
+| Version | 2.0 |
+| Date | February 23, 2026 |
+| Author | Gloria Folaron |
+| Status | Draft |
+| Plugin | PgmPro (Program Management) |
+| Core Dependencies | ResourceStructure domain (schema), Canvas domain (storage) |
+| Prerequisites | WorkStructure Core, Logic Model Canvas Phase 1, StrategyPro Wizard |
+| Applies to | `10-ADDENDUM-WORKSTRUCTURE-ARCHITECTURE.md` (schema pattern), `11-ADDENDUM-RESOURCE-DECISIONS.md` (PgmPro owns resources) |
+
+---
+
+## 1. Overview
+
+### 1.1 Problem Statement
+
+Program managers who route Logic Model work into a program need to answer two fundamental questions:
+
+1. **Planning:** "Do I have what I need to run this program?" — budget, people, hours, dependencies.
+2. **Tracking:** "Is reality matching my plan?" — actual hours logged vs. planned, budget spend vs. budgeted.
+
+Today, Leantime has no program-level resource view. Resource information exists as text notes on Logic Model Inputs items or scattered across child project settings. There is no visual allocation, no capacity view, no budget tracking, and no plan-vs-actual comparison.
+
+### 1.2 Solution
+
+Three deliverables:
+
+**ResourceStructure (Core Domain):** A schema definition layer — parallel to WorkStructure — that defines what resource types exist (people allocations, budget items, dependencies) and how they relate. Does not hold instance data. Stores in canvas tables.
+
+**Resource Canvas (Board Type):** A new canvas board type (`type = 'resource'`) registered by PgmPro. Resource items live in `zp_canvas` / `zp_canvas_items` — the same tables every other canvas uses. No new tables for resource data.
+
+**Resource Allocation View (PgmPro):** A custom visualization that reads from the Resource Canvas but renders completely differently from a standard canvas board. Fill-up containers, stacked bars, summary strips. Two modes: V1 (planning) and V2 (plan vs. actual).
+
+### 1.3 Architecture: Why Canvas Tables
+
+Leantime has 14 canvas variants, all extending a Canvas base domain. They all store in `zp_canvas` (boards) and `zp_canvas_items` (items). Each variant differentiates by `type` column and interprets the generic item fields (`box`, `description`, `assumptions`, `data`, `conclusion`, `status`, `tags`) for its own semantics.
+
+Resource allocation follows the same pattern:
+
+| Canvas field | Resource semantics |
+|---|---|
+| `type` (on canvas) | `'resource'` |
+| `box` (stage) | `'people'`, `'budget'`, `'dependency'` |
+| `description` | Item name (person name, budget line name, partner name) |
+| `assumptions` | Role (for people), category (for budget) |
+| `data` | JSON: structured fields (hours, amounts, projectId, userId) |
+| `conclusion` | Notes / completion prompt text |
+| `status` | `'stub'`, `'active'`, `'archived'` |
+| `milestoneId` | Links to related project milestone (optional) |
+| `author` | Who created the resource item |
+| `tags` | Tagging for filtering |
+
+This means:
+- No new database tables for resource data
+- Full CRUD service layer inherited from Canvas base
+- Entityrelations linking to parent program and source Logic Model already works
+- Comments, tags, milestone linking, sorting — all free
+- Every canvas infrastructure improvement automatically benefits resources
+
+### 1.4 Architecture: ResourceStructure as Schema Layer
+
+Just as WorkStructure defines the *shape* of work without holding work instances, ResourceStructure defines the *shape* of resources without holding resource instances.
+
+```
+WorkStructure pattern:
+  Schema defines: element types (milestone, task, goal), relationships, cross-structure mappings
+  Instance data lives in: zp_tickets, zp_canvas_items, zp_goal_canvas_items
+  Plugins read/write through: schema-aware service layer
+
+ResourceStructure pattern:
+  Schema defines: resource types (people, budget, dependency), relationships, field contracts
+  Instance data lives in: zp_canvas_items (type='resource')
+  Plugins read/write through: schema-aware service layer
+```
+
+ResourceStructure registers a structure definition in WorkStructure's registry with element types for people, budget, and dependency. This means the same cross-structure mapping system that translates "Logic Model output → Project milestone" can also translate "Logic Model input → Resource allocation" — the wizard already knows how.
+
+### 1.5 Design Principles
+
+- **No new tables.** Canvas infrastructure handles storage. ResourceStructure handles schema.
+- **V1 is beautiful.** The planning view is the foundation — clean, focused, visually delightful. V2 adds complexity on top but never degrades V1.
+- **Project-first workflow.** Projects are the primary organizing unit. People and budget are allocated TO projects.
+- **Unified hover.** A single `hoveredProject` state drives highlighting across project rows, person containers, and budget items simultaneously.
+- **Progressive disclosure.** People and Budget sections collapse with inline summaries via shared components.
+- **Canvas seeding.** Logic Model Inputs stage auto-classifies into resource canvas items with `status='stub'`.
+
+### 1.6 Relationship to Existing Documents
+
+| Document | Relationship |
+|---|---|
+| `10-ADDENDUM-WORKSTRUCTURE-ARCHITECTURE.md` | ResourceStructure mirrors the schema-definition pattern |
+| `11-ADDENDUM-RESOURCE-DECISIONS.md` | PgmPro owns resource management, ResourceStructure is core data layer |
+| `07-WORKSTRUCTURE.md` | Resource structure registers alongside work structures |
+| `09-ADDENDUM-MAPPING-CORRECTION.md` | Inputs stage maps to resource items (not work entities) |
+
+---
+
+## 2. ResourceStructure Core Domain
+
+### 2.1 What It Is
+
+A schema definition layer that registers resource types and their field contracts. Lives in `app/Domain/ResourceStructure/`. Follows the same architecture as WorkStructure (addendum 10).
+
+### 2.2 Structure Registration
+
+ResourceStructure registers a "Resource" structure in the WorkStructure registry:
+
+| Element type_key | Label | Description | Domain reference |
+|---|---|---|---|
+| `people` | People | Person allocated to program with weekly hours per project | Canvas (type='resource', box='people') |
+| `budget` | Budget | Budget line item allocated to a project | Canvas (type='resource', box='budget') |
+| `dependency` | Dependency | External partnership or facility required | Canvas (type='resource', box='dependency') |
+
+Relationship definitions within the Resource structure:
+
+| From | To | Relationship | Meaning |
+|---|---|---|---|
+| people | (project entity) | `assigned_to` | Person works on this project |
+| budget | (project entity) | `funds` | Budget line funds this project |
+| dependency | (project entity) | `required_by` | Dependency needed for this project |
+
+Cross-structure mapping (Logic Model → Resource):
+
+| Source structure | Source element | Target structure | Target element | mapping_type |
+|---|---|---|---|---|
+| Logic Model | input | Resource | people | `generates` (when classified as people) |
+| Logic Model | input | Resource | budget | `generates` (when classified as budget) |
+| Logic Model | input | Resource | dependency | `generates` (when classified as dependency) |
+
+### 2.3 Field Contracts
+
+Each resource type defines its expected fields in the `data` JSON column of `zp_canvas_items`:
+
+**People items** (`box = 'people'`):
+```json
+{
+  "userId": 42,
+  "capacity": 40,
+  "allocations": {
+    "projectId_1": 15,
+    "projectId_2": 20
+  }
+}
+```
+- `description` = person name
+- `assumptions` = role title
+- `status` = "stub" (unassigned) | "active" (allocated)
+
+**Budget items** (`box = 'budget'`):
+```json
+{
+  "projectId": 7,
+  "budgeted": 85000,
+  "spent": 62000,
+  "color": "#3E937A"
+}
+```
+- `description` = budget line name
+- `assumptions` = category (personnel, materials, facilities, etc.)
+- `status` = "stub" (no amount) | "active" (amount set)
+
+**Dependency items** (`box = 'dependency'`):
+```json
+{
+  "partnerName": "Community College",
+  "type": "facility",
+  "confirmed": false
+}
+```
+- `description` = dependency name
+- `conclusion` = notes on status
+- `status` = "stub" (unconfirmed) | "active" (confirmed)
+
+### 2.4 Service Layer
+
+ResourceStructure provides a thin service that wraps canvas access with resource-specific semantics:
+
+```php
+class ResourceStructureService
+{
+    // Schema queries
+    public function getResourceElementTypes(): array;
+    public function getFieldContract(string $typeKey): array;
+
+    // Read methods — resource-aware wrappers around canvas service
+    public function getPeopleByProgram(int $programId): array;
+    public function getBudgetByProgram(int $programId): array;
+    public function getDependenciesByProgram(int $programId): array;
+
+    // Aggregation — joins canvas data with timesheets for actuals
+    public function getActualHours(int $programId, string $period = 'this_week'): array;
+    public function getBudgetSummary(int $programId): array;
+
+    // Write methods — create/update resource canvas items
+    public function allocatePerson(int $canvasId, array $personData): int;
+    public function setBudgetItem(int $canvasId, array $budgetData): int;
+    public function addDependency(int $canvasId, array $depData): int;
+
+    // Stub seeding — called during program creation
+    public function seedFromCanvasInputs(int $programId, int $canvasId, array $canvasInputs): void;
+    public function getStubCompletionStatus(int $programId): array;
+}
+```
+
+### 2.5 Domain Location
+
+```
+app/Domain/ResourceStructure/
+├── Models/
+│   └── ResourceFieldContract.php    # Defines expected JSON fields per type
+├── Services/
+│   ├── ResourceStructureService.php # Resource-aware canvas wrapper
+│   └── ResourceRegistrar.php        # Registers "Resource" in WorkStructure registry
+├── Repositories/
+│   └── ResourceStructureRepository.php  # Canvas queries filtered by type='resource'
+└── register.php
+```
+
+### 2.6 What It Does NOT Contain
+
+- No new database tables (uses canvas tables)
+- No UI (PgmPro handles visualization)
+- No board renderer (the resource view is custom, not a standard canvas board)
+- No domain-specific models for individual allocations (those are canvas items)
+
+---
+
+## 3. Shared Blade Components
+
+These components live in `app/Views/Templates/components/` and are available to any board, plugin, or view across Leantime.
+
+### 3.1 Collapsible Section
+
+A reusable expandable/collapsible container with header, inline summary when collapsed, and animated content reveal.
+
+**Component:** `x-collapsible`
+
+**Props:**
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | string | required | Section header text |
+| `icon` | string | null | Emoji or icon class for header |
+| `default-open` | boolean | true | Initial expanded state |
+| `collapsed-summary` | view | null | Blade partial shown inline when collapsed |
+
+**Behavior:**
+| Trigger | Effect |
+|---|---|
+| Click header | Toggle expanded/collapsed |
+| Collapsed | Header shows inline summary, no bottom border |
+| Expanded | Content renders below, 1px `#F0F1F3` border between header and content |
+| Animation | `max-height` transition, 0.3s ease |
+| Chevron | Rotates 180° on toggle, 0.2s ease |
+
+**Styling:**
+- Container: white background, 12px radius, 1px `#E8ECF0` border
+- Header padding: 14px 20px
+- Content padding: 18px 20px
+- Title: 14px weight 700 `#1A1A2E`
+- Chevron: `#9CA3AF` stroke, 16×16 SVG
+
+**Used in:** Resource view (People, Budget), future: Logic Model stages, program dashboard sections, settings panels.
+
+### 3.2 Proportion Bar
+
+A horizontal stacked bar where segments fill proportionally by value.
+
+**Component:** `x-proportion-bar`
+
+**Props:**
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `segments` | array | required | `[{value, color, label?, overlay?}]` |
+| `total` | number | sum of values | Denominator for proportions |
+| `height` | string | '8px' | Bar height |
+| `radius` | string | '4px' | Border radius |
+| `show-labels` | boolean | false | Show text labels inside segments |
+| `track-color` | string | '#F0F1F3' | Background track color |
+
+**Variants:**
+| Variant | Height | Labels | Usage |
+|---|---|---|---|
+| Thin | 6-8px | No | Summary strip, collapsed summaries, budget line items |
+| Medium | 28px | Yes (when segment > 12% width) | Budget expanded bar |
+| With overlay | Any | Optional | V2 spent/actual layer |
+
+**Overlay support:** Each segment can have an `overlay` object `{value, color}` that renders as a second fill within the segment (for V2 plan-vs-actual).
+
+**Used in:** Resource summary strip, budget bar, capacity bars, collapsed section summaries, any percentage-breakdown visualization.
+
+### 3.3 Avatar Stack
+
+Overlapping circular avatars with initials, colored by status.
+
+**Component:** `x-avatar-stack`
+
+**Props:**
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `people` | array | required | `[{initials, status}]` |
+| `size` | number | 28 | Circle diameter in px |
+| `overlap` | number | -6 | Negative margin for overlap |
+| `max-show` | number | 8 | Max visible before "+N" |
+
+**Status colors:**
+- At capacity (`status: 'full'`): `#059669` background
+- Partial (`status: 'partial'`): `#4A85B5` background
+- Open/unassigned (`status: 'open'`): dashed `#D1D5DB` border, transparent background
+
+**Used in:** Resource collapsed People summary, project cards, task assignment views.
+
+### 3.4 Metric Cell
+
+A labeled number with optional secondary text and mini visualization.
+
+**Component:** `x-metric-cell`
+
+**Props:**
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `label` | string | required | Top label text |
+| `value` | string | required | Primary number/text |
+| `suffix` | string | null | Unit suffix (h, %, K) |
+| `secondary` | string | null | Below-value text |
+| `color` | string | '#1A1A2E' | Value color |
+| `secondary-color` | string | '#9CA3AF' | Secondary text color |
+
+**Styling:**
+- Label: 11px weight 500 `#9CA3AF`
+- Value: 22px weight 700
+- Suffix: 12px weight 400 `#9CA3AF`
+- Secondary: 11px
+- Padding: 14px 18px
+
+**Used in:** Resource summary strip (Team Capacity, Allocated, Available, People, Budget cells), any dashboard header.
+
+---
+
+## 4. V1 — Planning Mode
+
+V1 answers: **"Do I have what I need to run this program?"**
+
+### 4.1 Summary Strip
+
+A horizontal row of `x-metric-cell` components separated by 1px dividers, inside a rounded container with `#E8ECF0` gap color.
+
+| Cell | Label | Value | Secondary | Condition |
+|---|---|---|---|---|
+| Team Capacity | "Team Capacity" | `{pct}% used` | `x-proportion-bar` (thin, project-colored) | — |
+| Allocated | "Allocated" | `{hours}h` | `of {capacity}h/wk` | — |
+| Available | "Available" | `{remaining}h` | `{pct}% open` | Amber if > 40h |
+| People | "People" | `{active}/{total}` | `{full} at capacity` | — |
+| Budget | "Budget" | `${allocated}K` | `${unallocated}K unallocated` | Amber if unallocated > 0 |
+
+### 4.2 Project Rows
+
+Each project is a horizontal card. See Section 8.2 for exact measurements.
+
+| Element | Position | Spec |
+|---|---|---|
+| Color swatch | Left | 14×14px, 4px radius, project color |
+| Project name | Left of center | 14px, weight 600 |
+| People count | Below name | 12px, `#9CA3AF` |
+| Hours | Right of center | 24px weight 700 + 13px suffix |
+| Capacity bar | Far right | `x-proportion-bar` (thin, 100px wide, single project color) |
+| Capacity % | Below bar | 10px `#9CA3AF` |
+
+### 4.3 People Section
+
+Wrapped in `x-collapsible` with `collapsed-summary` showing `x-avatar-stack` + counts + `x-proportion-bar`.
+
+#### Person Containers (Expanded)
+
+Each person renders as a vertical container that fills from the bottom. This is the signature visualization — not a shared component, it's resource-view specific.
+
+**Container spec:**
+- Width: 64px, Height: 200px (constant)
+- Border radius: 8px
+- Background: `#F0F2F5` (has allocations) or dashed `#D1D5DB` border (empty)
+- Tick marks at 25%, 50%, 75%: `1px solid rgba(0,0,0,0.04)`
+
+**Fill segments** (bottom to top, one per project):
+- Height: `(hours / capacity) × 100%`
+- Background: solid project color
+- Separator: 1.5px `rgba(255,255,255,0.5)` between segments
+- Label: `{hours}h` white, 12px weight 700 (when segment > 14% height)
+
+**Percentage badge:** Floating pill at fill line.
+- Background: `#1A1A2E` (partial) or `#059669` (full)
+- Font: 10px weight 700, white, padding 2px 8px, radius 10px
+
+**Footer:** `{allocated}/{capacity}h` — 12px weight 700
+
+**Empty state:** Dashed border, "+" (20px) + "Assign" (10px)
+
+### 4.4 Budget Section
+
+Wrapped in `x-collapsible` with `collapsed-summary` showing text metrics + `x-proportion-bar`.
+
+#### Expanded State
+
+**Stacked bar:** `x-proportion-bar` (medium variant, 28px, with labels)
+
+**Line items:** Color swatch (10×10) + name + amount + `x-proportion-bar` (thin, 100px) + percentage
+
+**Unallocated row:** Shows when `TOTAL_BUDGET - sum(budgeted) > 0`
+
+---
+
+## 5. V2 — Plan vs. Actual Mode
+
+V2 answers: **"Is reality matching my plan?"**
+
+V2 preserves every element of V1 and adds a second data layer on top. V2 overlays are additive — they never modify V1 elements.
+
+### 5.1 Reading Guide
+
+Appears only in V2, between auto-fill and summary strip. Background `#FAFBFC`, border `1px solid #F0F1F3`. Visual legend: solid swatch = planned, light overlay swatch = actual logged, numbers format = actual/planned.
+
+### 5.2 Summary Strip Additions
+
+Adds one `x-metric-cell` after "Allocated":
+
+| Cell | Label | Value | Secondary |
+|---|---|---|---|
+| Actual | "Actual (this wk)" | `{actual}h` | Variance text, color-coded |
+
+Budget cell changes: primary shows spent, secondary shows "of ${budgeted}K budgeted".
+
+### 5.3 Project Row Additions
+
+Replaces single hours display with Planned column, Actual column, and variance badge. Capacity bar gains dark overlay for actual proportion.
+
+**Variance color logic:**
+- Green `#059669` / bg `#ECFDF5`: variance ≤ +2h
+- Amber `#D97706` / bg `#FEF3C7`: variance < -5h
+- Red `#DC2626` / bg `#FEE2E2`: variance > +2h
+
+### 5.4 Person Container Additions
+
+Each segment gains an **actual overlay**:
+- Fill: `rgba(255,255,255,0.22)` from bottom of segment
+- Height: `(actual / planned) × 100%` of segment
+- Border: `2px solid rgba(255,255,255,0.6)` at top when < 100%
+- Label changes to `{actual}/{planned}` in 10px (smaller to fit)
+
+Footer changes: primary = `{actual}/{allocated}h`, variance line = "{N}h under/over" or "On track"
+
+### 5.5 Budget Section Additions
+
+Stacked bar: `x-proportion-bar` with overlay support — each segment gets spent overlay `rgba(0,0,0,0.12)`. Labels change to `${spent}K / ${budgeted}K`.
+
+Line items gain: burn rate badge (`{pct}% spent`), spent column, proportion bar overlay.
+
+---
+
+## 6. Canvas Auto-Fill Preview
+
+### 6.1 Purpose
+
+Shows how Logic Model Inputs stage items were auto-classified into resource canvas items during program creation. Toggled via "Show Canvas Auto-Fill" button.
+
+### 6.2 Classification Rules
+
+| Pattern | Classification | Canvas item created |
+|---|---|---|
+| `/funding\|grant\|budget\|allocation/i` | budget | `box='budget'`, `status='stub'` |
+| `/staff\|people\|manager\|coordinator\|specialist\|director/i` | people | `box='people'`, `status='stub'` |
+| `/partner\|organization\|vendor\|facility\|agreement/i` | dependency | `box='dependency'`, `status='stub'` |
+
+Count extraction: "3 case managers" → creates 3 separate people canvas items.
+Amount extraction: "$250K annual budget" → populates `data.budgeted` field.
+
+### 6.3 Layout
+
+Two-column mapping: left shows original canvas inputs with classification dots, right shows generated resource stubs grouped by category with completion prompts (amber badges: "Amount?", "Who? Hours?", "Status?").
+
+### 6.4 Setting Up → Ongoing
+
+Program starts with `status='stub'` items. Dashboard prompts completion. As stubs transition to `status='active'`, program enters Ongoing mode.
+
+---
+
+## 7. Data Flow
+
+### 7.1 Creation Flow
+
+```
+Logic Model Canvas (zp_canvas_items, type='logicmodel')
+  │
+  │ StrategyPro wizard
+  │
+  ├─→ Activities → Tasks           (WorkStructure mapping)
+  ├─→ Outputs → Milestones          (WorkStructure mapping)
+  ├─→ Outcomes → Goals              (WorkStructure mapping)
+  ├─→ Impact → Project/Program      (WorkStructure mapping)
+  │
+  └─→ Inputs → Resource Canvas Items  (ResourceStructure mapping)
+       │
+       │ Auto-classified: box='people' / 'budget' / 'dependency'
+       │ Created with status='stub' in Resource Canvas (zp_canvas_items, type='resource')
+       │
+       └─→ Entityrelations link canvas input → resource item (seeded_from)
+```
+
+### 7.2 Read Flow
+
+```
+PgmPro Resource View
+  │
+  ├─→ ResourceStructureService.getPeopleByProgram()
+  │     └─→ Canvas query: type='resource', box='people', projectId=program
+  │
+  ├─→ ResourceStructureService.getBudgetByProgram()
+  │     └─→ Canvas query: type='resource', box='budget', projectId=program
+  │
+  └─→ ResourceStructureService.getActualHours()  (V2 only)
+        └─→ JOIN zp_timesheets ON projectId + userId, aggregate by period
+```
+
+### 7.3 Data Sources
+
+| Data | Source | How |
+|---|---|---|
+| Projects | `zp_projects` via parent | Existing Projects service |
+| People allocations | `zp_canvas_items` (type='resource', box='people') | ResourceStructure service |
+| Budget items | `zp_canvas_items` (type='resource', box='budget') | ResourceStructure service |
+| Dependencies | `zp_canvas_items` (type='resource', box='dependency') | ResourceStructure service |
+| Actual hours (V2) | `zp_timesheets` grouped by project + user | ResourceStructure service |
+| Canvas stubs | Logic Model items via `zp_entityrelations` | At program creation |
+| User details | `zp_user` | Existing Users service |
+
+---
+
+## 8. Visual Design Specification
+
+### 8.1 Color Palette
+
+**Project colors:** `#3E937A` (green), `#C09035` (amber), `#8E6AAD` (purple)
+
+**Status:** `#059669` good, `#D97706` warning, `#DC2626` critical, `#9CA3AF` neutral
+
+**Surfaces:** `#F8F9FB` page, `#ffffff` cards, `#F0F1F3` tracks, `#E8ECF0` borders, `#1A1A2E` primary text
+
+### 8.2 Typography
+
+| Element | Size | Weight | Color |
+|---|---|---|---|
+| Page title | 22px | 700 | `#1A1A2E` |
+| Program name | 12px | 500 | `#9CA3AF` |
+| Section headers | 14px | 700 | `#1A1A2E` |
+| Summary numbers | 22px | 700 | `#1A1A2E` |
+| Summary labels | 11px | 500 | `#9CA3AF` |
+| Project row name | 14px | 600 | `#1A1A2E` |
+| Project row hours | 24px | 700 | `#1A1A2E` |
+| Container segment (V1) | 12px | 700 | `#ffffff` |
+| Container segment (V2) | 10px | 700 | `#ffffff` |
+| Container person name | 12px | 600 | `#1A1A2E` |
+| Budget line name | 13px | 500 | `#4B5563` |
+| Budget line amount | 14px | 700 | `#1A1A2E` |
+
+### 8.3 Spacing & Sizing
+
+| Element | Spec |
+|---|---|
+| Max content width | 960px centered |
+| Page padding | 32px × 24px |
+| Container | 64px wide × 200px tall, 8px gap, 8px radius |
+| Cards | 12px radius, 1px `#E8ECF0` border |
+| Capacity bar (row) | 100px × 8px × 4px radius |
+| Budget bar | 28px × 8px radius |
+| Swatches | 14×14 (rows), 10×10 (budget lines) |
+| Avatar stack | 28px circles, -6px overlap |
+
+### 8.4 V2 Visual Encoding
+
+| Element | Encoding |
+|---|---|
+| Container actual overlay | `rgba(255,255,255,0.22)`, border `2px solid rgba(255,255,255,0.6)` |
+| Budget actual overlay | `rgba(0,0,0,0.12)` |
+| Budget line bar overlay | `rgba(0,0,0,0.15)` |
+| Variance badges | Colored pill: green/amber/red backgrounds |
+
+---
+
+## 9. Interaction Patterns
+
+### 9.1 Unified Hover
+
+Single `hoveredProject` state shared across all sections. Dimming: rows `0.4`, segments `0.12`, budget lines `0.3`. Labels in dimmed segments: `opacity: 0`.
+
+### 9.2 Collapsible Sections
+
+Via `x-collapsible` shared component. People defaults expanded, Budget defaults expanded. Collapsed inline summaries show `x-avatar-stack`, counts, `x-proportion-bar`.
+
+### 9.3 Version Toggle
+
+Segmented control in header. V1 default. Components accept `version` prop. V1 code paths never modified by V2.
+
+---
+
+## 10. Edge Cases
+
+- **New program:** All zeros, empty states, auto-fill toggle visible if from canvas
+- **Unassigned people:** Dashed container, "?", not counted in capacity
+- **Over-allocated:** Badge turns red, fill clipped at 100% visually
+- **V2 with no actuals:** Overlays empty, all variance shows "under"
+- **Budget fully allocated:** No unallocated row, $0 in green
+
+---
+
+## 11. Future Considerations (Not in Scope)
+
+- Project creation/editing flow and people assignment UI
+- Historical plan vs. actual (multi-week trends)
+- Variance threshold configuration and alerts
+- Dependency tracking visualization
+- Gap analysis automation
+- Responsive/mobile layout, print/export, accessibility audit
+- ACM personal capacity layer (`11-ADDENDUM-RESOURCE-DECISIONS.md`)
+
+---
+
+## 12. Reference Implementation
+
+**File:** `ResourceV1V2.jsx` (969 lines) — pixel-accurate React prototype with hardcoded sample data. Production implementation reads from Resource Canvas via ResourceStructure service.

--- a/Docs/13-RESOURCE-ALLOCATION-PROMPT.md
+++ b/Docs/13-RESOURCE-ALLOCATION-PROMPT.md
@@ -1,0 +1,1089 @@
+# Resource Allocation — Claude Code Implementation Prompt
+
+**For Claude Code Execution**
+
+| Field | Value |
+|---|---|
+| Project | Leantime — PgmPro Plugin |
+| Scope | Resource Allocation View with canvas-backed storage |
+| Architecture | ResourceStructure (schema) + Canvas (storage) + PgmPro (view) |
+| Depends on | WorkStructure core, Canvas base domain, StrategyPro wizard, timesheets |
+| Risk | MEDIUM — new schema domain, new canvas type, shared components |
+
+---
+
+## Pre-Read Documents (Read These First)
+
+1. `CLAUDE.md` — project conventions, DI patterns, Blade rules
+2. `Docs/07-WORKSTRUCTURE.md` — WorkStructure overview
+3. `Docs/10-ADDENDUM-WORKSTRUCTURE-ARCHITECTURE.md` — **Critical:** schema-definition pattern to mirror
+4. `Docs/11-ADDENDUM-RESOURCE-DECISIONS.md` — PgmPro owns resource management
+5. `Docs/12-RESOURCE-ALLOCATION.md` — **The PRD for this build**
+6. `ResourceV1V2.jsx` — **Pixel-accurate visual reference**
+
+Additionally, before writing any code:
+- Read an existing canvas domain (e.g., `app/Domain/Ideas/`) to understand the canvas pattern: how `zp_canvas` and `zp_canvas_items` work, how `type` differentiates board variants, how `box` categorizes items
+- Read `app/Domain/Goalcanvas/` for a more complex canvas example with JSON data fields
+- Read `app/Domain/Entityrelations/` to understand instance-level linking
+
+---
+
+## Critical Constraints
+
+### DO
+
+- Use `zp_canvas` and `zp_canvas_items` tables for resource data storage — **NO new tables**
+- Register resource board type with `type = 'resource'` on `zp_canvas`
+- Use `box` column for resource categories: `'people'`, `'budget'`, `'dependency'`
+- Use `data` column for structured JSON (hours, amounts, allocations)
+- Use `status` column for `'stub'` / `'active'` / `'archived'`
+- Use `zp_entityrelations` for linking resource items to source canvas inputs
+- Follow the WorkStructure schema pattern from addendum 10
+- Use `tw:` prefix for all Tailwind classes
+- Use CSS custom properties for colors
+- Follow HxController pattern for HTMX interactions
+- Use DI via `init()` not `__construct()`
+- Use `@props` in Blade components
+- Build shared components in `app/Views/Templates/components/`
+- Test each deliverable before proceeding to the next
+
+### DO NOT
+
+- Create `zp_resource_allocations` or `zp_resource_budgets` tables — those are **removed from v1 spec**
+- Modify existing canvas domain services or repositories
+- Modify Logic Model Canvas board code
+- Modify existing Projects, Tickets, Timesheets, or Users services
+- Create `.tpl.php` files (Blade only)
+- Add jQuery (HTMX + vanilla JS only)
+
+---
+
+## Deliverable 1: Shared Blade Components
+
+Build four reusable components in `app/Views/Templates/components/`. These are core infrastructure — not plugin code.
+
+### 1A: Collapsible Section
+
+**File:** `app/Views/Templates/components/collapsible.blade.php`
+
+```blade
+@props([
+    'title' => '',
+    'icon' => null,
+    'defaultOpen' => true,
+    'id' => null,
+])
+
+<div
+    x-data="{ open: {{ $defaultOpen ? 'true' : 'false' }} }"
+    @if($id) id="{{ $id }}" @endif
+    class="tw:bg-white tw:rounded-xl tw:border tw:border-[#E8ECF0] tw:overflow-hidden"
+>
+    {{-- Header --}}
+    <button
+        @click="open = !open"
+        class="tw:w-full tw:flex tw:items-center tw:gap-3 tw:px-5 tw:py-3.5 tw:cursor-pointer tw:select-none"
+        :class="open ? 'tw:border-b tw:border-[#F0F1F3]' : ''"
+    >
+        @if($icon)
+            <span class="tw:text-sm">{{ $icon }}</span>
+        @endif
+        <span class="tw:text-sm tw:font-bold tw:text-[#1A1A2E]">{{ $title }}</span>
+
+        {{-- Collapsed summary slot --}}
+        <span x-show="!open" x-cloak class="tw:flex tw:items-center tw:gap-2 tw:ml-2">
+            {{ $collapsedSummary ?? '' }}
+        </span>
+
+        <svg
+            class="tw:ml-auto tw:w-4 tw:h-4 tw:text-[#9CA3AF] tw:transition-transform tw:duration-200"
+            :class="open ? 'tw:rotate-180' : ''"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+    </button>
+
+    {{-- Content --}}
+    <div
+        x-show="open"
+        x-collapse
+        class="tw:px-5 tw:py-4"
+    >
+        {{ $slot }}
+    </div>
+</div>
+```
+
+### 1B: Proportion Bar
+
+**File:** `app/Views/Templates/components/proportion-bar.blade.php`
+
+```blade
+@props([
+    'segments' => [],
+    'total' => null,
+    'height' => '8px',
+    'radius' => '4px',
+    'showLabels' => false,
+    'trackColor' => '#F0F1F3',
+])
+
+@php
+    $computedTotal = $total ?? collect($segments)->sum('value');
+    if ($computedTotal <= 0) $computedTotal = 1;
+@endphp
+
+<div
+    class="tw:w-full tw:overflow-hidden tw:flex"
+    style="height: {{ $height }}; border-radius: {{ $radius }}; background: {{ $trackColor }}"
+>
+    @foreach($segments as $seg)
+        @php
+            $pct = ($seg['value'] / $computedTotal) * 100;
+            $overlayPct = isset($seg['overlay']) ? ($seg['overlay']['value'] / max($seg['value'], 1)) * 100 : 0;
+        @endphp
+        <div
+            class="tw:relative tw:h-full tw:flex tw:items-center tw:justify-center"
+            style="width: {{ $pct }}%; background: {{ $seg['color'] }}"
+        >
+            @if($showLabels && $pct > 12 && isset($seg['label']))
+                <span class="tw:text-[10px] tw:font-bold tw:text-white tw:relative tw:z-10">
+                    {{ $seg['label'] }}
+                </span>
+            @endif
+
+            {{-- V2 overlay --}}
+            @if(isset($seg['overlay']))
+                <div
+                    class="tw:absolute tw:bottom-0 tw:left-0 tw:w-full"
+                    style="height: {{ min($overlayPct, 100) }}%; background: {{ $seg['overlay']['color'] }}"
+                ></div>
+            @endif
+        </div>
+    @endforeach
+</div>
+```
+
+### 1C: Avatar Stack
+
+**File:** `app/Views/Templates/components/avatar-stack.blade.php`
+
+```blade
+@props([
+    'people' => [],
+    'size' => 28,
+    'overlap' => -6,
+    'maxShow' => 8,
+])
+
+@php
+    $visible = array_slice($people, 0, $maxShow);
+    $remaining = count($people) - $maxShow;
+    $statusColors = [
+        'full' => '#059669',
+        'partial' => '#4A85B5',
+        'open' => 'transparent',
+    ];
+@endphp
+
+<div class="tw:flex tw:items-center">
+    @foreach($visible as $i => $person)
+        @php
+            $bg = $statusColors[$person['status'] ?? 'partial'] ?? '#4A85B5';
+            $isOpen = ($person['status'] ?? '') === 'open';
+        @endphp
+        <div
+            class="tw:rounded-full tw:flex tw:items-center tw:justify-center tw:font-bold tw:text-white tw:flex-shrink-0
+                   {{ $isOpen ? 'tw:border-2 tw:border-dashed tw:border-[#D1D5DB]' : '' }}"
+            style="width: {{ $size }}px; height: {{ $size }}px;
+                   font-size: {{ $size * 0.32 }}px;
+                   background: {{ $bg }};
+                   {{ $i > 0 ? 'margin-left: ' . $overlap . 'px;' : '' }}
+                   {{ !$isOpen ? 'border: 2px solid white;' : '' }}"
+        >
+            {{ $person['initials'] ?? '?' }}
+        </div>
+    @endforeach
+
+    @if($remaining > 0)
+        <div
+            class="tw:rounded-full tw:flex tw:items-center tw:justify-center tw:font-bold tw:text-[#9CA3AF] tw:bg-[#F0F1F3] tw:flex-shrink-0"
+            style="width: {{ $size }}px; height: {{ $size }}px;
+                   font-size: {{ $size * 0.32 }}px;
+                   margin-left: {{ $overlap }}px;
+                   border: 2px solid white;"
+        >
+            +{{ $remaining }}
+        </div>
+    @endif
+</div>
+```
+
+### 1D: Metric Cell
+
+**File:** `app/Views/Templates/components/metric-cell.blade.php`
+
+```blade
+@props([
+    'label' => '',
+    'value' => '',
+    'suffix' => null,
+    'secondary' => null,
+    'color' => '#1A1A2E',
+    'secondaryColor' => '#9CA3AF',
+])
+
+<div class="tw:px-4 tw:py-3.5">
+    <div class="tw:text-[11px] tw:font-medium tw:text-[#9CA3AF] tw:mb-1">
+        {{ $label }}
+    </div>
+    <div class="tw:flex tw:items-baseline tw:gap-1">
+        <span class="tw:text-[22px] tw:font-bold" style="color: {{ $color }}">
+            {{ $value }}
+        </span>
+        @if($suffix)
+            <span class="tw:text-xs tw:font-normal tw:text-[#9CA3AF]">{{ $suffix }}</span>
+        @endif
+    </div>
+    @if($secondary)
+        <div class="tw:text-[11px] tw:mt-0.5" style="color: {{ $secondaryColor }}">
+            {{ $secondary }}
+        </div>
+    @endif
+    {{-- Optional slot for inline visualizations --}}
+    {{ $slot ?? '' }}
+</div>
+```
+
+### Test Deliverable 1
+
+Create a test view that uses all four components with hardcoded data. Verify:
+- Collapsible toggles with animation
+- Proportion bar renders segments correctly with and without overlays
+- Avatar stack overlaps and shows "+N" overflow
+- Metric cell displays all variants
+
+---
+
+## Deliverable 2: ResourceStructure Core Domain
+
+### 2A: Directory Structure
+
+```
+app/Domain/ResourceStructure/
+├── Models/
+│   └── ResourceFieldContract.php
+├── Services/
+│   ├── ResourceStructureService.php
+│   └── ResourceRegistrar.php
+├── Repositories/
+│   └── ResourceStructureRepository.php
+└── register.php
+```
+
+### 2B: ResourceRegistrar
+
+Registers the "Resource" structure in WorkStructure's registry. Uses the same `StructureRegistry` interface from addendum 10.
+
+```php
+class ResourceRegistrar
+{
+    public function register(StructureRegistry $registry): void
+    {
+        $structureId = $registry->registerStructure([
+            'title' => 'Resource',
+            'description' => 'People, budget, and dependency allocations for a program',
+            'type' => 'plugin', // registered by PgmPro
+        ]);
+
+        $registry->registerElementType($structureId, [
+            'type_key' => 'people',
+            'label' => 'People',
+            'description' => 'Person allocated with weekly hours per project',
+            'domain_reference' => 'Leantime\\Domain\\Canvas', // stored in canvas tables
+            'sort_order' => 1,
+            'meta' => json_encode(['box' => 'people', 'canvas_type' => 'resource']),
+        ]);
+
+        $registry->registerElementType($structureId, [
+            'type_key' => 'budget',
+            'label' => 'Budget',
+            'description' => 'Budget line item allocated to a project',
+            'domain_reference' => 'Leantime\\Domain\\Canvas',
+            'sort_order' => 2,
+            'meta' => json_encode(['box' => 'budget', 'canvas_type' => 'resource']),
+        ]);
+
+        $registry->registerElementType($structureId, [
+            'type_key' => 'dependency',
+            'label' => 'Dependency',
+            'description' => 'External partnership or facility required',
+            'domain_reference' => 'Leantime\\Domain\\Canvas',
+            'sort_order' => 3,
+            'meta' => json_encode(['box' => 'dependency', 'canvas_type' => 'resource']),
+        ]);
+
+        // Relationships within Resource structure
+        $registry->registerRelationship($structureId, 'people', 'project', 'assigned_to');
+        $registry->registerRelationship($structureId, 'budget', 'project', 'funds');
+        $registry->registerRelationship($structureId, 'dependency', 'project', 'required_by');
+    }
+}
+```
+
+### 2C: ResourceStructureRepository
+
+Wraps canvas table queries with resource-specific filters.
+
+```php
+class ResourceStructureRepository
+{
+    private ConnectionInterface $db;
+
+    public function init(DbCore $db): void
+    {
+        $this->db = $db->getConnection();
+    }
+
+    /**
+     * Get the resource canvas board for a program.
+     * Creates one if it doesn't exist.
+     */
+    public function getOrCreateResourceCanvas(int $programProjectId): int
+    {
+        $existing = $this->db->table('zp_canvas')
+            ->where('type', 'resource')
+            ->where('projectId', $programProjectId)
+            ->first();
+
+        if ($existing) {
+            return $existing->id;
+        }
+
+        return $this->db->table('zp_canvas')->insertGetId([
+            'title' => 'Resource Allocation',
+            'type' => 'resource',
+            'projectId' => $programProjectId,
+            'author' => session('userdata.id'),
+            'created' => now(),
+        ]);
+    }
+
+    /**
+     * Get resource items by category (box).
+     */
+    public function getItemsByBox(int $canvasId, string $box): array
+    {
+        $results = $this->db->table('zp_canvas_items')
+            ->where('canvasId', $canvasId)
+            ->where('box', $box)
+            ->orderBy('sortindex')
+            ->get();
+
+        return array_map(function ($item) {
+            $item = (array) $item;
+            // Parse the JSON data field
+            $item['parsedData'] = json_decode($item['data'] ?? '{}', true) ?: [];
+            return $item;
+        }, $results->toArray());
+    }
+
+    /**
+     * Get all resource items for a canvas.
+     */
+    public function getAllItems(int $canvasId): array
+    {
+        $results = $this->db->table('zp_canvas_items')
+            ->where('canvasId', $canvasId)
+            ->orderBy('box')
+            ->orderBy('sortindex')
+            ->get();
+
+        return array_map(function ($item) {
+            $item = (array) $item;
+            $item['parsedData'] = json_decode($item['data'] ?? '{}', true) ?: [];
+            return $item;
+        }, $results->toArray());
+    }
+
+    /**
+     * Create a resource canvas item.
+     */
+    public function addItem(int $canvasId, array $values): int
+    {
+        return $this->db->table('zp_canvas_items')->insertGetId([
+            'canvasId' => $canvasId,
+            'box' => $values['box'],
+            'description' => $values['description'] ?? '',
+            'assumptions' => $values['assumptions'] ?? '',
+            'data' => json_encode($values['data'] ?? []),
+            'conclusion' => $values['conclusion'] ?? '',
+            'status' => $values['status'] ?? 'stub',
+            'author' => $values['author'] ?? session('userdata.id'),
+            'created' => now(),
+            'modified' => now(),
+        ]);
+    }
+
+    /**
+     * Update a resource canvas item's data.
+     */
+    public function updateItemData(int $itemId, array $data): bool
+    {
+        return $this->db->table('zp_canvas_items')
+            ->where('id', $itemId)
+            ->update([
+                'data' => json_encode($data),
+                'modified' => now(),
+            ]) >= 0;
+    }
+
+    /**
+     * Update item status.
+     */
+    public function updateItemStatus(int $itemId, string $status): bool
+    {
+        return $this->db->table('zp_canvas_items')
+            ->where('id', $itemId)
+            ->update([
+                'status' => $status,
+                'modified' => now(),
+            ]) >= 0;
+    }
+
+    /**
+     * Get actual hours from timesheets, grouped by user + project.
+     * Returns: [{userId, projectId, totalHours}]
+     */
+    public function getActualHours(array $projectIds, string $dateFrom, string $dateTo): array
+    {
+        $results = $this->db->table('zp_timesheets')
+            ->select(
+                'userId',
+                'projectId',
+                $this->db->raw('SUM(hours) as totalHours')
+            )
+            ->whereIn('projectId', $projectIds)
+            ->whereBetween('workDate', [$dateFrom, $dateTo])
+            ->groupBy('userId', 'projectId')
+            ->get();
+
+        return array_map(fn ($r) => (array) $r, $results->toArray());
+    }
+
+    /**
+     * Get stubs that need completion.
+     */
+    public function getStubs(int $canvasId): array
+    {
+        return $this->getItemsByBox($canvasId, 'people')
+            + $this->getItemsByBox($canvasId, 'budget')
+            + $this->getItemsByBox($canvasId, 'dependency');
+        // Filter to status='stub' in service layer
+    }
+}
+```
+
+### 2D: ResourceStructureService
+
+```php
+class ResourceStructureService
+{
+    private ResourceStructureRepository $repo;
+
+    public function init(ResourceStructureRepository $repo): void
+    {
+        $this->repo = $repo;
+    }
+
+    /**
+     * Get complete resource summary for a program.
+     * This is the main method the PgmPro view controller calls.
+     */
+    public function getProgramResourceSummary(int $programProjectId, array $childProjectIds): array
+    {
+        $canvasId = $this->repo->getOrCreateResourceCanvas($programProjectId);
+
+        $people = $this->repo->getItemsByBox($canvasId, 'people');
+        $budget = $this->repo->getItemsByBox($canvasId, 'budget');
+        $dependencies = $this->repo->getItemsByBox($canvasId, 'dependency');
+
+        return [
+            'canvasId' => $canvasId,
+            'people' => $this->hydratePeople($people),
+            'budget' => $this->hydrateBudget($budget),
+            'dependencies' => $dependencies,
+            'projects' => $childProjectIds,
+        ];
+    }
+
+    /**
+     * Parse people items' JSON data into structured allocation arrays.
+     */
+    private function hydratePeople(array $items): array
+    {
+        return array_map(function ($item) {
+            $data = $item['parsedData'];
+            return [
+                'id' => $item['id'],
+                'name' => $item['description'],
+                'role' => $item['assumptions'],
+                'userId' => $data['userId'] ?? 0,
+                'capacity' => $data['capacity'] ?? 40,
+                'allocations' => $data['allocations'] ?? [],
+                'status' => $item['status'],
+                'sourceCanvasItemId' => $item['milestoneId'] ?? null,
+            ];
+        }, $items);
+    }
+
+    /**
+     * Parse budget items' JSON data into structured budget arrays.
+     */
+    private function hydrateBudget(array $items): array
+    {
+        return array_map(function ($item) {
+            $data = $item['parsedData'];
+            return [
+                'id' => $item['id'],
+                'name' => $item['description'],
+                'category' => $item['assumptions'],
+                'projectId' => $data['projectId'] ?? 0,
+                'budgeted' => $data['budgeted'] ?? 0,
+                'spent' => $data['spent'] ?? 0,
+                'color' => $data['color'] ?? '#9CA3AF',
+                'status' => $item['status'],
+            ];
+        }, $items);
+    }
+
+    /**
+     * Get actual hours for V2 mode.
+     */
+    public function getActualHours(array $projectIds, string $period = 'this_week'): array
+    {
+        [$dateFrom, $dateTo] = $this->getPeriodDates($period);
+        return $this->repo->getActualHours($projectIds, $dateFrom, $dateTo);
+    }
+
+    /**
+     * Seed resource canvas from Logic Model Inputs.
+     * Called by StrategyPro wizard during program creation.
+     */
+    public function seedFromCanvasInputs(int $programProjectId, array $canvasInputs): array
+    {
+        $canvasId = $this->repo->getOrCreateResourceCanvas($programProjectId);
+        $created = [];
+
+        foreach ($canvasInputs as $input) {
+            $text = $input['description'] ?? '';
+            $classification = $this->classifyInput($text);
+
+            if (!$classification) continue;
+
+            $itemData = $this->extractDataFromText($text, $classification);
+
+            $itemId = $this->repo->addItem($canvasId, [
+                'box' => $classification,
+                'description' => $text,
+                'assumptions' => $itemData['role'] ?? $itemData['category'] ?? '',
+                'data' => $itemData['data'],
+                'status' => 'stub',
+            ]);
+
+            $created[] = [
+                'itemId' => $itemId,
+                'sourceCanvasItemId' => $input['id'],
+                'classification' => $classification,
+            ];
+        }
+
+        return $created;
+    }
+
+    /**
+     * Classify a Logic Model input text into a resource category.
+     */
+    private function classifyInput(string $text): ?string
+    {
+        if (preg_match('/funding|grant|budget|allocation|\$\d/i', $text)) {
+            return 'budget';
+        }
+        if (preg_match('/staff|people|manager|coordinator|specialist|director|volunteer/i', $text)) {
+            return 'people';
+        }
+        if (preg_match('/partner|organization|vendor|facility|agreement|community center/i', $text)) {
+            return 'dependency';
+        }
+        return null;
+    }
+
+    /**
+     * Extract structured data from input text.
+     */
+    private function extractDataFromText(string $text, string $classification): array
+    {
+        $result = ['data' => []];
+
+        if ($classification === 'budget') {
+            // "$250K annual budget" → 250000
+            if (preg_match('/\$(\d+(?:\.\d+)?)\s*[kK]/', $text, $m)) {
+                $result['data']['budgeted'] = (float) $m[1] * 1000;
+            } elseif (preg_match('/\$(\d[\d,]*)/', $text, $m)) {
+                $result['data']['budgeted'] = (float) str_replace(',', '', $m[1]);
+            }
+            $result['category'] = 'general';
+        }
+
+        if ($classification === 'people') {
+            // "3 case managers" → count 3, role "case manager"
+            if (preg_match('/(\d+)\s+(.+)/i', $text, $m)) {
+                $result['data']['count'] = (int) $m[1];
+                $result['role'] = trim($m[2]);
+            }
+            $result['data']['capacity'] = 40;
+            $result['data']['allocations'] = [];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check stub completion status for Setting Up → Ongoing transition.
+     */
+    public function getStubCompletionStatus(int $programProjectId): array
+    {
+        $canvasId = $this->repo->getOrCreateResourceCanvas($programProjectId);
+        $allItems = $this->repo->getAllItems($canvasId);
+
+        $stubs = array_filter($allItems, fn ($i) => $i['status'] === 'stub');
+        $active = array_filter($allItems, fn ($i) => $i['status'] === 'active');
+
+        return [
+            'totalItems' => count($allItems),
+            'stubCount' => count($stubs),
+            'activeCount' => count($active),
+            'isComplete' => count($stubs) === 0 && count($allItems) > 0,
+            'stubs' => array_map(function ($stub) {
+                $prompt = match ($stub['box']) {
+                    'people' => 'Who? Hours?',
+                    'budget' => 'Amount?',
+                    'dependency' => 'Status?',
+                    default => 'Complete this',
+                };
+                return [
+                    'id' => $stub['id'],
+                    'type' => $stub['box'],
+                    'name' => $stub['description'],
+                    'prompt' => $prompt,
+                ];
+            }, array_values($stubs)),
+        ];
+    }
+
+    private function getPeriodDates(string $period): array
+    {
+        return match ($period) {
+            'this_week' => [
+                now()->startOfWeek()->format('Y-m-d'),
+                now()->endOfWeek()->format('Y-m-d'),
+            ],
+            'last_week' => [
+                now()->subWeek()->startOfWeek()->format('Y-m-d'),
+                now()->subWeek()->endOfWeek()->format('Y-m-d'),
+            ],
+            'this_month' => [
+                now()->startOfMonth()->format('Y-m-d'),
+                now()->endOfMonth()->format('Y-m-d'),
+            ],
+            default => [
+                now()->startOfWeek()->format('Y-m-d'),
+                now()->endOfWeek()->format('Y-m-d'),
+            ],
+        };
+    }
+}
+```
+
+### Test Deliverable 2
+
+Use tinker or a test route to verify:
+- `getOrCreateResourceCanvas()` creates a canvas with `type='resource'`
+- `addItem()` creates canvas items in correct `box` categories
+- `getProgramResourceSummary()` returns hydrated people/budget/dependency arrays
+- `seedFromCanvasInputs()` correctly classifies and creates stubs
+- `getStubCompletionStatus()` reports stub counts and prompts
+
+---
+
+## Deliverable 3: PgmPro Route, Controller, and V1 View
+
+### 3A: Route
+
+Add to PgmPro plugin routes:
+
+```php
+Route::get('/pgmpro/program/{programId}/resources', [
+    ResourceAllocationController::class, 'get'
+])->name('pgmpro.resources');
+```
+
+### 3B: Controller
+
+```php
+namespace Leantime\Plugins\PgmPro\Controllers;
+
+class ResourceAllocation
+{
+    private ResourceStructureService $resourceService;
+    private ProjectsService $projectsService;
+
+    public function init(
+        ResourceStructureService $resourceService,
+        ProjectsService $projectsService
+    ): void {
+        $this->resourceService = $resourceService;
+        $this->projectsService = $projectsService;
+    }
+
+    public function get(int $programId): mixed
+    {
+        // Get child projects under this program
+        $childProjects = $this->projectsService->getProjectsByParent($programId);
+        $childProjectIds = array_column($childProjects, 'id');
+
+        // Get resource summary
+        $resources = $this->resourceService->getProgramResourceSummary(
+            $programId,
+            $childProjectIds
+        );
+
+        // Get stub status
+        $stubStatus = $this->resourceService->getStubCompletionStatus($programId);
+
+        return $this->tpl->display('pgmpro::resources.index', [
+            'programId' => $programId,
+            'projects' => $childProjects,
+            'resources' => $resources,
+            'stubStatus' => $stubStatus,
+            'version' => 'v1', // default
+        ]);
+    }
+}
+```
+
+### 3C: Blade View Structure
+
+```
+resources/views/pgmpro/resources/
+├── index.blade.php
+├── partials/
+│   ├── header.blade.php
+│   ├── summary-strip.blade.php
+│   ├── project-rows.blade.php
+│   ├── people-section.blade.php
+│   ├── budget-section.blade.php
+│   ├── auto-fill.blade.php
+│   └── reading-guide.blade.php
+└── components/
+    ├── person-container.blade.php     (resource-view specific)
+    ├── project-row.blade.php          (resource-view specific)
+    ├── budget-bar.blade.php           (uses x-proportion-bar)
+    ├── budget-line.blade.php          (uses x-proportion-bar)
+    └── version-toggle.blade.php
+```
+
+### 3D: Person Container (Critical Visual)
+
+This is the signature component. **Match `ResourceV1V2.jsx` exactly.**
+
+```blade
+{{-- pgmpro::resources.components.person-container --}}
+@props([
+    'person' => [],
+    'projects' => [],
+    'version' => 'v1',
+    'actuals' => [],
+])
+
+@php
+    $capacity = $person['capacity'] ?? 40;
+    $allocations = $person['allocations'] ?? [];
+    $totalAllocated = array_sum($allocations);
+    $fillPct = $capacity > 0 ? min(($totalAllocated / $capacity) * 100, 100) : 0;
+    $isEmpty = $totalAllocated === 0;
+    $isFull = $fillPct >= 95;
+    $isOver = $totalAllocated > $capacity;
+@endphp
+
+<div class="tw:flex tw:flex-col tw:items-center tw:gap-1.5">
+    {{-- Container --}}
+    <div
+        class="tw:relative tw:w-16 tw:rounded-lg tw:overflow-hidden
+               {{ $isEmpty ? 'tw:border-2 tw:border-dashed tw:border-[#D1D5DB]' : 'tw:bg-[#F0F2F5]' }}"
+        style="height: 200px;"
+    >
+        @if($isEmpty)
+            {{-- Empty state --}}
+            <div class="tw:absolute tw:inset-0 tw:flex tw:flex-col tw:items-center tw:justify-center tw:gap-1">
+                <span class="tw:text-xl tw:text-[#D1D5DB]">+</span>
+                <span class="tw:text-[10px] tw:text-[#9CA3AF]">Assign</span>
+            </div>
+        @else
+            {{-- Tick marks --}}
+            @foreach([25, 50, 75] as $tick)
+                <div
+                    class="tw:absolute tw:left-0 tw:w-full tw:z-[1]"
+                    style="bottom: {{ $tick }}%; border-top: 1px solid rgba(0,0,0,0.04);"
+                ></div>
+            @endforeach
+
+            {{-- Segments (fill from bottom) --}}
+            @php $currentBottom = 0; @endphp
+            @foreach($allocations as $projectId => $hours)
+                @php
+                    $segPct = ($hours / $capacity) * 100;
+                    $project = collect($projects)->firstWhere('id', $projectId);
+                    $color = $project['color'] ?? '#9CA3AF';
+                    $actualHours = $actuals[$projectId] ?? 0;
+                    $actualPct = $hours > 0 ? ($actualHours / $hours) * 100 : 0;
+                @endphp
+                <div
+                    class="tw:absolute tw:left-0 tw:w-full tw:z-[2] tw:flex tw:items-center tw:justify-center"
+                    style="bottom: {{ $currentBottom }}%; height: {{ $segPct }}%; background: {{ $color }};"
+                    x-bind:style="segmentOpacity('{{ $projectId }}')"
+                >
+                    {{-- Label --}}
+                    @if($segPct > 14)
+                        <span class="tw:relative tw:z-[4] tw:text-white tw:font-bold
+                                     {{ $version === 'v2' ? 'tw:text-[10px]' : 'tw:text-xs' }}">
+                            @if($version === 'v2')
+                                {{ $actualHours }}/{{ $hours }}
+                            @else
+                                {{ $hours }}h
+                            @endif
+                        </span>
+                    @endif
+
+                    {{-- V2 actual overlay --}}
+                    @if($version === 'v2')
+                        <div
+                            class="tw:absolute tw:bottom-0 tw:left-0 tw:w-full tw:z-[3]"
+                            style="height: {{ min($actualPct, 100) }}%;
+                                   background: rgba(255,255,255,0.22);
+                                   {{ $actualPct < 100 ? 'border-top: 2px solid rgba(255,255,255,0.6);' : '' }}"
+                        ></div>
+                    @endif
+                </div>
+
+                {{-- Separator between segments --}}
+                @if(!$loop->first)
+                    <div
+                        class="tw:absolute tw:left-0 tw:w-full tw:z-[3]"
+                        style="bottom: {{ $currentBottom }}%; border-top: 1.5px solid rgba(255,255,255,0.5);"
+                    ></div>
+                @endif
+
+                @php $currentBottom += $segPct; @endphp
+            @endforeach
+
+            {{-- Percentage badge --}}
+            <div
+                class="tw:absolute tw:left-1/2 tw:-translate-x-1/2 tw:z-[5]
+                       tw:px-2 tw:py-0.5 tw:rounded-full
+                       tw:text-[10px] tw:font-bold tw:text-white tw:whitespace-nowrap"
+                style="bottom: {{ min($fillPct, 100) }}%;
+                       transform: translateX(-50%) translateY(50%);
+                       background: {{ $isFull ? '#059669' : ($isOver ? '#DC2626' : '#1A1A2E') }};"
+            >
+                {{ round($fillPct) }}%
+            </div>
+        @endif
+    </div>
+
+    {{-- Name --}}
+    <div class="tw:text-xs tw:font-semibold tw:text-[#1A1A2E] tw:text-center tw:truncate tw:max-w-16">
+        {{ $person['name'] ?? '?' }}
+    </div>
+
+    {{-- Role --}}
+    <div class="tw:text-[10px] tw:text-[#9CA3AF] tw:text-center tw:truncate tw:max-w-16">
+        {{ $person['role'] ?? '' }}
+    </div>
+
+    {{-- Footer --}}
+    <div class="tw:text-xs tw:font-bold tw:text-[#1A1A2E]">
+        @if($version === 'v2')
+            {{ array_sum($actuals) }}/{{ $totalAllocated }}h
+        @else
+            {{ $totalAllocated }}/{{ $capacity }}h
+        @endif
+    </div>
+
+    {{-- V2 variance --}}
+    @if($version === 'v2')
+        @php
+            $totalActual = array_sum($actuals);
+            $variance = $totalActual - $totalAllocated;
+            $varianceColor = $variance > 2 ? '#DC2626' : ($variance < -5 ? '#D97706' : '#9CA3AF');
+            $varianceText = $variance > 2 ? abs($variance) . 'h over'
+                          : ($variance < -5 ? abs($variance) . 'h under' : 'On track');
+        @endphp
+        <div class="tw:text-[10px]" style="color: {{ $varianceColor }}">
+            {{ $varianceText }}
+        </div>
+    @endif
+</div>
+```
+
+### 3E: JavaScript — Unified Hover
+
+```javascript
+// Alpine.js component for the resource view page
+function resourceView() {
+    return {
+        version: 'v1',
+        hoveredProject: null,
+        showAutoFill: false,
+        peopleExpanded: true,
+        budgetExpanded: true,
+
+        setVersion(v) { this.version = v; },
+        hoverProject(id) { this.hoveredProject = id; },
+
+        // Opacity helpers
+        projectRowOpacity(projectId) {
+            if (!this.hoveredProject) return 'opacity: 1';
+            return this.hoveredProject === projectId ? 'opacity: 1' : 'opacity: 0.4';
+        },
+        segmentOpacity(projectId) {
+            if (!this.hoveredProject) return 'opacity: 1';
+            return this.hoveredProject === projectId ? 'opacity: 1' : 'opacity: 0.12';
+        },
+        budgetLineOpacity(projectId) {
+            if (!this.hoveredProject) return 'opacity: 1';
+            return this.hoveredProject === projectId ? 'opacity: 1' : 'opacity: 0.3';
+        },
+    }
+}
+```
+
+---
+
+## Deliverable 4: V1 Complete
+
+Build all V1 partials — summary-strip, project-rows, people-section, budget-section.
+
+Use shared components: `x-collapsible` for sections, `x-proportion-bar` for all bars, `x-avatar-stack` for collapsed people, `x-metric-cell` for summary strip cells.
+
+Use `person-container` for each person in the People section.
+
+**Test:** Full V1 view renders matching `ResourceV1V2.jsx`. Hover highlights work across sections. Collapsible toggles work. All measurements match spec.
+
+---
+
+## Deliverable 5: V2 Overlays
+
+Add `getActualHours()` call in controller when `version === 'v2'`. Pass actuals to all components.
+
+Build:
+- V2 summary cell (Actual this week)
+- V2 project row columns (planned/actual/variance)
+- V2 person container overlays (already in component, activated by `version='v2'`)
+- V2 budget overlays (proportion bar overlay support)
+- Reading guide partial
+
+**Test:** Toggle V1 ↔ V2. V1 is unchanged. V2 shows overlays, variance badges, split columns. Reading guide appears/disappears.
+
+---
+
+## Deliverable 6: Canvas Auto-Fill + Stub Seeding
+
+Build `auto-fill.blade.php` partial — two-column layout showing classification results.
+
+Wire `seedFromCanvasInputs()` call into StrategyPro wizard after program creation.
+
+Record entityrelations: `canvas_input_id → resource_item_id` with type `seeded_from`.
+
+Build Setting Up indicator when stubs exist.
+
+**Test:** Create a program from Logic Model. Verify Inputs items produce resource stubs. Verify auto-fill preview shows classification. Verify stubs show completion prompts.
+
+---
+
+## Implementation Order
+
+| Step | Deliverable | Test gate |
+|---|---|---|
+| 1 | Shared components (collapsible, proportion-bar, avatar-stack, metric-cell) | All render correctly with test data |
+| 2 | ResourceStructure core (registrar, repository, service) | Canvas items CRUD works, seeding classifies correctly |
+| 3 | PgmPro route + controller + index.blade.php skeleton | Route loads, data reaches view |
+| 4 | V1 summary strip + project rows | Visual match to prototype |
+| 5 | V1 people section with person containers + hover | Expand/collapse, hover highlights |
+| 6 | V1 budget section | Full V1 complete |
+| 7 | V2 overlays + reading guide | V1 ↔ V2 toggle, overlays render |
+| 8 | Canvas auto-fill + stub seeding | End-to-end: Logic Model → Resource stubs |
+
+---
+
+## Quick Reference
+
+### Colors
+
+| Token | Value | Usage |
+|---|---|---|
+| Project green | `#3E937A` | First project |
+| Project amber | `#C09035` | Second project |
+| Project purple | `#8E6AAD` | Third project |
+| Good | `#059669` | At capacity, on track |
+| Warning | `#D97706` | Under-allocated |
+| Critical | `#DC2626` | Over-allocated |
+| Neutral | `#9CA3AF` | Labels, empty |
+| Page bg | `#F8F9FB` | Body |
+| Card bg | `#ffffff` | Cards |
+| Track bg | `#F0F1F3` | Bars, inactive |
+| Border | `#E8ECF0` | Card borders |
+| Text primary | `#1A1A2E` | Headers, values |
+
+### V2 Overlays
+
+| Element | Value |
+|---|---|
+| Container actual fill | `rgba(255,255,255,0.22)` |
+| Container actual border | `2px solid rgba(255,255,255,0.6)` |
+| Budget bar spent | `rgba(0,0,0,0.12)` |
+| Budget line spent | `rgba(0,0,0,0.15)` |
+
+### Variance Thresholds
+
+| Context | Green | Amber | Red |
+|---|---|---|---|
+| Hours | within ±2h | < -5h under | > +2h over |
+| Person footer | within 20% | > 20% under | over |
+| Summary | ≥ 85% | < 85% | over |
+| Budget | < 90% spent | — | > 90% spent |
+
+### Measurements
+
+| Element | Spec |
+|---|---|
+| Person container | 64px × 200px, 8px gap, 8px radius |
+| Cards | 12px radius |
+| Capacity bar | 100px × 8px × 4px radius |
+| Budget bar | 28px × 8px radius |
+| Summary bar | 6px × 3px radius |
+| Swatches | 14×14 (row), 10×10 (budget) |
+| Avatar stack | 28px, -6px overlap |
+| Max width | 960px |
+
+### Canvas Field Mapping
+
+| Canvas column | People | Budget | Dependency |
+|---|---|---|---|
+| `box` | `'people'` | `'budget'` | `'dependency'` |
+| `description` | Person name | Budget line name | Dependency name |
+| `assumptions` | Role title | Category | Type |
+| `data` (JSON) | `{userId, capacity, allocations}` | `{projectId, budgeted, spent, color}` | `{partnerName, type, confirmed}` |
+| `conclusion` | Notes | Notes | Status notes |
+| `status` | stub / active | stub / active | stub / active |

--- a/Docs/14-DESIGN-TOKENS-v2.md
+++ b/Docs/14-DESIGN-TOKENS-v2.md
@@ -1,0 +1,961 @@
+# Leantime Design Token Reference — v2.0
+
+**Single Source of Truth for Visual Properties, Theming, Accessibility, and Component Sizing**
+
+| Field | Value |
+|---|---|
+| Product | Leantime |
+| Document | 14-DESIGN-TOKENS.md |
+| Version | 2.0 |
+| Date | February 24, 2026 |
+| Author | Gloria Folaron |
+| Status | Living Document |
+| Replaces | v1.1 (Feb 23, 2026) — old palette (#1b75bb/#81B1A8) |
+| Source of truth for | Every visual property in the codebase. Component guide, Claude Code prompts, and contributor docs all derive from this. |
+
+---
+
+## How to Use This Document
+
+This document serves three purposes:
+
+1. **Build reference:** When creating new components, match these tokens exactly.
+2. **Audit target:** When normalizing existing components, compare against these tokens and fix deviations.
+3. **Accessibility and theming gate:** Every component must pass the accessibility checks and theming rules defined here before shipping.
+
+Every visual property should resolve to a token. Every interactive element should be keyboard-accessible. Every color should work in both light and dark mode. If you encounter something that doesn't meet these standards, it's either wrong (fix it) or a new decision is needed (flag it).
+
+### Prefixes and Conventions
+
+- **Tailwind classes use `tw:` prefix** — e.g., `tw:rounded-lg`, `tw:text-sm`
+- **CSS custom properties** — defined in theme files and `:root`, prefixed with `--`
+- **No jQuery** — all new interactivity via HTMX + Alpine.js + vanilla JS
+- **Blade only** — no `.tpl.php` files in new code
+- **Semantic HTML first** — use `<button>`, `<nav>`, `<main>`, `<dialog>`, `<details>` before reaching for ARIA
+
+### What Changed in v2.0
+
+| Area | v1.1 | v2.0 |
+|---|---|---|
+| Brand colors | 2 accents (#1b75bb, #81B1A8) | 4 accents (#004766, #00B893, #CADE1B, #F61067) |
+| Semantic colors | Separate green/red/yellow | Brand colors ARE semantic colors |
+| Font | System stack only | Hanken Grotesk primary, system fallback |
+| Font weights | 400/600/700 | Variable 450–800 |
+| Theme count | Light/dark | 3 themes × light/dark = 6 combos |
+| Glass effects | Not specified | Full spec (backdrop-filter, translucency) |
+| Component minimums | Touch targets mentioned | Enforced sizes with exact values |
+| Radius scale | 4/8/12/20 | 4/6/10/14/20 |
+| Stageflow colors | Data viz palette | Derived from brand accents |
+
+---
+
+## 1. Theming Architecture
+
+### 1.1 Theme Layers
+
+| Layer | What it controls | Customizable by | Storage |
+|---|---|---|---|
+| **Brand** | Accent colors (4), logo | Company admin | `zp_settings` + `.env` defaults |
+| **Scheme** | Light/dark mode, neutral palette swaps | Individual user | User preference + `prefers-color-scheme` |
+| **Theme** | Glass level, motion, density | Individual user | User preference |
+| **Fixed** | Semantic mappings, spacing, type scale | Nobody (system-defined) | Hardcoded in token definitions |
+
+**Rule:** Brand and Scheme layer tokens MUST use CSS custom properties. Fixed layer tokens CAN be hardcoded or use Tailwind utilities because they never change.
+
+### 1.2 Three Themes
+
+| Theme | Glass | Motion | Density | Font |
+|---|---|---|---|---|
+| **Leantime** | Full (`blur(8px)`, translucent surfaces) | Cubic-bezier transitions (200–350ms) | Standard | Hanken Grotesk variable |
+| **Focus** | Reduced (`blur(4px)` or opaque) | Minimal, fast (100–150ms) | Standard | Hanken Grotesk, fewer weight variations |
+| **High Contrast** | None (fully opaque) | `prefers-reduced-motion` default | Generous | Atkinson Hyperlegible option |
+
+Each theme supports light + dark mode (6 total combinations).
+
+### 1.3 CSS Custom Property Architecture
+
+```css
+:root {
+  /* ── Brand layer (set by company admin, overridden at runtime) ── */
+  --accent1: #004766;          /* Deep Teal — primary */
+  --accent2: #00B893;          /* Vibrant Emerald — success/secondary */
+  --accent3: #CADE1B;          /* Chartreuse — fills/badges ONLY */
+  --accent3-text: #A8B516;     /* Chartreuse darkened — text on light bg (3.1:1 large) */
+  --accent4: #F61067;          /* Hot Pink — danger/alerts (4.6:1) */
+
+  /* Derived tints for backgrounds */
+  --accent1-light: rgba(0, 71, 102, 0.06);    /* #E6EEF3 equivalent */
+  --accent2-light: rgba(0, 184, 147, 0.08);   /* #E6F9F4 equivalent */
+  --accent3-light: rgba(202, 222, 27, 0.10);  /* #F8FAE6 equivalent */
+  --accent4-light: rgba(246, 16, 103, 0.06);  /* #FDE8F0 equivalent */
+
+  /* Text-safe variant for accent2 (2.7:1 raw is too low for text) */
+  --accent2-text: #008F72;     /* Darkened emerald for text on white (4.5:1) */
+
+  /* ── Scheme layer (swap between light and dark) ── */
+  --color-text-primary: #1A1A2E;
+  --color-text-secondary: #4B5563;
+  --color-text-muted: #9CA3AF;
+  --color-text-disabled: #D1D5DB;
+  --color-text-on-accent: #FFFFFF;
+
+  --color-bg-page: #F5F5F5;
+  --color-bg-card: #FFFFFF;
+  --color-bg-muted: #F0F1F3;
+  --color-bg-hover: #F3F4F6;
+
+  --color-border-default: #E8ECF0;
+  --color-border-light: #F0F1F3;
+
+  /* ── Shadows (scheme — swap in dark mode) ── */
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.07);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.10);
+  --shadow-xl: 0 14px 48px rgba(0,0,0,0.13);
+
+  /* ── Focus ring ── */
+  --focus-ring: 0 0 0 2px var(--color-bg-card), 0 0 0 4px var(--accent1);
+
+  /* ── Glass treatment (theme layer) ── */
+  --glass-bg: rgba(255, 255, 255, 0.85);
+  --glass-blur: blur(8px);
+  --glass-border: 1px solid rgba(255, 255, 255, 0.2);
+  --glass-inner-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+
+  /* ── Stageflow stage colors (derived from brand) ── */
+  --s1: var(--accent1);                   /* Deep Teal */
+  --s2: var(--accent2);                   /* Emerald */
+  --s3: var(--accent3-text);              /* Chartreuse (text-safe) */
+  --s4: #C84D7C;                          /* accent4 softened to 60% */
+  --s5-start: var(--accent1);             /* Gradient start */
+  --s5-end: var(--accent2);               /* Gradient end */
+
+  --s1-bg: rgba(0, 71, 102, 0.06);
+  --s2-bg: rgba(0, 184, 147, 0.08);
+  --s3-bg: rgba(168, 181, 22, 0.08);
+  --s4-bg: rgba(246, 16, 103, 0.05);
+  --s5-bg: rgba(0, 71, 102, 0.04);
+}
+
+/* ── Dark mode ── */
+[data-mode="dark"], .theme-dark {
+  --color-text-primary: #E5E7EB;
+  --color-text-secondary: #9CA3AF;
+  --color-text-muted: #6B7280;
+  --color-text-disabled: #4B5563;
+
+  --color-bg-page: #111827;
+  --color-bg-card: #1F2937;
+  --color-bg-muted: #374151;
+  --color-bg-hover: #374151;
+
+  --color-border-default: #374151;
+  --color-border-light: #1F2937;
+
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.20);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.30);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.35);
+  --shadow-xl: 0 14px 48px rgba(0,0,0,0.40);
+
+  --glass-bg: rgba(30, 30, 46, 0.85);
+  --glass-border: 1px solid rgba(255, 255, 255, 0.08);
+  --glass-inner-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+}
+
+/* ── Focus theme (less glass) ── */
+.theme-focus {
+  --glass-bg: var(--color-bg-card);
+  --glass-blur: blur(4px);
+}
+
+/* ── High Contrast theme (no glass) ── */
+.theme-hc {
+  --glass-bg: var(--color-bg-card);
+  --glass-blur: none;
+  --glass-border: 1px solid var(--color-border-default);
+  --glass-inner-shadow: none;
+}
+```
+
+### 1.4 Accent Color Contrast Safety
+
+| Color | On white (#F5F5F5) | On dark (#1F2937) | Allowed uses |
+|---|---|---|---|
+| accent1 `#004766` | 9.2:1 ✅ | — | Text, fills, icons — anywhere |
+| accent2 `#00B893` | 2.7:1 ❌ | 6.8:1 ✅ | Fills, icons, large decorative. **Never as text on light bg** |
+| accent2-text `#008F72` | 4.5:1 ✅ | — | Text variant of accent2 when text is required |
+| accent3 `#CADE1B` | 1.9:1 ❌ | 8.3:1 ✅ | Fills/badges ONLY on light. Excellent text on dark |
+| accent3-text `#A8B516` | 3.1:1 ⚠️ | — | Large text only (≥18px or ≥14px bold) |
+| accent4 `#F61067` | 4.6:1 ✅ | 4.1:1 ⚠️ | Text and fills on light. Large text on dark |
+
+### 1.5 Theming Rules
+
+1. **Never hardcode hex in templates** — always `var(--token)`
+2. **Never use `accent2` as text on light backgrounds** — use `var(--accent2-text)` instead
+3. **Never use `accent3` as text** — use `var(--accent3-text)` for large text only
+4. **Test every change in**: default light, default dark, one custom accent
+5. **Glass applies to surfaces** (cards, modals, dropdowns, nav) — NEVER inputs, text areas, or data tables
+6. **White on accent backgrounds** — always `var(--color-text-on-accent)`, never hardcoded `#fff`
+7. **Surface elements (toggle handles, emboss handles)** — use `var(--color-bg-card)` not `white`
+
+---
+
+## 2. Semantic Color Mapping
+
+**Brand colors ARE semantic colors. No separate green/red/yellow system.**
+
+| Semantic | Token | Light value | Usage |
+|---|---|---|---|
+| Success | `var(--accent2)` | `#00B893` | Completed, on track, validated |
+| Danger / Error | `var(--accent4)` | `#F61067` | Blocked, overdue, critical, delete |
+| Warning | `var(--accent3-text)` | `#A8B516` | At risk, attention needed (large text only) |
+| Info | `var(--accent1)` | `#004766` | Informational, active, in progress |
+
+**Background tints for alerts/badges:**
+
+| Semantic | Background token | Value |
+|---|---|---|
+| Success bg | `var(--accent2-light)` | `rgba(0, 184, 147, 0.08)` |
+| Danger bg | `var(--accent4-light)` | `rgba(246, 16, 103, 0.06)` |
+| Warning bg | `var(--accent3-light)` | `rgba(202, 222, 27, 0.10)` |
+| Info bg | `var(--accent1-light)` | `rgba(0, 71, 102, 0.06)` |
+
+**Accessibility rule:** Semantic colors must NEVER be the only indicator. Always pair with icon AND text label (or `aria-label`).
+
+### 2.1 Status Colors
+
+| Status | Color token | Icon | aria-label pattern |
+|---|---|---|---|
+| Active / In Progress | `var(--accent1)` | `fa-spinner` or `fa-circle-dot` | "Status: In Progress" |
+| Validated / Complete | `var(--accent2)` | `fa-check` | "Status: Complete" |
+| Draft / Not Started | `var(--color-text-muted)` | `fa-circle` (outline) | "Status: Draft" |
+| Flagged / Blocked | `var(--accent4)` | `fa-exclamation` or `fa-flag` | "Status: Blocked" |
+| Warning / At Risk | `var(--accent3-text)` | `fa-exclamation-triangle` | "Status: At Risk" |
+
+### 2.2 Data Visualization Colors (Fixed — Both Modes)
+
+| Slot | Value | Notes |
+|---|---|---|
+| Viz 1 | `var(--accent1)` `#004766` | Primary series |
+| Viz 2 | `var(--accent2)` `#00B893` | Secondary series |
+| Viz 3 | `var(--accent3-text)` `#A8B516` | Tertiary series |
+| Viz 4 | `var(--accent4)` `#F61067` | Quaternary series |
+| Viz 5 | `var(--s4)` `#C84D7C` | Fifth series (softened pink) |
+
+**Rule:** Never themeable. Always include text labels or patterns — don't rely on color alone.
+
+---
+
+## 3. Typography
+
+### 3.1 Font Stack
+
+**Primary:** Hanken Grotesk (variable, 100–900)
+```css
+font-family: 'Hanken Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+```
+
+**Load:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&display=swap" rel="stylesheet">
+```
+
+**User font picker options:**
+- Hanken Grotesk (default)
+- Atkinson Hyperlegible (accessibility)
+- Shantell Sans (playful/handwritten)
+
+### 3.2 Weight Scale
+
+| Token | Weight | Usage |
+|---|---|---|
+| `--fw-body` | 450 | Body text |
+| `--fw-medium` | 500 | Labels, UI text |
+| `--fw-semi` | 600 | Subheadings, emphasized labels |
+| `--fw-heading` | 650 | Headings |
+| `--fw-bold` | 700 | Bold emphasis, numbers |
+| `--fw-display` | 800 | Display/hero text |
+
+### 3.3 Type Scale
+
+| Token | Size | Weight | Line Height | Usage |
+|---|---|---|---|---|
+| `--text-2xl` | 24px | 800 | 1.2 | Hero, display numbers |
+| `--text-xl` | 18px | 650 | 1.3 | Page titles, modal titles |
+| `--text-lg` | 16px | 650 | 1.3 | Section headers, card titles |
+| `--text-md` | 14px | 600 | 1.35 | Sub-sections, UI labels |
+| `--text-base` | 13px | 450 | 1.5 | Body text, descriptions |
+| `--text-sm` | 12px | 500 | 1.4 | Table cells, secondary info, captions |
+| `--text-xs` | 10px | 500–600 | 1.3 | Badges, counters, uppercase labels |
+
+### 3.4 Typography Accessibility
+
+| Rule | Standard | Details |
+|---|---|---|
+| **Absolute floor** | **10px** | Nothing in the product renders below 10px. Ever. |
+| Minimum body text | 13px | Primary readable content |
+| Minimum interactive label | 12px | Anything the user reads to take action |
+| Minimum decorative/metadata | 10px | Badges, timestamps, counters. Must not carry essential meaning alone. |
+| Body line height | ≥ 1.5 | WCAG 1.4.12 |
+| Paragraph spacing | ≥ 1.5× font size | Between paragraphs |
+| Uppercase letter spacing | 0.4–0.6px | Uppercase is harder to read |
+| Max line length | ~70–80 characters | Prevents eye-tracking fatigue |
+| Text alignment | Left-align | Never justify |
+| User font scaling | Must not break layout | Accommodate 200% browser zoom |
+
+**Removed from v1.1:** The "Tiny 9px" token is eliminated. The old 9px was used for uppercase flags and labels — those now use 10px (`--text-xs`) with letter-spacing.
+
+### 3.5 Typography Rules
+
+- **Headings:** Never below 14px
+- **Body:** Default 13px / 450 / 1.5
+- **Bold vs. Semibold:** 700 for numbers and emphasis, 650 for headings, 600 for labels. Never 800+ except display.
+- **Uppercase:** Only at `--text-xs` (10px), always with letter-spacing 0.4–0.6px
+- **Color:** Always use tokens, never hardcoded hex
+- **accent2 as text:** Use `var(--accent2-text)` not `var(--accent2)`
+
+---
+
+## 4. Spacing Scale
+
+### 4.1 Base Scale (4px unit)
+
+| Token | Value | Common usage |
+|---|---|---|
+| `--space-1` | 4px | Icon gaps, tight inline spacing |
+| `--space-2` | 8px | Component internal gaps, small padding |
+| `--space-3` | 12px | Standard padding, input padding |
+| `--space-4` | 16px | Card body padding, section gaps |
+| `--space-5` | 20px | Large gaps, modal padding |
+| `--space-6` | 24px | Page-level spacing |
+| `--space-8` | 32px | Major section breaks |
+
+### 4.2 Snap Rule
+
+No off-scale values. If a measurement doesn't match a token, snap to the nearest:
+- 3px → 4px (`--space-1`)
+- 5px → 4px or 8px (choose nearest)
+- 7px → 8px (`--space-2`)
+- 9px → 8px (`--space-2`)
+- 10px → 8px or 12px (choose nearest)
+- 11px → 12px (`--space-3`)
+- 13px → 12px (`--space-3`)
+- 15px → 16px (`--space-4`)
+
+### 4.3 Layout Spacing
+
+| Context | Value |
+|---|---|
+| Card body padding | `--space-4` (16px) |
+| Card header padding | `--space-3` (12px) |
+| List item padding | `--space-3` (12px) vertical, `--space-4` (16px) horizontal |
+| Section gaps | `--space-3` (12px) |
+| Component internal gap | `--space-2` (8px) |
+| Page margin | `--space-6` (24px) minimum |
+
+---
+
+## 5. Border Radius
+
+| Token | Value | Usage |
+|---|---|---|
+| `--radius-xs` | 4px | Inline badges, small chips |
+| `--radius-sm` | 6px | Buttons, inputs, small cards |
+| `--radius` | 10px | Cards, modals, containers |
+| `--radius-lg` | 14px | Large cards, hero sections |
+| `--radius-pill` | 20px | Pills, tags, toggle tracks |
+| `--radius-full` | 9999px | Avatars, circular buttons |
+
+---
+
+## 6. Shadows
+
+| Token | Value | Usage |
+|---|---|---|
+| `--shadow-sm` | `0 1px 3px rgba(0,0,0,0.04)` | Cards at rest |
+| `--shadow-md` | `0 4px 16px rgba(0,0,0,0.07)` | Hover states, elevated cards |
+| `--shadow-lg` | `0 8px 32px rgba(0,0,0,0.10)` | Dropdowns, popovers |
+| `--shadow-xl` | `0 14px 48px rgba(0,0,0,0.13)` | Modals, active stageflow stage |
+
+Dark mode shadows use higher opacity (see CSS architecture above).
+
+**Rule:** Never include `box-shadow` in `transition` properties — it causes repaint on every frame.
+
+---
+
+## 7. Transitions and Motion
+
+### 7.1 Duration Scale
+
+| Token | Value | Usage |
+|---|---|---|
+| `--duration-fast` | 100ms | Color changes, opacity |
+| `--duration-base` | 150ms | Most interactions |
+| `--duration-moderate` | 200ms | Panel reveals, size changes |
+| `--duration-slow` | 300ms | Complex animations, layout shifts |
+| `--duration-enter` | 350ms | Major reveals (stageflow, modals) |
+
+### 7.2 Easing
+
+| Usage | Value |
+|---|---|
+| Standard | `cubic-bezier(0.25, 0.46, 0.45, 0.94)` |
+| Enter | `cubic-bezier(0.0, 0.0, 0.2, 1.0)` |
+| Exit | `cubic-bezier(0.4, 0.0, 1.0, 1.0)` |
+
+### 7.3 Reduced Motion (Required)
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+**Rule:** This MUST be in the global stylesheet. Individual components do not need their own reduced motion handling if this is present.
+
+### 7.4 What NOT to Animate
+
+- No parallax
+- No animated blur (static only)
+- No auto-playing motion
+- No bouncing/pulsing indicators
+- No content shifts after page load
+
+---
+
+## 8. Accessibility Standards
+
+### 8.1 Philosophy
+
+Leantime is built for neurodiversity — ADHD, autism, dyslexia. Accessibility means reducing cognitive load, supporting focus, respecting processing speeds, accommodating reading patterns, and providing forgiveness for mistakes.
+
+### 8.2 WCAG Compliance
+
+| Standard | Level | Status |
+|---|---|---|
+| WCAG 2.1 Level AA | Required | All components |
+| WCAG 2.1 Level AAA | Aspirational | Text contrast, enhanced focus |
+
+### 8.3 Keyboard Navigation
+
+Every interactive element must be keyboard-accessible:
+
+| Element | Required behavior |
+|---|---|
+| Buttons | Focusable. `Enter` and `Space` activate. |
+| Links | Focusable. `Enter` activates. |
+| Dropdowns | Arrow keys navigate, `Enter` selects, `Escape` closes |
+| Modals | Focus trapped inside, `Escape` closes, focus returns to trigger |
+| Tabs / toggles | Arrow keys move between options, `Enter`/`Space` activates |
+| Collapsible sections | `Enter`/`Space` toggles, `aria-expanded` communicated |
+| Stageflow stages | Focusable via `tabindex="0"`, `Enter`/`Space` activates, `role="button"` |
+| Selectable cards | `role="radio"` or `role="checkbox"`, arrow keys navigate, `aria-checked` |
+| Inline edit triggers | `role="button"`, `Enter` opens editor |
+
+**Focus indicator:**
+```css
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+```
+Use `focus-visible` not `focus`. Apply to ALL interactive elements, not just buttons.
+
+### 8.4 Screen Reader Support
+
+| Pattern | Implementation |
+|---|---|
+| Status indicators | `aria-label="Status: In Progress"` on dots/pills |
+| Icon-only buttons | `aria-label="Close"` or `<span class="tw:sr-only">Close</span>` |
+| Decorative icons next to text | `aria-hidden="true"` on the icon |
+| Progress bars | `role="progressbar" aria-valuenow="72" aria-valuemin="0" aria-valuemax="100"` |
+| Expandable sections | `aria-expanded="true/false"` on trigger, `aria-controls="panel-id"` |
+| Live updates (HTMX) | `aria-live="polite"` on dynamically updating containers |
+| Data tables | `<th scope="col">` headers, `<caption>` for context |
+| Form fields | `<label>` with `for` attribute, or `aria-label` / `aria-describedby` |
+| Error messages | `aria-invalid="true"` on field, `role="alert"` on error text, linked via `aria-describedby` |
+| Modals | `role="dialog" aria-modal="true" aria-labelledby="title-id"` |
+| Loading states | `aria-busy="true"`, `role="status"` on spinner, `<span class="tw:sr-only">Loading...</span>` |
+| Mode toggles | `aria-live="polite"` region announcing "Dark mode enabled" / "Light mode enabled" |
+| Color-only segments | `role="img" aria-label="Done: 40%"` on each segment |
+
+**Screen reader utility:**
+```css
+.sr-only, .tw\:sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+```
+
+### 8.5 HTMX-Specific Accessibility
+
+```html
+<div id="content-area" aria-live="polite" aria-atomic="false">
+  <!-- HTMX swaps here -->
+</div>
+
+<div class="htmx-indicator" role="status" aria-label="Loading">
+  <span class="tw:sr-only">Loading...</span>
+</div>
+```
+
+Every HTMX target with meaningful content gets `aria-live="polite"`. Use `aria-busy="true"` during swap transitions.
+
+### 8.6 Color Contrast Requirements
+
+| Context | Minimum ratio | WCAG criterion |
+|---|---|---|
+| Body text (13px+) on background | 4.5:1 | 1.4.3 AA |
+| Large text (18px+ or 14px bold) | 3:1 | 1.4.3 AA |
+| UI components and borders | 3:1 against adjacent | 1.4.11 AA |
+| Focus indicators | 3:1 against background | 1.4.11 AA |
+| Text on accent backgrounds | 4.5:1 | 1.4.3 AA |
+
+Check in BOTH light and dark mode.
+
+### 8.7 Touch Targets (Enforced Minimums)
+
+| Context | Minimum rendered size | If visual is smaller |
+|---|---|---|
+| Primary actions (buttons) | 44×44px | — must be this size |
+| Secondary actions (icon buttons) | 32×32px | Extend with `::before { inset: -6px }` to reach 44px |
+| Dropdown menu items | 36px height minimum | — |
+| List items / rows | 44px height | — |
+| Close/dismiss buttons | 24×24px visual | Extend hit area to 44×44px with `::before` |
+| Toggle switches | 36×20px visual | Wrapper must be 44×44px clickable area |
+| Inline pills/chips | 28px height minimum | Extend with `::before` to 44px on mobile |
+
+**Touch extension pattern:**
+```css
+.touch-extend {
+  position: relative;
+}
+.touch-extend::before {
+  content: '';
+  position: absolute;
+  inset: -10px; /* Extend clickable area beyond visual bounds */
+}
+```
+
+### 8.8 Cognitive Accessibility (Neurodiversity-Specific)
+
+| Principle | Implementation |
+|---|---|
+| Consistent patterns | Same action = same UI pattern everywhere |
+| No time pressure | No auto-dismissing toasts. User dismisses manually. |
+| Clear hierarchy | One primary action per view. Secondary actions visually subordinate. |
+| Chunked information | Collapsible sections. Don't show everything at once. |
+| Predictable navigation | Tab order follows visual order. Back button always works. |
+| Forgiveness | Undo for destructive actions. Confirmation for irreversible ones. |
+| Reduced noise | No decorative animations. Accent for focus, not decoration. |
+| Working memory support | Show context inline. Breadcrumbs. "You are here" indicators. |
+| Reading support | Left-aligned text. No justified. High line-height. Clear font hierarchy. |
+
+---
+
+## 9. Component Patterns
+
+### 9.1 Buttons
+
+| Property | Value |
+|---|---|
+| Primary bg | `var(--accent1)` + `inset 0 1px 0 rgba(255,255,255,0.15)` |
+| Primary text | `var(--color-text-on-accent)` |
+| Ghost bg | Glass or `var(--color-bg-card)` |
+| Ghost border | `1px solid var(--color-border-default)` |
+| Danger bg | `var(--accent4)` |
+| Radius | `var(--radius-sm)` (6px) |
+| Focus | `var(--focus-ring)` |
+| Hover | `brightness(1.08)` or `var(--color-bg-hover)` for ghost |
+
+**Sizes:**
+
+| Size | Padding | Font | Min height | Touch target |
+|---|---|---|---|---|
+| XS | 4px 8px | `--text-xs` (10px) | 24px | Extend to 44px with `::before` |
+| SM | 6px 12px | `--text-xs` (10px) | 28px | Extend to 44px with `::before` |
+| Default | 8px 16px | `--text-sm` (12px) | 36px | Already meets 36px, extend for mobile |
+| LG | 12px 24px | `--text-md` (14px) | 44px | Native 44px ✅ |
+
+**States:** Hover darkens primary, hover adds bg-hover to ghost. Disabled: `opacity: 0.5; cursor: not-allowed;` + `aria-disabled="true"`. Loading: spinner replaces label, width stable, `aria-busy="true"`.
+
+### 9.2 Cards
+
+| Property | Value |
+|---|---|
+| Background | `var(--glass-bg)` with `backdrop-filter: var(--glass-blur)` |
+| Border | `var(--glass-border)` |
+| Radius | `var(--radius)` (10px) |
+| Shadow resting | `var(--shadow-sm)` |
+| Shadow hover | `var(--shadow-md)` |
+| Padding body | `var(--space-4)` (16px) |
+| Padding header | `var(--space-3)` (12px) |
+| Header border | `1px solid var(--color-border-light)` |
+
+If interactive: `tabindex="0"`, `role="button"` or `role="link"`, keyboard activation, focus ring.
+
+### 9.3 Inputs
+
+| Property | Value |
+|---|---|
+| Background | `rgba(255, 255, 255, 0.7)` (glass tint) |
+| Border | `1px solid rgba(0, 71, 102, 0.12)` (accent1 at low opacity) |
+| Radius | `var(--radius)` (10px) |
+| Font size | `var(--text-base)` (13px) |
+| Padding | `var(--space-2) var(--space-3)` (8px 12px) |
+| Min height | 36px |
+| Focus glow | `0 0 0 3px rgba(0, 184, 147, 0.2)` (accent2 glow) |
+| Placeholder | `var(--color-text-disabled)` |
+| Error border | `var(--accent4)` |
+| Error text | `var(--accent4)`, linked via `aria-describedby` |
+
+**Required:** Explicit `<label for="input-id">` for every input. No exceptions.
+
+### 9.4 Pills / Badges
+
+| Property | Value |
+|---|---|
+| Radius | `var(--radius-pill)` (20px) |
+| Font | `--text-xs` (10px) / weight 600 |
+| Padding | 2px 8px |
+| Min height | 20px |
+| Color | White on semantic background |
+| A11y | `aria-label="Status: [value]"` |
+
+### 9.5 Avatars
+
+| Size name | Dimensions | Font size | Usage |
+|---|---|---|---|
+| XS | 24×24px | 10px | Compact lists, inline mentions |
+| SM | 28×28px | 11px | Default in cards, comments |
+| MD | 32×32px | 13px | Profile indicators |
+| LG | 40×40px | 15px | Headers, profiles |
+| XL | 48×48px | 18px | Profile pages, settings |
+
+**Dropped:** 18px and 22px sizes from v1.1. Minimum is 24px.
+
+| Property | Value |
+|---|---|
+| Radius | `var(--radius-full)` |
+| Background | `linear-gradient(135deg, var(--accent1), var(--accent2))` |
+| Text | `var(--color-text-on-accent)` |
+| Font weight | 700 |
+| Stack border | `2px solid var(--color-bg-card)` (NOT white) |
+| Stack overlap | -6px margin |
+| A11y | `aria-label="[Person name]"` or `title` |
+
+### 9.6 Status Dots
+
+| Context | Size | Accompanied by |
+|---|---|---|
+| Inline (in text/pills) | 6px | Adjacent text |
+| Standalone | 8px | Text label or `aria-label` |
+| Emphasis | 10px | Text label or `aria-label` |
+
+**Minimum:** 6px. Nothing smaller.
+
+### 9.7 Dropdowns / Popovers
+
+| Property | Value |
+|---|---|
+| Background | `var(--glass-bg)` with `backdrop-filter: var(--glass-blur)` |
+| Border | `1px solid var(--color-border-default)` |
+| Radius | `var(--radius-sm)` (6px) |
+| Shadow | `var(--shadow-lg)` |
+| Item padding | `var(--space-2) var(--space-3)` (8px 12px) |
+| Item min height | 36px |
+| Item font | `var(--text-sm)` (12px) |
+| Item hover | `var(--color-bg-hover)` |
+| Keyboard | Arrow keys navigate, `Enter` selects, `Escape` closes |
+| ARIA | `role="menu"`, `role="menuitem"` |
+
+### 9.8 Modals
+
+| Property | Value |
+|---|---|
+| Background | `var(--glass-bg)` with `backdrop-filter: var(--glass-blur)` |
+| Radius | `var(--radius)` (10px) |
+| Shadow | `var(--shadow-xl)` |
+| Backdrop | `rgba(0,0,0,0.3)` light / `rgba(0,0,0,0.6)` dark |
+| Padding | `var(--space-5)` (20px) |
+| Title | `--text-xl` (18px) / weight 650 |
+| ARIA | `role="dialog" aria-modal="true" aria-labelledby="title-id"` |
+| Focus trap | Required |
+| Escape | Required — closes modal |
+| Return focus | Required — focus returns to trigger element |
+
+### 9.9 Toggle Switches
+
+| Property | Value |
+|---|---|
+| Track | 36×20px, `var(--radius-pill)` |
+| Handle | 16×16px, `var(--radius-full)`, `var(--color-bg-card)` (NOT white) |
+| Active | Track: `var(--accent1)` |
+| Inactive | Track: `var(--color-text-disabled)` |
+| Wrapper clickable area | 44×44px minimum (extend beyond visual) |
+| A11y | `role="switch"`, `aria-checked`, keyboard `Space` to toggle |
+
+### 9.10 Inline Edit Triggers (Dropdown Pills)
+
+| Property | Value |
+|---|---|
+| Padding | `var(--space-1) var(--space-3)` (4px 12px) |
+| Min height | 28px |
+| Font | `--text-xs` (10px) / weight 500 |
+| Border | `1px solid var(--color-border-default)` |
+| Radius | `var(--radius-pill)` (20px) |
+| Touch target | Extend to 44px with `::before` on mobile |
+| A11y | `role="button"`, `aria-haspopup="listbox"`, `aria-expanded` |
+
+### 9.11 Progress Bars
+
+| Property | Value |
+|---|---|
+| Track height | 6px |
+| Track bg | `var(--color-bg-muted)` (translucent for glass effect) |
+| Track radius | 3px |
+| Fill radius | 3px |
+| Default fill | `linear-gradient(90deg, var(--accent1), var(--accent2))` |
+| Danger fill | `var(--accent4)` gradient |
+| A11y | `role="progressbar" aria-valuenow="N" aria-valuemin="0" aria-valuemax="100"` |
+
+### 9.12 Icons
+
+| Context | Size | Color |
+|---|---|---|
+| Navigation | 16px | `var(--color-text-muted)` inactive, `var(--color-text-on-accent)` active |
+| In buttons | 12px | Match button text |
+| In labels | 10px | `var(--color-text-muted)` or semantic |
+| Standalone | 14–16px | `var(--color-text-muted)` |
+
+Font Awesome 6. `fa` prefix. Solid default.
+
+**Icons alone MUST have** `aria-label` or `<span class="tw:sr-only">`. Decorative icons next to text get `aria-hidden="true"`.
+
+---
+
+## 10. Stageflow Stage Colors
+
+| Stage | Color token | Background token | Usage |
+|---|---|---|---|
+| s1 (Inputs) | `var(--s1)` = accent1 | `var(--s1-bg)` | Deep teal |
+| s2 (Activities) | `var(--s2)` = accent2 | `var(--s2-bg)` | Emerald |
+| s3 (Outputs) | `var(--s3)` = accent3-text | `var(--s3-bg)` | Chartreuse (text-safe) |
+| s4 (Outcomes) | `var(--s4)` = #C84D7C | `var(--s4-bg)` | Hot pink softened |
+| s5 (Impact) | Gradient `var(--s5-start)` → `var(--s5-end)` | `var(--s5-bg)` | Teal to emerald |
+
+### Stageflow Component Sizing
+
+| Element | Active state | Inactive state |
+|---|---|---|
+| Stage icon | 36×36px, `var(--radius)` | 28×28px, 7px radius |
+| Stage name | `--text-lg` (16px) / weight 700 | `--text-sm` (12px) / weight 600 |
+| Stage subtitle | `--text-sm` (12px) | `--text-xs` (10px) |
+| Item title | `--text-base` (13px) / weight 600 | `--text-sm` (12px) / weight 500 |
+| Item description | `--text-sm` (12px) | Hidden |
+| Status dot | 8px | 6px |
+| Item border-left | 3px solid stage color | transparent |
+
+---
+
+## 11. Emboss / Timeline Bar Patterns
+
+### Bar Anatomy
+
+1. **Progress fill:** Opaque gradient (`accent1 → accent2` sweep)
+2. **Remaining track:** Translucent pill `rgba(255,255,255,0.08–0.12)` — allows background bleed-through
+3. **Progress handle:** Small circle at fill boundary (draggable affordance), `var(--color-bg-card)` background
+4. **Bar radius:** `var(--radius-pill)` (20px) — full pill shape
+
+### Color Coding
+
+| State | Fill |
+|---|---|
+| Standard | `accent1 → accent2` gradient |
+| Flagged/overdue | `accent4` gradient |
+| Ahead of schedule | `accent3` tint highlight |
+| Complete | 100% fill, no handle |
+
+### Dark Mode
+
+Bars appear as "frosted glass floating over dark surface." Unfilled track: `rgba(255,255,255,0.08)`. Filled portion glows. Diamond milestone markers hold up in grayscale.
+
+---
+
+## 12. Z-Index Scale
+
+| Layer | Value | Usage |
+|---|---|---|
+| Base | 0 | Default content |
+| Sticky headers | 10 | Table headers, toolbar |
+| Active stageflow stage | 10 | Elevated stage |
+| Dropdowns | 20 | Menus, popovers |
+| Modals | 30 | Dialog overlays |
+| Toasts | 40 | Notification popups |
+| AI trigger | 50 | Fixed position AI button |
+| Global header | 100 | Top navigation bar |
+
+---
+
+## 13. Audit Methodology
+
+### 13.1 Sweep Priority Order
+
+Sweeps are grouped. Complete one group before moving to the next.
+
+**Group A — Accessibility (blocks users)**
+1. Keyboard accessibility (tabindex, roles, keydown handlers)
+2. Screen reader support (aria-labels, live regions, sr-only)
+3. Color-only indicators (add icons/text companions)
+4. Touch targets (enforce minimums from §8.7)
+
+**Group B — Token Compliance (blocks theming)**
+5. Hardcoded brand colors → CSS variables (accent1–4)
+6. Hardcoded neutrals → CSS variables (text, bg, border)
+7. Dark mode verification
+8. Glass treatment application
+
+**Group C — Visual Consistency (polish)**
+9. Typography normalization (kill sub-10px, snap to scale)
+10. Border radius normalization
+11. Spacing normalization
+12. Shadow normalization
+13. Transition normalization
+
+**Group D — Legacy Cleanup**
+14. jQuery → Alpine.js/HTMX migration catalog
+15. `.tpl.php` → Blade migration catalog
+16. Inline style elimination
+
+### 13.2 Search Patterns
+
+```bash
+# ── Brand colors (old values) ──
+grep -rn "#1b75bb\|#1B75BB\|#81B1A8\|#81b1a8" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# ── Brand colors (new values, should be vars not hex) ──
+grep -rn "#004766\|#00B893\|#CADE1B\|#F61067\|#A8B516" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# ── Hardcoded white backgrounds ──
+grep -rn "background:\s*#[Ff][Ff][Ff]\|background-color:\s*#[Ff][Ff][Ff]\|background:\s*white" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# ── Sub-10px font sizes (violations) ──
+grep -rn "font-size:\s*[0-9]px\|font-size:\s*[7-9]px" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# ── Interactive divs without keyboard support ──
+grep -rn "@click\|onclick\|hx-get\|hx-post" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | grep -v "button\|<a " | head -20
+
+# ── Icon-only buttons missing aria-label ──
+grep -rn "<button[^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only"
+
+# ── Missing focus-visible ──
+grep -rn "focus-visible\|focus-ring\|:focus" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | wc -l
+```
+
+### 13.3 Reporting Format
+
+After each sweep:
+
+```markdown
+## Sweep: [Category Name]
+### Files checked: N
+### Issues found: N (critical / minor / flagged)
+
+#### Critical (breaks theming, locks out users, or fails WCAG AA)
+| File | Line | Issue | Fix |
+|---|---|---|---|
+
+#### Minor (cosmetic inconsistency)
+| File | Line | Issue | Fix |
+|---|---|---|---|
+
+#### Flagged (needs design decision)
+| File | Line | Issue | Question |
+|---|---|---|---|
+```
+
+---
+
+## 14. Migration Rules
+
+### 14.1 Color Migration
+
+| Priority | Old value | New value |
+|---|---|---|
+| 1 | `#1b75bb` (any case) | `var(--accent1)` |
+| 2 | `#81B1A8` (any case) | `var(--accent2)` |
+| 3 | Hardcoded `#059669` (success) | `var(--accent2)` |
+| 4 | Hardcoded `#DC2626` (error) | `var(--accent4)` |
+| 5 | Hardcoded `#D97706` (warning) | `var(--accent3-text)` |
+| 6 | Hardcoded white backgrounds | `var(--color-bg-card)` or `var(--glass-bg)` |
+| 7 | Hardcoded dark text | `var(--color-text-primary)` / `secondary` / `muted` |
+| 8 | Hardcoded borders | `var(--color-border-default)` or `var(--color-border-light)` |
+
+### 14.2 What NOT to Touch
+
+- Theme definition files (where CSS variables ARE being set)
+- Third-party CSS or JS
+- Files being actively rewritten by other contributors
+- SVG assets with baked-in colors (flag for later)
+- Comments or documentation referencing color codes
+
+---
+
+## 15. Testing Requirements
+
+### 15.1 After Every Sweep
+
+1. **Default light mode** — page looks identical to before the sweep
+2. **Default dark mode** — no invisible text, no white rectangles, borders visible
+3. **Custom accent** — change accent1 to orange (`#E65100`), accent2 to gold (`#FFB74D`) via console:
+   ```javascript
+   document.documentElement.style.setProperty('--accent1', '#E65100');
+   document.documentElement.style.setProperty('--accent2', '#FFB74D');
+   ```
+4. **Keyboard navigation** — tab through page, every interactive element receives visible focus
+5. **200% browser zoom** — layout doesn't break, text doesn't overflow
+
+### 15.2 Accessibility Testing
+
+- Screen reader: VoiceOver (Mac) or NVDA (Windows) — read through one complete flow
+- Keyboard-only: complete one full task without touching the mouse
+- Color blindness: simulate protanopia (red-blind) and deuteranopia (green-blind) — verify status is still readable via icons/text
+- Reduced motion: enable `prefers-reduced-motion` — verify no animations play
+
+---
+
+## 16. Changelog
+
+### v2.0 — February 24, 2026
+- **Brand palette:** Replaced 2-accent (#1b75bb, #81B1A8) with 4-accent (#004766, #00B893, #CADE1B, #F61067)
+- **Added:** accent2-text (#008F72) for safe text usage of emerald
+- **Added:** accent3, accent3-text, accent4 tokens with derived tints
+- **Added:** Glass treatment specs (backdrop-filter, translucency levels)
+- **Added:** 3-theme architecture (Leantime, Focus, High Contrast)
+- **Font:** Hanken Grotesk variable font (replaces system-only stack)
+- **Weights:** Variable scale 450–800 (replaces 400/600/700)
+- **Typography floor:** 10px absolute minimum (eliminated 9px "Tiny" token)
+- **Type scale:** Adjusted — 12px replaces 11px for `--text-sm`, 13px for `--text-base`
+- **Radius:** Added 6px and 14px stops (4/6/10/14/20 scale)
+- **Stageflow colors:** Derived from brand palette instead of separate viz colors
+- **Component minimums:** Enforced sizes with exact height/padding values
+- **Avatars:** Dropped 18px and 22px sizes, 24px minimum
+- **Status dots:** 6px minimum enforced
+- **Touch targets:** Full specification with extension patterns
+- **Toggle switches:** Spec for wrapper sizing and `role="switch"`
+- **Inline edit triggers:** Min 28px height, ARIA patterns
+- **Audit sweeps:** Reordered — accessibility before visual consistency
+- **Semantic colors:** Brand colors ARE semantic (no separate system)
+- **Surface whites:** Distinguished text-on-accent (keep white) from surface elements (use `var(--color-bg-card)`)
+- **Emboss patterns:** Timeline/Gantt bar specs added

--- a/Docs/15-DESIGN-TOKENS-PROMPT-v2.md
+++ b/Docs/15-DESIGN-TOKENS-PROMPT-v2.md
@@ -1,0 +1,642 @@
+# Design System Implementation — Claude Code Prompt v2
+
+**For Claude Code Execution Against the Leantime Codebase**
+
+| Field | Value |
+|---|---|
+| Project | Leantime |
+| Scope | Codebase-wide token compliance, accessibility, theming |
+| Reference | `docs/14-DESIGN-TOKENS.md` v2.0 — **Read this first, it's the source of truth** |
+| Risk | LOW per sweep (small, testable changes) |
+| Approach | One sweep at a time. Never batch multiple categories. |
+
+---
+
+## Pre-Read (Required)
+
+Before writing any code or running any grep, read these in order:
+
+1. `CLAUDE.md` — project conventions
+2. `docs/14-DESIGN-TOKENS.md` — **The canonical token reference. Every decision flows from this.**
+3. Skim `app/Views/Templates/components/` — understand Blade component layout
+4. Skim one existing Blade component to confirm `tw:` prefix convention and CSS variable usage
+
+---
+
+## Brand Palette (Confirmed — Do Not Change)
+
+| Token | Hex | Role |
+|---|---|---|
+| `--accent1` | `#004766` | Primary. Nav, buttons, links, active states |
+| `--accent2` | `#00B893` | Secondary/success. Fills, icons, progress |
+| `--accent2-text` | `#008F72` | Text-safe variant of accent2 (4.5:1 on white) |
+| `--accent3` | `#CADE1B` | Tertiary. Backgrounds/fills ONLY |
+| `--accent3-text` | `#A8B516` | Large text only (3.1:1) |
+| `--accent4` | `#F61067` | Danger/alerts (4.6:1) |
+
+**Old values being replaced:**
+- `#1b75bb` → `var(--accent1)`
+- `#81B1A8` → `var(--accent2)`
+- `#059669` (old success) → `var(--accent2)`
+- `#DC2626` (old error) → `var(--accent4)`
+- `#D97706` (old warning) → `var(--accent3-text)`
+
+---
+
+## Critical Constraints
+
+### DO
+
+- Work one sweep at a time — complete it, test it, confirm before starting the next
+- Use the exact token values from 14-DESIGN-TOKENS.md v2.0
+- Use `tw:` prefix for all Tailwind classes
+- Use CSS custom properties for all theme-layer colors
+- Produce a summary report after each sweep (format in section 13.3 of tokens doc)
+- Test in both light and dark mode after color changes
+- Preserve existing visual appearance while normalizing the underlying values
+- Add accessibility attributes (aria-label, roles, focus styles) as you encounter gaps
+- Use `var(--color-bg-card)` for surface whites (toggle handles, avatar borders, etc.)
+- Use `var(--color-text-on-accent)` for text on colored backgrounds
+
+### DO NOT
+
+- Change multiple categories in one sweep — colors and typography are separate passes
+- Invent new tokens not in the reference document — flag them instead
+- Remove existing functionality or change component behavior
+- Touch theme definition files (those define the custom properties)
+- Touch third-party CSS or JS
+- Touch files being actively rewritten by other contributors
+- Make cosmetic changes to pages scheduled for full redesign
+- Use `accent2` (#00B893) as text on light backgrounds — use `accent2-text` (#008F72)
+- Use `accent3` (#CADE1B) as text anywhere — use `accent3-text` (#A8B516) for large text only
+- Allow any font size below 10px in the rendered output
+
+---
+
+## Sweep Execution Order
+
+Sweeps are grouped by impact. Complete all sweeps in a group before moving to the next group.
+
+### GROUP A — Accessibility (Blocks Users)
+
+These come first because users are literally locked out without them.
+
+---
+
+### Sweep A1: Keyboard Accessibility
+
+**Goal:** Every interactive element has a visible focus indicator and can be activated with keyboard.
+
+#### Find
+
+```bash
+# Elements with click handlers but no keyboard support
+grep -rn "@click\|onclick\|hx-get\|hx-post" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | grep -v "button\|<a " | head -40
+
+# Check for focus-visible styles
+grep -rn "focus-visible\|focus-ring\|:focus" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | wc -l
+
+# Interactive elements total
+grep -rn "<button\|<a \|<input\|<select\|<textarea" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | wc -l
+```
+
+#### Fix
+
+For each interactive element:
+1. If it's a `<div>` or `<span>` with a click handler, either:
+   - Change to `<button>` (preferred) or `<a href>`
+   - Or add `tabindex="0"`, `role="button"`, `@keydown.enter="..."`, `@keydown.space.prevent="..."`
+2. Add focus style: `tw:focus-visible:ring-2 tw:focus-visible:ring-[var(--accent1)] tw:focus-visible:ring-offset-2`
+3. Or use the global `var(--focus-ring)` box-shadow
+
+**Specific patterns from known components:**
+
+| Component | Current | Fix |
+|---|---|---|
+| Stageflow stages | `onclick` on div | Add `tabindex="0"`, `role="button"`, `@keydown.enter`, `@keydown.space.prevent` |
+| Selectable cards | `onclick` on div | Add `role="radio"`, `tabindex="0"`, `aria-checked`, arrow key navigation |
+| Demo tabs | Click only | Add `role="tablist"` on container, `role="tab"` on each, `aria-selected`, arrow keys |
+| Inline edit triggers | Click only | Add `role="button"`, `tabindex="0"`, `aria-haspopup="listbox"` |
+| Props toggle buttons | Click only | Ensure `aria-expanded`, `aria-controls` |
+| Card action buttons | May be icon-only | Ensure `aria-label` present |
+
+#### Test
+
+Tab through every major page without touching the mouse. Every interactive element should receive visible focus, activate on Enter (and Space for buttons), and follow visual tab order.
+
+---
+
+### Sweep A2: Screen Reader Support
+
+**Goal:** Every element communicates its purpose to assistive technology.
+
+#### Find
+
+```bash
+# Icon-only buttons missing labels
+grep -rn "<button[^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Icon-only links missing labels
+grep -rn "<a [^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Decorative icons missing aria-hidden (icons next to text)
+grep -rn "<i class=\"fa" app/Views/ --include="*.blade.php" | grep -v "aria-hidden\|sr-only\|aria-label" | head -20
+
+# Inputs without labels
+grep -rn "<input " app/Views/ --include="*.blade.php" | grep -v "aria-label\|aria-labelledby" | head -20
+
+# Images without alt
+grep -rn "<img " app/Views/ --include="*.blade.php" | grep -v "alt=" | head -20
+
+# Progress bars without semantics
+grep -rn "progress\|progressbar\|hd-fill\|ind-fill" app/Views/ --include="*.blade.php" | grep -v "role=\|aria-value" | head -20
+
+# HTMX targets without aria-live
+grep -rn "hx-target\|hx-swap" app/Views/ --include="*.blade.php" | head -30
+```
+
+#### Fix
+
+| Pattern | Fix |
+|---|---|
+| Icon-only `<button>` | Add `aria-label="Action name"` |
+| Icon-only `<a>` | Add `aria-label="Link purpose"` |
+| Decorative icon next to text | Add `aria-hidden="true"` to the `<i>` element |
+| `<input>` without label | Add `<label for="input-id">` or `aria-label` |
+| `<img>` without alt | Add `alt="Description"` or `alt=""` if decorative |
+| Status dot/pill | Add `aria-label="Status: In Progress"` |
+| Progress bar divs | Add `role="progressbar" aria-valuenow="N" aria-valuemin="0" aria-valuemax="100"` |
+| HTMX target containers | Add `aria-live="polite" aria-atomic="false"` |
+| Loading indicators | Add `role="status"`, `<span class="tw:sr-only">Loading...</span>` |
+| Mode toggles | Add `aria-live="polite"` status region announcing mode change |
+
+#### Ensure sr-only utility exists
+
+```css
+.sr-only, .tw\:sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+```
+
+---
+
+### Sweep A3: Color-Only Indicators
+
+**Goal:** No status is communicated by color alone (WCAG 1.4.1).
+
+#### Find
+
+```bash
+# Status dots
+grep -rn "dot-ok\|dot-wip\|dot-draft\|dot-flag\|st-dot\|sf-m-dot" \
+  app/Views/ --include="*.blade.php"
+
+# Colored borders as sole status
+grep -rn "border-left.*color\|border-l-" app/Views/ --include="*.blade.php" | head -20
+
+# Proportion bars / micro progress
+grep -rn "proportion\|micro-progress\|demo-prop\|demo-micro" \
+  app/Views/ --include="*.blade.php" | head -20
+
+# Token compliance dots (component guide specific)
+grep -rn "td-ok\|td-warn\|td-err" app/Views/ --include="*.blade.php" | head -20
+```
+
+#### Fix
+
+Every colored indicator needs a companion:
+- Status dot → add `aria-label="Status: [name]"` or adjacent text
+- Pill → verify it has text label (most do)
+- Proportion bar segments → add `role="img" aria-label="Done: 40%, Active: 25%..."` on container
+- Border-left status → ensure nearby text states the status
+- Token compliance dots → add text label or `aria-label`
+
+---
+
+### Sweep A4: Touch Targets
+
+**Goal:** All interactive elements meet minimum touch target size from tokens doc §8.7.
+
+#### Find
+
+```bash
+# Small buttons
+grep -rn "btn-xs\|btn-sm\|padding:\s*[0-3]px" app/Views/ --include="*.blade.php" | head -20
+
+# Small icon buttons
+grep -rn "<button[^>]*class=\"[^\"]*\"[^>]*>\s*<i " app/Views/ --include="*.blade.php" | head -20
+
+# Dropdown pills
+grep -rn "dropdown-pill\|ddpill\|dropdownPill" app/Views/ --include="*.blade.php" | head -20
+
+# Toggle switches
+grep -rn "toggle\|switch" app/Views/ --include="*.blade.php" --include="*.css" | head -20
+```
+
+#### Fix
+
+| Element | Current issue | Fix |
+|---|---|---|
+| Button XS | ~18px tall | Set min-height 24px, add `::before { content:''; position:absolute; inset:-10px; }` for 44px touch |
+| Button SM | ~22px tall | Set min-height 28px, add `::before` extension to 44px |
+| Dropdown items | ~21px tall | Set min-height 36px |
+| Toggle switches | 20px track height | Wrap in 44×44px clickable container |
+| Dropdown pills | ~18px tall | Set min-height 28px, add `::before` for mobile |
+| Close buttons (×) | Often 14px visual | Extend hit area to 44×44px with `::before` |
+
+**Touch extension pattern:**
+```css
+.touch-extend {
+  position: relative;
+}
+.touch-extend::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+```
+
+---
+
+### GROUP B — Token Compliance (Blocks Theming)
+
+These must be complete before custom themes or dark mode can ship reliably.
+
+---
+
+### Sweep B1: Hardcoded Brand Colors
+
+**Goal:** Every instance of old brand hex values becomes a CSS variable.
+
+#### Find
+
+```bash
+# Old primary blue
+grep -rn "#1b75bb\|#1B75BB\|#1b75Bb" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" --include="*.js"
+
+# Old secondary teal
+grep -rn "#81B1A8\|#81b1a8" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" --include="*.js"
+
+# Old success green (if separate from accent2)
+grep -rn "#059669" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Old error red
+grep -rn "#DC2626\|#dc2626" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Old warning amber
+grep -rn "#D97706\|#d97706" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# New palette hex values that should be vars (anything in template, not theme definition)
+grep -rn "#004766\|#00B893\|#CADE1B\|#F61067\|#A8B516\|#008F72\|#C84D7C" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+```
+
+#### Fix
+
+| Found | Replace with |
+|---|---|
+| `#1b75bb` (any case) in CSS property | `var(--accent1)` |
+| `#81B1A8` (any case) in CSS property | `var(--accent2)` |
+| `#059669` in CSS property | `var(--accent2)` |
+| `#DC2626` in CSS property | `var(--accent4)` |
+| `#D97706` in CSS property | `var(--accent3-text)` |
+| Tailwind `tw:text-[#1b75bb]` | `tw:text-[var(--accent1)]` |
+| JS dynamic styling | `getComputedStyle(document.documentElement).getPropertyValue('--accent1')` |
+
+#### Exclude
+
+- Theme definition files where values ARE the defaults being set
+- Comments or documentation
+- SVG files with baked-in colors (flag for later asset pass)
+
+#### Test
+
+```javascript
+document.documentElement.style.setProperty('--accent1', '#E65100');
+document.documentElement.style.setProperty('--accent2', '#FFB74D');
+// Scan every changed page — nothing should remain the old blue/teal
+```
+
+---
+
+### Sweep B2: Hardcoded Neutral Colors
+
+**Goal:** Background, text, and border colors that are hardcoded hex become CSS custom properties.
+
+#### Find
+
+```bash
+# Hardcoded white backgrounds
+grep -rn "background:\s*#[Ff][Ff][Ff]\|background-color:\s*#[Ff][Ff][Ff]\|background:\s*white" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded dark text
+grep -rn "color:\s*#1[Aa]1[Aa]2[Ee]\|color:\s*#333\|color:\s*#222\|color:\s*#000" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded gray text
+grep -rn "color:\s*#[4-9]" app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -40
+
+# Hardcoded borders
+grep -rn "border.*:\s*.*#[EeFf][0-9A-Fa-f]" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -40
+
+# Surface whites (should be var(--color-bg-card), NOT white)
+grep -rn "background:\s*white\|background:\s*#fff\|border.*solid\s*white\|border.*solid\s*#fff" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -20
+```
+
+#### Fix
+
+| Hardcoded | Token |
+|---|---|
+| `#FFFFFF`, `white` (backgrounds) | `var(--color-bg-card)` |
+| `#F5F5F5`, `#F8F9FB`, `#fafafa` (page bg) | `var(--color-bg-page)` |
+| `#F0F1F3`, `#f0f0f0`, `#eee` (muted bg) | `var(--color-bg-muted)` |
+| `#F3F4F6` (hover bg) | `var(--color-bg-hover)` |
+| `#1A1A2E`, `#333`, `#222`, `#000` (dark text) | `var(--color-text-primary)` |
+| `#4B5563`, `#555`, `#666` (body text) | `var(--color-text-secondary)` |
+| `#9CA3AF`, `#999`, `#aaa` (muted text) | `var(--color-text-muted)` |
+| `#D1D5DB`, `#ccc`, `#ddd` (disabled text) | `var(--color-text-disabled)` |
+| `#E8ECF0`, `#e0e0e0`, `#ddd` (borders) | `var(--color-border-default)` |
+| `#F0F1F3` (light borders) | `var(--color-border-light)` |
+| `white` in toggle handles, avatar borders | `var(--color-bg-card)` |
+
+**Important distinction:** Text on accent-colored backgrounds (button labels on accent1 bg, etc.) should use `var(--color-text-on-accent)` which IS white in both modes. Don't replace those with `var(--color-bg-card)`.
+
+If a color doesn't map cleanly, flag it — don't guess.
+
+#### Test
+
+```javascript
+document.documentElement.classList.add('theme-dark');
+// Or: document.documentElement.setAttribute('data-mode', 'dark');
+// Check: no white rectangles on dark background, no invisible text, borders visible
+```
+
+---
+
+### Sweep B3: Dark Mode Verification
+
+**Goal:** After B1 and B2, systematically verify every major page in dark mode.
+
+#### Process
+
+For each major template in `app/Views/`:
+1. Load the page
+2. Toggle dark mode
+3. Check for:
+   - Text invisible or near-invisible against background
+   - Borders that disappear
+   - Cards that blend into page background
+   - Focus indicators not visible
+   - Shadows invisible (should use `var(--shadow-*)`)
+   - Images or icons assuming white background
+   - Toggle handles, avatar stack borders still white instead of `var(--color-bg-card)`
+
+#### Fix
+
+- Add missing dark mode token usage
+- Replace `var(--shadow-*)` for shadows not yet using variables
+- Add `var(--color-bg-card)` background to transparent elements that rely on a white parent
+
+---
+
+### Sweep B4: Glass Treatment
+
+**Goal:** Apply glass brutalist aesthetic to surface elements per theme.
+
+#### Find
+
+```bash
+# Card and modal backgrounds
+grep -rn "background.*var(--color-bg-card)\|background:\s*var(--bg-card)" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -30
+
+# Dropdown backgrounds
+grep -rn "dropdown\|popover\|flyout" \
+  app/Views/Templates/components/ --include="*.blade.php" -l
+```
+
+#### Fix
+
+For surface elements (cards, modals, dropdowns, popovers, nav sidebar):
+```css
+background: var(--glass-bg);
+backdrop-filter: var(--glass-blur);
+border: var(--glass-border);
+/* Optional: */ box-shadow: var(--glass-inner-shadow);
+```
+
+**Do NOT apply glass to:** inputs, textareas, data tables, or any element where translucency would impair readability of text content.
+
+**Glass degrades gracefully:** Focus theme gets reduced glass, High Contrast gets none. The CSS variables handle this automatically if the tokens are used.
+
+---
+
+### GROUP C — Visual Consistency (Polish)
+
+---
+
+### Sweep C1: Typography Normalization
+
+**Goal:** Kill every sub-10px font size. Snap all sizes to the type scale.
+
+#### Find
+
+```bash
+# Sub-10px font sizes (violations)
+grep -rn "font-size:\s*[1-9]px\b" app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css" | grep -v "font-size:\s*1[0-9]px"
+
+# 9px specifically
+grep -rn "font-size:\s*9px" app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css"
+
+# 8px and below
+grep -rn "font-size:\s*[1-8]px\b" app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css"
+
+# Off-scale sizes
+grep -rn "font-size:\s*15px\|font-size:\s*11px\|font-size:\s*17px\|font-size:\s*19px" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+```
+
+#### Fix
+
+| Found | Snap to |
+|---|---|
+| 7px, 8px, 9px | 10px (`--text-xs`) |
+| 11px | 12px (`--text-sm`) |
+| 15px | 14px (`--text-md`) or 16px (`--text-lg`) |
+| 17px | 16px (`--text-lg`) or 18px (`--text-xl`) |
+| 19px | 18px (`--text-xl`) |
+
+**Font integration:** If Hanken Grotesk is not yet loaded, add to the base layout:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&display=swap" rel="stylesheet">
+```
+
+---
+
+### Sweep C2: Border Radius Normalization
+
+#### Fix
+
+| Found | Snap to |
+|---|---|
+| 3px | 4px (`--radius-xs`) |
+| 5px | 6px (`--radius-sm`) |
+| 7px | 6px or 10px |
+| 8px | 10px (`--radius`) |
+| 11px, 12px | 10px or 14px (`--radius-lg`) |
+| 15px, 16px | 14px or 20px (`--radius-pill`) |
+
+---
+
+### Sweep C3: Spacing Normalization
+
+#### Fix
+
+Snap all off-scale padding/margin/gap values to the 4px grid:
+- 3px → 4px
+- 5px → 4px
+- 7px → 8px
+- 9px → 8px
+- 11px → 12px
+- 13px → 12px
+- 15px → 16px
+
+---
+
+### Sweep C4: Shadow Normalization
+
+Replace custom shadow values with tokens. Remove `box-shadow` from `transition` properties.
+
+---
+
+### Sweep C5: Transition Normalization
+
+Replace `transition: all` with specific properties. Ensure durations match scale (100/150/200/300/350ms).
+
+---
+
+### Sweep C6: Reduced Motion
+
+**Goal:** Global `prefers-reduced-motion` reset is present.
+
+#### Find
+
+```bash
+grep -rn "prefers-reduced-motion" app/Views/ app/Plugins/ \
+  --include="*.css" --include="*.blade.php" | wc -l
+```
+
+#### Fix
+
+If not present globally, add to base stylesheet:
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+---
+
+### GROUP D — Legacy Cleanup (Backlog)
+
+These create a catalog, not immediate fixes. Sort by page traffic/importance.
+
+---
+
+### Sweep D1: Legacy Pattern Catalog
+
+```bash
+# jQuery usage
+grep -rn "jQuery\|\\\$(" app/Views/ app/Plugins/ --include="*.blade.php" --include="*.js" | wc -l
+
+# .tpl.php files still in use
+find app/Views/ -name "*.tpl.php" | wc -l
+
+# Inline styles
+grep -rn "style=\"" app/Views/ --include="*.blade.php" | wc -l
+```
+
+Output: A ranked backlog of files to migrate, sorted by usage frequency and user-facing impact.
+
+---
+
+## Execution Rules
+
+1. **One sweep per session.** Complete it, test it, produce the report, confirm before starting the next.
+2. **Smallest possible changes.** Replace a color value, don't rewrite the component.
+3. **Preserve visual output.** The page should look identical after a sweep (in the default light theme). Only dark mode / custom theme / accessibility behavior should improve.
+4. **When uncertain, flag.** If a color doesn't map to a token, report it. Don't guess.
+5. **Test after every sweep.** Default light, default dark, one custom accent. Keyboard tab-through. Five checks.
+6. **Accessibility sweeps are not optional.** Group A comes before Group B for a reason — users are locked out without them.
+7. **Font size floor is absolute.** If you find 9px text, it becomes 10px. No exceptions. No "but it's just a label."
+
+---
+
+## Quick Reference: File Types to Scan
+
+| Path | What lives there |
+|---|---|
+| `app/Views/Templates/` | Core Blade templates |
+| `app/Views/Templates/components/` | Shared Blade components (this is the system) |
+| `app/Views/Templates/components/stageflow/` | Stageflow/Logic Model component |
+| `app/Views/Templates/components/kanban/` | Kanban micro components |
+| `app/Views/Templates/components/forms/` | Form components |
+| `app/Views/Templates/components/elements/` | UI element components |
+| `app/Views/Templates/components/feedback/` | Alerts, notifications |
+| `app/Views/Templates/components/actions/` | Modals, confirm dialogs |
+| `app/Plugins/PgmPro/Views/` | Plugin views |
+| `app/Plugins/StrategyPro/Views/` | Plugin views |
+| `public/dist/css/` | Compiled CSS |
+| `resources/css/` | Source CSS (pre-build) |
+
+---
+
+## Reporting Template
+
+After each sweep, produce this:
+
+```markdown
+## Sweep [ID]: [Name]
+**Date:** YYYY-MM-DD
+**Files checked:** N
+**Issues found:** N (critical: N / minor: N / flagged: N)
+
+### Critical
+| File | Line | Before | After | Notes |
+|---|---|---|---|---|
+
+### Minor
+| File | Line | Before | After | Notes |
+|---|---|---|---|---|
+
+### Flagged (needs design decision)
+| File | Line | Issue | Question |
+|---|---|---|---|
+
+### Test Results
+- [ ] Default light mode — visual match
+- [ ] Default dark mode — no regressions
+- [ ] Custom accent — all elements respond
+- [ ] Keyboard navigation — focus visible on all changed elements
+- [ ] 200% zoom — no overflow or clipping
+```

--- a/Docs/15-DESIGN-TOKENS-PROMPT.md
+++ b/Docs/15-DESIGN-TOKENS-PROMPT.md
@@ -1,0 +1,422 @@
+# Design Token Audit & Equalization — Claude Code Prompt
+
+**For Claude Code Execution**
+
+| Field | Value |
+|---|---|
+| Project | Leantime |
+| Scope | Codebase-wide visual equalization, theming, accessibility |
+| Reference | `Docs/14-DESIGN-TOKENS.md` — **Read this first, it's the source of truth** |
+| Risk | LOW per sweep (small, testable changes) |
+| Approach | One sweep at a time. Never batch multiple categories. |
+
+---
+
+## Pre-Read (Required)
+
+1. `CLAUDE.md` — project conventions
+2. `Docs/14-DESIGN-TOKENS.md` — **The canonical token reference. Every decision flows from this.**
+3. Skim `app/Views/Templates/` directory structure to understand component layout
+4. Skim one existing Blade component to confirm `tw:` prefix convention and CSS variable usage
+
+---
+
+## Critical Constraints
+
+### DO
+
+- Work one sweep at a time — complete it, test it, confirm before starting the next
+- Use the exact token values from 14-DESIGN-TOKENS.md
+- Use `tw:` prefix for all Tailwind classes
+- Use CSS custom properties for all theme-layer colors
+- Produce a summary report after each sweep (format in 14-DESIGN-TOKENS.md section 11.3)
+- Test in both light and dark mode after color changes
+- Preserve existing visual appearance while normalizing the underlying values
+- Add accessibility attributes (aria-label, roles, focus styles) as you encounter gaps
+
+### DO NOT
+
+- Change multiple categories in one sweep — colors and typography are separate passes
+- Invent new tokens not in the reference document — flag them instead
+- Remove existing functionality or change component behavior
+- Touch theme definition files (those define the custom properties)
+- Touch third-party CSS
+- Touch files being actively rewritten by other contributors
+- Make cosmetic changes to pages that are scheduled for full redesign
+
+---
+
+## Sweep 1: Hardcoded Brand Colors
+
+**Goal:** Every instance of `#1b75bb` and `#81B1A8` (and case variants) becomes `var(--accent1)` or `var(--accent2)`.
+
+### Find
+
+```bash
+grep -rn "#1b75bb\|#1B75BB\|#81B1A8\|#81b1a8\|#1B75Bb\|#81b1a8" \
+  app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css" --include="*.js"
+```
+
+### Fix
+
+For each instance:
+- If in a `color:` or `background:` CSS property → replace with `var(--accent1)` or `var(--accent2)`
+- If in a Tailwind class like `tw:text-[#1b75bb]` → replace with `tw:text-[var(--accent1)]` or equivalent
+- If in a `style=""` attribute → same replacement
+- If in a JavaScript string for dynamic styling → use `getComputedStyle(document.documentElement).getPropertyValue('--accent1')`
+
+### Exclude
+
+- Theme definition files where these ARE the default values being set
+- Comments or documentation referencing the color codes
+- SVG files where the color is baked into an asset (flag these for later)
+
+### Test
+
+```javascript
+// In browser console — change accent colors and verify nothing stays blue
+document.documentElement.style.setProperty('--accent1', '#E65100');
+document.documentElement.style.setProperty('--accent2', '#FFB74D');
+// Scan every changed page — nothing should remain the old blue/teal
+```
+
+### Report
+
+Produce the sweep report per section 11.3 format.
+
+---
+
+## Sweep 2: Hardcoded Neutral Colors (Dark Mode Prep)
+
+**Goal:** Background, text, and border colors that are hardcoded hex values become CSS custom properties so they swap in dark mode.
+
+### Find
+
+```bash
+# Hardcoded white backgrounds
+grep -rn "background:\s*#[Ff][Ff][Ff]\|background-color:\s*#[Ff][Ff][Ff]\|background:\s*white" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded dark text
+grep -rn "color:\s*#1[Aa]1[Aa]2[Ee]\|color:\s*#333\|color:\s*#222\|color:\s*#000" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded gray text
+grep -rn "color:\s*#[4-9][Bb][0-9]\|color:\s*#[Aa-Ff][0-9]" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -40
+
+# Hardcoded border colors
+grep -rn "border.*:\s*.*#[EeFf][0-9A-Fa-f]" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -40
+```
+
+### Fix
+
+Map each hardcoded value to the nearest token:
+
+| Hardcoded | Token |
+|---|---|
+| `#FFFFFF`, `white` (backgrounds) | `var(--color-bg-card)` |
+| `#F8F9FB`, `#f5f5f5`, `#fafafa` (page bg) | `var(--color-bg-page)` |
+| `#F0F1F3`, `#f0f0f0`, `#eee` (muted bg) | `var(--color-bg-muted)` |
+| `#F3F4F6` (hover bg) | `var(--color-bg-hover)` |
+| `#1A1A2E`, `#333`, `#222`, `#000` (dark text) | `var(--color-text-primary)` |
+| `#4B5563`, `#555`, `#666` (body text) | `var(--color-text-secondary)` |
+| `#9CA3AF`, `#999`, `#aaa` (muted text) | `var(--color-text-muted)` |
+| `#D1D5DB`, `#ccc`, `#ddd` (disabled text) | `var(--color-text-disabled)` |
+| `#E8ECF0`, `#e0e0e0`, `#ddd` (borders) | `var(--color-border-default)` |
+| `#F0F1F3` (light borders) | `var(--color-border-light)` |
+
+If a color doesn't map cleanly, flag it — don't guess.
+
+### Test
+
+```javascript
+// Toggle dark mode
+document.documentElement.classList.add('theme-dark');
+// Check: no white rectangles on dark background, no invisible text, borders visible
+```
+
+### Report
+
+Produce the sweep report. Note any colors that didn't map to a token — these need design decisions.
+
+---
+
+## Sweep 3: Dark Mode Verification
+
+**Goal:** After sweeps 1-2, systematically check every major page/component in dark mode.
+
+### Process
+
+For each major template in `app/Views/`:
+1. Load the page
+2. Toggle dark mode
+3. Check for:
+   - Text that's invisible or near-invisible against background
+   - Borders that disappear
+   - Cards that blend into the page background
+   - Focus indicators that aren't visible
+   - Shadows that are invisible (should use `var(--shadow-*)`)
+   - Images or icons that assume a white background
+
+### Fix
+
+- Add missing dark mode token usage
+- Add `var(--shadow-*)` for shadows not yet using CSS variables
+- Add `var(--color-bg-card)` background to elements that were transparent (worked on white, invisible on dark)
+
+---
+
+## Sweep 4: Keyboard Accessibility
+
+**Goal:** Every interactive element has a visible focus indicator and can be activated with keyboard.
+
+### Find
+
+```bash
+# Interactive elements: buttons, links, inputs, selects, textareas
+grep -rn "<button\|<a \|<input\|<select\|<textarea" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | wc -l
+
+# Elements with click handlers but no keyboard support
+grep -rn "@click\|onclick\|hx-get\|hx-post" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | grep -v "button\|<a " | head -20
+
+# Check for focus-visible styles
+grep -rn "focus-visible\|focus-ring\|:focus" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | wc -l
+```
+
+### Fix
+
+For each interactive element:
+1. If it's a `<div>` or `<span>` with a click handler, either:
+   - Change to `<button>` (preferred) or `<a href>`
+   - Or add `tabindex="0"`, `role="button"`, `@keydown.enter="..."`, `@keydown.space.prevent="..."`
+2. Add focus style: `tw:focus-visible:ring-2 tw:focus-visible:ring-[var(--accent1)] tw:focus-visible:ring-offset-2`
+3. Or use the global `var(--focus-ring)` box-shadow
+
+### Test
+
+Tab through every page without touching the mouse. Every interactive element should:
+- Receive visible focus
+- Activate on Enter (and Space for buttons)
+- Have a logical tab order matching visual layout
+
+---
+
+## Sweep 5: Screen Reader Basics
+
+**Goal:** Every element communicates its purpose to assistive technology.
+
+### Find
+
+```bash
+# Icon-only buttons (no text content)
+grep -rn "<button[^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Icon-only links
+grep -rn "<a [^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Inputs without labels
+grep -rn "<input " app/Views/ --include="*.blade.php" | grep -v "aria-label\|aria-labelledby" | head -20
+# Cross-reference: check if these have a <label for="..."> nearby
+
+# Images without alt
+grep -rn "<img " app/Views/ --include="*.blade.php" | grep -v "alt=" | head -20
+
+# Status dots/pills without text
+grep -rn "pill-ok\|pill-wip\|pill-draft\|pill-flag\|dot-ok\|dot-wip\|dot-draft\|dot-flag" \
+  app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only\|title=" | head -20
+```
+
+### Fix
+
+| Pattern | Fix |
+|---|---|
+| Icon-only `<button>` | Add `aria-label="Action name"` |
+| Icon-only `<a>` | Add `aria-label="Link purpose"` |
+| Decorative icon next to text | Add `aria-hidden="true"` to the icon |
+| `<input>` without label | Add `<label for="input-id">` or `aria-label` |
+| `<img>` without alt | Add `alt="Description"` or `alt=""` if decorative |
+| Status dot/pill | Add `aria-label="Status: In Progress"` |
+
+---
+
+## Sweep 6: HTMX Live Regions
+
+**Goal:** Dynamic content updates are announced to screen readers.
+
+### Find
+
+```bash
+# All HTMX targets
+grep -rn "hx-target\|hx-swap" app/Views/ --include="*.blade.php" | head -30
+
+# Check which target containers have aria-live
+# For each hx-target="#some-id", check if #some-id has aria-live
+```
+
+### Fix
+
+For each HTMX target that holds user-facing content:
+```html
+<div id="target-id" aria-live="polite" aria-atomic="false">
+  <!-- HTMX swaps here -->
+</div>
+```
+
+For loading indicators:
+```html
+<div class="htmx-indicator" role="status">
+  <span class="tw:sr-only">Loading...</span>
+  <!-- visual spinner -->
+</div>
+```
+
+---
+
+## Sweep 7: Reduced Motion
+
+**Goal:** All animations respect `prefers-reduced-motion`.
+
+### Find
+
+```bash
+# CSS animations
+grep -rn "@keyframes\|animation:" app/Views/ app/Plugins/ \
+  --include="*.css" --include="*.blade.php"
+
+# CSS transitions
+grep -rn "transition:" app/Views/ app/Plugins/ \
+  --include="*.css" --include="*.blade.php" | head -30
+
+# Check for existing reduced-motion support
+grep -rn "prefers-reduced-motion\|motion-reduce" app/Views/ app/Plugins/ \
+  --include="*.css" --include="*.blade.php" | wc -l
+```
+
+### Fix
+
+Option A — global reset (if not already present):
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Option B — per-component Tailwind:
+```html
+<div class="tw:transition-all tw:duration-200 tw:motion-reduce:transition-none">
+```
+
+---
+
+## Sweep 8: Color-Only Status Indicators
+
+**Goal:** No status is communicated by color alone.
+
+### Find
+
+```bash
+# Status dots
+grep -rn "dot-ok\|dot-wip\|dot-draft\|dot-flag" app/Views/ --include="*.blade.php"
+
+# Status backgrounds
+grep -rn "bg-green\|bg-red\|bg-yellow\|bg-blue" app/Views/ --include="*.blade.php" | head -20
+
+# Colored borders as sole status indicator
+grep -rn "border-left.*color\|border-l-" app/Views/ --include="*.blade.php" | head -20
+```
+
+### Fix
+
+Every colored status indicator needs a companion:
+- Dot → add icon inside or `aria-label`
+- Pill → already has text label (verify it does)
+- Border → ensure nearby text states the status
+- Chart segment → add text labels or patterns
+
+---
+
+## Sweep 9: Touch Targets
+
+**Goal:** All interactive elements meet minimum touch target size.
+
+### Find
+
+Look for small interactive elements:
+```bash
+# Small buttons (likely too small)
+grep -rn "padding:\s*[0-3]px\|tw:p-0\|tw:p-0.5\|tw:p-1" app/Views/ --include="*.blade.php" | head -20
+
+# Icon buttons without padding
+grep -rn "<button[^>]*class=\"[^\"]*\"[^>]*>\s*<i " app/Views/ --include="*.blade.php" | head -20
+```
+
+### Fix
+
+- Ensure minimum 44x44px clickable area (even if visual is smaller, extend with padding)
+- For icon buttons: `tw:p-2.5` minimum (10px padding around ~24px icon = 44px)
+- For close buttons: extend hit area with `::before` pseudo-element if needed
+
+---
+
+## Sweeps 10-15: Visual Consistency
+
+These sweeps normalize typography, radius, spacing, shadows, transitions, and legacy patterns. Follow the search patterns in 14-DESIGN-TOKENS.md section 11.2 and fix each deviation to the nearest token.
+
+### Sweep 10: Typography
+
+Fix off-scale font sizes (15px → 14px or 16px), missing line-heights, justified text → left-aligned, inconsistent weights for same semantic level.
+
+### Sweep 11: Border Radius
+
+Fix off-scale values: 3px → 4px, 5px → 4px or 6px, 7px → 8px, 10px → 8px or 12px, 16px → 12px or 20px.
+
+### Sweep 12: Spacing
+
+Fix arbitrary values: 15px → 16px, 13px → 12px, 7px → 8px, 11px → 12px, 9px → 8px or 10px.
+
+### Sweep 13: Shadows
+
+Replace custom shadow values with `var(--shadow-sm/md/lg/xl)`. Remove `box-shadow` from `transition` properties.
+
+### Sweep 14: Transitions
+
+Replace `transition: all` with specific properties. Ensure durations match scale (150/200/300/350ms). Remove `box-shadow` transitions.
+
+### Sweep 15: Legacy Patterns
+
+Catalog jQuery usage, `.tpl.php` files, and inline styles. Don't fix all at once — create a backlog sorted by page traffic/importance.
+
+---
+
+## Execution Rules
+
+1. **One sweep per session.** Complete, test, report, then move to the next.
+2. **Smallest possible changes.** Replace a color value, don't rewrite the component.
+3. **Preserve visual output.** The page should look identical after a token sweep (in the default theme). Only dark mode / custom theme behavior should improve.
+4. **When uncertain, flag.** If a color doesn't map cleanly to a token, report it. Don't guess.
+5. **Test after every sweep.** Light mode default, dark mode, one custom accent. Three checks.
+6. **Accessibility sweeps are not optional.** Sweeps 4-9 are just as important as the color sweeps. They come before cosmetic sweeps for a reason — users are literally locked out without them.
+
+---
+
+## Quick Reference: File Types to Scan
+
+| Path | What lives there | Primary sweep targets |
+|---|---|---|
+| `app/Views/Templates/` | Core Blade templates | All sweeps |
+| `app/Views/Templates/components/` | Shared Blade components | All sweeps |
+| `app/Plugins/PgmPro/Views/` | Plugin views | All sweeps |
+| `app/Plugins/StrategyPro/Views/` | Plugin views | All sweeps |
+| `public/dist/css/` | Compiled CSS | Sweeps 1-3, 11-14 |
+| `app/Domain/*/Templates/` | Domain-specific templates | All sweeps |
+| `resources/css/` | Source CSS (pre-build) | Sweeps 1-3, color vars |

--- a/Docs/16-CROSS-CUTTING-CONCERNS.md
+++ b/Docs/16-CROSS-CUTTING-CONCERNS.md
@@ -1,0 +1,781 @@
+# Cross-Cutting Concerns — Integration Contracts
+
+**How Every Feature Plugs into Shared Systems**
+
+| Field | Value |
+|---|---|
+| Product | Leantime |
+| Document | Cross-Cutting Concerns |
+| Version | 1.0 |
+| Date | February 23, 2026 |
+| Author | Gloria Folaron |
+| Status | Living Document |
+| Purpose | Define how features integrate with language, timezone, notifications, permissions, entity relations, events, search, and audit systems. Every new component, view, service, or plugin must follow these contracts. |
+
+---
+
+## Why This Document Exists
+
+Leantime has multiple systems that every feature touches but no single feature owns. When a developer builds a new view and hardcodes "Due Today" instead of using a translation key, or stores a datetime without UTC conversion, or creates records without firing events — it works in their dev environment and breaks somewhere else.
+
+This document defines the integration contract for each cross-cutting system. It answers: **what must every new feature do** to plug in correctly?
+
+---
+
+## 1. Language and Internationalization (i18n)
+
+### 1.1 How It Works
+
+Leantime uses INI-based translation files in `app/Language/{locale}/`. The `__()` helper function retrieves translated strings by key. Plugins register their own language files via `$registration->registerLanguageFiles()`.
+
+**Translation management happens through an external management platform** — developers don't edit translation files directly for non-English languages. The workflow is:
+
+1. Developer adds English translation keys to the `en-US.ini` file
+2. Keys sync to the translation management platform
+3. Translators work in the platform
+4. Translated files sync back to the codebase
+
+This means: **developers are responsible for creating keys and English strings.** Translation into other languages is handled externally. But keys must be structured, descriptive, and stable — renaming a key breaks all translations.
+
+### 1.2 The Contract
+
+**Every user-facing string MUST go through the translation system.** No exceptions.
+
+| Context | Pattern | Example |
+|---|---|---|
+| Blade template | `{{ __('domain.key') }}` | `{{ __('pgmpro.resources.add_person') }}` |
+| Blade with variables | `{{ sprintf(__('domain.key'), $var) }}` | `{{ sprintf(__('pgmpro.resources.hours_of_total'), $used, $total) }}` |
+| JavaScript (inline) | `data-label="{{ __('domain.key') }}"` | Pass as data attribute, read in JS |
+| JavaScript (Alpine) | `x-text="$el.dataset.label"` | Read from data attribute |
+| Notifications | `$this->language->__('domain.key')` | In notification service |
+| Validation messages | Translation keys | `__('validation.required')` |
+| Tooltips / aria-labels | `aria-label="{{ __('domain.key') }}"` | Accessibility text is also translatable |
+| Error messages | Translation keys | `__('pgmpro.errors.budget_exceeded')` |
+
+### 1.3 Key Naming Convention
+
+```
+{plugin_or_domain}.{feature}.{element}
+
+pgmpro.resources.title           = "Resource Allocation"
+pgmpro.resources.people_section  = "People"
+pgmpro.resources.add_person      = "Add person"
+pgmpro.resources.hours_allocated = "%d hours allocated"
+pgmpro.resources.capacity_full   = "At capacity"
+
+strategypro.wizard.step_mapping  = "Map to Projects"
+strategypro.wizard.next          = "Next"
+strategypro.wizard.generating    = "Generating..."
+```
+
+**Rules:**
+- Lowercase, dot-separated
+- Plugin/domain prefix first, then feature, then specific element
+- Use `%s` / `%d` for variable substitution (sprintf style)
+- Never embed HTML in translation strings — keep markup in templates
+- Never rename existing keys — this breaks all translations in the management platform
+- If a string changes meaning, create a new key and deprecate the old one
+
+### 1.4 Pluralization
+
+Leantime's INI format doesn't natively support pluralization rules. Pattern:
+
+```ini
+pgmpro.resources.person_count_one = "1 person"
+pgmpro.resources.person_count_other = "%d people"
+```
+
+```php
+$key = $count === 1 ? 'pgmpro.resources.person_count_one' : 'pgmpro.resources.person_count_other';
+echo sprintf(__($key), $count);
+```
+
+For languages with complex plural rules (Arabic, Polish), this two-form pattern covers common cases. The translation platform can handle the complexity — just provide the two English forms.
+
+### 1.5 Date and Number Formatting
+
+| Data type | Storage format | Display format | Notes |
+|---|---|---|---|
+| Dates | `Y-m-d` (ISO 8601) | User's locale format | Use Leantime's date formatter |
+| Datetimes | `Y-m-d H:i:s` UTC | User locale + timezone | Formatter handles TZ conversion |
+| Numbers | Raw numeric | User's locale (comma/period) | `number_format()` with locale |
+| Currency | Cents (integer) or float | Locale + currency symbol | Format in display layer only |
+| Percentages | 0-100 float | `XX%` | Display layer formatting |
+
+**Rule:** Never format dates or numbers in the storage/service layer. Store raw, format on display.
+
+### 1.6 RTL Support
+
+Leantime supports right-to-left languages (Arabic, Hebrew). New components must:
+
+- Use CSS logical properties: `margin-inline-start` not `margin-left`, `padding-inline-end` not `padding-right`
+- Or use Tailwind logical utilities: `tw:ms-4` (margin-start) not `tw:ml-4`
+- Never hardcode directional icons — use `dir`-aware alternatives
+- Flex layouts with `gap` work in RTL automatically — but verify
+- Test: `document.documentElement.dir = 'rtl'`
+
+### 1.7 Plugin Language File Registration
+
+```php
+// In plugin's register.php
+$registration->registerLanguageFiles(['en-US']);
+```
+
+Files live at:
+```
+app/Plugins/PgmPro/Language/en-US.ini
+app/Plugins/StrategyPro/Language/en-US.ini
+```
+
+### 1.8 What to Audit
+
+```bash
+# Hardcoded English strings in Blade templates
+grep -rn ">[A-Z][a-z].*</" app/Plugins/ --include="*.blade.php" | \
+  grep -v "__(\|{{\|@\|<!--" | head -30
+
+# Labels/placeholders not going through translation
+grep -rn "label=\"[A-Z]\|placeholder=\"[A-Z]\|title=\"[A-Z]\|aria-label=\"[A-Z]" \
+  app/Plugins/ --include="*.blade.php" | grep -v "__(" | head -20
+```
+
+---
+
+## 2. Timezones
+
+### 2.1 The Golden Rule
+
+**Store UTC. Display local. Compare in UTC.**
+
+### 2.2 How It Works
+
+- All datetimes in the database are stored in UTC
+- User's timezone is stored in their settings (`usersettings.timezone`)
+- Application converts to user-local on display
+- Application converts from user-local to UTC on input
+
+### 2.3 The Contract
+
+| Operation | Timezone | How |
+|---|---|---|
+| Storing a new datetime | Convert to UTC before saving | `$utc = $this->convertToUTC($userInput, $userTimezone)` |
+| Displaying a datetime | Convert from UTC to user's TZ | `$local = $this->convertToUserTimezone($utcDatetime)` |
+| Comparing dates (overdue?) | Compare in UTC | `$now = new DateTime('now', new DateTimeZone('UTC'))` |
+| "Due today" calculation | Convert "today" boundaries to UTC | See 2.4 |
+| Recurring events | Store rule + timezone | Expand in user's timezone |
+| Cross-user deadlines | Store UTC | Each user sees their own TZ display |
+| Timesheets | Date only (no time) + hours float | Calendar date — no TZ conversion needed |
+| Scheduled notifications | Compute send time in UTC from recipient's TZ | "9am" means 9am in their timezone |
+| Relative time ("3 hours ago") | Compute from UTC, display relative | No TZ conversion needed for relative |
+
+### 2.4 "Due Today" — The Common Bug
+
+"Today" is different for each user. This is where most timezone bugs live.
+
+```php
+// WRONG — uses server timezone
+$dueToday = $query->whereDate('dueDate', Carbon::today());
+
+// RIGHT — compute "today" in user's timezone, convert boundaries to UTC
+$userTz = new DateTimeZone($userTimezone);
+$startOfDay = new DateTime('today', $userTz);
+$endOfDay = new DateTime('tomorrow', $userTz);
+$startOfDay->setTimezone(new DateTimeZone('UTC'));
+$endOfDay->setTimezone(new DateTimeZone('UTC'));
+$dueToday = $query->whereBetween('dueDate', [$startOfDay, $endOfDay]);
+```
+
+### 2.5 Date Input Components
+
+When a user picks a date/time in a form:
+
+1. The date picker shows dates in the user's local timezone
+2. On submission, the value is converted to UTC before storage
+3. The conversion happens in the controller or service layer, NOT in JavaScript
+4. Hidden field carries the UTC value; visible field shows the local value
+
+```html
+<!-- Pattern for date/time inputs -->
+<input type="datetime-local"
+       name="dueDate_display"
+       value="{{ $localDateTime }}"
+       data-utc="{{ $utcDateTime }}"
+       @change="convertToUTC($event)">
+<input type="hidden" name="dueDate" :value="utcValue">
+```
+
+### 2.6 What to Audit
+
+```bash
+# Direct date comparisons without timezone conversion
+grep -rn "Carbon::today()\|Carbon::now()\|date('Y-m-d')\|new DateTime()" \
+  app/Domain/ app/Plugins/ --include="*.php" | \
+  grep -v "UTC\|timezone\|userTimezone" | head -20
+
+# Date formatting in service/repository layer (should be display-only)
+grep -rn "->format(\|date_format(\|strftime(" \
+  app/Domain/*/Repositories/ app/Domain/*/Services/ --include="*.php" | head -20
+```
+
+---
+
+## 3. Notifications
+
+### 3.1 How It Works
+
+Leantime has an event-driven notification system. Actions dispatch events, listeners determine who to notify and through which channels (in-app, email, Slack/Discord webhooks). The cron job processes the notification queue.
+
+### 3.2 The Contract
+
+Every feature that creates, changes, assigns, or completes something should fire the appropriate event. The notification system handles the rest.
+
+| Action type | Event pattern | Who gets notified |
+|---|---|---|
+| Item created | `{domain}.{entity}.created` | Assignee, watchers |
+| Item updated | `{domain}.{entity}.updated` | Assignee, watchers, commenters |
+| Item assigned | `{domain}.{entity}.assigned` | New assignee |
+| Item completed | `{domain}.{entity}.completed` | Assignee, watchers, parent owner |
+| Status changed | `{domain}.{entity}.statusChanged` | Assignee, watchers |
+| Comment added | `{domain}.{entity}.commented` | All participants |
+| Deadline approaching | `{domain}.{entity}.deadlineApproaching` | Assignee (cron-triggered) |
+| Deadline passed | `{domain}.{entity}.overdue` | Assignee, manager (cron-triggered) |
+
+### 3.3 Notification Properties
+
+Every notification must provide:
+
+| Property | Description | Example |
+|---|---|---|
+| `type` | Event type identifier | `pgmpro.resource.assigned` |
+| `subject` | Translation key for subject line | `__('pgmpro.notifications.resource_assigned_subject')` |
+| `message` | Translation key for message body | `__('pgmpro.notifications.resource_assigned_body')` |
+| `entity_type` | What kind of thing | `'resource'`, `'milestone'`, `'ticket'` |
+| `entity_id` | ID of the thing | `42` |
+| `url` | Deep link to the relevant view | `/pgmpro/program/5/resources#person-42` |
+| `recipients` | Array of user IDs | `[3, 7, 12]` |
+| `sender` | User ID of who triggered it | `session('userdata.id')` |
+| `priority` | Notification urgency | `'normal'`, `'high'` |
+
+### 3.4 Channel Rules
+
+| Channel | When | User control |
+|---|---|---|
+| In-app (notification bell) | Always | Cannot disable |
+| Email | Default on, user can disable per-type | User settings |
+| Slack/Discord webhook | If integration configured | Project-level setting |
+
+### 3.5 Notification Content Rules
+
+- All notification text goes through translation keys (i18n contract)
+- Notification subject must make sense in an email inbox (no "Update" — be specific)
+- Message body should include enough context to act without clicking through
+- URLs must be absolute (include `$appUrl`) — emails open in browser
+- Datetimes in notifications display in the RECIPIENT's timezone
+- Never send notifications to the person who triggered the action
+
+### 3.6 Batching and Deduplication
+
+- If multiple changes happen to the same entity within 5 minutes, batch into one notification
+- Never send more than one notification per entity per user per hour for the same event type
+- The cron job handles batching — features just fire events, they don't manage delivery
+
+### 3.7 PgmPro / StrategyPro Notification Events
+
+| Event | Trigger | Recipients |
+|---|---|---|
+| `pgmpro.resource.assigned` | Person allocated to a project | The allocated person |
+| `pgmpro.resource.overallocated` | Person exceeds capacity | The person + program manager |
+| `pgmpro.resource.stubCreated` | Wizard seeds resource stubs | Program manager |
+| `pgmpro.budget.thresholdReached` | Spending hits 80% or 90% of budget | Program manager |
+| `strategypro.program.created` | Wizard completes program creation | Program manager |
+| `strategypro.mapping.completed` | Logic model mapped to projects | Program manager |
+
+### 3.8 What to Audit
+
+```bash
+# Find service methods that create/update records without dispatching events
+grep -rn "function create\|function update\|function save\|function delete" \
+  app/Plugins/*/Services/ --include="*.php" | head -20
+# Then check: do these methods call dispatch() or events->dispatch()?
+
+# Find events that are dispatched but have no listener
+grep -rn "dispatch(" app/Plugins/ --include="*.php" | head -20
+# Cross-reference with registered listeners
+```
+
+---
+
+## 4. Permissions and Access Control
+
+### 4.1 How It Works
+
+Leantime uses a role-based permission system. Users have a role within the system and optionally per-project roles. Permissions are checked in controllers before rendering views and in services before performing actions.
+
+### 4.2 Role Hierarchy
+
+| Role | Level | Scope |
+|---|---|---|
+| Owner / Admin | Highest | Full system access |
+| Manager | High | Can manage projects, assign users, view reports |
+| Editor | Medium | Can create/edit items in assigned projects |
+| Commenter | Low | Can view and comment, not edit |
+| Client | Restricted | Can view limited project data, provide feedback |
+
+### 4.3 The Contract
+
+**Every controller method and every service method that modifies data must check permissions.**
+
+| Layer | What to check | How |
+|---|---|---|
+| Controller (view) | Can user see this page? | `$this->authService->userHasRole(['manager', 'admin'])` |
+| Controller (action) | Can user perform this action? | `$this->authService->userCanAccess($projectId)` |
+| Service (data) | Can user access this entity? | Check project membership before returning data |
+| API | Same as controller | Middleware or explicit check |
+
+### 4.4 Program-Level Permissions (PgmPro)
+
+Programs add a layer above projects:
+
+| Permission | Who | Description |
+|---|---|---|
+| View program dashboard | Program manager + project members | Anyone in a child project can see the program |
+| Edit resource allocation | Program manager + admin | Budget and people allocation is sensitive |
+| View budget details | Program manager + admin | Budget amounts may be confidential |
+| Create/modify projects under program | Program manager + admin | Structural changes |
+| View individual timesheets | Program manager + admin | Personal time data is sensitive |
+| View aggregated metrics | All program members | Totals are fine, individual detail is not |
+
+### 4.5 Data Sensitivity Rules
+
+| Data type | Who can see individual records | Who can see aggregates |
+|---|---|---|
+| Budget amounts | Program manager, admin | All program members (total only) |
+| Individual hours worked | The person themselves, their manager, admin | All program members (totals) |
+| Salary/rate information | Admin only | Never exposed in UI |
+| Resource allocation (who works on what) | All project members | All program members |
+| Performance metrics (on-track/behind) | Program manager, admin | All program members |
+
+### 4.6 What to Audit
+
+```bash
+# Controller methods without permission checks
+grep -rn "function get\|function post\|function put\|function delete" \
+  app/Plugins/*/Controllers/ --include="*.php" | head -20
+# Check: does each method verify permissions before proceeding?
+
+# Service methods that return sensitive data without access check
+grep -rn "function getBudget\|function getHours\|function getTimesheets" \
+  app/Plugins/*/Services/ --include="*.php" | head -20
+```
+
+---
+
+## 5. Entity Relations
+
+### 5.1 How It Works
+
+`zp_entityrelations` is Leantime's system for linking entities across domains. It's a flexible many-to-many relation table that connects any entity type to any other entity type.
+
+### 5.2 Table Structure
+
+| Column | Purpose | Example |
+|---|---|---|
+| `entityA_id` | Source entity ID | `42` (canvas item) |
+| `entityA_type` | Source entity type | `'canvasItem'` |
+| `entityB_id` | Target entity ID | `7` (project) |
+| `entityB_type` | Target entity type | `'project'` |
+| `relationship_type` | What kind of link | `'generates'`, `'seeded_from'`, `'assigned_to'` |
+| `meta` | JSON metadata | `'{"mappingStep": "wizard"}'` |
+| `created` | When the link was made | Timestamp |
+
+### 5.3 The Contract
+
+Every feature that creates a relationship between entities across domains MUST use `zp_entityrelations`. Don't create custom link tables.
+
+| Relationship | entityA | entityB | relationship_type |
+|---|---|---|---|
+| Logic Model output → Project milestone | canvasItem (output) | milestone | `generates` |
+| Logic Model input → Resource canvas item | canvasItem (input) | canvasItem (resource) | `seeded_from` |
+| Resource person → Project | canvasItem (resource) | project | `assigned_to` |
+| Program → Child project | project (program) | project (child) | `parent_of` |
+| Goal → Project | goal | project | `tracks` |
+| Canvas item → Ticket | canvasItem | ticket | `generates` |
+
+### 5.4 Querying Relations
+
+```php
+// Find all projects generated from a canvas output
+$relations = $this->entityRelationsRepo->getRelationsByType(
+    entityA_id: $canvasItemId,
+    entityA_type: 'canvasItem',
+    relationship_type: 'generates'
+);
+
+// Find the source canvas item for a resource allocation
+$source = $this->entityRelationsRepo->getRelationsByType(
+    entityB_id: $resourceItemId,
+    entityB_type: 'canvasItem',
+    relationship_type: 'seeded_from'
+);
+```
+
+### 5.5 Rules
+
+- **Always bidirectional-queryable:** you should be able to find both "what did this generate?" and "where did this come from?"
+- **Use specific relationship_type strings:** not generic "related_to" — be explicit about the nature of the link
+- **Clean up on delete:** when an entity is deleted, its relations should be cleaned up (or marked inactive)
+- **Don't duplicate:** if a link already exists, don't create a second one. Check first.
+- **Metadata is for context:** use the `meta` JSON for information about HOW the link was made (wizard step, manual, auto-seeded), not for the link's data itself
+
+### 5.6 What to Audit
+
+```bash
+# Custom link tables that should use entityrelations
+grep -rn "CREATE TABLE.*link\|CREATE TABLE.*map\|CREATE TABLE.*rel" \
+  app/Domain/ app/Plugins/ --include="*.php" | head -10
+
+# Hardcoded joins instead of entityrelations queries
+grep -rn "JOIN.*ON.*\.id\s*=\s*.*\..*_id" \
+  app/Plugins/ --include="*.php" | grep -v "entityrelations" | head -20
+```
+
+---
+
+## 6. Events System
+
+### 6.1 How It Works
+
+Leantime has an event dispatch system that allows plugins and core code to hook into actions. Events follow a naming convention and carry payload data. This is the backbone that notifications, webhooks, integrations, and audit logging plug into.
+
+### 6.2 Event Naming Convention
+
+```
+leantime.{domain}.{entity}.{action}
+
+leantime.pgmpro.resource.created
+leantime.pgmpro.resource.updated
+leantime.pgmpro.resource.deleted
+leantime.pgmpro.budget.thresholdReached
+leantime.strategypro.program.created
+leantime.strategypro.mapping.completed
+leantime.core.ticket.statusChanged
+leantime.core.project.userAssigned
+```
+
+### 6.3 The Contract
+
+**Every state-changing operation MUST dispatch an event.** This enables:
+- Notifications to be sent
+- Webhooks to fire
+- Audit trail to be recorded
+- Plugin extensions to react
+
+| When to dispatch | Event type | Payload must include |
+|---|---|---|
+| Entity created | `*.created` | Entity ID, entity data, creator user ID |
+| Entity updated | `*.updated` | Entity ID, changed fields (old + new values), updater user ID |
+| Entity deleted | `*.deleted` | Entity ID, entity data (snapshot before delete), deleter user ID |
+| Status changed | `*.statusChanged` | Entity ID, old status, new status, changer user ID |
+| Assignment changed | `*.assigned` | Entity ID, old assignee, new assignee, assigner user ID |
+| Threshold reached | `*.thresholdReached` | Entity ID, metric name, threshold value, current value |
+
+### 6.4 Event Payload Structure
+
+```php
+$this->eventsDispatcher->dispatch('leantime.pgmpro.resource.created', [
+    'entityId' => $resourceItemId,
+    'entityType' => 'resourceCanvasItem',
+    'projectId' => $programId,
+    'data' => $resourceData,
+    'userId' => session('userdata.id'),
+    'timestamp' => gmdate('Y-m-d H:i:s'), // UTC
+]);
+```
+
+### 6.5 Listening to Events
+
+```php
+// In plugin's register.php
+$this->events->listen('leantime.pgmpro.resource.created', function ($payload) {
+    // React to resource creation
+    $this->notificationService->notifyResourceAssigned($payload);
+});
+```
+
+### 6.6 Rules
+
+- Fire events AFTER the database operation succeeds (not before — don't notify about failed saves)
+- Event payloads should be serializable (no objects, no closures — plain arrays)
+- Listeners should be fast — if heavy work is needed, push to the queue
+- Don't rely on event ordering — listeners may execute in any order
+- Idempotent listeners — the same event firing twice should not cause double-effects
+
+---
+
+## 7. Search and Filtering
+
+### 7.1 How It Works
+
+Leantime provides search and filtering across entities. Each domain that stores user-facing data should be searchable.
+
+### 7.2 The Contract
+
+Any new entity type that users interact with should be findable through search.
+
+| Requirement | Implementation |
+|---|---|
+| Full-text search | Entity title/name/description indexed |
+| Filter by status | Status field is filterable |
+| Filter by assignee | User ID field is filterable |
+| Filter by project | Project ID field is filterable |
+| Filter by date range | Date fields support range queries |
+| Sort options | At minimum: name, date created, date modified, status |
+
+### 7.3 Search Integration Pattern
+
+```php
+// Register searchable fields for a new entity type
+public function getSearchableFields(): array
+{
+    return [
+        'title' => ['weight' => 10, 'type' => 'text'],
+        'description' => ['weight' => 5, 'type' => 'text'],
+        'status' => ['weight' => 0, 'type' => 'filter'],
+        'assignedUserId' => ['weight' => 0, 'type' => 'filter'],
+        'projectId' => ['weight' => 0, 'type' => 'filter'],
+    ];
+}
+```
+
+### 7.4 Filter UI Consistency
+
+All filter interfaces should follow the same pattern:
+
+| Element | Standard |
+|---|---|
+| Filter bar position | Top of content area, below page header |
+| Filter chips | Removable pills showing active filters |
+| Clear all | Single action to reset all filters |
+| Result count | Show "N results" or "N of M" when filtered |
+| Empty state | Clear message when filters return no results, with suggestion to adjust |
+| Persistence | Filters persist within session for the same page |
+| URL parameters | Filters should be reflected in URL for shareability |
+
+---
+
+## 8. Error Handling
+
+### 8.1 The Contract
+
+| Layer | Error handling pattern |
+|---|---|
+| Controller | Catch service exceptions, display user-friendly message (translated), log technical details |
+| Service | Throw domain-specific exceptions with context. Never silently swallow errors. |
+| Repository | Throw data-layer exceptions (connection failures, constraint violations) |
+| Blade view | Use `@error` directive for form validation. Show inline errors. |
+| HTMX | Return appropriate HTTP status codes. 422 for validation, 403 for permission, 500 for server errors. |
+| JavaScript | Catch promise rejections. Show user feedback. Never silent failures. |
+
+### 8.2 User-Facing Error Messages
+
+- Always go through translation system: `__('errors.permission_denied')`
+- Be specific enough to act on: "You don't have permission to edit resource allocations" not just "Access denied"
+- Never expose stack traces, SQL queries, or internal paths to the user
+- Provide a next step: "Contact your admin" or "Try again" or "Check your input"
+
+### 8.3 Error Display Patterns
+
+| Context | Pattern |
+|---|---|
+| Form validation | Inline red text below the field, `aria-invalid="true"` + `aria-describedby` |
+| Page-level error | Banner at top of content area, dismissible, `role="alert"` |
+| HTMX swap error | Replace target with error message, or show banner |
+| Network error | Persistent banner: "Connection lost. Changes will save when reconnected." |
+| Permission error | Redirect to appropriate page with flash message |
+| 404 | Friendly page with navigation back to safety |
+
+### 8.4 Cognitive Accessibility for Errors
+
+- Never blame the user ("Invalid input" → "Please enter a number between 1 and 100")
+- Don't clear the form on error — preserve what they entered
+- Focus the first error field automatically (for screen readers and attention)
+- Group multiple errors at the top AND show inline (users may miss one or the other)
+- Use gentle language. The user isn't "wrong" — the system needs different input.
+
+---
+
+## 9. Audit Trail
+
+### 9.1 The Contract
+
+Every significant data change should be traceable. At minimum:
+
+| What to log | Fields |
+|---|---|
+| Who | User ID |
+| What | Entity type, entity ID, action (create/update/delete) |
+| When | UTC timestamp |
+| Details | Changed fields with old and new values |
+| Context | IP address, session ID (for security audit) |
+
+### 9.2 What Counts as "Significant"
+
+| Log | Don't log |
+|---|---|
+| Create, update, delete of any entity | Read/view operations |
+| Status changes | Filter or sort changes |
+| Assignment changes | UI state (collapsed sections, etc.) |
+| Permission changes | Session heartbeats |
+| Budget changes | Draft saves (log on publish only) |
+| Login/logout | Page navigation |
+
+### 9.3 Implementation
+
+Audit logging should happen via event listeners — not hardcoded into every service method. The events system (section 6) fires events, and an audit listener records them.
+
+```php
+// Audit listener registered globally
+$this->events->listen('leantime.*.*.*', function ($eventName, $payload) {
+    if ($this->isAuditableEvent($eventName)) {
+        $this->auditRepo->log([
+            'event' => $eventName,
+            'userId' => $payload['userId'] ?? session('userdata.id'),
+            'entityType' => $payload['entityType'] ?? null,
+            'entityId' => $payload['entityId'] ?? null,
+            'data' => json_encode($payload['data'] ?? []),
+            'timestamp' => gmdate('Y-m-d H:i:s'),
+        ]);
+    }
+});
+```
+
+---
+
+## 10. Cron and Background Jobs
+
+### 10.1 The Contract
+
+Features that need periodic processing must plug into Leantime's cron system — not create their own schedulers.
+
+| Job type | Frequency | Examples |
+|---|---|---|
+| Notification delivery | Every 5-15 minutes | Email queue, Slack webhook queue |
+| Deadline checks | Daily | Overdue detection, approaching deadline alerts |
+| Data aggregation | Daily or weekly | Timesheet summaries, budget rollups |
+| Cleanup | Weekly | Old session data, expired tokens |
+
+### 10.2 Rules
+
+- Jobs must be idempotent — running the same job twice produces the same result
+- Jobs must be fast — if a job takes > 30 seconds, it should be chunked
+- Jobs must log their execution (start, end, items processed, errors)
+- Jobs must handle partial failure gracefully — one failed item shouldn't stop the batch
+- All times in cron jobs use UTC
+
+---
+
+## 11. URL and Routing Conventions
+
+### 11.1 URL Structure
+
+```
+/{plugin}/{entity}/{id}/{action}
+
+/pgmpro/program/5/resources          — resource allocation view
+/pgmpro/program/5/dashboard          — program dashboard
+/strategypro/wizard/start            — wizard entry
+/strategypro/wizard/step/mapping     — wizard step
+```
+
+### 11.2 Rules
+
+- RESTful where possible: GET for reading, POST for creating, PUT for updating, DELETE for removing
+- HTMX endpoints return partial HTML (fragments), not full pages
+- IDs in URLs are entity IDs, not slugs (simpler, no collision risk)
+- Plugin routes are prefixed with plugin name
+- Core routes follow existing Leantime conventions
+- All URLs should be bookmarkable/shareable — state reflected in URL, not just session
+
+### 11.3 HTMX Route Conventions
+
+```
+GET  /pgmpro/program/{id}/resources                  — full page
+GET  /pgmpro/program/{id}/resources/people            — partial: people section only
+POST /pgmpro/program/{id}/resources/people             — create person allocation
+PUT  /pgmpro/program/{id}/resources/people/{personId}  — update person allocation
+GET  /pgmpro/program/{id}/resources/summary            — partial: summary strip only
+```
+
+HTMX requests include `HX-Request: true` header. Controllers detect this and return partials instead of full pages.
+
+---
+
+## 12. Integration Checklist
+
+**Before shipping any new feature, verify all of the following:**
+
+### Language
+- [ ] All user-facing strings use `__()` translation helper
+- [ ] Translation keys added to `en-US.ini` with English strings
+- [ ] No HTML embedded in translation strings
+- [ ] Date and number formatting uses locale-aware helpers
+- [ ] RTL layout tested (or at minimum, logical CSS properties used)
+
+### Timezone
+- [ ] All datetimes stored in UTC
+- [ ] All datetimes displayed in user's timezone
+- [ ] "Due today" logic uses user's timezone boundaries
+- [ ] Date inputs convert to UTC before storage
+- [ ] No bare `Carbon::today()` or `date('Y-m-d')` without timezone context
+
+### Notifications
+- [ ] State-changing actions dispatch events
+- [ ] Notification content uses translation keys
+- [ ] Notification includes deep link URL
+- [ ] Notification datetimes use recipient's timezone
+- [ ] Actor is excluded from notification recipients
+
+### Permissions
+- [ ] Controller checks role/access before rendering view
+- [ ] Service checks access before returning sensitive data
+- [ ] Budget and timesheet data respects visibility rules
+- [ ] Admin-only features are gated appropriately
+
+### Entity Relations
+- [ ] Cross-domain links use `zp_entityrelations`
+- [ ] No custom link tables created
+- [ ] Relations cleaned up on entity deletion
+- [ ] Relations are queryable in both directions
+
+### Events
+- [ ] All create/update/delete operations dispatch events
+- [ ] Events fire AFTER successful database operation
+- [ ] Event payloads are serializable (plain arrays)
+- [ ] Event naming follows convention
+
+### Search and Filtering
+- [ ] New entity types are searchable
+- [ ] Filters follow standard UI pattern
+- [ ] Active filters reflected in URL
+- [ ] Empty states show helpful message
+
+### Error Handling
+- [ ] User-facing errors use translation keys
+- [ ] Errors are specific and actionable
+- [ ] Form errors show inline + summary
+- [ ] No stack traces exposed to user
+- [ ] Forms preserve input on error
+
+### Accessibility
+- [ ] (Refer to 14-DESIGN-TOKENS.md section 8 — full accessibility checklist)
+
+### Theming
+- [ ] (Refer to 14-DESIGN-TOKENS.md section 1 — full theming checklist)
+
+---
+
+## Changelog
+
+| Date | Change | Author |
+|---|---|---|
+| 2026-02-23 | v1.0 — initial cross-cutting concerns: i18n (with management platform note), timezones, notifications, permissions, entity relations, events, search, error handling, audit trail, cron, routing, integration checklist | GF |

--- a/Docs/16-RESOURCE-ALLOCATION-REQUIREMENTS.md
+++ b/Docs/16-RESOURCE-ALLOCATION-REQUIREMENTS.md
@@ -1,0 +1,219 @@
+# 16 · Resource Allocation Tab — Requirements
+
+**Surface:** `/pgmPro/resourceAllocation` (PgmPro plugin, program-scope)
+**Status:** V1 structure landed (`feature/resources-revival`, PR #72). This doc is the durable spec the build conforms to.
+**Companion mockups:** `resource-allocation-v1.html`, `resource-allocation-v2.html`, `resource-states.html`
+
+---
+
+## 1. Purpose & scope
+
+The Resource Allocation tab is the **authoring surface** for a program's resources — the people allocated to it, the money budgeted against it, and the external dependencies it relies on. It is the source end of a contract whose read-out end is the stakeholder report's Resources section. Author here; it shows compactly in the board packet.
+
+- **Scope object:** a single program — a `zp_projects` row where `type = 'program'`. The tab aggregates resources across that program's child projects.
+- **Two modes, one layout:** `?version=v1` (planning) and `?version=v2` (plan-vs-actual). V2 is the same layout plus an actual-hours overlay drawn from timesheets. V2 **layers onto** V1; it does not fork it.
+- **Print parity is first-class.** Board packets sometimes include a resources snapshot, so print is a real output, not an afterthought (see §7).
+
+---
+
+## 2. Structure (fixed)
+
+Three authoring sections, **always in this order, always present**: **People → Budget → Dependencies.** The structure is fixed by contract — it is not user-configurable. (A future per-section *visibility* toggle may hide a section at the view layer without changing this structure or the return shape; that is out of scope here and must never remove a block from the summary object.)
+
+For screen presentation the mockup paginates these into four tabs mirroring the stakeholder report — **Overview · People · Budget · Dependencies** — where Overview carries the program context, the summary strip, and the project color legend/rollup. Tabs are a **screen affordance only**; they must not leak into the print path (§7) or the data model.
+
+---
+
+## 3. The data contract
+
+Every screen consumes the return of `ResourceStructureService::getProgramResourceSummary(int $programProjectId, array $childProjectIds)`. **Design and build against this shape; ignore any prior template layout.**
+
+### 3.1 Top-level return
+
+```
+[
+  'canvasId'     => int,
+  'people'       => people[],        // hydrated, shape below
+  'budget'       => budget[],        // hydrated, shape below
+  'dependencies' => canvas_item[],   // RAW canvas_item rows (not hydrated)
+  'projects'     => int[],           // child project ids
+]
+```
+
+### 3.2 `people[]`
+
+```
+[
+  'id'                 => int,             // canvas_items.id
+  'name'               => string,
+  'role'               => string,
+  'userId'             => int,             // 0 = not linked to a real user
+  'capacity'           => int,             // hours / week
+  'allocations'        => array<int,float>,// { projectId => hoursPerWeek }
+  'status'             => string,          // 'active' | 'stub' | 'archived'
+  'sourceCanvasItemId' => ?int,            // provenance → originating LM Input canvas item
+]
+```
+
+### 3.3 `budget[]`
+
+```
+[
+  'id'        => int,
+  'label'     => string,
+  'projectId' => int,      // 0 = program-level line
+  'budgeted'  => float,
+  'spent'     => float,
+  'color'     => string,   // '#RRGGBB', default '#9CA3AF'
+  'status'    => string,   // 'active' | 'stub' | 'archived'
+]
+```
+
+### 3.4 `dependencies[]` (raw canvas_item)
+
+```
+[
+  'id'          => int,
+  'description' => string,  // partner-name fallback
+  'data'        => string,  // JSON: { partnerName, type, confirmed }
+  'status'      => string,
+  // ...other canvas_item columns
+]
+```
+Reshaped in the controller to `{ id, partnerName, type, confirmed:bool }`.
+
+### 3.5 Controller-derived view data
+
+The controller computes **all aggregates** so Blade stays presentation-only. These are the template's vocabulary:
+
+- `$projectRows[]` — `{ id, name, color, hours, actual, delta, actualPct, people, pctOfCapacity, shareOfAllocated }`
+- `$teamStats` — `{ capacity, allocated, available, capacityUsedPct, availablePct, peopleCount, fullPeople, actualTotal, actualDelta, peopleOverActual }`
+- `$budgetStats` — `{ total, spent, spentPct, atRiskCount, linesCount, stubCount }`
+- `$depStats` — `{ total, confirmed, tentative }`
+- `$budgetLines` — real lines (label non-empty **and** non-zero)
+- `$stubBudgetLines` — stubs (empty label **or** all zeros), split out for the "complete me" affordance, **excluded from `$budgetStats` totals**
+- `$hoursByProject`, plus V2: `$actuals`, `$actualsByUser`, `$actualsByProject`
+- `$stubStatus` — `{ people:int, budget:int, dependencies:int, isEmpty:bool }` — per-box counts for the setup badge
+
+---
+
+## 4. The four data blocks — rendering
+
+### Block 1 — Program context + summary strip (Overview)
+
+Program name (`zp_projects.name`), optional dates, child-project count. Then a **5-read summary strip** mapped to `$teamStats` and `$budgetStats`: Team capacity (`capacityUsedPct`, segmented by project color), Allocated (`allocated`), Available (`available` / `availablePct`), People (`peopleCount` / `fullPeople` "at capacity"), Budget (`spent` of `total`, `atRiskCount`).
+
+**At capacity** = a person `≥99%` allocated (this is what `fullPeople` counts). Do not gate on literal 100%.
+
+### Block 2 — Child projects = the color legend (Overview)
+
+Each child project carries a stable `color` (assigned by `Programs::getColoredProgramProjects()` cycling `PROJECT_COLORS`). **`$projectRows[].color` is the single source of truth for the project palette.** The same color means the same project across every people-bar segment, budget aggregate strip segment, and summary strip. This is the visual through-line.
+
+Each project row shows: color, name, `people` assigned, `hours` planned/wk, `pctOfCapacity` mini-bar.
+
+### Block 3 — People (capacity view)
+
+One row per person: identity, weekly `capacity`, and a horizontal allocation bar whose colored segments (from `allocations`, colored by project) sum toward capacity, with any remainder as a light "available" tail. Right-side read: allocated/capacity, available hours, % used.
+
+States (from `$teamStats` + per-person fields):
+- **available** — has an available tail.
+- **at capacity** — `≥99%` allocated, no tail (amber treatment).
+- **over-allocated** — allocation exceeds capacity (design-supported even if absent from current seed).
+
+Column totals ("landing on each project") sum `allocations` per project, colored by project.
+
+### Block 4 — Budget (money view)
+
+One row per line: `label`, assigned project (`projectId`, `0` = program-level), a `budgeted`→`spent` bar filled 0→100%, and % spent. **`≥90%` spent = at-risk (red); `≥100%` = over (red + weight).** Program strip = `spent` of `total`, `atRiskCount`, segments colored by project (a mini-legend).
+
+**`budget.color` is independent of `$projectRows[].color`** (see gotcha §6.4). Render budget fills from `budget.color`; default `#9CA3AF` gray for unassigned lines.
+
+### Block 5 — Dependencies
+
+One row per external partner: `partnerName`, `type`, and a confirmed/tentative toggle. **Confirmed vs. tentative is the primary signal**; tentative reads as a risk (amber), confirmed as locked-in (green).
+
+---
+
+## 5. States (empty, stub, orphaned)
+
+The old design hid empty sections. The new design surfaces them as **invite-to-author** affordances, and the summary strip must stay **honest** when nothing is authored. Mockup: `resource-states.html`.
+
+### 5.1 Empty section — invite to author
+
+When a section has no rows: icon, plain-language line, and two actions with **"Fill from Logic Model Inputs" leading** (the auto-creation seam), then the section's own "Add …". All three sections offer the fill action — `ResourceRegistrar::registerMappings()` declares `lm_inputs → {people, budget, dependency}` as `generates`, so all three are first-class seed targets. If nothing classifies to a box, the seeder returns "0 new … added" gracefully.
+
+### 5.2 Honest summary strip — nothing authored
+
+When `$teamStats` and `$budgetStats.total` are zero: muted em-dashes and honest labels ("no budget set", "no capacity set", "none added") — never zeros dressed as data.
+
+### 5.3 Stub person — `status === 'stub'`
+
+A person seeded from an LM Input: has a `name` but no linked user. Dashed "complete me" row treatment, a **"Seeded"** chip that links to the source via `sourceCanvasItemId`, and a primary CTA of **"Link user"** — because the one mandatory field to flip stub → active is `userId` (`capacity` defaults to 40 in `allocatePerson()`; `allocations` is optional). Excluded from `$teamStats` totals until completed.
+
+### 5.4 Stub budget line — `status === 'stub'`
+
+The `$stubBudgetLines` "Untitled / complete me" row: dashed, `--warn-tx` text, "Complete line" CTA. A legitimate authored-but-unfilled state, **never rendered as a real $0 line**, excluded from `$budgetStats`.
+
+### 5.5 V2 — actuals can't be tracked
+
+**Keyed on `userId === 0`, independent of `status`** (see gotcha §6.1 / §6.5). A person with no linked user has no timesheets, so actuals are always 0. In plan-vs-actual this must **not** render as a discrepancy ("fully under" in alarm-amber) — that misreads "cannot log" as "failed to log." Show a neutral, dashed "No linked user — actuals can't be tracked yet" in the actual bar, and "link a user to track" in place of the delta.
+
+---
+
+## 6. Build constraints (gotchas — normative)
+
+These six are the traps a fresh implementer must not fall into. They are constraints, not suggestions.
+
+1. **`userId === 0` is the actuals axis, not `status`.** Any person with `userId === 0` cannot have timesheet actuals, regardless of `status`. A `status === 'active'` person whose linked user was deleted is *also* `userId === 0`. Key the V2 "can't-track-actuals" treatment on `userId === 0` alone. Key the stub-*row* treatment on `status === 'stub'`. They usually co-occur; the orphaned-user case splits them, and both must be handled.
+2. **Budget stubs are their own path.** Split `status === 'stub'` (or empty-label / all-zero) budget lines into `$stubBudgetLines`, render the "complete me" affordance, and exclude them from `$budgetStats` totals. Never let a stub read as a real $0 line.
+3. **Cast `allocations` keys.** JSON-decode stringifies the keys; always `(int) $pid` before using a project id from `allocations`.
+4. **`budget.color` is independent of the project palette.** `$projectRows[].color` is the project through-line; `budget.color` is its own field (default `#9CA3AF`). Render budget fills from `budget.color`, not by re-deriving from the assigned project.
+5. **V2 fields are always present, never null.** In V1 mode the V2-only fields (`actual`, `delta`, `actualPct`, `actualTotal`, `actualDelta`, `peopleOverActual`, `actuals*`) are `0`/empty, not null. Templates may reference them unguarded — one template, no `@if version` forks.
+6. **`getActualHours` period is hardcoded `this_week`.** No period UI yet; the service accepts `this_week | last_week | this_month`, but the controller pins `this_week`. Do not build period-switch UI against a control that doesn't exist.
+
+---
+
+## 7. Print parity
+
+`@media print`: collapse the tab deck and **expand all four pages into one flowing snapshot**; hide the mode toggle, tab bar, arrow buttons, and add buttons; `page-break-inside: avoid` on rows. Tabs and swipe are screen affordances — the print path renders the fixed three-section structure in full.
+
+---
+
+## 8. Interaction surface (HTMX, in-place, no reload)
+
+- Add person / budget line / dependency — inline "add stub" → click-to-edit.
+- Edit allocation — click a segment on a person's bar to change that person × project's hours.
+- Edit budget — click the amount to edit.
+- Toggle confirmed — one-click on a dependency.
+- Delete — hover-reveal, confirm dialog, hard delete.
+- V1/V2 — segmented control, `?version=`-backed.
+
+---
+
+## 9. ResourcesGateway seam
+
+> **This section is self-contained by design.** It describes the tab→report contract in pure terms, with no back-references, so it can be lifted verbatim into the stakeholder-report requirements (or a shared reference doc) when that work begins.
+
+The Resource Allocation tab is the authoring end of a two-ended contract. The read-out end is the stakeholder report's Resources section. The two communicate only through `ResourcesGateway` (`getForProjects` / `getForProgram`), which exposes the summarized form of the four resource blocks: **program context, projects, people totals, budget totals, dependencies summary.**
+
+Invariants the gateway guarantees to both ends:
+
+- The gateway returns the same four-block shape for every program, always — even when a block is empty (it returns an empty-but-typed block, never a missing key).
+- All aggregates are computed once, upstream of both consumers, so the authoring surface and the report render identical numbers (capacity utilization, per-project hour rollups, budget spent %, at-risk detection at `≥90%`, dependency confirmed/tentative counts). Neither consumer recomputes; both read.
+- The project-identity color is carried in the payload (per-project `color`), so the through-line is consistent wherever a project appears, on either surface.
+- Distinct states are represented in data, not inferred: authored-but-unfilled (stub), empty, and — for people — untrackable (`userId === 0`). A consumer renders these honestly rather than guessing from zeros.
+- The tab authors what the report reads. Any capacity-utilization or budget-at-risk pattern the tab establishes has a smaller companion at report scale; the report never introduces resource facts the tab could not author.
+
+Consumers must treat this shape as frozen. Changes to the shape are schema events shipped as a pair (gateway + both consumers), never a one-sided edit.
+
+---
+
+## 10. Non-negotiables (summary)
+
+- Aggregates in the controller; Blade presentation-only.
+- `.ra-scope` class-prefix isolates all styles.
+- Fixed three-section structure; tabs are screen-only.
+- Project palette from `$projectRows[].color`; budget color independent.
+- Stub / empty / `userId === 0` states rendered honestly, keyed per §6.
+- V2 layers onto V1 — one structure, `?version=`-switched.
+- Print expands all sections; screen affordances hidden.

--- a/Docs/17-MOBILE-RESPONSIVENESS.md
+++ b/Docs/17-MOBILE-RESPONSIVENESS.md
@@ -1,0 +1,748 @@
+# Mobile Responsiveness Standards
+
+**Adaptive Layout Patterns for Leantime**
+
+| Field | Value |
+|---|---|
+| Product | Leantime |
+| Document | Mobile Responsiveness Standards |
+| Version | 1.0 |
+| Date | February 23, 2026 |
+| Author | Gloria Folaron |
+| Status | Living Document |
+| Purpose | Define how every view, component, and interaction adapts across screen sizes. Leantime is a desktop-first project management tool, but must be usable on tablets and phones for quick actions, status checks, and approvals on the go. |
+
+---
+
+## 1. Philosophy
+
+### 1.1 Desktop-First, Mobile-Usable
+
+Leantime is a project management tool. The primary work surface is desktop — users build project plans, manage budgets, write detailed descriptions, and analyze dashboards on large screens. But they also need to:
+
+- Check status on their phone while commuting
+- Approve a request from a tablet during a meeting
+- Quickly add a comment or update a status from anywhere
+- View a dashboard on a projector or conference room display
+
+This means: **desktop is the authoring environment, mobile is the consumption and quick-action environment.** We don't try to make every desktop interaction work identically on a 375px screen. Instead, we prioritize the mobile use cases that matter and make those excellent.
+
+### 1.2 What Mobile Must Support Well
+
+| Use case | Priority | Notes |
+|---|---|---|
+| View project/program status | **Critical** | Dashboard, kanban, list views |
+| Update ticket status | **Critical** | Quick status change, drag-to-column on tablet |
+| Add comments | **Critical** | Text input + mention |
+| View notifications | **Critical** | Notification list, mark as read |
+| View and respond to assignments | **Critical** | "What's assigned to me" |
+| Time tracking (log hours) | **High** | Quick timesheet entry |
+| View calendar | **High** | Milestone and deadline overview |
+| Basic navigation | **Critical** | Find projects, switch context |
+| Create new ticket | **High** | Quick capture |
+| Edit ticket details | **Medium** | Full editing is desktop-preferred |
+| Resource allocation | **Low** | Desktop only — too data-dense for phone |
+| Wizard flows | **Low** | Desktop only — multi-step complex forms |
+| Canvas board editing | **Low** | Desktop only — spatial manipulation |
+| Budget detail editing | **Low** | Desktop only — tabular data entry |
+
+### 1.3 Progressive Disclosure on Small Screens
+
+The same information exists at every breakpoint — but how much is immediately visible changes:
+
+| Screen | Strategy |
+|---|---|
+| Desktop (1200px+) | Full detail. Side panels. Multi-column layouts. |
+| Tablet (768-1199px) | Reduce columns. Collapse side panels to overlays. Slightly smaller text/padding. |
+| Phone (< 768px) | Single column. Bottom navigation. Collapsible sections. Summary views that expand on tap. |
+
+**Never hide critical information on mobile.** Instead, restructure it — summaries up top, details behind a tap.
+
+---
+
+## 2. Breakpoints
+
+### 2.1 Breakpoint Scale
+
+| Name | Min-width | Tailwind | Primary target |
+|---|---|---|---|
+| Phone | 0px | (default) | iPhone SE through iPhone Pro Max (375-430px) |
+| Phone landscape | 480px | `tw:xs:` | Phone in landscape orientation |
+| Tablet portrait | 768px | `tw:md:` | iPad Mini, iPad (768-834px) |
+| Tablet landscape | 1024px | `tw:lg:` | iPad landscape, small laptops |
+| Desktop | 1200px | `tw:xl:` | Standard laptop/desktop |
+| Wide | 1440px | `tw:2xl:` | Large monitors |
+
+### 2.2 How to Use
+
+Leantime is desktop-first in design but mobile-first in CSS (Tailwind convention). Write the mobile styles as default, then override with responsive prefixes:
+
+```html
+<!-- Single column on phone, two columns on tablet, three on desktop -->
+<div class="tw:grid tw:grid-cols-1 tw:md:grid-cols-2 tw:xl:grid-cols-3 tw:gap-4">
+```
+
+### 2.3 Breakpoint Rules
+
+| Rule | Details |
+|---|---|
+| Never use arbitrary breakpoints | Only the six defined breakpoints |
+| Test at actual device widths | 375px (iPhone SE), 390px (iPhone 14), 768px (iPad), 1024px (iPad landscape), 1280px (laptop), 1440px (desktop) |
+| Content determines breakpoints, not the other way around | If a layout breaks at 900px, it needs a fix at `tw:md:` (768px), not a custom 900px breakpoint |
+| Browser zoom at 200% must work | At 1280px viewport with 200% zoom, effective layout width is 640px — must still be usable |
+
+---
+
+## 3. Layout Patterns
+
+### 3.1 Page Shell
+
+The page shell (navigation + content area) adapts across breakpoints:
+
+| Component | Desktop (1200px+) | Tablet (768-1199px) | Phone (< 768px) |
+|---|---|---|---|
+| Left sidebar nav | Visible, 220-260px wide | Collapsed to icons (60px) or hidden | Hidden, hamburger trigger |
+| Top header | Sticky, full width | Sticky, full width | Sticky, simplified |
+| Content area | Full width minus sidebar | Full width minus icon sidebar | Full width |
+| Right panel (details) | Inline side panel, 320-400px | Overlay/drawer from right | Full-screen overlay |
+
+### 3.2 Navigation on Mobile
+
+| Element | Phone behavior |
+|---|---|
+| Primary navigation | Hamburger menu → slide-out drawer from left |
+| Project switcher | In the drawer, or top header dropdown |
+| User menu | Top-right avatar → dropdown |
+| Breadcrumbs | Truncate to last 2 levels with "..." for ancestors |
+| Tab bars (page-level) | Horizontally scrollable with fade edges |
+| Bottom nav (optional) | For high-frequency actions: Home, My Work, Notifications, Timer |
+
+### 3.3 Sidebar-to-Drawer Pattern
+
+The left sidebar collapses in stages:
+
+```
+Desktop (1200px+):    [Full sidebar 240px] [Content ─────────────]
+Tablet (768-1199px):  [Icons 60px] [Content ──────────────────────]
+Phone (< 768px):      [Content ────────────────────────────────────]
+                      [Hamburger ☰ triggers drawer overlay]
+```
+
+Drawer behavior:
+- Slides in from left
+- Backdrop overlay (`rgba(0,0,0,0.3)`)
+- Close on backdrop tap, swipe left, or X button
+- `aria-hidden="true"` when closed, focus trapped when open
+- Escape key closes
+
+### 3.4 Content Area Patterns
+
+| Layout | Desktop | Tablet | Phone |
+|---|---|---|---|
+| **Multi-column grid** | 3-4 columns | 2 columns | 1 column |
+| **Table** | Full table | Horizontally scrollable OR priority columns | Card list (see 3.5) |
+| **Kanban board** | All columns visible | Horizontally scrollable | Single column with tab/swipe |
+| **Dashboard widgets** | 2-3 column grid | 2 column grid | Stacked single column |
+| **Form** | 2-column layout possible | Single column | Single column |
+| **Detail + sidebar** | Content + side panel | Content + overlay panel | Content, panel is full-screen |
+| **Canvas / flow** | Horizontal flow | Horizontally scrollable | Vertical stack or simplified |
+
+### 3.5 Table-to-Card Transformation
+
+Data tables don't work on phone screens. When a table has more than 3 columns, transform it on mobile:
+
+**Desktop (table):**
+```
+| Name     | Status    | Due Date   | Assigned | Priority |
+|----------|-----------|------------|----------|----------|
+| Task A   | In Prog   | Mar 15     | MJ       | High     |
+| Task B   | Done      | Mar 10     | GF       | Low      |
+```
+
+**Phone (card list):**
+```
+┌──────────────────────────┐
+│ Task A                   │
+│ In Progress · Mar 15     │
+│ MJ · High                │
+└──────────────────────────┘
+┌──────────────────────────┐
+│ Task B                   │
+│ Done · Mar 10            │
+│ GF · Low                 │
+└──────────────────────────┘
+```
+
+Pattern:
+- Row 1: Title/name (full width, bold)
+- Row 2: Status + primary date
+- Row 3: Assignee + secondary info
+- Tap card to expand or navigate to detail
+
+```html
+<!-- Responsive table/card -->
+<div class="tw:hidden tw:md:block">
+  <!-- Full table for tablet+ -->
+  <table>...</table>
+</div>
+<div class="tw:block tw:md:hidden">
+  <!-- Card list for phone -->
+  @foreach($items as $item)
+    <div class="tw:p-3 tw:border-b tw:border-[var(--color-border-light)]">
+      <div class="tw:font-semibold tw:text-sm">{{ $item->title }}</div>
+      <div class="tw:text-xs tw:text-[var(--color-text-muted)] tw:mt-1">
+        {{ $item->status }} · {{ $item->dueDate }}
+      </div>
+    </div>
+  @endforeach
+</div>
+```
+
+### 3.6 Canvas and Flow Layouts
+
+Canvas boards (Logic Model, resource allocation) are inherently spatial. On small screens:
+
+| Approach | When to use |
+|---|---|
+| **Horizontal scroll** | Tablet — user can swipe through stages. Add scroll indicators. |
+| **Vertical stack** | Phone — stages become accordion sections, one expanded at a time |
+| **Summary only** | Phone — show summary metrics, link to desktop for full editing |
+| **Simplified view** | Phone — show a card list per stage, omit spatial relationships |
+
+Logic Model specifically:
+- Desktop: horizontal 5-column flow (current design)
+- Tablet landscape: horizontal scroll with snap points per stage
+- Tablet portrait: 2-column wrap (Inputs+Activities, Outputs+Outcomes, Impact full-width)
+- Phone: vertical accordion — tap stage header to expand, only one open at a time
+
+### 3.7 Modal Behavior on Mobile
+
+| Screen | Modal behavior |
+|---|---|
+| Desktop | Centered floating dialog with backdrop |
+| Tablet | Same, but max-width constrained to 90% viewport |
+| Phone | **Full-screen sheet** sliding up from bottom |
+
+Phone modal (bottom sheet) pattern:
+- Slides up from bottom edge
+- Drag handle at top for dismiss gesture
+- Full viewport width, 90-100% viewport height
+- Close button (X) always visible top-right
+- Back/cancel at top-left
+- Primary action button fixed at bottom (above keyboard if input focused)
+
+```html
+<!-- Responsive modal -->
+<dialog class="
+  tw:w-full tw:h-full tw:m-0 tw:rounded-none
+  tw:md:w-[600px] tw:md:h-auto tw:md:m-auto tw:md:rounded-xl
+  tw:md:max-h-[85vh]
+">
+```
+
+---
+
+## 4. Touch Interactions
+
+### 4.1 Touch Target Sizes
+
+Reiterated from 14-DESIGN-TOKENS.md but critical here:
+
+| Element | Minimum touch target | Notes |
+|---|---|---|
+| Primary buttons | 44x44px | Full tap area, not just visual bounds |
+| Icon buttons | 44x44px | Extend hit area with padding |
+| List items / rows | 44px height minimum | Entire row tappable |
+| Close / dismiss | 44x44px | Even if the X icon is 12px, hit area is 44px |
+| Checkboxes / toggles | 44x44px | Include label in tap area |
+| Links in text | 44px vertical spacing | Enough space between links to not mis-tap |
+| Dropdown items | 44px height | Finger-friendly item height |
+
+### 4.2 Touch Gestures
+
+| Gesture | Usage | Implementation |
+|---|---|---|
+| Tap | Primary interaction | Standard click events |
+| Long press | Context menu (optional) | `@touchstart` + timeout, cancel on move |
+| Swipe left on row | Quick action (archive, delete) | Reveal action buttons behind row |
+| Swipe right on row | Quick action (complete, approve) | Reveal action buttons behind row |
+| Pull to refresh | Refresh list/dashboard | Native browser or HTMX reload |
+| Pinch to zoom | Disabled on canvas views | `touch-action: pan-x pan-y` (no zoom) |
+| Swipe between tabs | Tab navigation | Scroll snap on tab content |
+
+### 4.3 Hover States on Touch
+
+Hover doesn't exist on touch devices. Every interaction that relies on hover must have a touch alternative:
+
+| Desktop (hover) | Mobile (touch) |
+|---|---|
+| Tooltip on hover | Tap to show, tap elsewhere to dismiss |
+| Dropdown on hover | Tap to toggle open/close |
+| Card hover elevation | No visual change (or use active/pressed state) |
+| Row actions revealed on hover | Swipe to reveal, or tap row to show actions |
+| Preview on hover | Tap to navigate directly |
+
+**Rule:** Never put critical functionality behind hover-only. Every hover interaction must be reachable by tap.
+
+### 4.4 Keyboard on Mobile
+
+When an input field is focused on mobile, the virtual keyboard covers ~50% of the screen.
+
+| Issue | Solution |
+|---|---|
+| Submit button hidden by keyboard | Fix submit button above keyboard (`position: sticky; bottom: 0`) or use `env(safe-area-inset-bottom)` |
+| Active field scrolled off screen | `scrollIntoView({ block: 'center' })` on focus |
+| Form too long to scroll while typing | Keep forms short on mobile. Use multi-step if needed. |
+| Dropdown behind keyboard | Position dropdown above input when near bottom of viewport |
+
+---
+
+## 5. Typography on Mobile
+
+### 5.1 Scale Adjustments
+
+The type scale from 14-DESIGN-TOKENS.md stays the same — we don't shrink fonts for mobile. The minimum body text (14px) is already appropriate for phone screens.
+
+Adjustments:
+
+| Token | Desktop | Phone | Reason |
+|---|---|---|---|
+| Display | 22px | 20px | Prevent overflow on narrow screens |
+| Heading L | 18px | 17px | Slight reduction acceptable |
+| All others | Same | Same | 14px body is fine on mobile |
+
+```html
+<h1 class="tw:text-xl tw:md:text-[22px]">Page Title</h1>
+```
+
+### 5.2 Line Length on Mobile
+
+On desktop, max line length is ~70-80 characters. On a 375px phone with 16px padding each side, the content width is ~343px. At 14px, this gives ~40-45 characters per line — which is fine for mobile readability. No action needed.
+
+### 5.3 Text Truncation
+
+On small screens, long titles and labels need truncation:
+
+```html
+<!-- Truncate with ellipsis -->
+<span class="tw:truncate tw:max-w-[200px] tw:md:max-w-none">
+  {{ $longTitle }}
+</span>
+
+<!-- Multi-line clamp (2 lines max) -->
+<p class="tw:line-clamp-2 tw:md:line-clamp-none">
+  {{ $description }}
+</p>
+```
+
+**Rules:**
+- Never truncate the primary identifier (ticket title, project name) below readability — use 2-line clamp if needed
+- Always show full text somewhere accessible (tooltip on desktop, tap to expand on mobile)
+- Truncate supplementary text (descriptions, paths, URLs) aggressively
+- Breadcrumbs: show last 2 segments, "..." for the rest
+
+---
+
+## 6. Spacing on Mobile
+
+### 6.1 Spacing Reductions
+
+The 4px spacing scale from 14-DESIGN-TOKENS.md applies at all breakpoints. But some layout-level spacings reduce on mobile:
+
+| Context | Desktop | Phone | Tailwind pattern |
+|---|---|---|---|
+| Page padding horizontal | 24px (tw:px-6) | 16px (tw:px-4) | `tw:px-4 tw:md:px-6` |
+| Page padding vertical | 32px (tw:py-8) | 20px (tw:py-5) | `tw:py-5 tw:md:py-8` |
+| Section gap | 24px (tw:gap-6) | 16px (tw:gap-4) | `tw:gap-4 tw:md:gap-6` |
+| Card inner padding | 16px (tw:p-4) | 12px (tw:p-3) | `tw:p-3 tw:md:p-4` |
+| Card gap | 12px (tw:gap-3) | 8px (tw:gap-2) | `tw:gap-2 tw:md:gap-3` |
+
+### 6.2 Safe Area Insets
+
+Devices with notches, dynamic islands, and home indicators need safe area handling:
+
+```css
+/* For fixed bottom elements (bottom nav, sticky buttons) */
+padding-bottom: env(safe-area-inset-bottom, 0);
+
+/* For full-screen overlays */
+padding-top: env(safe-area-inset-top, 0);
+padding-left: env(safe-area-inset-left, 0);
+padding-right: env(safe-area-inset-right, 0);
+```
+
+```html
+<!-- Bottom fixed bar with safe area -->
+<div class="tw:fixed tw:bottom-0 tw:left-0 tw:right-0 tw:bg-[var(--color-bg-card)]
+            tw:border-t tw:border-[var(--color-border-default)]
+            tw:pb-[env(safe-area-inset-bottom)]">
+  <div class="tw:p-3 tw:flex tw:gap-2">
+    <button>Cancel</button>
+    <button>Save</button>
+  </div>
+</div>
+```
+
+**Meta tag required:**
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+```
+
+---
+
+## 7. Images and Media
+
+### 7.1 Responsive Images
+
+| Rule | Implementation |
+|---|---|
+| Max width 100% | `tw:max-w-full tw:h-auto` on all images |
+| Lazy loading | `loading="lazy"` on images below the fold |
+| Aspect ratio preservation | `tw:aspect-video` or `tw:aspect-square` containers |
+| Avatar sizes | Same across breakpoints (18/28/36px) — already small enough |
+
+### 7.2 Charts and Data Visualization
+
+| Chart type | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Bar chart | Full width, labels visible | Full width, labels may rotate 45° | Full width, horizontal bars instead of vertical |
+| Line chart | Full width, all data points | Full width, fewer labels | Full width, simplified (fewer data points) |
+| Pie/donut | 200-300px diameter | 200px diameter | 180px diameter, legend below (not beside) |
+| Progress bars | Inline with labels | Same | Same — works at any width |
+| Sparklines | Inline | Same | Same — inherently compact |
+
+**Rule:** Charts must have text alternatives. On mobile where chart detail is reduced, ensure the key numbers are shown as text above/below the chart.
+
+---
+
+## 8. Performance on Mobile
+
+### 8.1 Mobile-Specific Performance Rules
+
+| Rule | Why | Implementation |
+|---|---|---|
+| No layout shift on load | Mobile viewports magnify shifts | Set explicit dimensions on images, embeds, dynamic containers |
+| Minimize paint on scroll | Mobile GPUs are weak | Avoid `box-shadow` changes on scroll. Use `will-change` sparingly. |
+| Lazy load below-fold content | Mobile bandwidth is variable | HTMX `hx-trigger="revealed"` for sections below the fold |
+| Reduce initial payload | 3G connections still exist | Critical content first, enhance with HTMX partials |
+| Avoid large DOM | Mobile browsers have less memory | Virtualize long lists (100+ items). Paginate rather than infinite scroll for data tables. |
+| Debounce resize/scroll handlers | Mobile fires these rapidly | 100-200ms debounce |
+| Touch event passive listeners | Prevents scroll jank | `{ passive: true }` on scroll and touch listeners |
+
+### 8.2 HTMX on Mobile
+
+HTMX is well-suited for mobile — it sends small HTML fragments instead of full JSON payloads that need client-side rendering. But:
+
+| Consideration | Rule |
+|---|---|
+| Loading indicators | Always show a spinner or skeleton on mobile — network latency is higher |
+| Error recovery | Network drops happen more on mobile. Show "retry" button on failed requests. |
+| Offline state | Detect `navigator.onLine` and show persistent banner when offline |
+| Request size | Keep HTMX responses small — mobile bandwidth is limited |
+| Swap animations | Disable on `prefers-reduced-motion` AND on slow connections (use `navigator.connection.effectiveType`) |
+
+---
+
+## 9. Component-Specific Responsive Patterns
+
+### 9.1 Header / Top Bar
+
+| Element | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Logo + app name | Visible | Logo only | Logo only (smaller) |
+| Search | Visible input field | Icon that expands to full-width input | Icon that opens full-screen search overlay |
+| Notifications bell | Icon + count badge | Same | Same |
+| User avatar + menu | Avatar + name + dropdown | Avatar + dropdown | Avatar + dropdown |
+| Page title | In header or breadcrumb area | Same | Truncated, single line |
+
+### 9.2 Kanban Board
+
+| Element | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Columns | All visible side by side | Horizontally scrollable with snap | Single column with column tab selector |
+| Column width | 280-320px | 260px | Full viewport width minus padding |
+| Card detail | Click opens side panel | Click opens overlay | Click navigates to full-screen detail |
+| Drag and drop | Full drag between columns | Tap + select target column | Tap card → action menu → "Move to..." |
+| Column header | Sticky top | Sticky top | Fixed tab bar |
+| WIP limits | Shown in column header | Same | Shown in tab label |
+
+Phone kanban pattern:
+```
+[To Do ▼] [In Progress ▼] [Done ▼]     ← tab selector, scrollable
+┌──────────────────────────────────┐
+│ Card 1                           │    ← cards for selected column
+│ Status · Assignee · Due          │
+└──────────────────────────────────┘
+┌──────────────────────────────────┐
+│ Card 2                           │
+│ Status · Assignee · Due          │
+└──────────────────────────────────┘
+```
+
+### 9.3 Forms
+
+| Element | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Layout | 2-column where logical | Single column | Single column |
+| Labels | Above input (not beside) | Same | Same |
+| Select dropdowns | Native or custom | Native (better touch) | **Always native `<select>`** |
+| Date pickers | Custom calendar widget | Custom or native | **Native `<input type="date">`** |
+| Multi-select | Custom tag input | Same | Bottom sheet with checkboxes |
+| Rich text editor | Full toolbar | Condensed toolbar | Minimal toolbar (bold, italic, list, link) |
+| Submit button | Bottom of form, right-aligned | Same | Full-width, sticky at bottom |
+| Form steps (wizard) | Progress bar + side navigation | Progress bar only | Step counter "2 of 5" + next/back |
+
+**Phone form rule:** Use native form controls (`<select>`, `<input type="date">`, `<input type="time">`) whenever possible on phone. They invoke the OS-native picker which is better for touch than any custom widget.
+
+### 9.4 Notifications Panel
+
+| Element | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Container | Dropdown from bell icon, 380px wide | Same | Full-screen overlay |
+| Item height | Compact (60-70px) | Same | Slightly taller (comfortable tap target) |
+| Mark as read | Hover → show mark-read icon | Same | Swipe left to mark read |
+| Group by | Today / Earlier / This Week | Same | Same |
+| Empty state | "All caught up" + icon | Same | Same |
+
+### 9.5 Dashboard Widgets
+
+| Widget type | Desktop | Tablet | Phone |
+|---|---|---|---|
+| Metric card (number + label) | 3-4 across | 2 across | 2 across (compact) or 1 across |
+| Chart widget | 2 across | 1-2 across | 1 across, full width |
+| Activity feed | Side panel or column | Below main content | Below, limited to 5 items + "show more" |
+| Quick actions | Button row | Same | Sticky bottom bar |
+
+### 9.6 Logic Model Flow
+
+Detailed breakpoint behavior for the Logic Model specifically:
+
+| Breakpoint | Layout | Behavior |
+|---|---|---|
+| Desktop 1200px+ | 5-column horizontal flow | All stages visible, one active/expanded |
+| Tablet landscape 1024px | Horizontal scroll, 5 columns | Scroll snap per stage, swipe to navigate |
+| Tablet portrait 768px | 2x2 + 1 grid | Inputs+Activities row, Outputs+Outcomes row, Impact full-width |
+| Phone < 768px | Vertical accordion | Stage headers always visible, tap to expand one at a time |
+
+Phone accordion pattern:
+```
+┌────────────────────────────┐
+│ ▶ Inputs (4)               │  ← collapsed, shows count
+├────────────────────────────┤
+│ ▼ Activities (3)           │  ← expanded
+│   ┌────────────────────┐   │
+│   │ Reading assessments │   │
+│   │ Status: In Progress │   │
+│   └────────────────────┘   │
+│   ┌────────────────────┐   │
+│   │ 1-on-1 tutoring    │   │
+│   │ Status: Validated   │   │
+│   └────────────────────┘   │
+│   ┌────────────────────┐   │
+│   │ Family literacy     │   │
+│   │ Status: Draft       │   │
+│   └────────────────────┘   │
+│   [+ Add activity]         │
+├────────────────────────────┤
+│ ▶ Outputs (3)              │
+├────────────────────────────┤
+│ ▶ Outcomes (3)             │
+├────────────────────────────┤
+│ ▶ Impact (2)               │
+└────────────────────────────┘
+```
+
+### 9.7 Resource Allocation View
+
+Resource allocation is desktop-only for editing. On mobile, show a read-only summary:
+
+| Breakpoint | View |
+|---|---|
+| Desktop 1200px+ | Full canvas table with fill-up containers, editable |
+| Tablet landscape 1024px | Simplified table, horizontally scrollable, editable |
+| Tablet portrait 768px | Card list per person with allocation bars, read-only |
+| Phone < 768px | Summary only — total people, total budget, top-line utilization. Link to desktop for detail. |
+
+---
+
+## 10. Orientation Handling
+
+### 10.1 Landscape vs. Portrait
+
+| Rule | Details |
+|---|---|
+| Support both orientations | Never lock orientation (except for specific canvas views if needed) |
+| Landscape phone ≈ tablet portrait | At 667px wide (iPhone landscape), treat like narrow tablet |
+| Avoid layout shift on rotation | Use viewport-relative units and flex/grid, not fixed pixel widths |
+
+### 10.2 When Landscape Helps
+
+| Feature | Landscape benefit |
+|---|---|
+| Kanban board | More columns visible |
+| Tables | More columns visible without scroll |
+| Canvas / Logic Model | More of the horizontal flow visible |
+| Timeline / Gantt | More date range visible |
+| Forms | Not helpful — stick to single column |
+
+---
+
+## 11. Accessibility on Mobile
+
+### 11.1 Mobile-Specific Accessibility
+
+These are in addition to the base accessibility standards in 14-DESIGN-TOKENS.md:
+
+| Concern | Rule |
+|---|---|
+| Screen reader (VoiceOver/TalkBack) | All touch targets must be accessible via screen reader gestures (swipe to navigate) |
+| Focus order on mobile | Must follow visual order. Drawer/overlay must trap focus when open. |
+| Zoom | Never disable zoom. `user-scalable=yes` always. |
+| Dynamic type (iOS) | Respect system text size settings where possible |
+| Reduced motion | Applies doubly on mobile — animations cause more nausea on moving devices |
+| Color inversion (iOS smart invert) | Images should have `data-smart-invert-ignore` if color-meaningful |
+| Voice Control (iOS) | Buttons need visible labels or aria-label for voice targeting |
+| Switch Control | All interactions reachable via single switch (tab + activate) |
+
+### 11.2 Viewport Meta Tag
+
+```html
+<!-- Required for proper mobile rendering -->
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+
+<!-- NEVER do this: -->
+<meta name="viewport" content="... user-scalable=no ...">   <!-- Blocks zoom accessibility -->
+<meta name="viewport" content="... maximum-scale=1 ...">    <!-- Same problem -->
+```
+
+---
+
+## 12. Testing Requirements
+
+### 12.1 Device Matrix
+
+Test at minimum:
+
+| Device / Width | Priority | What to test |
+|---|---|---|
+| 375px (iPhone SE) | **Critical** | Smallest common phone — if it works here, it works on bigger phones |
+| 390px (iPhone 14/15) | **Critical** | Most common phone width |
+| 430px (iPhone Pro Max) | High | Largest phone — verify it doesn't look stretched |
+| 768px (iPad Mini/iPad portrait) | **Critical** | Tablet portrait — major layout shift point |
+| 1024px (iPad landscape) | High | Tablet landscape — sidebar collapse point |
+| 1200px (laptop) | **Critical** | Desktop layout kicks in |
+| 1440px (external monitor) | Medium | Wide layout verification |
+| 1280px at 200% zoom | **Critical** | Effective 640px — accessibility requirement |
+
+### 12.2 Test Checklist Per Component
+
+- [ ] Renders correctly at 375px width
+- [ ] Renders correctly at 768px width
+- [ ] Renders correctly at 1200px width
+- [ ] No horizontal overflow / scrollbar at any breakpoint
+- [ ] Touch targets meet 44px minimum on phone/tablet
+- [ ] All hover interactions have touch alternatives
+- [ ] Modals become bottom sheets on phone
+- [ ] Tables become card lists on phone
+- [ ] Forms use native inputs on phone where appropriate
+- [ ] Loading states show on mobile (higher latency expected)
+- [ ] Text doesn't overflow containers — truncation or wrapping works
+- [ ] Fixed/sticky elements respect safe area insets
+- [ ] Orientation change doesn't break layout
+- [ ] Virtual keyboard doesn't hide the active input or submit button
+- [ ] Screen reader can navigate all content (VoiceOver swipe test)
+
+### 12.3 Browser Testing
+
+| Browser | Priority |
+|---|---|
+| Safari iOS (latest) | **Critical** — many iOS-specific layout quirks |
+| Chrome Android (latest) | **Critical** — most common Android browser |
+| Chrome Desktop | **Critical** — development primary |
+| Firefox Desktop | High |
+| Safari Desktop | High — WebKit differences |
+| Edge Desktop | Medium |
+| Samsung Internet | Medium — significant Android market share |
+
+### 12.4 Common Mobile Bugs to Watch For
+
+| Bug | Cause | Fix |
+|---|---|---|
+| 100vh is too tall on mobile | Mobile browser chrome (address bar) eats viewport height | Use `100dvh` (dynamic viewport height) instead of `100vh` |
+| Sticky footer overlaps content | Content doesn't account for fixed bottom element | Add `padding-bottom` equal to footer height + safe area |
+| Tap delay (300ms) | Old mobile browsers wait to detect double-tap zoom | `touch-action: manipulation` on interactive elements |
+| Input zoom on iOS | iOS zooms in when font-size < 16px on inputs | Ensure input font-size is >= 16px on mobile |
+| Rubber-band scroll on iOS | Body scroll bounces past edges | `overscroll-behavior: none` on scroll containers |
+| Position fixed inside transform | Fixed elements don't work inside transformed parents | Move fixed elements outside transformed containers |
+| :hover sticky on touch | Hover state persists after tap on mobile | Use `@media (hover: hover)` for hover-only styles |
+
+```css
+/* Fix: hover-only styles that don't stick on touch */
+@media (hover: hover) {
+  .card:hover {
+    box-shadow: var(--shadow-md);
+  }
+}
+```
+
+---
+
+## 13. Audit Methodology
+
+### 13.1 What to Search For
+
+```bash
+# Fixed pixel widths that will overflow on mobile
+grep -rn "width:\s*[0-9]\{3,\}px" app/Views/ --include="*.blade.php" --include="*.css" | head -30
+
+# Hardcoded heights that may cause issues
+grep -rn "height:\s*100vh" app/Views/ --include="*.blade.php" --include="*.css" | head -20
+
+# Missing responsive prefixes on grid/flex layouts
+grep -rn "grid-cols-[2-9]\|grid-cols-1[0-2]" app/Views/ --include="*.blade.php" | \
+  grep -v "tw:md:\|tw:lg:\|tw:xl:" | head -20
+
+# Hover-only interactions (no touch alternative)
+grep -rn ":hover\|@mouseenter\|@mouseover" app/Views/ --include="*.blade.php" --include="*.css" | \
+  grep -v "@media.*hover" | head -20
+
+# Viewport zoom disabled (accessibility violation)
+grep -rn "user-scalable=no\|maximum-scale=1" app/Views/ --include="*.blade.php" | head -10
+
+# Missing viewport meta tag
+grep -rL "viewport" app/Views/Templates/layouts/ --include="*.blade.php"
+
+# Fixed positioning without safe area
+grep -rn "position:\s*fixed\|tw:fixed" app/Views/ --include="*.blade.php" | \
+  grep -v "safe-area\|env(" | head -20
+```
+
+### 13.2 Reporting Format
+
+Same format as 14-DESIGN-TOKENS.md section 11.3:
+
+```
+## Sweep: Mobile Responsiveness
+### Files checked: N
+### Issues found: N (critical / minor / flagged)
+
+#### Critical (broken on mobile, inaccessible, or overflow)
+- file.blade.php:42 — grid-cols-3 without responsive prefix, overflows on phone
+- file.blade.php:67 — hover-only dropdown, no touch alternative
+- layout.blade.php:5 — viewport meta has maximum-scale=1 (blocks zoom)
+
+#### Minor (suboptimal but functional)
+- file.blade.php:120 — 100vh used, should be 100dvh for mobile browser chrome
+- file.blade.php:135 — touch targets 32px, should be 44px minimum
+
+#### Flagged (needs design decision)
+- canvas.blade.php:200 — spatial canvas on phone. Summary view or vertical accordion?
+```
+
+---
+
+## Changelog
+
+| Date | Change | Author |
+|---|---|---|
+| 2026-02-23 | v1.0 — initial mobile responsiveness standards: philosophy, breakpoints, layout patterns, navigation, touch interactions, typography, spacing, safe areas, images/charts, performance, component-specific patterns (kanban, forms, notifications, dashboard, logic model, resources), orientation, mobile accessibility, testing matrix, common bugs, audit methodology | GF |

--- a/Docs/RESOURCE-ALLOCATION-QA.md
+++ b/Docs/RESOURCE-ALLOCATION-QA.md
@@ -1,0 +1,112 @@
+# Resource Allocation — QA Walkthrough
+
+**Surface:** `/pgmPro/resourceAllocation`
+**Scope:** V1 planning + V2 plan-vs-actual, backward auto-fill (people/budget from existing data), all state variations.
+**Out of scope:** Forward LM-Inputs classifier (§7 follow-up), Dependencies auto-fill (no deterministic source), stakeholder report Resources section.
+
+---
+
+## Setup
+
+Have ready:
+- A **program** (a `zp_projects` row with `type = 'program'`).
+- 2+ **child projects** parented to that program.
+- At least one child project with **users assigned** (for the people seeder).
+- At least one child project with **`dollarBudget > 0`** (for the budget seeder).
+- A separate program with **no** child projects — for empty-state verification.
+
+Set the current project to the program before loading the URL.
+
+---
+
+## Flow 1 — Fresh program (no resources authored)
+
+1. Load `/pgmPro/resourceAllocation` on the fresh program.
+2. Overview summary strip should read **honest em-dashes** — not zeros:
+   - Team capacity: `—`
+   - Allocated: `0h` with sub-label `nothing allocated`
+   - Available: `—` with `no capacity set`
+   - People: `0` with `none added`
+   - Budget: `—` with `no budget set`
+3. People / Budget / Dependencies tabs each show an **invite-to-author card** — icon + hint + two buttons:
+   - People: **"Add everyone from child projects"** (working) + "Add person" (manual)
+   - Budget: **"Add lines from child project budgets"** (working) + "Add budget line" (manual)
+   - Dependencies: "Fill from Logic Model Inputs — soon" (disabled, tooltip explains) + "Add dependency"
+4. Global bar top-right shows **"Auto-fill from existing data"** (working, not disabled).
+
+## Flow 2 — Backward auto-fill (one click)
+
+5. Click **"Auto-fill from existing data"** in the top bar.
+6. Page reloads with a **success toast**: `"Added N people and M budget lines. Skipped 0 already present."`
+7. Overview strip now shows real numbers (capacity used %, allocated hours, available, people count, budget total).
+8. People tab: one row per assigned user across all child projects, deduped, with `capacity = 40h/wk` and empty allocation bar (all available).
+9. Budget tab: one line per child project with `dollarBudget > 0`, spend at $0, project name as label, project color on the segment.
+10. Click **"Auto-fill from existing data"** again — toast says: `"Everything is already added (N matches skipped)."` No duplicates created.
+
+## Flow 3 — Per-section seeders
+
+11. Reset to fresh state (delete all resources for the program).
+12. Go to People tab → click **"Add everyone from child projects"** in the empty state.
+13. Page reloads; only people are added, budget remains empty.
+14. Go to Budget tab → click **"Add lines from child project budgets"**.
+15. Page reloads; only budget lines added.
+
+## Flow 4 — V1 planning interactions
+
+16. On People tab (with people present), click a project-color segment on any person's allocation bar → hours-per-project edit should surface.
+17. Add hours; the person's total allocation updates; the summary strip's "Allocated" and "Available" recompute; "% used" mini-bar reflects the new state.
+18. Any person at ≥99% shows the **at-capacity amber treatment** and the People summary cell shows "N at capacity."
+19. On Budget tab, click a budget line's amount to edit; ≥90% spent renders red (at-risk); ≥100% renders red + bold (over).
+20. On Dependencies tab, toggle a dependency between confirmed / tentative — chip color flips green ↔ amber.
+
+## Flow 5 — Stub person (seeded from LM Input, not linked to a user)
+
+21. **Setup** (until forward LM seeder ships, do this manually):
+    - Insert a row into `zp_canvas_items` where `box='people'`, `status='stub'`, `data` JSON has `{"userId": 0, "capacity": 40, "allocations": {}}`, `description = 'Jordan Rivera'`, optionally set `milestoneId` to a canvas item id for the "source" link.
+22. Reload the People tab. The stub row renders below active people as a **dashed "complete me"** row.
+23. **"Seeded"** chip shows next to the name; if `milestoneId`/`sourceCanvasItemId` was set, it's a hyperlink (opens the LM Input source).
+24. The bar area reads: `"Link a user to set capacity & hours"` (no fake allocation).
+25. Right column shows a **"Link user"** button.
+26. Stub is **not counted** in `teamStats` totals — summary strip's "Allocated" excludes them.
+
+## Flow 6 — V2 plan-vs-actual mode
+
+27. Append `?version=v2` to the URL (or use the mode toggle).
+28. Summary strip now has **6 cells** (adds "Actual (this wk)" between Allocated and Available).
+29. Reading-guide bar shows plan/actual legend + `Xh / Yh logged this week` chip.
+30. Overview projects table has header row (Project / Planned / Actual / Δ / bar) and each row shows planned+actual overlaid.
+31. People tab renders **two bars per person**: planned (thick) + actual ghost (thin dashed).
+32. Delta column reads `+Xh over` (red) / `−Xh under` (amber) / `on plan`.
+33. Log some timesheet entries against a child-project ticket for one of the users; reload — the actual bar fills, the delta updates.
+
+## Flow 7 — V2 orphaned-user state (`userId === 0` on an active row)
+
+34. **Setup**: find an active person, edit their canvas_item's `data` JSON to set `userId: 0` (simulating a deleted linked user).
+35. In V2 mode, that row's **actual bar becomes a neutral dashed strip** reading: `"No linked user — actuals can't be tracked yet"`.
+36. The delta column reads `link a user to track` (italic, muted) — **not** alarm-amber "fully under."
+37. Same treatment applies to stub-status persons in V2 (they always have `userId === 0`).
+
+## Flow 8 — Empty states persist correctly
+
+38. Set state where only budget exists (delete people, keep budget) → People tab shows the invite-card, Budget tab shows real rows.
+39. Delete all resources → all three tabs show invite cards, summary strip returns to em-dashes.
+
+## Flow 9 — Print parity
+
+40. From the tab, hit browser print (or `Cmd+P`). Should show **all sections in one flowing snapshot** (Overview → People → Budget → Dependencies) — not just the current tab.
+41. Global bar (mode toggle, auto-fill button) + tab bar + add-buttons should be **hidden** in print.
+42. Rows should not break across pages (page-break-inside: avoid).
+
+## Flow 10 — MCP / RPC surface
+
+43. Via MCP client: call `seedResourcesFromProjects` with `programId` = your program id + `type` = `both`. Response text should show added/skipped counts.
+44. Via JSON-RPC: `POST /api/jsonrpc` with method `leantime.rpc.PgmPro.ResourceStructureService.seedPeopleFromChildProjects`, params `{programId: N}`. Returns `{added, skipped, canvasId}`.
+45. Both should be idempotent and return the same shape as the UI.
+
+---
+
+## Known-limited (do not flag)
+
+- The **"Fill from Logic Model Inputs"** button on Dependencies (and the future forward-direction path elsewhere) is intentionally disabled with a "coming soon" tooltip. §7 scoped this as follow-up.
+- No period switcher in V2 — `getActualHours` is hardcoded to `this_week`. Service accepts other periods but there's no UI yet.
+- **Old `12-RESOURCE-ALLOCATION.md` and `13-RESOURCE-ALLOCATION-PROMPT.md`** in Docs are the pre-revival versions; the current spec is `16-RESOURCE-ALLOCATION-REQUIREMENTS.md` (pending renumber to `19-` to clear the `16-CROSS-CUTTING-CONCERNS.md` collision).

--- a/Docs/STAKEHOLDER-REPORT-PROMPT.md
+++ b/Docs/STAKEHOLDER-REPORT-PROMPT.md
@@ -48,7 +48,7 @@ Title + provenance line left. Top-right: the **status verdict** — a stated ver
 KPI band (4 big-number tiles from `stats`), the **"peak this period" hero** (recommend-and-override — nominate from a structural closure OR a completed milestone carrying `outcomeImpact`; expose the override), needs-attention block (from `needsAttention`), Theory-of-Change narrative (stage-colored sentence from `logicModel.narrative`), theory-health strip (from `zp_logicmodel_health`).
 
 ### 5. Page 2 — Logic Model read-out
-The 5-stage board (`lm_inputs → lm_impact`, colors per design §5). Cards = **task-card standard**: title left; status pill + owner avatar top-right; assumption line (`hp-text`); linked projects; dashed divider → "This period" fold-out with count, delta, attributed close.
+The 5-stage board (`lm_inputs → lm_impact`, colors per design §5). Cards = **task-card standard**: title left; status pill + owner avatar top-right; assumption line (from the `assumptions` canvas-item column); linked projects; dashed divider → "This period" fold-out with count, delta, attributed close.
 - **Outputs and Outcomes** carry the fold-out read-out (default folded).
 - **Resources / Activities / Impact** stay lean (context header + status line).
 - **Connection-health badges** between stages from `zp_logicmodel_health.health_status` (ok/warning/risk).

--- a/Docs/STAKEHOLDER-REPORT-PROMPT.md
+++ b/Docs/STAKEHOLDER-REPORT-PROMPT.md
@@ -1,0 +1,98 @@
+# Stakeholder Report — Implementation Prompt
+
+**Reference doc:** `STAKEHOLDER-REPORT-REQUIREMENTS.md` (the design guide — read it first; this prompt sequences the build against it).
+**Mockup:** `board-report-swipe.html` (pages p1–p4) — the visual target. Match its structure, chrome, and the `minmax(0,1fr)` layout discipline.
+
+---
+
+## Role & goal
+
+You're implementing the **stakeholder report** — the `Report` view of the Logic Model page (`Logic Model // Report ▾`) in Leantime. It's the Logic Model canvas **read out** for a board: the same chain the team authors on the Board, with progress, completed work, and health laid over it. Strategy and program scope only.
+
+The defining property: **it is a live projection, never a snapshot.** Every render reads the same `zp_canvas` / goal / `zp_logicmodel_health` tables the Board writes, resolved at report time. There is no report record to freeze. If you find yourself copying canvas state into a saved report, stop — that's the one wrong turn.
+
+---
+
+## Step 0 — The data contract is already verified
+
+§8 of the requirements doc reflects the actual code on `origin/feature/report-screens` (verified). Do not re-derive the shape; **read from §8 and bind to those exact keys.**
+
+The five things you MUST know before writing render code (all in §8, restated for emphasis):
+
+1. **`StrategyReport::getStrategyReport()` nests `buildReport()`'s output at `.report`.** Templates read `$strategyReport['report']['stats']`, `$strategyReport['report']['milestones']`, etc. — NOT top-level.
+2. **`logicModel` can be `null`** (no LM canvas authored). Every render path must handle it — no field access without a null check.
+3. **Canvas type is `'logicmodel'`, not `'logicmodelcanvas'`.** Any query that filters `zp_canvas.type` uses `'logicmodel'`.
+4. **Assumption/hypothesis field is `assumptions`** (the canvas_items column, labeled *Evidence* in the LM UI). No `hp-text` column exists.
+5. **Program-level report has no wrapper service.** Call `ReportEngine::buildReport([$programId, ...descendants], $period)` directly; do not invent a `getProgramReport()`.
+
+Also: `zp_logicmodel_health` is plugin-owned (StrategyPro). If you find yourself reading it from core `Reports\*`, back up — go through the plugin's `LogicModel` service instead.
+
+Only re-run verification if a §8 field access fails at runtime (drift since the doc was written).
+
+---
+
+## Build sequence
+
+### 1. Shell & view toggle
+Add `Report` as a view on the existing Logic Model page — a toggle beside `Board` (`Logic Model // Board ▾` ↔ `Logic Model // Report ▾`), same page, same chrome, **no new nav entry.** Board authors; Report reads out. Both read the same canvas.
+
+### 2. The 4-page deck
+Four pages — Overview, Logic Model, Resources & Coverage, Programs — in a horizontal tab bar **on the background** (the To-Dos `Kanban·Table·List` treatment), plus swipe / arrow-key / arrow-button navigation. Deck sizes to the active page. Persistent report header.
+
+**Layout discipline (hard):** every grid track is `minmax(0,1fr)`, every flex/grid child gets `min-width:0`. Must fit a 12–13" laptop with **zero horizontal scroll.** The mockup already solves this — match it.
+
+### 3. Persistent header + status verdict
+Title + provenance line left. Top-right: the **status verdict** — a stated verdict with a provenance line, *not* a tappable pill. Computed by default (`from metrics · 4/5 goals on track`), owner can override (`set by GF · overrides metrics`). Render whichever applies; never show the verdict without its source.
+
+### 4. Page 1 — Overview
+KPI band (4 big-number tiles from `stats`), the **"peak this period" hero** (recommend-and-override — nominate from a structural closure OR a completed milestone carrying `outcomeImpact`; expose the override), needs-attention block (from `needsAttention`), Theory-of-Change narrative (stage-colored sentence from `logicModel.narrative`), theory-health strip (from `zp_logicmodel_health`).
+
+### 5. Page 2 — Logic Model read-out
+The 5-stage board (`lm_inputs → lm_impact`, colors per design §5). Cards = **task-card standard**: title left; status pill + owner avatar top-right; assumption line (`hp-text`); linked projects; dashed divider → "This period" fold-out with count, delta, attributed close.
+- **Outputs and Outcomes** carry the fold-out read-out (default folded).
+- **Resources / Activities / Impact** stay lean (context header + status line).
+- **Connection-health badges** between stages from `zp_logicmodel_health.health_status` (ok/warning/risk).
+- **Delta is v2-gated** — render only when `zp_goal_history` has snapshots; the card must be complete without it.
+
+### 6. Page 3 — Resources & Coverage
+Resource summary (people / budget / dependencies) read from **`ResourcesGateway`** (`getForProjects` / `getForProgram`) — **do not recompute; read the gateway's aggregates.** Coverage matrix: per focus area, a resource-backed verdict (covered/thin/gap) requiring *both* goals-tracked and resources-allocated. Empty cell = honestly ambiguous → "load from Logic Model Inputs," never an asserted gap.
+
+### 7. Page 4 — Programs & Narrative
+Program rows with RAG (`zp_comment` `module='project'` `.status`), status narrative (`statusUpdates`), "also this period" secondary closures.
+
+### 8. Print parity
+`@media print` expands all four pages into one flowing snapshot; hides tab bar, arrows, view toggle, fold toggles (read-outs shown expanded); `page-break-inside: avoid` on cards and stage columns.
+
+---
+
+## Constraints (do / never)
+
+- **DO** resolve everything live from `zp_canvas` / goals / `zp_logicmodel_health` at render time. **NEVER** snapshot or cache canvas state into a report record.
+- **DO** treat `zp_projects.parent`'s `NULL` (strategy) vs `0` (top-level program/project) as distinct when walking the tree.
+- **DO** read resource figures from `ResourcesGateway`. **NEVER** recompute capacity/budget/dependency aggregates in the report — they're computed once, upstream, and the tab and report must show identical numbers.
+- **DO** render the status verdict's provenance. **NEVER** show "On track" without saying whether it's from metrics or an owner.
+- **DO** gate deltas on `zp_goal_history` existing. **NEVER** make the delta load-bearing — the card is complete without it.
+- **DO** build strategy and program reports only. **NEVER** add a project-level report — project uses `/reports/project`.
+- **DO** keep the three health lenses distinct (execution / outcome / theory). **NEVER** collapse "behind schedule" and "fragile theory" into one signal.
+
+---
+
+## Acceptance criteria
+
+- Report renders at strategy and program scope, live from canvas/goal/health tables; editing the Board changes the report with no snapshot step.
+- All four pages fit a 1280px-wide viewport with no horizontal scroll; deck sizes to the active page.
+- Status verdict shows computed-vs-override provenance.
+- Logic Model cards match the task-card standard; Outputs/Outcomes fold out; connection badges reflect `zp_logicmodel_health`.
+- Resources section reads `ResourcesGateway` output verbatim (numbers match the PgmPro tab exactly).
+- Coverage verdicts are resource-backed; empty cells offer the load affordance rather than asserting gaps.
+- Print expands all pages into one snapshot with screen affordances hidden.
+- No delta renders until `zp_goal_history` has data; cards are complete without it.
+
+---
+
+## Out of scope (this pass)
+
+- Project-level report (exists as `/reports/project`).
+- Writing/computing resource aggregates (the report is a `ResourcesGateway` consumer only).
+- The `zp_goal_history` read path for deltas (v2 — snapshots are write-only for now).
+- The Resources & Coverage page (p3) itself — scope depends on §10.d: either **shell ships with p3 as a placeholder** (build p1/p2/p4 now, land p3 in a follow-up that adds `ResourcesGateway` wiring + resource-backed coverage verdict), or **block on p3 landing complete**. Confirm with product before starting p3 code.

--- a/Docs/STAKEHOLDER-REPORT-REQUIREMENTS.md
+++ b/Docs/STAKEHOLDER-REPORT-REQUIREMENTS.md
@@ -1,0 +1,256 @@
+# Stakeholder Report — Requirements & Design Guide
+
+**Surface:** the `Report` view of the Logic Model page — `Logic Model // Report ▾`
+**Scope levels:** strategy and program only (project keeps Marcel's existing `/reports/project`)
+**Companion mockup:** `board-report-swipe.html` (pages p1–p4)
+**Status:** design locked; data contract verified against `origin/feature/report-screens` (§8 updated with the drifts caught). Ready for prompt companion.
+
+---
+
+## 1. Purpose & what this is
+
+The stakeholder report is **the Logic Model canvas, read out** — a board-facing view of the same chain a team authors on the Logic Model Board. It is not a new document type and not a separate report builder. It lives as a **view toggle** on the existing Logic Model page: `Board` (author) ↔ `Report` (read out), same page, same chrome, same data.
+
+The core idea: a board should be able to see not just *what the plan is* (the canvas) but *how it's going* (progress, completed work, health) laid over that plan — without the team maintaining a second artifact. The report is a **live projection**, never a snapshot (see §6.1 — this is the single most important build constraint).
+
+It answers three questions a board actually asks, kept as three distinct health lenses (§4):
+1. **Are we doing the work?** (execution)
+2. **Is it producing the outcomes?** (outcome)
+3. **Is the underlying theory sound?** (theory health) — the lens boards usually lack.
+
+---
+
+## 2. Structure — a 4-page swipeable deck
+
+One report, four pages, navigated by a horizontal tab bar on the background (the To-Dos `Kanban · Table · List` convention) plus swipe / arrow-key / arrow-button conveniences. The deck sizes to the active page (no dead space on short pages). Persistent report header across all four.
+
+1. **Overview** — the board-level read: KPI band, "peak this period" hero, needs-attention, Theory-of-Change narrative, theory-health strip.
+2. **Logic Model** — the 5-stage chain read out (Resources → Activities → Outputs → Outcomes → Impact), canvas-context cards with fold-out "this period" read-outs, connection-health badges.
+3. **Resources & Coverage** — resource summary reads (people / budget / dependencies) from `ResourcesGateway`, and the coverage matrix (is each focus area resourced *and* tracked?).
+4. **Programs** — program rows with RAG, and the status narrative.
+
+Tabs are a **screen affordance**; print expands all four into one flowing snapshot (§7).
+
+**Hard layout constraint:** fits a 12–13" laptop with **no horizontal scroll.** Root cause of prior overflow was CSS grid `1fr` (= `minmax(auto,1fr)`, won't shrink below content). Fix is `minmax(0,1fr)` on every grid track + `min-width:0` on flex/grid children. This is non-negotiable and already solved in the mockup.
+
+---
+
+## 3. The persistent report header
+
+Across all pages:
+- **Title + provenance** left: report subject, `Strategy report · Q2 2026 · last closed period · updated {date}`.
+- **Status verdict** top-right — a **stated verdict with quiet provenance**, not a tappable pill. "On track" with a colored dot, and beneath it the source line: `from metrics · 4/5 goals on track` when computed, or `set by GF · overrides metrics` when an owner has overridden. This is the **computed-by-default, owner-can-override** model made visible (§5). A board must never wonder whether the verdict is the arithmetic talking or a human.
+- **Period + Export** actions.
+
+---
+
+## 4. The three health lenses (keep distinct)
+
+The report deliberately separates three signals that boards often collapse:
+
+- **Execution health** — from `ReportEngine` `needsAttention` / `stats`. Overdue milestones, stalled work. Rendered as the needs-attention block (p1) and RAG on program rows (p4).
+- **Outcome health** — goal RAG from the goal rollup. Are the tracked goals on track? Rendered in the KPI band and the Outcomes column read-outs (p2).
+- **Theory health** — from `zp_logicmodel_health`. Is each *connection* in the chain sound, and are its assumptions evidenced? This is the lens boards lack. Rendered as the theory-health strip (p1) and connection badges between stages (p2). A fragile Outputs→Outcomes link with an unproven, un-evidenced assumption is a distinct risk from "behind schedule" — surface it as such.
+
+---
+
+## 5. Page-by-page rendering
+
+### Page 1 — Overview
+
+- **KPI band** — the anchor scale. 4 big-number tiles (completed w/ delta, goals on track, milestones overdue, headline outcome metric). Big numbers read in one glance.
+- **"Peak this period" hero** — a recommend-and-override slot. The system nominates the period's most significant closure (fires on **structural closure** OR a **completed milestone carrying `outcomeImpact`**); the owner can pin/override. Shows the achievement, its linked goal, and date. Labeled "Recommended · change" so the owner knows it's proposable.
+- **Needs-attention** — the execution lens; the at-risk callout.
+- **Theory of Change narrative** — the chain rendered as a sentence, stage-colored: *By investing in {inputs}, delivering {activities}, we produce {outputs} — toward {outcomes}, in service of {impact}.*
+- **Theory-health strip** — the fragile-connection warning drawn from `zp_logicmodel_health`.
+
+### Page 2 — Logic Model read-out
+
+The 5-stage board (same stages, colors, and order as the canvas):
+
+| Stage | box | color |
+|---|---|---|
+| Resources | `lm_inputs` | `#4A85B5` blue |
+| Activities | `lm_activities` | `#3E937A` teal |
+| Outputs | `lm_outputs` | `#C09035` amber |
+| Outcomes | `lm_outcomes` | `#8E6AAD` purple |
+| Impact | `lm_impact` | `#2D7D5E` green |
+
+**Cards follow the task-card standard** (so it's unmistakably a canvas item, read out):
+- Title left; **status pill + owner avatar top-right** (`Validated` / `In Progress` / `Draft`, plus a `High` risk flag where applicable).
+- **Assumption / hypothesis line** beneath (the canvas item's `assumptions` column — the field labeled *Evidence* in the Logic Model UI; `hp-text` is not a real column).
+- **Linked projects** ("Linked to 2 projects").
+- A dashed divider → **"This period"** → the read-out layer: the count phrased as a count ("180 of 300 sent · 112 attended"), a **delta** (`▲ +1.2` — **v2-gated on `zp_goal_history`**; absent in v1, card still complete), and the **attributed close** (who closed it, when, evidence files — from the completed milestone's `outcomeImpact`).
+
+**Targeted density:** Outputs and Outcomes carry the fold-out read-out (default folded behind a "this period" toggle, so the board opens compact). Resources / Activities / Impact stay lean — canvas-context header + a status line only; there's nothing measured there to read out.
+
+**Connection-health badges** sit between stages (ok / warning / risk = strong / needs-work / gap), from `zp_logicmodel_health.health_status`; amber warns a fragile link.
+
+Board-page controls follow Leantime convention: filter top-left in-panel, sort / `⋮` top-right.
+
+### Page 3 — Resources & Coverage
+
+- **Resource summary** — three reads from `ResourcesGateway`: People (FTE + capacity utilization), Budget (spent vs. plan, at-risk), Dependencies (confirmed vs. pending). This is the summarized companion to the PgmPro Resource Allocation tab; full detail lives there. (See §11 for the shared contract.)
+    > **Not yet wired** in `origin/feature/report-screens` — `StrategyReport` has zero `ResourcesGateway` references today. This section is new scope for the report build (see §10.d).
+- **Coverage matrix** — the current code (`StrategyReport::buildCoverageMatrix`) returns `{stages, columns, cells, unalignedColumns}`: a boolean matrix of LM-item → program/project linkage, with a separate list of programs/projects that have no LM-item home (**off-strategy work**). To reach the resource-backed **covered ● / thin ◐ / gap ○** verdict this page targets, `buildCoverageMatrix` needs a second pass that overlays `ResourcesGateway` per cell:
+    - **covered** — LM item linked to a program AND the program has resources authored for it (people + budget)
+    - **thin** — linked but resources incomplete (only one of people/budget, or a stub-only allocation)
+    - **gap** — linked, expected to be resourced, none authored
+    - **empty cell** — no LM linkage; honestly ambiguous → offer "load from Logic Model Inputs" rather than asserting a gap
+    - **off-strategy work** — programs in `unalignedColumns` render as a distinct callout beneath the matrix (they're a fourth signal, not a coverage-cell state — see §10.a resolution)
+
+### Page 4 — Programs & Narrative
+
+- **Program rows** — each child program with its RAG status and a count of completed work.
+- **Status narrative** — the portfolio-level and per-program status updates (from `statusUpdates`).
+- **"Also this period"** — secondary closures not chosen as the hero, with a link to attach them to an outcome.
+
+---
+
+## 6. Build constraints (normative)
+
+1. **Live projection, never a snapshot.** Every page reads the *same* canvas / goal / health tables the Board writes, resolved at report time. Do not copy, freeze, or cache the canvas into a report record. Edit a card on the Board → it changes here. A goal advances → the bar moves here. There is one dataset, two views. This is the defining property of the feature; a snapshotted report is a wrong report.
+2. **Strategy and program levels only.** Do not build a third project-level report; project uses the existing `/reports/project`. `getStrategyReport` (strategy) and the program equivalent are the two entry points.
+3. **Hierarchy hazard.** `zp_projects.parent` is a self-FK, but **strategies have `parent = NULL` while top-level programs/projects have `parent = 0`.** Resolve the tree with that in mind; don't assume `NULL` and `0` are interchangeable.
+4. **Delta is v2-gated.** The `▲ +1.2 vs Q1` deltas need `zp_goal_history` snapshots to exist. In v1, `zp_goal_history` is **write-only** (snapshots accumulate but aren't read back); deltas render only once there's a quarter of history. Design must be complete *without* the delta — it's additive, never load-bearing.
+5. **Status is computed-default, owner-override** (§3). Render provenance honestly; never show "On track" without saying whether it's from metrics or a person.
+6. **The hero is recommend-and-override.** The system proposes, the owner disposes. Never auto-pin without exposing the override; never leave it blank if a qualifying closure exists.
+7. **`zp_logicmodel_health` is a plugin-owned table.** It's defined and populated by StrategyPro. Core `Reports\Services\ReportEngine` must **not** read it directly — that would let core know about a plugin's schema. Health data reaches the report through `StrategyReport::getStrategyReport()` (plugin-side), which calls the plugin-side `LogicModel::getHealthBadges()`. Same boundary discipline as `ResourcesGateway`.
+
+---
+
+## 7. Print parity
+
+`@media print`: expand the 4-page deck into one flowing snapshot; hide the tab bar, arrows, view toggle, and fold toggles (print shows read-outs expanded); `page-break-inside: avoid` on cards and stage columns. Tabs/swipe are screen-only.
+
+---
+
+## 8. Data contract (from `ReportEngine` / `StrategyReport`)
+
+> Verified against `origin/feature/report-screens` (as of the read-through that produced this doc). Return shapes below are the actual code, not the earlier design shorthand.
+
+### `Reports\Services\ReportEngine::buildReport(int[] $projectIds, ReportPeriod $period): array`
+
+```php
+[
+  'period'         => ReportPeriod,        // echoed for template convenience
+  'projectIds'     => int[],               // filtered to authorized ids
+  'summaries'      => object[],            // per-project summary rows
+  'milestones'     => [
+    'completed' => [...], 'inProgress' => [...], 'overdue' => [...],
+    'upcoming' => [...],  'allDone' => [...],    'slippage' => [...],
+  ],
+  'goals'          => ['goals' => object[], 'byProject' => [...], 'counts' => ['ontrack' => int, ...]],
+  'statusUpdates'  => [...],
+  'effort'         => ['total' => float, ...],
+  'deltas'         => ['completedPrior', 'completedDelta', 'hoursPrior', 'hoursDelta', 'priorPeriodLabel'],
+  'needsAttention' => [...],               // execution-lens block
+  'stats'          => [
+    'completed'    => int,   // → KPI tile 1
+    'inFlight'     => int,
+    'overdue'      => int,   // → KPI tile 3
+    'upcoming'     => int,
+    'goalsOnTrack' => int,   // → KPI tile 2 (numerator)
+    'goalsTotal'   => int,   // → KPI tile 2 (denominator)
+    'hoursLogged'  => float,
+  ],
+]
+```
+
+### `StrategyPro\Services\StrategyReport::getStrategyReport(int $strategyId, ReportPeriod $period): array`
+
+**Critical:** `buildReport()`'s output is **nested at `.report`**, NOT spread top-level. Templates read `$strategyReport['report']['stats']`, `$strategyReport['report']['milestones']`, etc.
+
+```php
+[
+  'report'            => <buildReport() output above>,   // nested, not spread
+  'strategyGoals'     => ['goals' => object[], 'byProject' => [...], 'counts' => [...]],
+                                                          // each goal->childGoalCount populated when setting==='linkAndReport'
+  'programRows'       => object[],                        // one row per program + direct project
+  'programSummaries'  => object[],                        // program-only summaries (for coverage/rollups)
+  'programUpdates'    => [...],                           // → "Also this period" (p4)
+  'logicModel'        => null | [                         // null when no LM canvas authored
+    'canvasId'       => int,
+    'narrative'      => ['text' => string, 'hasItems' => bool, 'stageTexts' => array],
+    'stageProgress'  => ['lm_inputs' => ['percent', 'validated', 'total'], ...],
+    'healthBadges'   => [                                 // keyed 1..4 (connectors between stages)
+      1 => ['from_stage', 'connector_label', 'health_status', 'assumption_text', 'risk_level', 'evidence_notes', 'has_data'],
+      ...
+    ],
+    'coverageMatrix' => [                                 // see §5.3 for the resource-backed upgrade planned
+      'stages'           => ['lm_inputs' => ['title', 'icon', 'items'], ...],
+      'columns'          => [projectId => ['id', 'name'], ...],   // programs + direct projects
+      'cells'            => [itemId => [columnId => true, ...], ...],  // boolean linkage matrix
+      'unalignedColumns' => int[],                        // programs/projects with no LM linkage = OFF-STRATEGY WORK
+    ],
+  ],
+]
+```
+
+### Program-level entry point
+
+`ReportEngine::buildReport()` composed directly with `[$programId, ...descendants]`. No `getProgramReport()` wrapper exists today; `PgmPro\Controllers\Report` and `PgmPro\Hxcontrollers\Report` call the engine directly with a descendant-id set. Adding a `PgmPro\Services\ProgramReport` wrapper is optional and only worth it if the program-level report needs plugin-specific enrichment the strategy one does.
+
+### Source tables
+
+- **Logic Model canvas** = `zp_canvas` with **`type = 'logicmodel'`** (not `'logicmodelcanvas'`). Verified: `Logicmodelcanvas::CANVAS_NAME = 'logicmodel'`.
+- **Canvas items** = `zp_canvas_items`; stage = `box` ∈ `{lm_inputs, lm_activities, lm_outputs, lm_outcomes, lm_impact}`.
+- **Canvas item fields** — main text = `description`; **assumption / hypothesis** = `assumptions` column (labeled "Evidence" in the LM UI); validation status = `status` (`status_draft`, `status_review`, `status_valid`, `status_hold`, `status_invalid`).
+- **Theory / connection health** = `zp_logicmodel_health` (**plugin-owned**, StrategyPro) — `from_stage` (1–4), `health_status` (`ok|warning|risk`), `assumption_text`, `risk_level`, `evidence_notes`. See §6.7 — must be read via plugin service, never directly from core `ReportEngine`.
+- **Focus areas** = `zp_canvas` `type = 'goalcanvas'`; **goals** = `zp_canvas_items` `box = 'goal'`; cross-project rollup via `$goal->setting === 'linkAndReport'` + `Goalcanvas::getChildGoalsForReporting()` at `ReportEngine.php:231`.
+- **Status / RAG** = `zp_comment` `module = 'project'`, `.status`.
+- **Attributed close** = `zp_tickets.outcomeImpact` on completed milestones.
+- **KPI snapshots** = `zp_goal_history` (v2 delta source; write-only in v1).
+
+---
+
+## 9. States
+
+- **No logic model authored** — the report can't project a chain that doesn't exist. Invite to the Board ("build your logic model to see it read out here") rather than an empty deck.
+- **Stage with no items** — show the stage, empty, with its context (don't hide it; the chain shape is information).
+- **Goal with no history** — render current value, omit the delta (per §6.4).
+- **Coverage cell empty** — ambiguous by honest design; offer "load from Logic Model Inputs," don't assert a gap.
+- **Status not overridden** — provenance reads "from metrics," not blank.
+
+---
+
+## 10. Open items
+
+- **a. Coverage rollup scope — RESOLVED.** Strategy focus areas only. Off-strategy work is a *separate signal*, not a coverage-cell state — it surfaces via the `unalignedColumns` list (`buildCoverageMatrix` already returns it) rendered as an "Off-strategy work" callout beneath the matrix. Same principle as §4's three-lens split: distinct signals stay distinct. The code already produces `unalignedColumns`, so this is a rendering decision, not a query change.
+- **b. Program-level report entry point — RESOLVED.** No wrapper service. Program reports call `ReportEngine::buildReport([$programId, ...descendants], $period)` directly. `PgmPro/Controllers/Report.php` and `PgmPro/Hxcontrollers/Report.php` on `feature/report-screens` already follow this pattern. Add a `PgmPro\Services\ProgramReport` wrapper later only if plugin-specific enrichment (like the LM-canvas overlay `StrategyReport` does) becomes necessary at program level.
+- **c. `ReportEngine` return-key verification — RESOLVED.** Done against `origin/feature/report-screens`; §8 above reflects the actual code, not the earlier design shorthand. Drifts caught: nested `.report` key, missing `programSummaries`/`programUpdates`, `logicModel` nullability, canvas type `'logicmodel'` (not `'logicmodelcanvas'`), field `assumptions` (not `hp-text`).
+- **d. Resources & Coverage page (p3) — scope question, still open.** Two live constraints: (1) `ResourcesGateway` has zero references in `feature/report-screens` today — the p3 resource summary is new integration scope. (2) `buildCoverageMatrix` returns a boolean linkage matrix; the resource-backed **covered/thin/gap** verdict this page targets requires overlaying `getForProjects()` per cell. Decision: **does the report shell ship in v1 with p3 as a placeholder** ("Resource coverage view coming soon"), **or block on p3 landing complete** (gateway wiring + coverage matrix upgrade before shell merges)? Blocking is cleaner UX (no "coming soon" tab in a shipping product); shell-first is faster to get eyes on p1/p2/p4. Product call.
+
+---
+
+## 11. ResourcesGateway seam (consumer side)
+
+> This is the **read-out end** of the same contract the Resource Allocation tab authors. The section below is the frozen contract description, identical in intent to the resource-tab doc's seam section — the report *consumes* what the tab *produces*.
+
+The report's Resources section (page 3) reads through `ResourcesGateway` (`getForProjects` / `getForProgram`), which exposes the summarized form of the four resource blocks: **program context, projects, people totals, budget totals, dependencies summary.**
+
+Invariants the report relies on:
+- The gateway returns the same four-block shape for every program, always — even when a block is empty (empty-but-typed, never a missing key).
+- All aggregates are computed once, upstream of both consumers, so the report and the authoring tab render identical numbers (capacity utilization, per-project rollups, budget spent %, at-risk at `≥90%`, dependency confirmed/tentative). The report **does not recompute**; it reads.
+- Project-identity color is carried in the payload, consistent wherever a project appears.
+- Distinct states are represented in data, not inferred: authored-but-unfilled (stub), empty, untrackable. The report renders these honestly (this is what lets the coverage matrix distinguish "gap" from "unauthored").
+- The report never introduces resource facts the tab could not author.
+
+The report is a pure consumer here. If it needs a resource figure the gateway doesn't expose, that's a gateway change shipped as a pair (gateway + tab + report), never a report-side computation.
+
+---
+
+## 12. Non-negotiables (summary)
+
+- **Live projection, never snapshot** (§6.1) — the defining property.
+- Strategy + program only; project uses existing `/reports/project`.
+- Fits a laptop, no horizontal scroll (`minmax(0,1fr)` everywhere).
+- Three health lenses kept distinct (execution / outcome / theory).
+- Status = computed-default + owner-override, provenance shown.
+- Cards = task-card standard; Outputs/Outcomes fold-out, others lean.
+- Coverage verdict is resource-backed; empty = honestly ambiguous.
+- Resources read from `ResourcesGateway`, never recomputed.
+- Delta v2-gated; design complete without it.
+- Print expands all pages; screen affordances hidden.
+- `zp_logicmodel_health` reached via plugin service; core `ReportEngine` never reads a plugin table directly.
+- Template access uses the actual return shape: `$strategyReport['report']['stats']` (nested), not `$strategyReport['stats']`.

--- a/Docs/content-templates-design-2026-06-04.md
+++ b/Docs/content-templates-design-2026-06-04.md
@@ -1,0 +1,192 @@
+# Generic Content Template System — Design
+
+Draft for Marcel's review. Operationalizing his feedback on the StrategyPro sector-templates work.
+
+## Problem
+
+We have three parallel "template" notions in the codebase today, with different storage, different lifecycles, no shared infrastructure:
+
+1. **Wiki templates** — hardcoded PHP arrays in a Blade view. One HTML blob per template (Meeting Notes, PRD). Inserted into the TipTap editor.
+2. **Blueprints' `TemplateRegistry`** — YAML definitions for canvas types (SWOT, Lean, OBM). These declare the SCHEMA of a canvas type — which boxes exist, their icons, their titles.
+3. **StrategyPro Logic Model sector fixtures** — JSON files. Pre-populate an LM board with example items by sector. Built in the StrategyPro plugin.
+
+The first two predate the LM work. The third is new and currently plugin-side. Marcel's read on the recent sector-templates work: don't bake this into Blueprints' registry, but build a **generic file-based content-template system** that handles "canvas-typed" content (LM, goals, lean canvas, etc.) AND wikis, with Blueprints optionally referencing content templates rather than owning them. Vision: standardized format enables a future marketplace where users export their boards/wikis as importable templates.
+
+## Marcel's vision (verbatim)
+
+> "Would this be a concept we would repeat in other blueprints? Technically wiki templates could follow the same infrastructure. I don't think that I would make that part of the primary blueprint template but probably a file based template system that can be used for 'canvas typed' content. (even cross applying to goals for example: defining quarterly goals for startup or so or wikis with predefined content and multi page wikis). So I would think it's somewhere in between A & B? 'A' (the blueprint templates) could still have a reference to the start content template and load it with it. Or it's a secondary step in the process. think it's actually a good idea. What if we start offering a template marketplace? If we have a standardized format users can export their stuff as templates and put them on this marketplace. Could be lean canvas examples or so. But also wikis/wiki structures with pre-pared articles etc."
+
+## Scope
+
+### In scope
+- A core domain for content templates (probably `app/Domain/ContentTemplates/`).
+- File-based storage with a registry service.
+- A schema that handles two consumer categories today: **canvas-typed items** (LM, goals, lean canvas, etc.) and **wiki content** (single article or multi-page tree).
+- A plugin extension API so plugins can register their own templates without touching core (StrategyPro's LM sector templates being the first user).
+- Migration path for the existing systems.
+
+### Out of scope
+- Marketplace UI itself (the schema is designed to enable it; building it is a separate effort).
+- Versioning of applied content (if a template's definition changes after a user applied it, the user's data is untouched — they're snapshots at apply time).
+- Project-scoped templates (per-org, per-user, etc.). v1 is system-wide. Per-scope filtering can layer on later.
+- Replacing Blueprints' canvas-type definitions. Those stay as-is and describe SCHEMA. Content templates describe SEED CONTENT.
+
+## Shape
+
+### Storage
+
+YAML files on disk, mirroring `Blueprints/Templates/definitions/*.yaml` so the pattern is familiar. Directory layout:
+
+```
+app/Domain/ContentTemplates/Library/
+├── logicmodel/
+│   ├── education-k12.yaml
+│   ├── community-health.yaml
+│   ├── workforce-development.yaml
+│   └── ...
+├── goal/
+│   ├── startup-quarterly.yaml
+│   └── ...
+├── leancanvas/
+│   └── ...
+└── wiki/
+    ├── meeting-notes.yaml
+    ├── prd.yaml
+    └── ...
+```
+
+Plugins can register additional library roots. StrategyPro's existing JSON fixtures get migrated to YAML and placed in `app/Plugins/StrategyPro/ContentTemplates/logicmodel/`, registered via the plugin's `register.php`.
+
+### Schema
+
+Single base shape with consumer-specific payload. The `appliesTo` field tells the registry which applier to use.
+
+```yaml
+key: "education-k12"                       # unique within (appliesTo, key)
+title: "K-12 Education Program"
+description: "After-school and tutoring programs improving student outcomes."
+
+appliesTo: "logicmodel"                    # canvas type or "wiki"
+sector: "education"                        # optional tag for grouping
+icon: "fa-graduation-cap"                  # optional, for UI selectors
+author: "Leantime"                         # for marketplace attribution
+version: "1.0.0"                           # for marketplace versioning
+license: "CC0"                             # for marketplace licensing
+
+# ── For canvas-typed content (LM, goal, lean, etc.) ──
+canvas:
+  items:
+    - box: "lm_inputs"
+      title: "Federal Title I funding"
+      description: "Annual allocation for supplemental educational services in high-need schools."
+      status: "status_draft"
+    # ...
+
+# ── For wiki content ──
+wiki:
+  articles:
+    - title: "Project Overview"
+      content: "<h1>...</h1>"
+      children:
+        - title: "Subtopic A"
+          content: "..."
+```
+
+Only ONE of `canvas:` or `wiki:` is present per template (determined by `appliesTo`).
+
+### Registry
+
+`ContentTemplateRegistry` service in core, mirroring `Blueprints/Services/TemplateRegistry`:
+
+```php
+namespace Leantime\Domain\ContentTemplates\Services;
+
+class ContentTemplateRegistry
+{
+    /** Get a single template by appliesTo + key */
+    public function get(string $appliesTo, string $key): ?ContentTemplate;
+
+    /** All templates for a canvas type or "wiki" */
+    public function forAppliesTo(string $appliesTo): array;
+
+    /** All templates across all appliesTo */
+    public function all(): array;
+
+    /** Register an additional library root (plugin extension point) */
+    public function registerLibraryRoot(string $absolutePath): void;
+}
+```
+
+### Appliers
+
+The registry holds DEFINITIONS. Applying a template to a target is a separate concern, one applier per target type:
+
+- `CanvasItemsApplier::apply(int $canvasId, ContentTemplate $tpl, array $opts): int`
+  - Inserts canvas_items rows. Handles add/replace/cancel like StrategyPro's existing `loadFixture` flow.
+- `WikiApplier::apply(int $wikiId, ContentTemplate $tpl, array $opts): int`
+  - Inserts article rows, handles multi-page nesting.
+
+Appliers are registered by their domain (Canvas domain registers the canvas applier, Wiki domain registers the wiki applier). The registry routes by `appliesTo`.
+
+### Plugin extension API
+
+In a plugin's `register.php`:
+
+```php
+app(\Leantime\Domain\ContentTemplates\Services\ContentTemplateRegistry::class)
+    ->registerLibraryRoot(__DIR__ . '/ContentTemplates');
+```
+
+Plugin's library directory mirrors the core layout (e.g., `StrategyPro/ContentTemplates/logicmodel/*.yaml`). The registry scans all registered roots at boot and merges.
+
+## Migration path
+
+Phased so nothing breaks at once:
+
+| Phase | Move | Risk |
+|---|---|---|
+| 1 | Build `ContentTemplates` core domain (registry + canvas applier + wiki applier + base library directory). No consumers yet. | Low — pure addition. |
+| 2 | Migrate StrategyPro's 5 sector JSON fixtures to YAML in the plugin's `ContentTemplates/logicmodel/`. Plugin's `register.php` registers the library root. Delete `BoardTemplate` HxController's bespoke loader; call the core applier instead. Selector partial reads from the registry. | Medium — touches a working flow but it's plugin-scoped. |
+| 3 | Migrate Wiki templates from hardcoded PHP arrays in `Wiki/Templates/templates.blade.php` to YAML files in `app/Domain/ContentTemplates/Library/wiki/`. Wiki controller reads from the registry. Drop the hardcoded arrays. | Medium — touches user-facing wiki feature. Translator-touched content; rename keys carefully. |
+| 4 | Optional: Blueprints' YAML definitions get a `startContent:` field that references a content-template key. When a user creates a new SWOT or Lean Canvas, the registered start content (if any) auto-applies on creation. | Low — Blueprints registry stays as-is, just gains a hook. |
+
+Each phase is shippable independently.
+
+## Marketplace alignment
+
+Standardized format unlocks export/import without much additional design:
+
+- **Export**: any user's board or wiki can serialize to the same YAML shape. UI button on the board/wiki: "Save as template" → produces a downloadable .yaml or .zip of yamls.
+- **Import**: drop a .yaml in a library directory (manual today, marketplace UI later) and it's discoverable.
+- **Marketplace plugins**: bundle template packs as plugin assets. Plugin's `ContentTemplates/` directory is auto-registered. Buying a "Nonprofit Strategy Bundle" plugin gets you 20 LM templates + 10 wiki templates + 5 goal templates.
+- **Attribution + licensing**: `author`, `version`, `license` fields in the YAML carry through, surface in the selector UI.
+
+## Open questions for Marcel
+
+1. **YAML vs JSON**: Blueprints uses YAML, StrategyPro uses JSON. Picking YAML for the new system aligns with the existing core precedent and reads cleaner for content. Agreed?
+2. **Library directory naming**: `ContentTemplates/Library/` vs `ContentTemplates/Definitions/` (matching Blueprints' `Templates/definitions/`)? Slight preference for `Library` since "definitions" reads as schema/structure to me.
+3. **`appliesTo` taxonomy**: should it be free-form strings ("logicmodel", "wiki", "leancanvas", "goal") or an enum? Free-form is easier for plugins to add canvas types, enum is safer. Recommend free-form for v1.
+4. **Add/Replace/Cancel default behavior on existing content**: StrategyPro's current flow surfaces a 3-option confirmation when the target has items. Carry this forward as the applier's default? Or apply-time option?
+5. **Per-language content**: should templates themselves be translatable, or is the user expected to translate after applying? Recommend latter — templates are starter content, user customizes anyway.
+6. **Versioning of applied content**: if a template definition changes after a user applied it, the user's data is untouched (no auto-update). Confirming this is the right call for v1 — it matches the generator pattern (Rails scaffold, etc.).
+7. **Permissions**: who can apply a template — editor? owner? Same as creating a board today? Default: anyone who can edit the target canvas/wiki can apply.
+
+## What this changes about the in-flight work
+
+- **StrategyPro PR #46 doesn't need to wait**. The sector-template work that landed there is plugin-scoped and uses internal interfaces — it remains the v1 user-facing experience. Phase 2 of this design (migrate StrategyPro's fixtures to the core registry) ships AFTER this design is approved and Phase 1 of the core domain is built.
+- The per-sector icon polish I had uncommitted gets re-applied as part of Phase 2 cleanup, in the new directory layout.
+- No core PR opens until this design is approved.
+
+## Recommendation
+
+Approve the broad shape, then sequence:
+
+- Phase 1 (~2-3 days): core `ContentTemplates` domain + registry + canvas applier + wiki applier + plumbing tests.
+- Phase 2 (~1-2 days): StrategyPro migration. Stops at parity with what we have today.
+- Phase 3 (~1-2 days): Wiki migration. Adds genuine new UX since wiki templates today are inflexible.
+- Phase 4 (~0.5 day): Blueprints' optional `startContent:` reference.
+- Marketplace surfaces: separate roadmap entry, not part of this design.
+
+Total: roughly a week of focused work, ships as four independent PRs.
+
+What's the read?

--- a/Docs/emboss-leantime-mapping.md
+++ b/Docs/emboss-leantime-mapping.md
@@ -1,0 +1,111 @@
+# Emboss ↔ Leantime Data Model Mapping
+
+## The Core Translation
+
+| Leantime Entity | Emboss Row Type | Visual Treatment |
+|---|---|---|
+| **Milestone** | `phase` | Colored thin bar spanning children, collapsible, sidebar pill with chevron |
+| **Task** | `task` | Glass bar with progress fill, drag handles, status coloring |
+| **Subtask** | `subtask` | Smaller glass bar (barHeight - 6px), indented, inherits parent color at 70% |
+
+## What About Diamonds?
+
+The diamond (`type: 'milestone'` in the current spec) becomes **optional deadline markers**. They represent a point-in-time checkpoint — not a container.
+
+In Leantime terms, a diamond could represent:
+- A due date for a milestone group (e.g., "Design Review deadline")
+- A sprint boundary or release date
+- An external dependency date
+
+**Rename in the "+" menu:**
+- ~~Add Milestone~~ → **Add Deadline** (creates a diamond row)
+- "Add Milestone" → creates a `phase` (collapsible group), matching Leantime's terminology
+
+## "+" Menu Options (Leantime Context)
+
+| Menu Item | Creates | Emboss Row Type |
+|---|---|---|
+| **Add Milestone** | A new collapsible group | `phase` |
+| **Add Task** | A task under the current milestone | `task` |
+| **Add Deadline** | A diamond date marker | `milestone` (diamond) |
+
+## Field Mapping
+
+### Leantime Milestone → Emboss Phase Row
+
+```typescript
+{
+  id: leantime.milestone.id,
+  type: 'phase',
+  name: leantime.milestone.headline,
+  depth: 0,
+  parentId: null,
+  collapsed: false,
+  hidden: false,
+  start: dayOffset(leantime.milestone.editFrom),
+  duration: daysBetween(editFrom, editTo),
+  progress: computedFromChildren,  // average or weighted
+  status: derivedFromChildren,
+  dependencies: [],
+  phaseColor: leantime.milestone.color || autoAssign,
+  phaseName: leantime.milestone.headline,
+  children: leantime.milestone.tasks.map(t => t.id)
+}
+```
+
+### Leantime Task → Emboss Task Row
+
+```typescript
+{
+  id: leantime.task.id,
+  type: 'task',
+  name: leantime.task.headline,
+  depth: 1,
+  parentId: leantime.task.milestoneId,
+  collapsed: false,
+  hidden: false,
+  start: dayOffset(leantime.task.editFrom),
+  duration: daysBetween(editFrom, editTo),
+  progress: leantime.task.percentDone || 0,
+  status: mapStatus(leantime.task.status),
+  dependencies: leantime.task.dependingTicketId ? [leantime.task.dependingTicketId] : [],
+  assignee: leantime.task.editorFirstname,
+  assigneeColor: hashToColor(leantime.task.editorId)
+}
+```
+
+### Leantime Subtask → Emboss Subtask Row
+
+```typescript
+{
+  id: leantime.subtask.id,
+  type: 'subtask',
+  name: leantime.subtask.headline,
+  depth: 2,
+  parentId: leantime.subtask.parentTicketId,
+  // ... same pattern, smaller visual treatment
+}
+```
+
+## Status Mapping
+
+| Leantime Status | Emboss Status |
+|---|---|
+| `NEW`, `OPEN`, `BLOCKED` | `upcoming` |
+| `IN_PROGRESS`, `WAITING` | `active` |
+| `DONE`, `CLOSED` | `done` |
+
+## Implications for the Build
+
+1. **Rename internally:** The `type: 'milestone'` row type keeps its diamond rendering, but in Leantime-facing UI it's called "Deadline"
+2. **"Add Milestone" in Leantime creates a phase:** The "+" menu labels match Leantime vocabulary
+3. **Phase progress is computed:** Roll up from children's progress, not set directly
+4. **Phase dates are computed:** Span from earliest child start to latest child end
+5. **The demo should use Leantime terminology** in the sidebar labels and creation menu
+
+## What This Doesn't Change
+
+- The Emboss engine is terminology-agnostic — it works with row types, not business labels
+- The extension API stays the same
+- Other integrations (Jira, Asana, Monday) can map their own terms to the same row types
+- The diamond visual is still useful — it just serves a different purpose than "Leantime milestone"

--- a/Docs/leantime-4.0-dev-unique-changes.md
+++ b/Docs/leantime-4.0-dev-unique-changes.md
@@ -1,0 +1,318 @@
+# Leantime Codebase Changes: v3.6.2 → 4.0-dev
+
+## Forward-Porting Reference Document
+
+**Scope:** 752 commits | 929 files changed | 5 contributors
+**Comparison:** `v3.6.2...4.0-dev` (everything on 4.0-dev NOT yet in v3.6.2)
+**Purpose:** Catalog of YOUR component development work that needs to be forward-ported onto the current v3.6.2 codebase
+**Generated:** February 12, 2026
+
+---
+
+## Context: What IS the 4.0-dev Branch?
+
+Per the [Leantime roadmap discussion (#2696)](https://github.com/Leantime/leantime/discussions/2696), the 4.0-dev branch is the next major version with four pillars:
+
+1. **🧱 Component System** — DaisyUI as base theme, Blade components for all HTML elements
+2. **⚡ HTMX Everywhere** — Server-side rendering with HTMX replacing custom JS
+3. **📦 JS Module Conversion** — All custom JS converted to ES modules, webpack improvements
+4. **🏗️ Deeper Laravel Core Migration** — Further replacement of custom classes with Laravel equivalents
+
+The branch diverged from mainline around early-mid 2024 (pre-v3.2.0). Since then, mainline has received **20+ releases** (v3.2.0 → v3.6.2) with their own significant changes, which is why this forward-port is necessary.
+
+---
+
+## ⚠️ CRITICAL: What v3.6.2 Changed UNDER You
+
+While 4.0-dev was being developed, mainline made these **breaking changes** that will cause merge conflicts:
+
+### Session Management (v3.2.0)
+- All `$_SESSION` access replaced with Laravel session facade across the ENTIRE codebase
+- **Impact on 4.0-dev:** Any 4.0-dev file that still uses `$_SESSION` will need updating
+
+### File Management System (v3.5.4)
+- `app/Core/Files/Fileupload.php` was **DELETED** (429 lines)
+- Replaced by new `app/Core/Files/FileManager.php` (356 lines) using Laravel file storage
+- New `FileManagerInterface`, `FileValidationException`, `filesystems.php` config
+- **Impact on 4.0-dev:** If your branch modified or depends on `Fileupload.php`, those changes are lost
+
+### Canvas Domain (v3.4.12)
+- All Canvas controllers massively refactored
+- Canvas repository (~1,215 lines changed), service (~456 lines changed)
+- **Impact on 4.0-dev:** If you componentized Canvas views, the underlying controllers/services changed
+
+### String Utilities (v3.5.7)
+- `StrMacros.php` deleted, replaced with 5 individual classes in `Core/Support/String/`
+- **Impact on 4.0-dev:** Any imports of StrMacros need updating
+
+### Event System
+- `DispatchesEvents` trait significantly refactored (v3.4.12)
+- `EventDispatcher` enhanced with new methods (v3.5.6–v3.5.7)
+- `dispatchFilter` now returns values instead of echoing
+- **Impact on 4.0-dev:** Event dispatch/filter calls may behave differently
+
+### Plugin System (v3.4.11–v3.5.8)
+- New `RouteLoader.php` for plugin/module route files
+- PHAR file support for plugins
+- Plugin marketplace integration
+- ConsoleKernel expanded for plugin command loading
+- **Impact on 4.0-dev:** Plugin hooks and loading behavior changed
+
+### New Files Added in v3.6.2 (Not in 4.0-dev)
+```
+app/Core/Files/FileManager.php (NEW — replaces Fileupload.php)
+app/Core/Files/Contracts/FileManagerInterface.php
+app/Core/Files/Exceptions/FileValidationException.php
+app/Core/Routing/RouteLoader.php
+app/Core/Plugins/Plugins.php
+app/Core/Support/String/AlphaNumeric.php
+app/Core/Support/String/BeautifyFilename.php
+app/Core/Support/String/SanitizeFilename.php
+app/Core/Support/String/SanitizeForLLM.php
+app/Core/Support/String/ToMarkdown.php
+app/Core/Support/Attributes/AITool.php
+app/Command/CleanupOrphanedFilesCommand.php
+app/Domain/Files/Events/FileUploaded.php
+app/Domain/Help/Controllers/Support.php
+app/Domain/Plugins/Hxcontrollers/Marketplaceplugins.php
+app/Domain/Widgets/Templates/partials/myToDosLoadMore.blade.php
+config/filesystems.php
+CLAUDE.md
+.claude/commands/conversation-analysis-system.md
+.junie/guidelines.md
+```
+
+### Files Deleted in v3.6.2 (May still exist in 4.0-dev)
+```
+app/Core/Files/Fileupload.php (DELETED — replaced by FileManager)
+app/Core/Support/StrMacros.php (DELETED — replaced by individual String classes)
+public/download.php (DELETED)
+public/js/libs/tinymce-plugins/llamadorian/plugin.js (RENAMED to aiTools)
+```
+
+---
+
+## 🧱 4.0-DEV PILLAR 1: COMPONENT SYSTEM (DaisyUI + Blade Components)
+
+This is the **largest body of work** on 4.0-dev — the complete UI componentization.
+
+### What It Includes
+- **DaisyUI integration** as the base CSS component framework (replacing custom CSS)
+- **Blade components** for all standard HTML elements (buttons, forms, cards, modals, etc.)
+- New `app/Views/Components/` directory tree with reusable Blade components
+- Component-based templates replacing inline HTML across all domain views
+- Consistent theming through DaisyUI theme variables
+- Dramatically reduced CSS/JS footprint through component reuse
+
+### Expected File Impact (929 files, ~80% estimated to be component work)
+- **New directory:** `app/Views/Components/` — entire component library
+- **Modified:** Every `.blade.php` template across all domains refactored to use components
+- **Modified:** `webpack.mix.js` / build pipeline for DaisyUI/Tailwind
+- **Modified:** `package.json` — DaisyUI, Tailwind CSS dependencies added
+- **Modified:** CSS files — massive reduction as styles move to components
+- **New/Modified:** Tailwind config (`tailwind.config.js`)
+- **Modified:** Layout templates (`app.blade.php`, `header.blade.php`, etc.)
+
+### High-Conflict Zones
+These template/view files were ALSO modified in v3.6.2 and will have conflicts:
+
+| Area | v3.6.2 Changes | 4.0-dev Changes | Conflict Risk |
+|------|---------------|-----------------|---------------|
+| Widget templates (MyToDos) | Rewritten with infinite scroll | Componentized with DaisyUI | 🔴 HIGH |
+| Ticket/Kanban templates | Preloading, load more, drag-drop | Componentized | 🔴 HIGH |
+| Layout templates | Premium links removed, header/footer updated | Componentized | 🟡 MEDIUM |
+| Canvas templates | Controllers refactored, views updated | Componentized | 🟡 MEDIUM |
+| Menu templates | Plugin marketplace links, composer changes | Componentized | 🟡 MEDIUM |
+| Project selector | CSS fixes, hxcontroller updates | Componentized | 🟡 MEDIUM |
+| File management views | New FileManager UI | Componentized | 🔴 HIGH |
+| Auth/Login templates | Updated login info | Componentized | 🟢 LOW |
+
+---
+
+## ⚡ 4.0-DEV PILLAR 2: HTMX EXPANSION
+
+### What It Includes
+- Extended HTMX usage across pages that previously used traditional form submissions
+- New `hx-*` attributes on componentized templates
+- Server-side rendered partials replacing JavaScript-rendered content
+- HTMX-based navigation and partial page updates
+- New Hxcontroller classes for additional domains
+
+### Expected File Impact
+- **Modified:** Hxcontrollers across all domains
+- **New:** Additional Hxcontroller classes for domains that didn't have them
+- **Modified:** All `.blade.php` templates with HTMX attributes
+- **Modified:** Route definitions for HTMX partial endpoints
+
+### Conflict Zones
+- v3.6.2 added its own HTMX improvements (MyToDos infinite scroll, load more)
+- v3.6.2 enhanced HTMX event management (v3.4.12)
+- The approach may differ between branches
+
+---
+
+## 📦 4.0-DEV PILLAR 3: JS MODULE CONVERSION
+
+### What It Includes
+- Custom JavaScript files converted from IIFE/globals to ES modules
+- `import`/`export` syntax throughout JS codebase
+- Webpack configuration updates for module bundling
+- Removal of global scope pollution
+- Better tree-shaking and code splitting
+
+### Expected File Impact
+- **Modified:** All files in `public/js/` and custom JS controllers
+- **Modified:** `webpack.mix.js` — significant build pipeline changes
+- **Modified:** `package.json` — new build dependencies, scripts
+- **Modified:** JS controllers referenced in templates
+
+### Conflict Zones
+| File/Area | v3.6.2 Change | 4.0-dev Change |
+|-----------|--------------|----------------|
+| TinyMCE plugins | Renamed `llamadorian` → `aiTools` (v3.5.6) | Likely modularized |
+| Ticket JS controller | Updated (v3.5.6) | Modularized |
+| Confetti management | Updated | Modularized |
+| Webpack config | Updated (v3.5.6) | Significantly rewritten |
+
+---
+
+## 🏗️ 4.0-DEV PILLAR 4: DEEPER LARAVEL MIGRATION
+
+### What It Includes
+- Continued replacement of custom Leantime classes with Laravel equivalents
+- Extended service container usage
+- More Laravel middleware adoption
+- Deeper Eloquent integration where applicable
+- Laravel-style configuration patterns
+
+### Expected File Impact
+- **Modified:** `app/Core/` classes — Application, Bootloader, Bootstrap files
+- **Modified:** Service providers
+- **Modified:** Configuration files
+- **Modified:** Middleware stack
+
+### Conflict Zones
+v3.6.2 also continued Laravel migration, creating parallel evolution:
+
+| Core Area | v3.6.2 State | 4.0-dev State |
+|-----------|-------------|---------------|
+| Session management | Fully Laravel (v3.2.0) | May have own implementation |
+| File storage | Laravel FileManager (v3.5.4) | May use Fileupload.php still |
+| Database | Laravel improvements (v3.5.3) | Own DB layer changes |
+| Configuration | `laravelConfig.php` expanded | Own config changes |
+| HTTP Kernel | Updated (v3.5.7) | Own kernel changes |
+| Console Kernel | PHAR support (v3.5.8) | Own CLI changes |
+| Event Dispatcher | Enhanced (v3.5.6-7) | Own event changes |
+
+---
+
+## 📋 RECOMMENDED FORWARD-PORT STRATEGY
+
+### Phase 1: Assess Actual Divergence
+Run locally to get the real picture:
+```bash
+# See what 4.0-dev changed
+git diff v3.6.2...4.0-dev --stat
+
+# See conflicts specifically in templates
+git diff v3.6.2...4.0-dev --stat -- '*.blade.php'
+
+# See conflicts in Core
+git diff v3.6.2...4.0-dev --stat -- 'app/Core/'
+
+# See new files only on 4.0-dev
+git diff v3.6.2...4.0-dev --diff-filter=A --name-only
+
+# See files modified on BOTH branches (highest conflict risk)
+comm -12 \
+  <(git diff $(git merge-base v3.6.2 4.0-dev)...v3.6.2 --name-only | sort) \
+  <(git diff $(git merge-base v3.6.2 4.0-dev)...4.0-dev --name-only | sort)
+```
+
+### Phase 2: Rebase or Cherry-Pick
+
+**Option A: Rebase 4.0-dev onto v3.6.2** (cleanest but most work)
+```bash
+git checkout 4.0-dev
+git rebase v3.6.2
+# Resolve ~hundreds of conflicts
+```
+
+**Option B: Create fresh branch, cherry-pick component work** (recommended)
+```bash
+git checkout -b 4.0-dev-rebased v3.6.2
+
+# Cherry-pick ONLY the component/UI commits (skip infrastructure that v3.6.2 already has)
+git log v3.6.2...4.0-dev --oneline | grep -i "component\|daisyui\|htmx\|module"
+# Cherry-pick those commits
+```
+
+**Option C: Manual merge with strategic conflict resolution**
+```bash
+git checkout -b 4.0-dev-merged v3.6.2
+git merge 4.0-dev --no-commit
+# Resolve conflicts file by file, favoring v3.6.2 for Core/ and 4.0-dev for Views/Components/
+```
+
+### Phase 3: Conflict Resolution Priority
+
+| Priority | Area | Strategy |
+|----------|------|----------|
+| 1 | `app/Core/` | **Favor v3.6.2** — it has newer infrastructure (FileManager, session, events) |
+| 2 | `app/Views/Components/` | **Favor 4.0-dev** — this is YOUR new work |
+| 3 | `*.blade.php` templates | **Manual merge** — take 4.0-dev components but apply v3.6.2 logic changes |
+| 4 | JS/Webpack | **Favor 4.0-dev** for module structure, add back v3.6.2 aiTools rename |
+| 5 | CSS/Tailwind | **Favor 4.0-dev** for DaisyUI, verify v3.6.2 CSS removals still apply |
+| 6 | `package.json`/`composer.json` | **Manual merge** — combine dependencies from both |
+| 7 | Domain Services/Repos | **Favor v3.6.2** for bug fixes, add 4.0-dev changes on top |
+| 8 | Tests | **Favor v3.6.2** for new tests (FileManagerTest), add 4.0-dev component tests |
+
+### Phase 4: Validation Checklist
+After merging:
+- [ ] `composer install` succeeds
+- [ ] `npm install && npm run dev` succeeds
+- [ ] DaisyUI components render correctly
+- [ ] HTMX interactions work
+- [ ] File upload/management works (uses new FileManager, not old Fileupload)
+- [ ] Session management works (Laravel sessions)
+- [ ] Plugin system works (route loader, PHAR support)
+- [ ] API authentication works (non-jsonrpc paths)
+- [ ] Canvas boards work (refactored controllers)
+- [ ] Widget dashboard works (MyToDos infinite scroll + components)
+- [ ] All existing unit tests pass
+- [ ] Acceptance tests pass
+
+---
+
+## 🔴 TOP 10 HIGHEST-RISK COLLISION ZONES
+
+Ranked by likelihood of painful merge conflicts:
+
+1. **Widget/Dashboard Templates** — v3.6.2 rewrote MyToDos with infinite scroll; 4.0-dev componentized it
+2. **File Management** — v3.6.2 replaced entire system; 4.0-dev may still reference old one
+3. **Webpack/Build Pipeline** — both branches modified significantly
+4. **Layout Templates** — both branches made structural changes
+5. **Ticket/Kanban Views** — v3.6.2 added features; 4.0-dev componentized
+6. **Core Infrastructure** — parallel Laravel migration work on both branches
+7. **Event System** — both branches modified dispatch behavior
+8. **CSS/Styles** — v3.6.2 removed transitions, dark theme fixes; 4.0-dev replaced with DaisyUI
+9. **Plugin System** — v3.6.2 added routing, PHAR, marketplace; 4.0-dev may have own plugin hooks
+10. **package.json / composer.json** — dependency trees diverged significantly
+
+---
+
+## 📊 SCALE SUMMARY
+
+| Metric | Value |
+|--------|-------|
+| Commits on 4.0-dev not in v3.6.2 | **752** |
+| Files changed | **929** |
+| Contributors | **5** |
+| Estimated component/UI files | ~700+ (75%+) |
+| Estimated infrastructure files | ~150+ |
+| Estimated config/build files | ~50+ |
+| Releases between branch point and v3.6.2 | **20+** (v3.2.0-beta → v3.6.2) |
+
+---
+
+*This document was compiled from the GitHub comparison page (v3.6.2...4.0-dev), the Leantime 4.0 roadmap discussion (#2696), release notes for v3.2.0 through v3.6.2, and commit log analysis. For exact file-by-file diffs, run `git diff v3.6.2...4.0-dev` locally as GitHub cannot render this comparison (too large).*

--- a/Docs/leantime-design-system-claude-code-prompt.md
+++ b/Docs/leantime-design-system-claude-code-prompt.md
@@ -1,0 +1,449 @@
+# Leantime Design System — Claude Code Implementation Prompt
+
+**For Claude Code Execution**
+
+| Field | Value |
+|---|---|
+| Project | Leantime |
+| Scope | Codebase-wide visual equalization, theming, accessibility |
+| Source of Truth | `leantime-design-system-requirements.md` — **all design decisions are there** |
+| Token Reference | `docs/14-DESIGN-TOKENS.md` — update this first, then reference it |
+| Risk | LOW per sweep (small, testable changes) |
+| Approach | One sweep at a time. Never batch multiple categories. |
+
+---
+
+## Pre-Read (Required)
+
+Before writing any code, read these files in order:
+
+1. `CLAUDE.md` — project conventions
+2. `leantime-design-system-requirements.md` — **every design decision, confirmed and final**
+3. `docs/14-DESIGN-TOKENS.md` — current token definitions (will be updated in Sweep 0)
+4. Skim `app/Views/Templates/components/` to understand Blade component structure
+5. Confirm `tw:` prefix convention in one existing component
+
+---
+
+## Brand Palette (memorize these)
+
+```
+accent1:      #004766  (deep teal)     — primary, nav, buttons, links, info
+accent2:      #00B893  (emerald)       — secondary, success, gradients, progress
+accent3:      #CADE1B  (chartreuse)    — fills/backgrounds ONLY, never text on white
+accent3-text: #A8B516  (dark chartreuse) — warning text, large text only
+accent4:      #F61067  (hot pink)      — danger, error, destructive actions
+accent4-soft: #C84D7C  (softened pink) — stageflow s4, muted danger contexts
+```
+
+**Semantic mapping:** Success=accent2, Danger=accent4, Warning=accent3-text, Info=accent1
+
+**Old colors being replaced:**
+- `#1b75bb` (old accent1) → `var(--accent1)` `#004766`
+- `#81B1A8` (old accent2) → `var(--accent2)` `#00B893`
+- `#1B75BB` variants → `var(--accent1)`
+
+---
+
+## Critical Constraints
+
+### DO
+
+- Work one sweep at a time — complete it, test it, confirm before starting the next
+- Use exact token values from the requirements document
+- Use `tw:` prefix for all Tailwind classes
+- Use CSS custom properties for ALL theme-layer colors
+- Produce a summary report after each sweep
+- Test in both light and dark mode after color changes
+- Preserve existing visual appearance while normalizing underlying values
+- Add accessibility attributes (aria-label, roles, focus styles) as you encounter gaps
+
+### DO NOT
+
+- Change multiple categories in one sweep
+- Invent new tokens not in the requirements doc — flag them instead
+- Remove existing functionality or change component behavior
+- Touch theme definition files (those define the custom properties) — except in Sweep 0
+- Touch third-party CSS
+- Touch files being actively rewritten by other contributors
+- Make cosmetic changes to pages scheduled for full redesign
+- Use `#1b75bb` or `#81B1A8` anywhere — these are the OLD palette
+
+---
+
+## Sweep 0: Update Token Reference Document
+
+**Goal:** Update `docs/14-DESIGN-TOKENS.md` to match the requirements doc. This makes it the canonical in-codebase reference.
+
+### Changes needed:
+1. Replace old palette (`#1b75bb`, `#81B1A8`) with new 4-accent system
+2. Add `--accent3`, `--accent3-text`, `--accent4`, `--accent4-soft` token definitions
+3. Update semantic color mapping table
+4. Add glass treatment tokens (`--glass-bg`, `--glass-border`, `--glass-inset`)
+5. Update typography tokens (Hanken Grotesk, weight scale 450–800)
+6. Add stageflow stage color definitions (s1–s5)
+7. Verify spacing, radius, shadow tokens match requirements doc
+
+### Also update:
+- Add accent3/accent4 to theme system in `app/Core/UI/Theme.php`
+- Add new tokens to `public/theme/default/theme.ini` and `public/theme/minimal/theme.ini`
+
+### Test:
+- Themes still load correctly
+- Color picker still works for accent1/accent2
+- No console errors
+
+---
+
+## Sweep 1: Hardcoded Brand Colors
+
+**Goal:** Every instance of old brand hex values becomes CSS custom properties.
+
+### Find
+
+```bash
+grep -rn "#1b75bb\|#1B75BB\|#81B1A8\|#81b1a8\|#004666\|#00a887" \
+  app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css" --include="*.js"
+```
+
+Also search for the new palette values that might be hardcoded instead of tokenized:
+```bash
+grep -rn "#004766\|#00B893\|#CADE1B\|#F61067\|#A8B516" \
+  app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css" --include="*.js"
+```
+
+### Fix
+
+| Found | Replace with |
+|-------|-------------|
+| `#1b75bb` / `#1B75BB` / `#004666` / `#004766` in CSS | `var(--accent1)` |
+| `#81B1A8` / `#81b1a8` / `#00a887` / `#00B893` in CSS | `var(--accent2)` |
+| `#CADE1B` in CSS backgrounds | `var(--accent3)` |
+| `#A8B516` in CSS text | `var(--accent3-text)` |
+| `#F61067` in CSS | `var(--accent4)` |
+| `tw:text-[#1b75bb]` | `tw:text-[var(--accent1)]` |
+| `style="color: #1b75bb"` | `style="color: var(--accent1)"` |
+| JS dynamic styling | `getComputedStyle(document.documentElement).getPropertyValue('--accent1')` |
+
+### Exclude
+
+- Theme definition files where these ARE the default values being set
+- Comments or documentation
+- SVG files with baked-in colors (flag for later)
+
+### Test
+
+```javascript
+// In browser console — swap accents and verify nothing stays old color
+document.documentElement.style.setProperty('--accent1', '#E65100');
+document.documentElement.style.setProperty('--accent2', '#FFB74D');
+// Scan every changed page — nothing should remain the old blue/teal
+```
+
+---
+
+## Sweep 2: Hardcoded Neutral Colors
+
+**Goal:** Background, text, and border hex values become CSS custom properties for dark mode.
+
+### Find
+
+```bash
+# Hardcoded white backgrounds
+grep -rn "background:\s*#[Ff][Ff][Ff]\|background-color:\s*#[Ff][Ff][Ff]\|background:\s*white" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded dark text
+grep -rn "color:\s*#1[Aa]1[Aa]2[Ee]\|color:\s*#333\|color:\s*#222\|color:\s*#000" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css"
+
+# Hardcoded borders
+grep -rn "border.*:\s*.*#[EeFf][0-9A-Fa-f]" \
+  app/Views/ app/Plugins/ --include="*.blade.php" --include="*.css" | head -40
+```
+
+### Fix
+
+| Hardcoded | Token |
+|---|---|
+| `#FFFFFF`, `white` (backgrounds) | `var(--color-bg-card)` |
+| `#F8F9FB`, `#f5f5f5`, `#fafafa` (page bg) | `var(--color-bg-page)` |
+| `#F0F1F3`, `#f0f0f0`, `#eee` (muted bg) | `var(--color-bg-muted)` |
+| `#F3F4F6` (hover bg) | `var(--color-bg-hover)` |
+| `#1A1A2E`, `#333`, `#222`, `#000` (dark text) | `var(--color-text-primary)` |
+| `#4B5563`, `#555`, `#666` (body text) | `var(--color-text-secondary)` |
+| `#9CA3AF`, `#999`, `#aaa` (muted text) | `var(--color-text-muted)` |
+| `#D1D5DB`, `#ccc`, `#ddd` (disabled text) | `var(--color-text-disabled)` |
+| `#E8ECF0`, `#e0e0e0`, `#ddd` (borders) | `var(--color-border-default)` |
+| `#F0F1F3` (light borders) | `var(--color-border-light)` |
+
+If a color doesn't map cleanly, flag it — don't guess.
+
+### Test
+
+```javascript
+document.documentElement.classList.add('theme-dark');
+// Check: no white rectangles, no invisible text, borders visible
+```
+
+---
+
+## Sweep 3: Dark Mode Verification
+
+**Goal:** Systematically check every major page/component in dark mode after Sweeps 1-2.
+
+### Process
+
+For each major template in `app/Views/`:
+1. Load the page
+2. Toggle dark mode
+3. Check for: invisible text, disappeared borders, cards blending into background, invisible focus indicators, invisible shadows, images assuming white background
+
+### Fix
+
+- Add missing dark mode token usage
+- Add `var(--shadow-*)` for shadows not yet using CSS variables
+- Add `var(--color-bg-card)` background to elements that were transparent
+
+---
+
+## Sweep 4: Keyboard Accessibility
+
+**Goal:** Every interactive element has visible focus indicator and keyboard activation.
+
+### Find
+
+```bash
+# Elements with click handlers but no keyboard support
+grep -rn "@click\|onclick\|hx-get\|hx-post" \
+  app/Views/ app/Plugins/ --include="*.blade.php" | grep -v "button\|<a " | head -20
+```
+
+### Fix
+
+For each interactive element:
+1. Non-semantic click targets (`<div>`, `<span>`) → change to `<button>` or add `tabindex="0"`, `role="button"`, keyboard event handlers
+2. Add focus style: `tw:focus-visible:ring-2 tw:focus-visible:ring-[var(--accent1)] tw:focus-visible:ring-offset-2`
+
+### Test
+
+Tab through every page without mouse. Every interactive element: receives visible focus, activates on Enter/Space, logical tab order.
+
+---
+
+## Sweep 5: Screen Reader Basics
+
+**Goal:** Every element communicates purpose to assistive technology.
+
+### Find
+
+```bash
+# Icon-only buttons without labels
+grep -rn "<button[^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Icon-only links
+grep -rn "<a [^>]*>\s*<i " app/Views/ --include="*.blade.php" | grep -v "aria-label\|sr-only" | head -20
+
+# Inputs without labels
+grep -rn "<input " app/Views/ --include="*.blade.php" | grep -v "aria-label\|aria-labelledby" | head -20
+
+# Images without alt
+grep -rn "<img " app/Views/ --include="*.blade.php" | grep -v "alt=" | head -20
+```
+
+### Fix
+
+| Pattern | Fix |
+|---|---|
+| Icon-only `<button>` | `aria-label="Action name"` |
+| Icon-only `<a>` | `aria-label="Link purpose"` |
+| Decorative icon next to text | `aria-hidden="true"` on icon |
+| `<input>` without label | `<label for>` or `aria-label` |
+| `<img>` without alt | `alt="Description"` or `alt=""` if decorative |
+| Status dot/pill | `aria-label="Status: In Progress"` |
+
+---
+
+## Sweep 6: HTMX Live Regions
+
+**Goal:** Dynamic content updates announced to screen readers.
+
+### Find
+
+```bash
+grep -rn "hx-target\|hx-swap" app/Views/ --include="*.blade.php" | head -30
+```
+
+### Fix
+
+For each HTMX target with user-facing content:
+```html
+<div id="target-id" aria-live="polite" aria-atomic="false">
+```
+
+For loading indicators:
+```html
+<div class="htmx-indicator" role="status">
+  <span class="tw:sr-only">Loading...</span>
+</div>
+```
+
+---
+
+## Sweep 7: Reduced Motion
+
+**Goal:** All animations respect `prefers-reduced-motion`.
+
+### Find
+
+```bash
+grep -rn "@keyframes\|animation:\|transition:" app/Views/ app/Plugins/ \
+  --include="*.css" --include="*.blade.php" | head -30
+```
+
+### Fix
+
+Global reset (if not already present):
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Or per-component: `tw:motion-reduce:transition-none`
+
+---
+
+## Sweep 8: Color-Only Status Indicators
+
+**Goal:** No status communicated by color alone.
+
+### Find
+
+```bash
+grep -rn "dot-ok\|dot-wip\|dot-draft\|dot-flag\|bg-green\|bg-red\|bg-yellow" \
+  app/Views/ --include="*.blade.php" | head -20
+```
+
+### Fix
+
+Every colored status indicator needs a companion: icon inside, `aria-label`, or adjacent text. Verify pills already have text labels.
+
+---
+
+## Sweep 9: Touch Targets
+
+**Goal:** All interactive elements meet 44×44px minimum.
+
+### Find
+
+```bash
+grep -rn "padding:\s*[0-3]px\|tw:p-0\|tw:p-0.5\|tw:p-1" \
+  app/Views/ --include="*.blade.php" | head -20
+```
+
+### Fix
+
+- Minimum 44×44px clickable area
+- Icon buttons: `tw:p-2.5` minimum
+- Extend hit area with padding or `::before` pseudo-element if visual must stay small
+
+---
+
+## Sweep 10: Typography Migration
+
+**Goal:** Replace Roboto with Hanken Grotesk. Normalize off-scale font sizes.
+
+### Find
+
+```bash
+grep -rn "Roboto\|roboto" app/Views/ app/Plugins/ \
+  --include="*.blade.php" --include="*.css" --include="*.js"
+
+grep -rn "font-size:\s*15px\|font-size:\s*17px\|font-size:\s*19px" \
+  app/Views/ --include="*.blade.php" --include="*.css"
+```
+
+### Fix
+
+- Replace font-family declarations with Hanken Grotesk stack
+- Snap off-scale sizes: 15px → 14px or 16px, 17px → 16px or 18px
+- Normalize font-weights to scale: 450 (body), 500 (medium), 600 (semibold), 650 (heading), 700 (bold)
+
+---
+
+## Sweeps 11-15: Visual Normalization
+
+### Sweep 11: Border Radius
+3px → 4px, 5px → 6px, 7px → 8px, 10px → 10px (keep), 16px → 14px or 20px
+
+### Sweep 12: Spacing
+15px → 16px, 13px → 12px, 7px → 8px, 11px → 12px, 9px → 8px or 10px
+
+### Sweep 13: Shadows
+Replace custom `box-shadow` with `var(--shadow-sm/md/lg/xl)`. Remove `box-shadow` from `transition` properties.
+
+### Sweep 14: Transitions
+Replace `transition: all` with specific properties. Ensure durations match scale (150/200/300/350ms).
+
+### Sweep 15: Legacy Pattern Catalog
+Catalog jQuery usage, `.tpl.php` files, inline styles. Don't fix all at once — create prioritized backlog.
+
+---
+
+## Execution Rules
+
+1. **One sweep per session.** Complete, test, report, then move to the next.
+2. **Smallest possible changes.** Replace a value, don't rewrite the component.
+3. **Preserve visual output.** Page looks identical after a token sweep in default theme. Only dark mode / custom theme behavior improves.
+4. **When uncertain, flag.** Report unmapped colors. Don't guess.
+5. **Test after every sweep.** Light mode default, dark mode, one custom accent. Three checks.
+6. **Accessibility sweeps (4-9) are not optional.** They come before cosmetic sweeps. Users are locked out without them.
+7. **Use the NEW palette.** `#004766` not `#1b75bb`. `#00B893` not `#81B1A8`. If you see old values in the codebase, those are what you're replacing.
+
+---
+
+## File Scan Targets
+
+| Path | What | Sweep targets |
+|---|---|---|
+| `app/Views/Templates/` | Core Blade templates | All sweeps |
+| `app/Views/Templates/components/` | Shared components | All sweeps |
+| `app/Plugins/PgmPro/Views/` | Plugin views | All sweeps |
+| `app/Plugins/StrategyPro/Views/` | Plugin views | All sweeps |
+| `public/dist/css/` | Compiled CSS | Sweeps 1-3, 11-14 |
+| `app/Domain/*/Templates/` | Domain templates | All sweeps |
+| `resources/css/` | Source CSS | Sweeps 1-3 |
+| `app/Core/UI/Theme.php` | Theme engine | Sweep 0 only |
+| `public/theme/*/` | Theme configs | Sweep 0 only |
+
+---
+
+## Sweep Report Template
+
+After each sweep, produce:
+
+```markdown
+## Sweep [N]: [Name]
+**Files changed:** [count]
+**Instances replaced:** [count]
+
+### Changes
+- [file]: [what changed] × [count]
+
+### Flagged (needs design decision)
+- [file:line]: [description of unmapped value]
+
+### Test Results
+- [ ] Light mode: looks identical to before
+- [ ] Dark mode: no invisible text, missing borders, white rectangles
+- [ ] Custom accent: no hardcoded colors remain
+- [ ] No console errors
+- [ ] No broken layouts
+```

--- a/Docs/leantime-design-system-handoff.md
+++ b/Docs/leantime-design-system-handoff.md
@@ -1,0 +1,428 @@
+# Leantime Design System — Complete Handoff Document
+
+**Purpose:** This document captures every design decision made across ~15 sessions of collaborative work between Gloria (Leantime founder) and Claude. Drop this into a new chat along with the referenced project files to continue work without losing context.
+
+**Owner:** Gloria Folaron · gloriafolaron@gmail.com
+**Project:** Leantime (open-source project management)
+**Codebase:** `/Users/gloriafolaron/Herd/leantime`
+**Stack:** PHP / Laravel Blade / HTMX / Alpine.js / jQuery (legacy) / Tailwind CSS (`tw:` prefix)
+
+---
+
+## Table of Contents
+
+1. [Brand Palette (Confirmed)](#1-brand-palette)
+2. [Semantic Color Mapping](#2-semantic-color-mapping)
+3. [Stageflow Stage Colors](#3-stageflow-stage-colors)
+4. [Contrast & Accessibility Notes](#4-contrast--accessibility)
+5. [Glass Brutalist Aesthetic](#5-glass-brutalist-aesthetic)
+6. [3-Theme Architecture](#6-3-theme-architecture)
+7. [Typography](#7-typography)
+8. [Spacing, Radius & Shadows](#8-spacing-radius--shadows)
+9. [Component Modernization Specs](#9-component-modernization-specs)
+10. [Milestone / Gantt Bar Patterns](#10-milestone--gantt-bar-patterns)
+11. [Existing Codebase Architecture](#11-existing-codebase-architecture)
+12. [What's Been Built](#12-whats-been-built)
+13. [What Still Needs Doing](#13-what-still-needs-doing)
+14. [File Locations](#14-file-locations)
+15. [Claude Code Prompt (for implementation)](#15-claude-code-prompt)
+
+---
+
+## 1. Brand Palette
+
+**These are confirmed. Do not change.**
+
+| Token | Hex | Name | Role |
+|-------|-----|------|------|
+| `--accent1` | `#004766` | Deep Teal | Primary. Nav, buttons, links, active states |
+| `--accent2` | `#00B893` | Vibrant Emerald | Secondary. Success, gradients, progress fills |
+| `--accent3` | `#CADE1B` | Chartreuse | Tertiary. Backgrounds/fills ONLY (fails WCAG on white) |
+| `--accent4` | `#F61067` | Hot Pink | Danger/alerts. Passes AA on white (4.6:1) |
+| Page bg | `#F5F5F5` | Light Gray | Page background |
+
+**accent3 text variant:** When chartreuse must appear as text, darken to `#A8B516` (passes 3:1 for large text). Never use `#CADE1B` as text on white — it's 1.9:1 contrast ratio. On dark backgrounds, chartreuse is excellent (8.3:1).
+
+---
+
+## 2. Semantic Color Mapping
+
+**Brand colors double as semantic colors. No separate green/red/yellow system.**
+
+| Semantic | Maps to | Token |
+|----------|---------|-------|
+| Success | accent2 `#00B893` | `var(--accent2)` |
+| Danger / Error | accent4 `#F61067` | `var(--accent4)` |
+| Warning | accent3 `#A8B516` (darkened) | `var(--accent3-text)` |
+| Info | accent1 `#004766` | `var(--accent1)` |
+
+Background tints for alerts/badges:
+- Success bg: `rgba(0, 184, 147, 0.08)` or `#E6F9F4`
+- Danger bg: `rgba(246, 16, 103, 0.06)` or `#FDE8F0`
+- Warning bg: `rgba(202, 222, 27, 0.10)` or `#F8FAE6`
+- Info bg: `rgba(0, 71, 102, 0.06)` or `#E6EEF3`
+
+---
+
+## 3. Stageflow Stage Colors
+
+The Logic Model / Stageflow component uses 5 stages (Inputs → Activities → Outputs → Outcomes → Impact). Each stage needs its own color.
+
+| Stage | Color | Notes |
+|-------|-------|-------|
+| s1 (Inputs) | `#004766` (accent1) | Deep teal |
+| s2 (Activities) | `#00B893` (accent2) | Emerald |
+| s3 (Outputs) | `#A8B516` (accent3 darkened) | Chartreuse for text, `#CADE1B` for fills |
+| s4 (Outcomes) | `#F61067` at 60% opacity | Hot pink softened. Or `#C84D7C` solid |
+| s5 (Impact) | Gradient accent1→accent2 | Deep teal to emerald sweep |
+
+---
+
+## 4. Contrast & Accessibility
+
+### WCAG Results (on white `#FFFFFF`)
+
+| Color | Ratio | AA Normal | AA Large | Notes |
+|-------|-------|-----------|----------|-------|
+| accent1 `#004766` | 9.2:1 | ✅ Pass | ✅ Pass | Excellent |
+| accent2 `#00B893` | 2.7:1 | ❌ Fail | ❌ Fail | Use for fills/icons only, not text |
+| accent3 `#CADE1B` | 1.9:1 | ❌ Fail | ❌ Fail | Fills/badges ONLY |
+| accent3-text `#A8B516` | 3.1:1 | ❌ Fail | ✅ Pass (3:1) | Large text only |
+| accent4 `#F61067` | 4.6:1 | ✅ Pass | ✅ Pass | Good for buttons/badges |
+
+### On dark backgrounds (`#1A1A2E`)
+
+| Color | Ratio | Notes |
+|-------|-------|-------|
+| accent3 `#CADE1B` | 8.3:1 | Excellent — chartreuse shines in dark mode |
+| accent2 `#00B893` | 6.8:1 | Good |
+| accent4 `#F61067` | 4.1:1 | Acceptable for large text |
+
+### Rules
+- Status must NEVER be communicated by color alone (WCAG 1.4.1)
+- Every colored indicator needs: icon, text label, or pattern companion
+- Focus indicators: `ring-2 ring-[var(--accent1)] ring-offset-2`
+- Minimum touch target: 44×44px
+
+---
+
+## 5. Glass Brutalist Aesthetic
+
+Gloria's design direction: "glass brutalist" — clean, modern, slightly translucent surfaces with bold typography and sharp functional layout.
+
+### Glass Treatment Specs
+
+**"More" (Leantime theme):**
+- `backdrop-filter: blur(8px)`
+- `background: rgba(255, 255, 255, 0.85)` (light) / `rgba(30, 30, 46, 0.85)` (dark)
+- `border: 1px solid rgba(255, 255, 255, 0.2)`
+- Subtle inner shadow: `inset 0 1px 0 rgba(255,255,255,0.1)`
+
+**"Less" (Focus theme):**
+- `backdrop-filter: blur(4px)` or none
+- More opaque backgrounds
+- Minimal decoration
+
+**Neurodivergent-safe:**
+- No parallax
+- No animated blur
+- No auto-playing motion
+- `prefers-reduced-motion` respected globally
+
+### Where Glass Applies
+- Card backgrounds
+- Modal overlays
+- Dropdown menus
+- Navigation sidebar
+- Tooltip/popover backgrounds
+- NOT on text areas, inputs, or data-dense tables
+
+---
+
+## 6. 3-Theme Architecture
+
+Leantime's existing theme system uses `theme.ini` files in `/public/theme/{name}/`. Each theme declares `primaryColor`, `secondaryColor`, `colorModeSupport`, `colorPickerSupport`.
+
+### Existing Themes (in codebase)
+
+| Theme | Primary | Secondary | Features |
+|-------|---------|-----------|----------|
+| "Default" (More) | `#004666` | `#00a887` | Color mode + picker |
+| "Minimal" (Less) | `#004666` | `#00a887` | Color mode + picker |
+
+### Proposed 3-Theme System
+
+| Theme | Personality | Glass | Motion | Typography |
+|-------|------------|-------|--------|-----------|
+| **Leantime** | Rich, expressive | Full blur(8px) + translucency | Cubic-bezier transitions | Hanken Grotesk, variable weights |
+| **Focus** | Calm, minimal | Reduced or opaque | Minimal, fast transitions | Same font, fewer weight variations |
+| **High Contrast** | Accessibility-first | None (opaque surfaces) | `prefers-reduced-motion` default | Atkinson Hyperlegible option |
+
+Each theme supports light + dark mode (6 total combinations). Colors come from CSS custom properties that swap per mode.
+
+---
+
+## 7. Typography
+
+### Font: Hanken Grotesk (replacing Roboto)
+
+- **Source:** Google Fonts, variable font (100–900 weight axis)
+- **Load:** `<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&display=swap">`
+- **Fallback:** `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`
+
+### Weight Scale
+
+| Use | Weight | Token |
+|-----|--------|-------|
+| Body text | 450 | `--font-weight-body` |
+| Labels / UI text | 500 | `--font-weight-medium` |
+| Subheadings | 600 | `--font-weight-semibold` |
+| Headings | 650 | `--font-weight-heading` |
+| Bold emphasis | 700 | `--font-weight-bold` |
+| Display / Hero | 800 | `--font-weight-display` |
+
+### Size Scale
+
+| Token | Size | Use |
+|-------|------|-----|
+| `--text-xs` | 10px | Captions, timestamps |
+| `--text-sm` | 11px | Help text, metadata |
+| `--text-base` | 13px | Body text |
+| `--text-md` | 14px | UI labels, card titles |
+| `--text-lg` | 16px | Section headers |
+| `--text-xl` | 18px | Page titles |
+| `--text-2xl` | 24px | Hero/display |
+
+### Font Picker (user preference)
+- Hanken Grotesk (default)
+- Atkinson Hyperlegible (accessibility option)
+- Shantell Sans (handwritten/playful option)
+
+---
+
+## 8. Spacing, Radius & Shadows
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--radius-xs` | 4px | Inline badges, small chips |
+| `--radius-sm` | 6px | Buttons, inputs, small cards |
+| `--radius` | 10px | Cards, modals, containers |
+| `--radius-lg` | 14px | Large cards, hero sections |
+| `--radius-pill` | 20px | Pills, tags, toggle tracks |
+| `--radius-full` | 9999px | Avatars, circular buttons |
+
+### Spacing
+
+| Context | Value |
+|---------|-------|
+| Card body padding | 14px |
+| Card header padding | 12px |
+| List item padding | 10px |
+| Section gaps | 10px |
+| Component internal gap | 6–8px |
+| Dense mode reduction | ~75% of standard |
+
+### Shadows
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--shadow-sm` | `0 1px 3px rgba(0,0,0,0.04)` | Cards at rest |
+| `--shadow-md` | `0 4px 16px rgba(0,0,0,0.07)` | Hover, elevated cards |
+| `--shadow-lg` | `0 8px 32px rgba(0,0,0,0.10)` | Dropdowns, popovers |
+| `--shadow-xl` | `0 14px 48px rgba(0,0,0,0.13)` | Modals, active focus |
+
+---
+
+## 9. Component Modernization Specs
+
+### Buttons
+- Primary: accent1 fill + subtle inset highlight (`inset 0 1px 0 rgba(255,255,255,0.15)`)
+- Ghost: translucent backdrop-filter background
+- Hover: `transform: scale(1.01)`, brightness shift
+- Radius: `--radius-sm` (6px)
+- Focus: `ring-2 ring-[var(--accent1)] ring-offset-2`
+
+### Inputs
+- Background: `rgba(255, 255, 255, 0.7)` (glass effect)
+- Border: `1px solid rgba(0, 71, 102, 0.12)` (accent1 at low opacity)
+- Focus ring: `0 0 0 3px rgba(0, 184, 147, 0.2)` (accent2 glow)
+- Radius: 10px (`--radius`)
+- Placeholder: `var(--text-disabled)` color
+
+### Cards
+- Glass background per theme level
+- `--shadow-sm` at rest, `--shadow-md` on hover
+- `--radius` (10px)
+- Header: bottom border using `var(--border-default)`
+
+### Status Indicators
+- Always pair color dot with text label
+- Dot sizes: 6px (inline), 8px (standalone), 10px (emphasis)
+- Use semantic colors from Section 2
+
+---
+
+## 10. Milestone / Gantt Bar Patterns
+
+From visual reference screenshots analyzed in session. Two-layer bar construction:
+
+### Bar Anatomy
+1. **Progress fill:** Opaque gradient (`accent1 → accent2` sweep)
+2. **Remaining track:** Translucent pill `rgba(255,255,255,0.08–0.12)` allowing grid bleed-through
+3. **Progress handle:** Small circle at fill boundary (draggable affordance)
+4. **Bar radius:** `--radius-pill` (20px) — full pill shape
+
+### Color Coding for Milestones
+- Standard: `accent1 → accent2` gradient (teal to emerald)
+- Flagged/overdue: `accent4` gradient (hot pink)
+- Ahead of schedule: `accent3` tint (chartreuse highlight)
+
+### Dark Mode
+- Bars read as "frosted glass floating over dark surface"
+- Unfilled track: `rgba(255,255,255,0.08–0.12)` for lift
+- Filled portion appears to glow from within
+
+### Grayscale Validation
+- Shape/shadow/glass carry visual weight without color ✅
+- Progress readable via darker fill vs empty shell ✅
+- Diamond milestone marker holds up perfectly ✅
+
+---
+
+## 11. Existing Codebase Architecture
+
+### Theme System
+- **Theme.php:** `app/Core/UI/Theme.php` — Manages theme loading, CSS variable injection
+- **Theme configs:** `public/theme/{name}/theme.ini` — Declares name, colors, feature flags
+- **Theme CSS:** `public/theme/{name}/css/` — Theme-specific overrides
+- **Color picker:** Users can override accent1/accent2 via admin UI
+
+### Component System
+- **Blade components:** `app/Views/Templates/components/` — `<x-global::component>`
+- **Stageflow:** `components/stageflow/card.blade.php` + `item.blade.php` + `styles.blade.php` (392 lines)
+- **Forms:** `components/forms/input.blade.php`, `select.blade.php`, etc.
+- **Elements:** `components/elements/card.blade.php`, `dropdown.blade.php`, etc.
+- **Kanban:** `components/kanban/` subfolder with micro components
+- **Tailwind prefix:** All Tailwind classes use `tw:` prefix
+
+### Key Patterns
+- HTMX for dynamic content (`hx-get`, `hx-post`, `hx-target`, `hx-swap`)
+- Alpine.js for client-side reactivity
+- jQuery still present (tabs, selectable, some dropdowns) — migration planned
+- Bootstrap 2.x class mapping still in button component
+
+### CSS Custom Properties (current)
+- `--accent1`, `--accent2` — Set by theme + user color picker
+- Neutral palette tokens exist in design token docs but not fully implemented
+- Many hardcoded hex values throughout templates
+
+---
+
+## 12. What's Been Built
+
+### Visual Component Guide v1
+- **File:** `leantime-component-guide.html` (925 lines, standalone HTML)
+- **Contents:** 28 components across 7 categories with live demos, props tables, token compliance indicators
+- **Uses OLD palette:** Still has `#1b75bb` / `#81B1A8` — needs update to new brand colors
+
+### Logic Model v11
+- **File:** `logic-model-v11.html` — Full stageflow prototype
+- **Shows:** Core vs Plugin mode toggle, stage focus interaction, health indicators, AI assist trigger
+- **Uses CUSTOM palette:** Has its own stage colors that need harmonizing
+
+### Design Tokens Audit Prompt
+- **File:** `15-DESIGN-TOKENS-PROMPT.md` — Claude Code prompt for 15-sweep codebase audit
+- **References:** `14-DESIGN-TOKENS.md` (in Leantime docs folder)
+- **Status:** Ready to execute but uses old color references
+
+---
+
+## 13. What Still Needs Doing
+
+### Priority 1 — Requirements Docs (this is what Gloria asked for)
+- [ ] Create requirements document for the updated design system (all decisions above)
+- [ ] Create Claude Code prompt for implementing these changes in the codebase
+
+### Priority 2 — Update Component Guide
+- [ ] Rebuild component guide HTML with corrected 4-accent palette
+- [ ] Apply glass brutalist styling to all 28 component demos
+- [ ] Integrate Hanken Grotesk font
+- [ ] Update token compliance indicators for new palette
+- [ ] Add Timeline/Gantt Bar as new component section
+- [ ] Document 3-theme architecture visually
+
+### Priority 3 — Codebase Implementation
+- [ ] Update `14-DESIGN-TOKENS.md` with new palette and all decisions above
+- [ ] Update `15-DESIGN-TOKENS-PROMPT.md` to use new color values
+- [ ] Execute token sweeps (hardcoded colors → CSS variables)
+- [ ] Add accent3/accent4 tokens to theme system
+- [ ] Implement glass effects in component CSS
+- [ ] Typography migration (Roboto → Hanken Grotesk)
+- [ ] Dark mode improvements
+- [ ] Accessibility sweeps (keyboard, screen reader, reduced motion)
+
+---
+
+## 14. File Locations
+
+| What | Path |
+|------|------|
+| Leantime codebase | `/Users/gloriafolaron/Herd/leantime` |
+| Design tokens doc | `docs/14-DESIGN-TOKENS.md` |
+| Token audit prompt | `docs/15-DESIGN-TOKENS-PROMPT.md` |
+| Theme engine | `app/Core/UI/Theme.php` |
+| Default theme | `public/theme/default/` |
+| Minimal theme | `public/theme/minimal/` |
+| Blade components | `app/Views/Templates/components/` |
+| Stageflow component | `app/Views/Templates/components/stageflow/` |
+| Component guide v1 | (standalone HTML, attached to project) |
+| Logic model v11 | (standalone HTML, attached to project) |
+
+---
+
+## 15. Claude Code Prompt (for implementation)
+
+When ready to implement in the codebase, use this prompt structure:
+
+```
+You are working on the Leantime open-source project management application.
+
+REQUIRED READING FIRST:
+1. docs/14-DESIGN-TOKENS.md — canonical token reference
+2. CLAUDE.md — project conventions
+3. This handoff document (for all design decisions)
+
+BRAND PALETTE:
+- accent1: #004766 (deep teal) — primary
+- accent2: #00B893 (emerald) — success/secondary  
+- accent3: #CADE1B (chartreuse) — backgrounds only, #A8B516 for text
+- accent4: #F61067 (hot pink) — danger/alerts
+
+RULES:
+- Use tw: prefix for all Tailwind classes
+- Use CSS custom properties for ALL colors (no hardcoded hex)
+- One sweep at a time — complete, test, confirm before next
+- Test light mode, dark mode, and custom accent after every change
+- Preserve visual appearance while normalizing underlying values
+- Never touch theme definition files, third-party CSS, or files being actively rewritten
+
+[Then specify which sweep to execute — see 15-DESIGN-TOKENS-PROMPT.md for sweep definitions]
+```
+
+---
+
+## How to Use This Document
+
+**To continue the visual component guide work:**
+> "I'm building a visual component guide for Leantime. Here's my design system handoff document [paste or attach this file]. I also have the current component guide HTML [attach leantime-component-guide.html] and a logic model prototype [attach logic-model-v11.html]. Please rebuild the component guide using the corrected palette and glass brutalist aesthetic described in the handoff."
+
+**To create the requirements doc:**
+> "Here's my design system handoff document [paste/attach]. Please create a formal requirements document covering the visual design system, suitable for sharing with contributors and referencing during implementation."
+
+**To start codebase implementation:**
+> "Here's my design system handoff document [paste/attach]. I also have the design tokens audit prompt [attach 15-DESIGN-TOKENS-PROMPT.md]. Please start with Sweep 1: replacing hardcoded brand colors with CSS variables, using the updated palette from the handoff."
+
+**To resume any specific task:**
+> Reference the relevant section number from this document. All decisions are final unless you explicitly want to revisit them.

--- a/Docs/leantime-design-system-requirements.md
+++ b/Docs/leantime-design-system-requirements.md
@@ -1,0 +1,374 @@
+# Leantime Design System — Requirements Document
+
+**Version:** 1.0
+**Date:** February 23, 2026
+**Owner:** Gloria Folaron
+**Status:** Approved — ready for implementation
+
+---
+
+## 1. Purpose
+
+This document defines the visual design system for Leantime, an open-source project management application. It serves as the canonical reference for all contributors implementing UI changes. Every design decision here is final unless explicitly revisited by the project owner.
+
+**Companion documents:**
+- `leantime-design-system-claude-code-prompt.md` — Implementation prompt (sweep-by-sweep execution plan)
+- `leantime-component-guide-v2.html` — Live visual reference (28 components rendered with this system)
+- `docs/14-DESIGN-TOKENS.md` — Token definitions in codebase (to be updated per this spec)
+
+---
+
+## 2. Brand Palette
+
+Four accent colors. Confirmed. Do not change.
+
+| Token | Hex | Name | Role | WCAG on White |
+|-------|-----|------|------|---------------|
+| `--accent1` | `#004766` | Deep Teal | Primary. Nav, buttons, links, active states | 9.2:1 ✅ AA |
+| `--accent2` | `#00B893` | Vibrant Emerald | Secondary. Success, gradients, progress fills | 2.7:1 ❌ Fills only |
+| `--accent3` | `#CADE1B` | Chartreuse | Tertiary. Background fills ONLY | 1.9:1 ❌ Fills only |
+| `--accent4` | `#F61067` | Hot Pink | Danger/alerts, destructive actions | 4.6:1 ✅ AA |
+
+**accent3 text variant:** `--accent3-text: #A8B516` — Darkened chartreuse for text contexts. Passes 3:1 for large text only. On dark backgrounds (#1A1A2E), chartreuse hits 8.3:1 — excellent.
+
+**Page background:** `#F5F5F5`
+
+### 2.1 Semantic Color Mapping
+
+Brand colors double as semantic colors. No separate green/red/yellow system.
+
+| Semantic | Maps to | Token | Background Tint |
+|----------|---------|-------|-----------------|
+| Success | accent2 | `var(--accent2)` | `rgba(0, 184, 147, 0.08)` / `#E6F9F4` |
+| Danger / Error | accent4 | `var(--accent4)` | `rgba(246, 16, 103, 0.06)` / `#FDE8F0` |
+| Warning | accent3 darkened | `var(--accent3-text)` | `rgba(202, 222, 27, 0.10)` / `#F8FAE6` |
+| Info | accent1 | `var(--accent1)` | `rgba(0, 71, 102, 0.06)` / `#E6EEF3` |
+
+### 2.2 Neutral Palette (Scheme Layer — swaps in dark mode)
+
+| Token | Light | Dark | Use |
+|-------|-------|------|-----|
+| `--color-text-primary` | `#1A1A2E` | `#E8E8ED` | Headings, primary text |
+| `--color-text-secondary` | `#4B5563` | `#A0A7B5` | Body text, descriptions |
+| `--color-text-muted` | `#9CA3AF` | `#6B7280` | Captions, timestamps, help text |
+| `--color-text-disabled` | `#D1D5DB` | `#4B5563` | Disabled states, placeholders |
+| `--color-bg-page` | `#F5F5F5` | `#131320` | Page background |
+| `--color-bg-card` | `#FFFFFF` | `#1E1E2E` | Card/surface backgrounds |
+| `--color-bg-muted` | `#F0F1F3` | `#252538` | Muted backgrounds, table headers |
+| `--color-bg-hover` | `#F3F4F6` | `#2A2A3E` | Hover states |
+| `--color-border-default` | `#E8ECF0` | `#2E2E42` | Standard borders |
+| `--color-border-light` | `#F0F1F3` | `#252538` | Subtle dividers |
+
+---
+
+## 3. Typography
+
+### 3.1 Font Family
+
+**Primary:** Hanken Grotesk (variable, Google Fonts, weights 100–900)
+**Load:** `<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&display=swap">`
+**Fallback:** `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`
+**Replaces:** Roboto
+
+**User font picker options:**
+- Hanken Grotesk (default)
+- Atkinson Hyperlegible (accessibility)
+- Shantell Sans (playful)
+
+### 3.2 Weight Scale
+
+| Token | Weight | Use |
+|-------|--------|-----|
+| `--font-weight-body` | 450 | Body text |
+| `--font-weight-medium` | 500 | Labels, UI text |
+| `--font-weight-semibold` | 600 | Subheadings |
+| `--font-weight-heading` | 650 | Headings |
+| `--font-weight-bold` | 700 | Bold emphasis |
+| `--font-weight-display` | 800 | Hero/display |
+
+### 3.3 Size Scale
+
+| Token | Size | Use |
+|-------|------|-----|
+| `--text-xs` | 10px | Captions, timestamps |
+| `--text-sm` | 11px | Help text, metadata |
+| `--text-base` | 13px | Body text |
+| `--text-md` | 14px | UI labels, card titles |
+| `--text-lg` | 16px | Section headers |
+| `--text-xl` | 18px | Page titles |
+| `--text-2xl` | 24px | Hero/display |
+
+---
+
+## 4. Spacing, Radius & Shadows
+
+### 4.1 Spacing Scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--space-1` | 4px | Tight gaps |
+| `--space-2` | 8px | Component internal |
+| `--space-3` | 12px | Card header padding |
+| `--space-4` | 16px | Card body padding, section gaps |
+| `--space-5` | 20px | Large section gaps |
+| `--space-6` | 24px | Page-level padding |
+| `--space-8` | 32px | Hero spacing |
+
+### 4.2 Border Radius
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--radius-xs` | 4px | Inline badges, small chips |
+| `--radius-sm` | 6px | Buttons, inputs |
+| `--radius` | 10px | Cards, modals, containers |
+| `--radius-lg` | 14px | Large cards, hero sections |
+| `--radius-pill` | 20px | Pills, tags, toggle tracks, timeline bars |
+| `--radius-full` | 9999px | Avatars, circular buttons |
+
+### 4.3 Shadows (Scheme layer — adjust opacity in dark mode)
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--shadow-sm` | `0 1px 3px rgba(0,0,0,0.04)` | Cards at rest |
+| `--shadow-md` | `0 4px 16px rgba(0,0,0,0.07)` | Hover, elevated cards |
+| `--shadow-lg` | `0 8px 32px rgba(0,0,0,0.10)` | Dropdowns, popovers |
+| `--shadow-xl` | `0 14px 48px rgba(0,0,0,0.13)` | Modals, active focus |
+
+---
+
+## 5. Glass Brutalist Aesthetic
+
+Design direction: clean, modern, translucent surfaces with bold typography and sharp functional layout.
+
+### 5.1 Glass Treatment
+
+| Property | Leantime Theme | Focus Theme | High Contrast Theme |
+|----------|---------------|-------------|-------------------|
+| `backdrop-filter` | `blur(8px)` | `blur(4px)` or none | None |
+| Background (light) | `rgba(255,255,255,0.85)` | `rgba(255,255,255,0.95)` | `#FFFFFF` opaque |
+| Background (dark) | `rgba(30,30,46,0.85)` | `rgba(30,30,46,0.95)` | `#1E1E2E` opaque |
+| Border | `rgba(255,255,255,0.2)` | Standard token border | Standard token border |
+| Inner highlight | `inset 0 1px 0 rgba(255,255,255,0.1)` | None | None |
+
+**CSS tokens:**
+- `--glass-bg` — swaps per mode (light/dark)
+- `--glass-border` — swaps per mode
+- `--glass-inset` — subtle top highlight
+
+### 5.2 Where Glass Applies
+
+- ✅ Card backgrounds, modal overlays, dropdown menus, navigation sidebar, tooltip/popover backgrounds
+- ❌ NOT on text areas, inputs, data-dense tables, or anywhere readability would suffer
+
+### 5.3 Neurodivergent Safety
+
+- No parallax
+- No animated blur
+- No auto-playing motion
+- `prefers-reduced-motion` respected globally via CSS media query
+
+---
+
+## 6. Theme Architecture
+
+Three themes, each supporting light + dark mode (6 total combinations).
+
+| Theme | Personality | Glass | Motion | Target User |
+|-------|-----------|-------|--------|-------------|
+| **Leantime** | Rich, expressive | Full `blur(8px)` + translucency | Cubic-bezier transitions | Default experience |
+| **Focus** | Calm, minimal | Reduced or opaque | Minimal, fast transitions | Distraction-sensitive |
+| **High Contrast** | Accessibility-first | None (opaque) | `prefers-reduced-motion` default | Low vision, a11y needs |
+
+**Implementation:** Theme configs live in `public/theme/{name}/theme.ini`. Each declares `primaryColor`, `secondaryColor`, `colorModeSupport`, `colorPickerSupport`. Colors flow through CSS custom properties that swap per mode.
+
+**User color picker:** Users can override accent1/accent2 via admin UI. accent3/accent4 tokens need to be added to the theme system.
+
+---
+
+## 7. Stageflow Stage Colors
+
+The Logic Model / Stageflow component (Inputs → Activities → Outputs → Outcomes → Impact) uses per-stage colors:
+
+| Stage | Color | Fill | Text |
+|-------|-------|------|------|
+| s1 (Inputs) | `#004766` | accent1 | accent1 |
+| s2 (Activities) | `#00B893` | accent2 | accent2 |
+| s3 (Outputs) | `#CADE1B` / `#A8B516` | accent3 for fills | accent3-text for labels |
+| s4 (Outcomes) | `#C84D7C` | accent4 at 60% opacity | accent4 |
+| s5 (Impact) | gradient | `linear-gradient(accent1, accent2)` | accent1 |
+
+---
+
+## 8. Component Standards
+
+### 8.1 Buttons
+
+- Primary: accent1 fill + `inset 0 1px 0 rgba(255,255,255,0.15)`
+- Ghost: translucent glass background
+- Danger: accent4 fill
+- Success: accent2 fill
+- Warning: accent3-text fill
+- Hover: `brightness(1.08)` shift
+- Radius: `--radius-sm` (6px)
+- Focus: `ring-2 ring-[var(--accent1)] ring-offset-2`
+- Minimum touch target: 44×44px
+
+### 8.2 Inputs
+
+- Background: `rgba(255,255,255,0.7)` (glass)
+- Border: `1px solid rgba(0,71,102,0.12)` (accent1 at low opacity)
+- Focus ring: `0 0 0 3px rgba(0,184,147,0.2)` (accent2 glow)
+- Radius: `--radius` (10px)
+- Placeholder: `var(--color-text-disabled)`
+
+### 8.3 Cards
+
+- Glass background per theme level
+- `--shadow-sm` at rest, `--shadow-md` on hover
+- `--radius` (10px)
+- Header: bottom border `var(--color-border-default)`
+
+### 8.4 Status Indicators
+
+- ALWAYS pair color with text label (WCAG 1.4.1)
+- Dot sizes: 6px (inline), 8px (standalone), 10px (emphasis)
+- Use semantic color mapping from Section 2.1
+
+### 8.5 Timeline / Gantt Bars (Emboss Pattern)
+
+Two-layer construction:
+1. **Progress fill:** Opaque gradient `accent1 → accent2`
+2. **Remaining track:** Translucent pill `rgba(0,0,0,0.04)` light / `rgba(255,255,255,0.08)` dark
+3. **Handle:** 8px circle at fill boundary, white with accent2 border
+4. **Bar radius:** `--radius-pill` (20px)
+5. **Diamond milestone markers:** 10px rotated square, colored by state
+
+**Flagged/overdue:** accent4 gradient
+**Ahead of schedule:** accent3 tint
+**Dark mode:** Bars appear as frosted glass floating over dark surface
+
+---
+
+## 9. Accessibility Requirements
+
+These are not optional. They ship before cosmetic improvements.
+
+### 9.1 Color
+
+- No status communicated by color alone (WCAG 1.4.1)
+- Every colored indicator needs: icon, text label, or pattern companion
+- accent2 and accent3 fail WCAG on white — fills/icons only, never standalone text
+- accent1 (9.2:1) and accent4 (4.6:1) pass AA for text on white
+
+### 9.2 Keyboard
+
+- Every interactive element has visible focus indicator
+- Focus style: `ring-2 ring-[var(--accent1)] ring-offset-2` or `var(--focus-ring)` box-shadow
+- All click handlers have keyboard equivalents (Enter + Space for buttons)
+- Logical tab order matches visual layout
+- No keyboard traps
+
+### 9.3 Screen Reader
+
+- Icon-only buttons: `aria-label="Action name"`
+- Decorative icons: `aria-hidden="true"`
+- Inputs without visible labels: `aria-label` or `<label for>`
+- Status dots/pills: `aria-label="Status: In Progress"`
+- HTMX dynamic content targets: `aria-live="polite"` on swap containers
+- Loading indicators: `role="status"` + `<span class="tw:sr-only">Loading...</span>`
+
+### 9.4 Motion
+
+- All animations respect `prefers-reduced-motion`
+- Global CSS reset or per-component `tw:motion-reduce:transition-none`
+- No auto-playing animations
+
+### 9.5 Touch Targets
+
+- Minimum 44×44px clickable area on all interactive elements
+- Icon buttons: minimum `tw:p-2.5` (10px padding around icon)
+
+---
+
+## 10. Codebase Conventions
+
+### 10.1 Tech Stack
+
+- PHP / Laravel Blade templates
+- HTMX for dynamic content
+- Alpine.js for client-side reactivity
+- jQuery (legacy — migration planned)
+- Tailwind CSS with `tw:` prefix on ALL classes
+- Bootstrap 2.x class mapping still in button component
+
+### 10.2 CSS Custom Properties
+
+- `--accent1`, `--accent2` — currently set by theme + user color picker
+- `--accent3`, `--accent4` — need to be added to theme system
+- Neutral palette tokens — defined in design token docs but not fully implemented in codebase
+- Many hardcoded hex values remain throughout templates — these are the implementation target
+
+### 10.3 Key File Locations
+
+| What | Path |
+|------|------|
+| Theme engine | `app/Core/UI/Theme.php` |
+| Default theme | `public/theme/default/` |
+| Minimal theme | `public/theme/minimal/` |
+| Blade components | `app/Views/Templates/components/` |
+| Stageflow | `app/Views/Templates/components/stageflow/` |
+| Design tokens doc | `docs/14-DESIGN-TOKENS.md` |
+| Token audit prompt | `docs/15-DESIGN-TOKENS-PROMPT.md` |
+
+### 10.4 Implementation Rules
+
+- Use `tw:` prefix for ALL Tailwind classes
+- Use CSS custom properties for ALL colors — no hardcoded hex in templates
+- One sweep at a time — complete, test, confirm before next
+- Test light mode, dark mode, and custom accent after every change
+- Preserve visual appearance while normalizing underlying values
+- Never touch theme definition files, third-party CSS, or files being actively rewritten
+- Flag any color that doesn't map cleanly to a token — don't guess
+
+---
+
+## 11. Implementation Priority
+
+### Phase 1 — Foundation (do first)
+1. Update `docs/14-DESIGN-TOKENS.md` with this spec's palette and tokens
+2. Add accent3/accent4 to theme system (`Theme.php` + theme.ini files)
+3. Sweep hardcoded brand colors → CSS variables
+4. Sweep hardcoded neutrals → CSS variables
+
+### Phase 2 — Accessibility (do before cosmetic work)
+5. Keyboard focus indicators on all interactive elements
+6. Screen reader basics (aria-labels, roles, live regions)
+7. Reduced motion support
+8. Color-only status indicator fixes
+9. Touch target compliance
+
+### Phase 3 — Visual Polish
+10. Typography migration (Roboto → Hanken Grotesk)
+11. Glass effect implementation
+12. Dark mode verification pass
+13. Border radius normalization
+14. Spacing normalization
+15. Shadow normalization
+16. Transition normalization
+17. Legacy pattern catalog (jQuery, inline styles, .tpl.php files)
+
+---
+
+## 12. Acceptance Criteria
+
+A sweep is complete when:
+- All instances in target files are replaced
+- Default light theme looks identical before/after
+- Dark mode renders correctly (no invisible text, missing borders, white rectangles)
+- Custom accent test passes (swap accent1/accent2 in console — nothing hardcoded remains)
+- Sweep report produced per `14-DESIGN-TOKENS.md` section 11.3 format
+- No regressions in existing functionality
+
+---
+
+*This document is the source of truth. When it conflicts with older documents (component guide v1, logic model v11, original 15-DESIGN-TOKENS-PROMPT.md), this document wins.*

--- a/Docs/leantime-glass-effects-claude-code-prompt.md
+++ b/Docs/leantime-glass-effects-claude-code-prompt.md
@@ -1,0 +1,494 @@
+# Glass Effects Implementation — Claude Code Prompt
+
+**For Claude Code Execution**
+
+| Field | Value |
+|---|---|
+| Project | Leantime |
+| Scope | Glass effect implementation across UI surfaces |
+| Reference | `leantime-glass-effects-requirements.md` — **Read first, it's the surface decision map** |
+| Depends on | Design System v2 foundation (token aliasing) — must be complete |
+| Risk | LOW per phase (visual changes, no logic changes) |
+| Approach | One phase at a time. Complete, test, confirm before next. |
+
+---
+
+## Pre-Read (Required)
+
+1. `CLAUDE.md` — project conventions
+2. `leantime-glass-effects-requirements.md` — **The surface decision map. Every decision flows from this.**
+3. `docs/14-DESIGN-TOKENS.md` — current token definitions
+4. Skim `app/Views/Templates/layouts/` to understand main layout structure
+5. Skim `app/Views/Templates/components/elements/card.blade.php` to see existing glass prop
+
+---
+
+## Critical Constraints
+
+### DO
+
+- Work one phase at a time — complete, test, confirm
+- Use the exact glass token names from the requirements doc
+- Use `tw:` prefix for all Tailwind classes
+- Test in both light and dark mode after every change
+- Test in both "default" and "minimal" themes
+- Test with browser DevTools "Layers" panel to verify composite layer count
+- Preserve existing visual appearance — glass is an enhancement, not a redesign
+- Add `-webkit-backdrop-filter` alongside `backdrop-filter` for Safari
+
+### DO NOT
+
+- Add glass to surfaces marked ⬜ (No glass) in the requirements doc
+- Add `backdrop-filter` to components that render in lists (kanban cards, table rows, timeline bars)
+- Animate blur values — glass appears instant
+- Use `[data-theme="dark"]` or `.theme-dark` selectors — dark mode uses separate CSS files
+- Use `.theme-focus` or `.theme-high-contrast` selectors — these don't exist
+- Remove the `glass` prop from card component — it's the opt-in mechanism
+- Exceed 15 simultaneously visible glass surfaces on any page
+
+### ARCHITECTURE AWARENESS
+
+Leantime has **two themes** ("default" and "minimal"), each with **two mode files**:
+- `public/theme/default/css/light.css`
+- `public/theme/default/css/dark.css`
+- `public/theme/minimal/css/light.css`
+- `public/theme/minimal/css/dark.css`
+
+Dark mode is NOT controlled by CSS selectors. Leantime loads the appropriate CSS file. All dark-mode token values must go in `dark.css` files, not in `@media` queries or attribute selectors in shared CSS.
+
+---
+
+## Phase A: Dark Mode Normalization + Subtle Glass Tokens + Utility Classes
+
+**Goal:** (1) Correct the existing dark mode glass values that are too translucent. (2) Add the missing `--glass-bg-subtle` and `--glass-blur-subtle` tokens to all 4 theme files. (3) Add `.lt-glass` and `.lt-glass-subtle` utility classes to shared CSS.
+
+### Step 0: Normalize existing dark mode glass values
+
+The current dark.css files have wrong values. Fix them BEFORE adding subtle tokens.
+
+**In `public/theme/default/css/dark.css`** — find and replace:
+```css
+/* CURRENT (wrong): */
+--glass-bg: rgba(0, 0, 0, 0.5);   /* 50% opacity pure black — too translucent */
+--glass-blur: blur(24px);          /* too heavy */
+
+/* REPLACE WITH: */
+--glass-bg: rgba(30, 30, 46, 0.85);  /* 85% opacity, tinted dark — matches light mode ratio */
+--glass-blur: blur(8px);              /* matches light mode */
+```
+
+**In `public/theme/minimal/css/dark.css`** — check current `--glass-bg` value. If it's 30% opacity, update to match minimal's opaque philosophy:
+```css
+/* Minimal dark should be near-opaque, consistent with minimal light */
+--glass-bg: var(--color-bg-card);  /* fully opaque */
+--glass-blur: blur(4px);           /* keep light blur for minimal */
+```
+
+**Verify the hierarchy is correct after changes:**
+- default/light: 85% opacity, blur(8px) ✓
+- default/dark: 85% opacity, blur(8px) ✓ (was 50%, blur(24px))
+- minimal/light: 100% opacity, blur(4px) ✓
+- minimal/dark: 100% opacity, blur(4px) ✓ (was 30%)
+
+### Step 1: Find theme CSS files
+
+```bash
+# Locate the 4 theme CSS files
+find public/theme/ -name "light.css" -o -name "dark.css" | sort
+
+# Verify primary glass tokens already exist
+grep -n "glass-blur\|glass-bg\|glass-border\|glass-inset" \
+  public/theme/default/css/light.css \
+  public/theme/default/css/dark.css \
+  public/theme/minimal/css/light.css \
+  public/theme/minimal/css/dark.css
+```
+
+### Step 2: Add subtle tokens to each file
+
+**In `public/theme/default/css/light.css`** — find the existing glass tokens block and add:
+```css
+--glass-bg-subtle: rgba(255, 255, 255, 0.92);
+--glass-blur-subtle: blur(4px);
+```
+
+**In `public/theme/default/css/dark.css`** — add:
+```css
+--glass-bg-subtle: rgba(30, 30, 46, 0.92);
+--glass-blur-subtle: blur(4px);
+```
+
+**In `public/theme/minimal/css/light.css`** — add:
+```css
+--glass-bg-subtle: var(--color-bg-card);
+--glass-blur-subtle: none;
+```
+
+**In `public/theme/minimal/css/dark.css`** — add:
+```css
+--glass-bg-subtle: var(--color-bg-card);
+--glass-blur-subtle: none;
+```
+
+### Step 3: Add utility classes
+
+Find the shared CSS file where global utility classes live:
+
+```bash
+# Check where existing glass-related styles are
+grep -rn "\.glass\|glass-bg\|backdrop-filter.*var(--glass" \
+  resources/css/ app/Views/ \
+  --include="*.css" --include="*.blade.php" | head -20
+
+# Find the main stylesheet
+ls resources/css/main.css resources/css/app.css 2>/dev/null
+```
+
+Add these utility classes to the shared CSS (NOT in a theme file — these reference tokens that the theme files define):
+
+```css
+/* Glass utility classes */
+.lt-glass {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-inset), var(--shadow-sm);
+}
+
+.lt-glass-subtle {
+  background: var(--glass-bg-subtle);
+  backdrop-filter: var(--glass-blur-subtle);
+  -webkit-backdrop-filter: var(--glass-blur-subtle);
+  border: 1px solid var(--glass-border);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .lt-glass, .lt-glass-subtle {
+    background: var(--color-bg-card);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+```
+
+**Note:** Phase A may have committed `--emboss-track` and `--emboss-highlight` tokens alongside glass tokens. These are inert (nothing references them). Leave them — a future emboss spec will consume them. Do not add emboss utility classes to glass.css.
+
+### Test
+
+```bash
+# Build CSS if needed
+# [check CLAUDE.md for build command]
+
+# Then in browser:
+```
+
+```javascript
+// Verify subtle tokens exist
+getComputedStyle(document.documentElement).getPropertyValue('--glass-bg-subtle');
+// Should return rgba value, not empty
+
+// Verify utility classes work
+const test = document.createElement('div');
+test.className = 'lt-glass';
+test.style.cssText = 'width:100px;height:100px;position:fixed;top:50%;left:50%;z-index:9999';
+document.body.appendChild(test);
+console.log('backdrop-filter:', getComputedStyle(test).backdropFilter);
+// Should return blur(Xpx), not 'none'
+document.body.removeChild(test);
+
+// Switch to minimal theme and verify glass is degraded
+// (reload with minimal theme active)
+```
+
+### Report
+
+List: files modified, tokens added per file, any conflicts found.
+
+---
+
+## Phase B: Overlay Surfaces (Modal, Dropdown, Tooltip, Popover)
+
+**Goal:** Add glass treatment to floating/overlay surfaces. Highest impact, lowest risk — they appear one at a time. Also fix the hardcoded blur on `#modal-blur-overlay`.
+
+### Find overlay components
+
+```bash
+# Modal
+find app/Views/Templates/components/actions/ -name "*.blade.php" | head -10
+grep -n "background\|backdrop\|bg-white\|bg-card\|blur" \
+  app/Views/Templates/components/actions/modal.blade.php \
+  app/Views/Templates/components/actions/confirm-delete.blade.php 2>/dev/null
+
+# Dropdowns
+find app/Views/Templates/components/ -name "*dropdown*" -o -name "*drop-down*" | head -10
+grep -n "background\|bg-white\|bg-card" \
+  app/Views/Templates/components/elements/dropdown.blade.php 2>/dev/null
+
+# Tooltips / popovers
+grep -rn "tooltip\|popover\|health-pop\|tip\|preview" \
+  app/Views/Templates/components/ \
+  --include="*.blade.php" | head -20
+
+# THE HARDCODED BLUR — must fix
+grep -n "modal-blur-overlay\|blur(12px)" resources/css/main.css
+```
+
+### Fix — Modal
+
+The global modal already uses `var(--glass-blur)`. Verify it's fully wired:
+
+```bash
+grep -n "glass\|backdrop-filter\|blur" \
+  app/Views/Templates/components/actions/modal.blade.php
+```
+
+If the modal panel (the white rectangle, not the backdrop) doesn't use the glass class yet, add it:
+
+```php
+{{-- Modal panel should use glass class --}}
+<div class="lt-glass tw:rounded-[var(--radius)] ...">
+```
+
+The `::backdrop` / scrim stays dark and opaque:
+```css
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+```
+
+### Fix — Hardcoded modal blur overlay
+
+In `resources/css/main.css`, find `#modal-blur-overlay` with `backdrop-filter: blur(12px)`:
+
+```css
+/* BEFORE */
+#modal-blur-overlay {
+  backdrop-filter: blur(12px);
+}
+
+/* AFTER */
+#modal-blur-overlay {
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+}
+```
+
+### Fix — Dropdowns
+
+Find the dropdown menu container in each dropdown component. Replace its background with glass:
+
+```php
+{{-- BEFORE: opaque dropdown --}}
+<div class="tw:bg-[var(--color-bg-card)] tw:border tw:border-[var(--color-border-default)] tw:rounded-[var(--radius-sm)] tw:shadow-lg ...">
+
+{{-- AFTER: glass dropdown --}}
+<div class="lt-glass tw:rounded-[var(--radius-sm)] tw:shadow-[var(--shadow-lg)] ...">
+```
+
+The `.lt-glass` class includes border and background — remove any duplicate `tw:bg-*` and `tw:border-*` classes that would conflict.
+
+### Fix — Tooltips / Popovers
+
+These are smaller surfaces. Use `lt-glass-subtle`:
+
+```php
+{{-- BEFORE --}}
+<div class="tw:bg-[var(--color-bg-card)] tw:border ...">
+
+{{-- AFTER --}}
+<div class="lt-glass-subtle tw:rounded-[var(--radius-sm)] ...">
+```
+
+### Test
+
+1. Open a modal → glass panel visible, backdrop is dark scrim
+2. Open a dropdown → glass menu, text readable
+3. Hover a tooltip → subtle glass, not overwhelming
+4. Dark mode → all overlays adapt automatically
+5. minimal theme → all overlays should be opaque or near-opaque (tokens degrade)
+6. Verify `#modal-blur-overlay` uses token now, not hardcoded blur(12px)
+
+---
+
+## Phase C: Layout Surfaces (Nav Sidebar, Top Header)
+
+**Goal:** Add glass to the navigation sidebar (full) and sticky top header (subtle). Also fix the hardcoded inline blur on the registration layout.
+
+### Find layout templates
+
+```bash
+# Main layout
+find app/Views/Templates/layouts/ -name "*.blade.php" | head -20
+
+# Nav sidebar
+grep -rn "nav\|sidebar\|side-bar" \
+  app/Views/Templates/layouts/ \
+  --include="*.blade.php" | head -20
+
+# Top header
+grep -rn "header\|top-bar\|topbar\|app-bar" \
+  app/Views/Templates/layouts/ \
+  --include="*.blade.php" | head -20
+
+# Registration layout with hardcoded blur
+grep -rn "backdrop-filter.*blur(3px)\|blur(3px)" \
+  app/Views/Templates/ \
+  --include="*.blade.php" | head -10
+```
+
+### Fix — Nav Sidebar
+
+Find the nav sidebar container element. Add full glass:
+
+```php
+{{-- Nav sidebar --}}
+<nav class="lt-glass tw:h-full tw:overflow-y-auto ...">
+```
+
+Or if using inline styles:
+```php
+style="background: var(--glass-bg); backdrop-filter: var(--glass-blur); -webkit-backdrop-filter: var(--glass-blur); border-right: 1px solid var(--glass-border);"
+```
+
+### Fix — Top Header
+
+The top header is sticky. Use subtle glass so scrolling content blurs through gently:
+
+```php
+{{-- Top header --}}
+<header class="lt-glass-subtle tw:sticky tw:top-0 tw:z-50 ...">
+```
+
+### Fix — Registration layout hardcoded blur
+
+Find the inline `backdrop-filter: blur(3px)` and replace:
+
+```php
+{{-- BEFORE --}}
+style="backdrop-filter: blur(3px);"
+
+{{-- AFTER --}}
+style="backdrop-filter: var(--glass-blur-subtle); -webkit-backdrop-filter: var(--glass-blur-subtle);"
+```
+
+### Test
+
+1. Scroll the page → header shows content blurring through subtly
+2. Sidebar shows page content blurring through
+3. Dark mode → both surfaces adapt
+4. No "double blur" where sidebar meets header (separate blur contexts)
+5. minimal theme → sidebar and header should be opaque or near-opaque
+6. Mobile/responsive → sidebar may collapse to drawer. Glass applies when open.
+7. Registration page → verify blur uses token, not hardcoded 3px
+
+---
+
+## Phase D: Container Opt-In (Card glass prop, Widget subtle glass)
+
+**Goal:** Wire the card component's `glass` prop to the `.lt-glass` utility class (fixing the nonexistent `tw:glass`). Add subtle glass to widget component.
+
+### Find card component
+
+```bash
+grep -n "glass" app/Views/Templates/components/elements/card.blade.php
+```
+
+### Fix — Card
+
+The card already has `glass => false`. It likely maps to a Tailwind class `tw:glass` that doesn't exist. Replace with the plain CSS `.lt-glass` class:
+
+```php
+{{-- In card.blade.php --}}
+@props([
+  'glass' => false,
+  {{-- ... other props --}}
+])
+
+<div class="
+  tw:rounded-[var(--radius)]
+  {{ $glass ? 'lt-glass' : 'tw:bg-[var(--color-bg-card)] tw:border tw:border-[var(--color-border-default)]' }}
+  tw:shadow-[var(--shadow-sm)]
+  ...
+">
+```
+
+Key: when `glass=true`, the `.lt-glass` class provides background, border, and backdrop-filter. When `glass=false`, standard opaque styling with explicit bg and border.
+
+### Fix — Widget
+
+In `components/content/widget.blade.php`, add subtle glass:
+
+```php
+<div class="lt-glass-subtle tw:rounded-[var(--radius)] ...">
+```
+
+### DO NOT add glass to stageflow
+
+Per design decision #2 (locked), stageflow active cards do NOT get glass. The accent border + elevation already differentiates. Skip this component entirely.
+
+### Test
+
+1. Dashboard → widget cards show subtle glass (slight blur-through on page bg)
+2. Any page with `<x-global::elements.card :glass="true">` → full glass card
+3. Cards without glass prop → opaque, no blur
+4. Dark mode → all variants
+5. minimal theme → widgets should be opaque (subtle tokens degrade to opaque in minimal)
+6. Count visible glass surfaces on dashboard → should stay under 15
+
+---
+
+## Phase E: Dark Mode + Theme Verification
+
+**Goal:** Systematic check of every glass surface in dark mode, in both themes.
+
+### Process
+
+For each surface modified in Phases B-E, check in 4 combinations:
+1. default theme + light mode
+2. default theme + dark mode
+3. minimal theme + light mode
+4. minimal theme + dark mode
+
+### Checklist per surface
+
+- [ ] Glass surface visible but not "bright rectangle on dark background"
+- [ ] Text on glass surface is readable
+- [ ] Borders visible but subtle (not bright white lines)
+- [ ] Shadows visible (dark mode may need boosted opacity)
+- [ ] minimal theme: glass is degraded (opaque or near-opaque)
+
+### Find any remaining hardcoded blurs
+
+```bash
+# Any backdrop-filter not using tokens
+grep -rn "backdrop-filter:\s*blur" \
+  app/Views/ resources/css/ \
+  --include="*.blade.php" --include="*.css" \
+  | grep -v "var(--glass"
+```
+
+Any results are hardcoded values that won't respect theme degradation. Replace with appropriate `var(--glass-blur)` or `var(--glass-blur-subtle)`.
+
+### Report
+
+For each glass surface:
+
+| Surface | default/light | default/dark | minimal/light | minimal/dark | Fix |
+|---------|--------------|-------------|---------------|-------------|-----|
+| Modal | ✅ | ✅ / ⚠️ | ✅ | ✅ / ⚠️ | (describe) |
+| ... | | | | | |
+
+---
+
+## Execution Rules
+
+1. **One phase per session.** A-E in order. Phase A must be complete before any others.
+2. **Glass tokens, not hardcoded values.** Every `backdrop-filter: blur(Xpx)` must use `var(--glass-blur)` or `var(--glass-blur-subtle)`. Every translucent background must use `var(--glass-bg)` or `var(--glass-bg-subtle)`.
+3. **No dark mode selectors in shared CSS.** Dark values live in `dark.css` files. Do not add `[data-theme="dark"]` or `.theme-dark` rules.
+4. **Performance awareness.** After each phase, count glass surfaces on the most complex page. Stay under 15.
+5. **Safari compatibility.** Always pair `backdrop-filter` with `-webkit-backdrop-filter`.
+6. **No animated blur.** Glass appears/disappears with the component. Blur value never transitions.
+7. **When uncertain, skip.** If glass looks wrong or hurts readability, mark it ⬜ and flag it.
+8. **This spec is glass only.** `backdrop-filter` frosted surfaces. Progress bar emboss, milestone bar polish, toggle track treatments are separate specs. Don't add them here.
+9. **Test all 4 combos.** default/light, default/dark, minimal/light, minimal/dark. Every phase.

--- a/Docs/leantime-glass-effects-requirements.md
+++ b/Docs/leantime-glass-effects-requirements.md
@@ -1,0 +1,331 @@
+# Leantime Glass Effects — Surface Map & Requirements
+
+**Version:** 1.3
+**Date:** February 24, 2026
+**Owner:** Gloria Folaron
+**Status:** Design decisions locked — ready for implementation
+**Depends on:** Design System v2 foundation (token aliasing) — ✅ Complete
+
+**Changelog v1.3:** Removed emboss patterns from glass effects scope. Emboss (inset track/fill treatment for progress bars, milestones, toggles) is a separate visual polish concern, not glass (backdrop-filter) effects. Section 4 replaced with scope redirect. Phase E removed from implementation priority. Emboss tokens committed in Phase A are inert — harmless but will be referenced by a future emboss spec, not this one.
+
+**Changelog v1.2:** Fixed dark mode value contradiction between sections 2.1 and 7 — Section 7 now documents target values explicitly, Phase A scope expanded to normalize existing dark values. Moved phase row UX redesign to separate Logic Model Canvas spec (out of scope for glass). Renamed utility classes `.glass` → `.lt-glass` to avoid third-party collisions.
+
+**Changelog v1.1:** Fixed theme architecture to match actual codebase (default/minimal themes, separate light.css/dark.css files). Removed fictional .theme-focus/.theme-high-contrast selectors. Added subtle glass token gap. Added card glass Tailwind class gap. Locked all 5 design review questions. Added hardcoded blur inventory.
+
+---
+
+## 1. Purpose
+
+This document maps every UI surface in Leantime to a glass treatment decision. The design system requirements doc (section 5) established the general rules — this document gets specific: which Blade components, which page regions, which interactive elements get glass, and at what level.
+
+**Why this needs a separate doc:** Glass effects touch performance (backdrop-filter is GPU-composited), accessibility (translucent backgrounds can reduce text contrast), and theme architecture (two themes × two modes = four combinations that all need to work). Rushing this creates visual regressions. Surface-by-surface decisions prevent that.
+
+**Companion documents:**
+- `leantime-design-system-requirements.md` — Section 5 (Glass Brutalist Aesthetic)
+- `leantime-glass-effects-claude-code-prompt.md` — Implementation prompt
+- `leantime-component-guide-v2.html` — Visual reference showing glass in action
+
+---
+
+## 2. Glass Token System
+
+### 2.1 What Already Exists
+
+These primary glass tokens are **already defined** in all 4 theme CSS files:
+
+| Token | Purpose | Defined in |
+|-------|---------|-----------|
+| `--glass-blur` | Primary blur value | All 4 theme files |
+| `--glass-background` | Glass bg (alias) | All 4 theme files |
+| `--glass-border` | Glass border color | All 4 theme files |
+| `--glass-bg` | Glass bg (primary) | All 4 theme files |
+| `--glass-inset` | Inner highlight | All 4 theme files |
+
+**Current values across themes:**
+
+| Theme file | --glass-blur | --glass-bg opacity | Notes |
+|-----------|-------------|-------------------|-------|
+| default/light.css | `blur(8px)` | 85% | Full glass |
+| default/dark.css | `blur(24px)` | 50% (`rgba(0,0,0,0.5)`) | ⚠️ Too translucent — needs correction |
+| minimal/light.css | `blur(4px)` | 100% | Effectively no glass (opaque) |
+| minimal/dark.css | `blur(4px)` | 30% | ⚠️ Too translucent — needs correction |
+
+**⚠️ Dark mode values need normalization (Phase A).** The current `default/dark.css` uses `rgba(0,0,0,0.5)` (50% opacity, pure black base) with `blur(24px)`. This creates a muddy dark wash. Section 7 defines the corrected target values: `rgba(30,30,46,0.85)` (85% opacity, tinted dark base) with `blur(8px)`. Phase A must update both existing full-tier dark values AND add the new subtle tier. The hierarchy must be:
+
+- **Full glass dark:** 85% opacity, `blur(8px)` — most translucent, most blur
+- **Subtle glass dark:** 92% opacity, `blur(4px)` — less translucent, less blur
+- **No glass (minimal):** 100% opacity, no blur — opaque
+
+**Already using glass:**
+- Global modal uses `backdrop-filter: var(--glass-blur)` ✅
+- Card component has `glass => false` prop scaffold ✅
+
+### 2.2 What's Missing (Must Add)
+
+**Subtle glass tier tokens** — referenced throughout this document but not yet defined:
+
+| Token | Purpose | Status |
+|-------|---------|--------|
+| `--glass-bg-subtle` | Subtle glass background | ❌ Not in any theme file |
+| `--glass-blur-subtle` | Subtle blur value | ❌ Not in any theme file |
+
+These must be added to all 4 theme CSS files in Phase A.
+
+**Proposed values:**
+
+| Theme file | --glass-bg-subtle | --glass-blur-subtle |
+|-----------|------------------|-------------------|
+| default/light.css | `rgba(255, 255, 255, 0.92)` | `blur(4px)` |
+| default/dark.css | `rgba(30, 30, 46, 0.92)` | `blur(4px)` |
+| minimal/light.css | `var(--color-bg-card)` (opaque) | `none` |
+| minimal/dark.css | `var(--color-bg-card)` (opaque) | `none` |
+
+**Card glass Tailwind class** — card.blade.php maps `glass => true` to `tw:glass`, but that class is not defined in Tailwind config. Fix: define `.lt-glass` as a plain CSS utility class (section 2.3) and update card.blade.php to use `lt-glass` instead of `tw:glass`. Prefixed to avoid third-party class name collisions.
+
+### 2.3 Glass Utility Classes (To Add)
+
+```css
+/* Full glass surface */
+.lt-glass {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-inset), var(--shadow-sm);
+}
+
+/* Subtle glass surface */
+.lt-glass-subtle {
+  background: var(--glass-bg-subtle);
+  backdrop-filter: var(--glass-blur-subtle);
+  -webkit-backdrop-filter: var(--glass-blur-subtle);
+  border: 1px solid var(--glass-border);
+}
+
+/* Fallback for browsers without backdrop-filter */
+@supports not (backdrop-filter: blur(1px)) {
+  .lt-glass, .lt-glass-subtle {
+    background: var(--color-bg-card);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+```
+
+### 2.4 Theme Degradation (How It Actually Works)
+
+Leantime has **two** themes: "default" and "minimal". Each theme has separate light.css and dark.css files that define their own token values. There are no CSS class selectors like `.theme-focus` or `.theme-high-contrast`.
+
+**Degradation is automatic** — it happens because each theme file sets different values for the same glass tokens:
+
+| Surface type | default theme | minimal theme |
+|-------------|--------------|---------------|
+| Full-glass surface | blur(8px), 85% opacity | blur(4px), 100% (effectively opaque) |
+| Subtle-glass surface | blur(4px), 92% opacity | opaque, no blur |
+| No-glass surface | Opaque | Opaque |
+
+Components reference tokens. Theme files control what those tokens resolve to. No conditional CSS logic needed in components.
+
+**Dark mode is handled by separate CSS files** — Leantime loads `light.css` or `dark.css` per theme. There are no `[data-theme="dark"]` or `.theme-dark` attribute selectors in shared CSS. All dark-mode glass values live in the respective `dark.css` files.
+
+---
+
+## 3. Surface Decision Map
+
+### Decision key
+- ✅ **Full glass** — Primary floating surface. Uses `--glass-bg` / `--glass-blur`.
+- 🔵 **Subtle glass** — Secondary/nested. Uses `--glass-bg-subtle` / `--glass-blur-subtle`.
+- ⬜ **No glass** — Opaque `var(--color-bg-card)` or `var(--color-bg-page)`.
+- 🔶 **Conditional** — Glass only in specific contexts (documented below).
+
+### 3.1 Layout Surfaces
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Navigation sidebar** | Main layout template | ✅ Full | Permanent landmark. Signature glass surface. |
+| **Top header bar** | Main layout template | 🔵 Subtle | Sticky — full blur on scroll is distracting. |
+| **Page background** | Body / main wrapper | ⬜ No glass | This IS the background. |
+| **Footer** | Main layout template | ⬜ No glass | Opaque to anchor the page. |
+| **Sidebar panels** (right) | Various views | 🔵 Subtle | Contextual surfaces — lighter than nav (intentional asymmetry). |
+
+### 3.2 Container Components
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Card** | `elements/card.blade.php` | 🔶 Conditional | Glass when `glass` prop is true. Default false. Templates opt in. |
+| **Card (glass mode)** | glass=true | ✅ Full | Explicitly opted in. |
+| **Card (default)** | glass=false | ⬜ No glass | Opaque `var(--color-bg-card)`. |
+| **Widget** | `content/widget.blade.php` | 🔵 Subtle | blur(4px) is cheap even at 10+ widgets. |
+| **Accordion** | `accordion.blade.php` | ⬜ No glass | Text readability. |
+| **Collapsible** | `collapsible.blade.php` | ⬜ No glass | Same. |
+
+### 3.3 Overlay Surfaces
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Modal** | `actions/modal.blade.php` | ✅ Full | Already using glass tokens. |
+| **Modal (confirm-delete)** | `actions/confirm-delete.blade.php` | ✅ Full | Same. |
+| **Dropdown menu** | `elements/dropdown.blade.php` | ✅ Full | Small floating surface. |
+| **Button dropdown** | `button-dropdown.blade.php` | ✅ Full | Same. |
+| **Link dropdown** | `link-dropdown.blade.php` | ✅ Full | Same. |
+| **Tooltip** | Custom / inline | 🔵 Subtle | Small, transient. |
+| **Popover** | Health popover, etc. | 🔵 Subtle | Medium floating. |
+| **Toast / notification** | Floating alert | 🔵 Subtle | Position TBD (not a glass decision). |
+| **Context menu** | Right-click menus | ✅ Full | Dropdown pattern. |
+
+### 3.4 Form Elements
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Input** | `forms/input.blade.php` | ⬜ No glass | **Never glass.** |
+| **Select** | `forms/select.blade.php` | ⬜ No glass | Same. |
+| **Textarea** | `forms/textarea.blade.php` | ⬜ No glass | Same. |
+| **Checkbox/Toggle** | `forms/checkbox.blade.php` | ⬜ No glass | Opaque for clarity. |
+| **Custom select dropdown** | JS select only | ✅ Full | Options panel follows dropdown rules. |
+
+### 3.5 Data Display
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Table** | `elements/table.blade.php` | ⬜ No glass | **Never glass.** |
+| **Table wrapper card** | Card wrapping table | ⬜ No glass | No glass for tabular content. |
+| **Metric cell** | `metric-cell.blade.php` | ⬜ No glass | Number readability. |
+| **Proportion bar** | `proportion-bar.blade.php` | ⬜ No glass | Small data element — stay opaque. |
+| **Progress bar** | `progress.blade.php` | ⬜ No glass | Small data element — stay opaque. See future emboss spec. |
+
+### 3.6 Specialized Components
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Stageflow card (active)** | `stageflow/card.blade.php` | ⬜ No glass | Shadow + accent border + scale already differentiates. Glass is noise. |
+| **Stageflow card (inactive)** | `stageflow/card.blade.php` | ⬜ No glass | Dimmed/scaled — glass fights "receded" look. |
+| **Kanban column** | `kanban/` components | ⬜ No glass | Content-dense. |
+| **Kanban card** | Task cards | ⬜ No glass | N cards = N composites. |
+| **Selectable tiles** | `selectable.blade.php` | 🔶 Conditional | Selected = subtle glass. Unselected = opaque. |
+| **Inline edits** | `inlineLinks/Select/dropdownPill` | ⬜ No glass | Stay opaque for focus. |
+| **Dropdown pill** | `dropdownPill.blade.php` | ⬜ No glass | Its dropdown menu IS glass per 3.3. |
+| **Empty state** | `empty-state.blade.php` | ⬜ No glass | Illustration provides interest. |
+| **Page header** | `pageheader.blade.php` | ⬜ No glass | Structural. Sticky header (3.1) gets glass. |
+| **Tabs** | `tabs.blade.php` | ⬜ No glass | Nav element, not a surface. |
+| **Timeline / Gantt bars** | Milestone bars | ⬜ No glass | Many instances — stay opaque. See future emboss spec. |
+
+### 3.7 Alert & Feedback
+
+| Surface | Blade Component | Decision | Rationale |
+|---------|----------------|----------|-----------|
+| **Alert (inline)** | `feedback/alert.blade.php` | ⬜ No glass | Semantic bg tints = status signal. |
+| **Alert (floating/toast)** | Same, floating context | 🔵 Subtle | Floats over content. |
+| **Badge** | `badge.blade.php` | ⬜ No glass | Tiny element. |
+| **Health popover** | Stageflow health | 🔵 Subtle | Small floating panel. |
+| **AI assist popover** | AI trigger | 🔵 Subtle | Floating preview. |
+
+---
+
+## 4. Emboss Patterns — OUT OF SCOPE
+
+Emboss (inset track/fill treatment for progress bars, milestones, toggles) is **not** glass. Glass = `backdrop-filter` frosted surfaces. Emboss = layered opacity for depth on small bar elements. Different visual concern, different implementation pattern.
+
+| Topic | Redirect |
+|-------|----------|
+| Progress bar emboss | Future spec: Progress & Bar Visual Polish |
+| Milestone/Gantt bar emboss | Future spec: Timeline Visual Polish |
+| Toggle track emboss | Future spec: Form Component Polish |
+
+The `--emboss-track` and `--emboss-highlight` tokens committed in Phase A are inert (nothing references them). They will be consumed by the emboss spec when written.
+
+---
+
+## 5. Hardcoded Blur Inventory
+
+These existing hardcoded blur values must be migrated to glass tokens:
+
+| Location | Current Value | Should Be | Phase |
+|----------|-------------|-----------|-------|
+| `resources/css/main.css` `#modal-blur-overlay` | `backdrop-filter: blur(12px)` | `backdrop-filter: var(--glass-blur)` | B |
+| Registration layout | Inline `backdrop-filter: blur(3px)` | `backdrop-filter: var(--glass-blur-subtle)` | C |
+
+Search for others:
+```bash
+grep -rn "backdrop-filter:\s*blur" \
+  app/Views/ resources/css/ \
+  --include="*.blade.php" --include="*.css" \
+  | grep -v "var(--glass"
+```
+
+---
+
+## 6. Performance Budget
+
+**Target:** ≤15 simultaneously visible glass surfaces.
+
+**Worst case — Dashboard:** Sidebar (1) + Header (1) + 10 widgets (subtle) + 1 dropdown (full) = 13 ✅
+
+**Subtle is cheap:** `blur(4px)` costs roughly half the composite time of `blur(8px)`. Having 10 subtle surfaces ≈ 5 full surfaces in GPU cost.
+
+**Fallback:** `@supports not (backdrop-filter: blur(1px))` → opaque `var(--color-bg-card)`.
+
+---
+
+## 7. Dark Mode
+
+**Current dark values are wrong.** The existing `default/dark.css` uses `rgba(0,0,0,0.5)` (50% opacity pure black) with `blur(24px)`. This is too translucent and too blurry — dark mode glass should be MORE opaque than light mode, not less. Phase A corrects these.
+
+**Target values (Phase A will apply these):**
+
+| Token | light.css (no change) | dark.css (CORRECTED) |
+|-------|-----------------------|---------------------|
+| `--glass-bg` | `rgba(255,255,255,0.85)` | `rgba(30,30,46,0.85)` ← was `rgba(0,0,0,0.5)` |
+| `--glass-blur` | `blur(8px)` | `blur(8px)` ← was `blur(24px)` |
+| `--glass-bg-subtle` | `rgba(255,255,255,0.92)` | `rgba(30,30,46,0.92)` (new) |
+| `--glass-blur-subtle` | `blur(4px)` | `blur(4px)` (new) |
+| `--glass-border` | `rgba(255,255,255,0.2)` | `rgba(255,255,255,0.06)` |
+| `--glass-inset` | `inset 0 1px 0 rgba(255,255,255,0.1)` | `inset 0 1px 0 rgba(255,255,255,0.04)` |
+
+**Opacity hierarchy (both modes):**
+- Subtle glass (92%) > Full glass (85%) > Page background — subtle is MORE opaque (less glass), which is correct
+- minimal theme: 100% opacity both tiers (no glass at all)
+
+**Pitfalls:** Border at 0.06 white is the sweet spot (higher = bright outline, lower = invisible).
+
+---
+
+## 8. Accessibility
+
+- Glass surfaces: minimum 12px content padding
+- minimal theme serves as reduced-glass fallback (100% opacity light, 4px blur dark)
+- `prefers-reduced-motion: reduce` → transition duration near-zero, glass is instant
+- No "blur in/out" animations
+
+---
+
+## 9. Design Decisions (Locked)
+
+| # | Question | Decision | Rationale |
+|---|---------|----------|-----------|
+| 1 | Widget glass level | 🔵 **Subtle on all** | blur(4px) at 92% is cheap |
+| 2 | Stageflow active card | ⬜ **No glass** | Already differentiated by shadow + border + scale |
+| 3 | Sidebar asymmetry | **Intentional** | Nav = landmark (full), panels = contextual (subtle) |
+| 4 | Toast position | **Deferred** | Notification system decision, not glass |
+| 5 | Card glass default | **Keep false** | Templates opt in |
+
+---
+
+## 10. Out of Scope (Tracked Elsewhere)
+
+The following items were discussed during glass effects design review but belong in separate specs:
+
+| Item | Why it's separate | Tracked in |
+|------|------------------|------------|
+| Phase row UX redesign (chevron-left layout, grayscale picker, dual swatch palettes) | Interaction/layout design, not visual surface treatment | Logic Model Canvas spec (Phase 2a) |
+| Toast/notification positioning | Notification system decision, not glass | Deferred |
+| Consumer migration (Leantime → Focus theme) | Theme strategy, not glass effects | Pending decision |
+
+## 11. Implementation Priority
+
+| Phase | What | Effort |
+|-------|------|--------|
+| **A** | Normalize dark mode values + subtle glass tokens + utility classes in 4 theme files | Small–Medium |
+| **B** | Overlay surfaces + `#modal-blur-overlay` hardcoded fix | Medium |
+| **C** | Layout surfaces + registration inline blur fix | Medium |
+| **D** | Card glass prop fix (tw:lt-glass → .lt-glass), widget subtle glass | Medium |
+| **E** | Dark mode verification across both themes | Testing |

--- a/Docs/leantime-mobile-backend-compatibility.md
+++ b/Docs/leantime-mobile-backend-compatibility.md
@@ -1,0 +1,275 @@
+# Leantime Mobile App: Backend Compatibility Audit
+
+## Companion to `leantime-4.0-dev-unique-changes.md` and `leantime-plugin-changes-forward-port.md`
+
+**Mobile App:** React Native (Expo) at `/Users/gloriafolaron/Herd/leantime-mobile`
+**Backend Target:** v3.6.2 (current mainline)
+**Risk Assessment:** How the mobile app connects to the backend, and what breaks on 4.0-dev
+**Generated:** February 12, 2026
+
+---
+
+## Architecture Overview
+
+The mobile app communicates with Leantime via two mechanisms:
+
+1. **JSON-RPC** (`/api/jsonrpc`) — All data operations (tasks, projects, users, calendar, timesheets, notes, comments)
+2. **Direct HTTP** — Authentication only (`/advancedAuth/getToken`, `/advancedAuth/mobileStatus`)
+
+Authentication uses Bearer tokens from the AdvancedAuth plugin's personal token system. Every API call goes through a single `apiClient` class that adds `Authorization: Bearer {token}` headers.
+
+---
+
+## 🔴 CRITICAL: Authentication Depends on AdvancedAuth Plugin
+
+The mobile app's entire auth flow requires the **AdvancedAuth plugin** (new in v3.6.2, does NOT exist in 4.0-dev):
+
+### Login Flow
+```
+POST /advancedAuth/getToken
+Content-Type: application/x-www-form-urlencoded
+Body: username={email}&password={pass}&device_name=Leantime+Mobile
+→ Returns: { id, token, user? }
+```
+
+### Instance Discovery
+```
+GET /advancedAuth/mobileStatus
+→ Returns: { mobileAuthEnabled, instanceName, version, minAppVersion }
+```
+
+**4.0-dev has NO AdvancedAuth plugin.** The mobile app cannot authenticate at all against 4.0-dev without it. This is a hard blocker — not a degraded experience, a complete failure to connect.
+
+### What's Needed
+The forward-ported branch must include the AdvancedAuth plugin AND the core auth service that supports `createToken()`:
+- `app/Plugins/AdvancedAuth/Controllers/GetToken.php` — handles POST login + token creation
+- `app/Domain/Auth/Services/AccessToken.php` — personal token generation (verify this exists in v3.6.2)
+- The `mobileStatus` endpoint does NOT exist in the codebase yet (the mobile app gracefully falls back when it's missing)
+
+---
+
+## JSON-RPC Method Inventory
+
+Every RPC call the mobile app makes, mapped to the backend service method. All use the pattern:
+`leantime.rpc.{Domain}.{Service}.{method}`
+
+### ✅ Tickets (Tasks) — `app/Domain/Tickets/Services/Tickets.php`
+
+All methods verified present in v3.6.2:
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Tickets.Tickets.getAll` | `getAll(?array $searchCriteria, ?int $limit)` | ✅ |
+| `Tickets.Tickets.getAllOpenUserTickets` | `getAllOpenUserTickets(?int $userId, ?int $project)` | ✅ |
+| `Tickets.Tickets.getOpenUserTicketsThisWeekAndLater` | `getOpenUserTicketsThisWeekAndLater(...)` | ✅ |
+| `Tickets.Tickets.getTicket` | `getTicket($id)` | ✅ |
+| `Tickets.Tickets.patch` | `patch($id, $params)` | ✅ |
+| `Tickets.Tickets.quickAddTicket` | `quickAddTicket($params)` | ✅ |
+| `Tickets.Tickets.addTicket` | `addTicket($values)` | ✅ |
+| `Tickets.Tickets.delete` | `delete($id)` | ✅ |
+| `Tickets.Tickets.getAllSubtasks` | `getAllSubtasks(int $ticketId)` | ✅ |
+| `Tickets.Tickets.upsertSubtask` | `upsertSubtask($values, $parentTicket)` | ✅ |
+| `Tickets.Tickets.getStatusLabels` | `getStatusLabels($projectId)` | ✅ |
+| `Tickets.Tickets.getAllStatusLabelsByUserId` | `getAllStatusLabelsByUserId($userId)` | ✅ |
+| `Tickets.Tickets.getAllMilestones` | `getAllMilestones($searchCriteria)` | ✅ |
+| `Tickets.Tickets.getPriorityLabels` | `getPriorityLabels()` | ✅ |
+| `Tickets.Tickets.getEffortLabels` | `getEffortLabels()` | ✅ |
+| `Tickets.Tickets.getTicketTypes` | `getTicketTypes()` | ✅ |
+| `Tickets.Tickets.quickAddMilestone` | `quickAddMilestone(array $params)` | ✅ |
+| `Tickets.Tickets.getScheduledTasks` | `getScheduledTasks(...)` | ✅ |
+| `Tickets.Tickets.pollForNewAccountTodos` | `pollForNewAccountTodos(...)` | ✅ |
+| `Tickets.Tickets.pollForUpdatedAccountTodos` | `pollForUpdatedAccountTodos(...)` | ✅ |
+
+### ✅ Projects — `app/Domain/Projects/Services/Projects.php`
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Projects.Projects.getProjectsAssignedToUser` | `getProjectsAssignedToUser(...)` | ✅ |
+| `Projects.Projects.getProjectsUserHasAccessTo` | `getProjectsUserHasAccessTo($userId)` | ✅ |
+| `Projects.Projects.getProjectHierarchyAssignedToUser` | `getProjectHierarchyAssignedToUser(...)` | ✅ |
+| `Projects.Projects.getAllProjects` | ⚠️ Not found as service method | ⚠️ |
+| `Projects.Projects.getProject` | `getProject(int $id)` | ✅ |
+| `Projects.Projects.getProjectName` | `getProjectName($projectId)` | ✅ |
+| `Projects.Projects.getProjectProgress` | `getProjectProgress($projectId)` | ✅ |
+| `Projects.Projects.getUsersAssignedToProject` | `getUsersAssignedToProject($projectId)` | ✅ |
+| `Projects.Projects.isUserAssignedToProject` | `isUserAssignedToProject(int $userId, int $projectId)` | ✅ |
+| `Projects.Projects.getProjectRole` | `getProjectRole($userId, $projectId)` | ✅ |
+| `Projects.Projects.addProject` | `addProject(array $values)` | ✅ |
+| `Projects.Projects.editProject` | ⚠️ Not a service method (controller-level) | ⚠️ |
+| `Projects.Projects.patch` | `patch($id, $params)` | ✅ |
+| `Projects.Projects.changeCurrentSessionProject` | `changeCurrentSessionProject($projectId)` | ✅ |
+| `Projects.Projects.duplicateProject` | `duplicateProject(...)` | ✅ |
+| `Projects.Projects.getProjectAvatar` | `getProjectAvatar($id)` | ✅ |
+| `Projects.Projects.findProject` | ⚠️ Not found as service method | ⚠️ |
+| `Projects.Projects.getProjectTypes` | `getProjectTypes()` | ✅ |
+| `Projects.Projects.pollForNewProjects` | ⚠️ Not found | ⚠️ |
+| `Projects.Projects.pollForUpdatedProjects` | ⚠️ Not found | ⚠️ |
+
+**Notes:** The `getAllProjects`, `findProject`, `editProject`, `pollForNewProjects`, and `pollForUpdatedProjects` methods are called by the mobile app but may not exist as public service methods exposed to RPC. These may exist in repositories or controllers only. The mobile app should handle RPC errors gracefully for these — verify against actual API testing.
+
+### ✅ Calendar — `app/Domain/Calendar/Services/Calendar.php`
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Calendar.Calendar.getCalendar` | `getCalendar(int $userId, ...)` | ✅ |
+| `Calendar.Calendar.getEvent` | `getEvent(int $eventId)` | ✅ |
+| `Calendar.Calendar.addEvent` | `addEvent(array $values)` | ✅ |
+| `Calendar.Calendar.editEvent` | `editEvent(array $values)` | ✅ |
+| `Calendar.Calendar.patch` | `patch($id, $params)` | ✅ |
+| `Calendar.Calendar.delEvent` | `delEvent(int $id)` | ✅ |
+| `Calendar.Calendar.getICalUrl` | `getICalUrl()` | ✅ |
+| `Calendar.Calendar.getExternalCalendarEvents` | `getExternalCalendarEvents(...)` | ✅ |
+
+### ⚠️ Comments — `app/Domain/Comments/Services/Comments.php`
+
+| Mobile RPC Call | Backend Method | Signature Match |
+|---|---|:---:|
+| `Comments.Comments.getComments` | `getComments($module, $entityId, ...)` | ⚠️ |
+| `Comments.Comments.addComment` | `addComment($values, $module, $entityId, $entity)` | ⚠️ |
+| `Comments.Comments.editComment` | `editComment($values, $id)` | ⚠️ |
+| `Comments.Comments.deleteComment` | `deleteComment($commentId)` | ✅ |
+| `Comments.Comments.pollComments` | `pollComments(?int $projectId, ?int $moduleId)` | ⚠️ |
+
+**Signature mismatch concern:** The mobile app sends `{ moduleId, module }` as named params, but the backend `getComments()` signature is `($module, $entityId, ...)` — parameter ORDER matters for JSON-RPC. The mobile sends `moduleId` but backend expects `entityId`. Similarly, `addComment` expects 4 positional params but mobile sends a `values` object. These may work if the RPC layer maps named params, but could break if it uses positional mapping. **Test thoroughly.**
+
+### ✅ Users — `app/Domain/Users/Services/Users.php`
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Users.Users.getUser` | `getUser($id)` | ✅ |
+| `Users.Users.getUserByEmail` | `getUserByEmail($email)` | ✅ |
+| `Users.Users.getAll` | `getAll()` | ✅ |
+| `Users.Users.getUsersWithProjectAccess` | `getUsersWithProjectAccess(int $currentUser, int $projectId)` | ⚠️ |
+| `Users.Users.getNumberOfUsers` | `getNumberOfUsers()` | ✅ |
+| `Users.Users.addUser` | `addUser(array $values)` | ✅ |
+| `Users.Users.createUserInvite` | `createUserInvite(array $values)` | ✅ |
+| `Users.Users.editUser` | `editUser($values, $id)` | ✅ |
+| `Users.Users.editOwn` | `editOwn($values, $id)` | ⚠️ |
+| `Users.Users.updateUserSettings` | `updateUserSettings($category, $setting, $value)` | ⚠️ |
+| `Users.Users.deleteUser` | `deleteUser(int $id)` | ✅ |
+| `Users.Users.usernameExist` | `usernameExist(string $username, ...)` | ✅ |
+| `Users.Users.getProfilePicture` | `getProfilePicture($id)` | ✅ |
+| `Users.Users.checkPasswordStrength` | `checkPasswordStrength(string $password)` | ✅ |
+
+**Signature concerns:**
+- `getUsersWithProjectAccess` — backend requires `($currentUser, $projectId)` but mobile sends `{ projectId }` only
+- `editOwn` — backend requires `($values, $id)` but mobile sends `params` without `$id`
+- `updateUserSettings` — backend requires 3 positional params `($category, $setting, $value)` but mobile sends `{ oderId: userId, ...settings }`
+
+### ✅ Timesheets — `app/Domain/Timesheets/Services/Timesheets.php`
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Timesheets.Timesheets.logTime` | `logTime(int $ticketId, array $params)` | ✅ |
+| `Timesheets.Timesheets.upsertTime` | `upsertTime(int $ticketId, array $params)` | ✅ |
+| `Timesheets.Timesheets.isClocked` | `isClocked(int $sessionId)` | ✅ |
+| `Timesheets.Timesheets.punchIn` | `punchIn(int $ticketId)` | ✅ |
+| `Timesheets.Timesheets.punchOut` | `punchOut(int $ticketId)` | ✅ |
+| `Timesheets.Timesheets.getLoggedHoursForTicketByDate` | `getLoggedHoursForTicketByDate(int $ticketId)` | ✅ |
+| `Timesheets.Timesheets.getSumLoggedHoursForTicket` | `getSumLoggedHoursForTicket(int $ticketId)` | ✅ |
+| `Timesheets.Timesheets.getRemainingHours` | `getRemainingHours(int|Tickets $ticketOrId)` | ✅ |
+| `Timesheets.Timesheets.getUsersTicketHours` | `getUsersTicketHours(int $ticketId, int $userId)` | ✅ |
+| `Timesheets.Timesheets.getLoggableHourTypes` | `getLoggableHourTypes()` | ✅ |
+| `Timesheets.Timesheets.pollForNewTimesheets` | `pollForNewTimesheets(?int $projectId)` | ✅ |
+| `Timesheets.Timesheets.pollForUpdatedTimesheets` | `pollForUpdatedTimesheets(?int $projectId)` | ✅ |
+| `Timesheets.Timesheets.deleteTime` | `deleteTime(int $id)` | ✅ |
+
+**Note:** `getAll` and `getWeeklyTimesheets` require `CarbonInterface` date params which can't be passed via JSON-RPC. The mobile app correctly avoids these, using `pollForNewTimesheets` instead with client-side date filtering.
+
+### ⚠️ Notes — `app/Plugins/Notes/Services/Notes.php`
+
+| Mobile RPC Call | Backend Method | Status |
+|---|---|:---:|
+| `Notes.Notes.getAllCanvas` | Plugin method | ⚠️ |
+| `Notes.Notes.getCanvasItemsByNotebookId` | Plugin method | ⚠️ |
+| `Notes.Notes.getCurrentNotebook` | Plugin method | ⚠️ |
+| `Notes.Notes.getSingleCanvasItem` | Plugin method | ⚠️ |
+| `Notes.Notes.addCanvasItem` | Plugin method | ⚠️ |
+| `Notes.Notes.patchCanvasItem` | Plugin method | ⚠️ |
+| `Notes.Notes.delCanvasItem` | Plugin method | ⚠️ |
+| `Notes.Notes.addCanvas` | Plugin method | ⚠️ |
+| `Notes.Notes.deleteCanvas` | Plugin method | ⚠️ |
+| `Notes.Notes.patchCanvas` | Plugin method | ⚠️ |
+
+**The Notes plugin exists in BOTH 4.0-dev and v3.6.2**, but v3.6.2's version has 23 files changed (pin/star, sort/filter, color management). The `patchCanvasItem` and `patchCanvas` methods may be new in v3.6.2. If the mobile app targets 4.0-dev without advancing the plugins submodule, Notes will be outdated and `patchCanvasItem`/`patchCanvas` may not exist.
+
+---
+
+## 4.0-dev Compatibility Impact Summary
+
+### Hard Blockers (Mobile app WILL NOT WORK)
+
+| Issue | Why |
+|---|---|
+| **No AdvancedAuth plugin** | Login endpoint `/advancedAuth/getToken` doesn't exist. App can't authenticate. |
+| **No personal token support** | Bearer token auth requires `AccessToken` service that may not exist in 4.0-dev core |
+
+### Likely Broken (Features will fail)
+
+| Issue | Why |
+|---|---|
+| **Notes plugin outdated** | `patchCanvasItem`, `patchCanvas` may not exist in 4.0-dev's Notes version |
+| **Event dispatch changes** | 4.0-dev rewrote `DispatchesEvents` to use Laravel Event facade — RPC method routing may behave differently if it depends on the event system |
+| **Session handling** | 4.0-dev may still use `$_SESSION` which doesn't work with Bearer token auth (tokens bypass session) |
+
+### Probably Fine (Core RPC should work)
+
+| Domain | Why |
+|---|---|
+| **Tickets/Tasks** | All 20 methods exist in both versions. Core CRUD hasn't changed. |
+| **Projects** | Most methods exist. Some edge-case methods may be missing. |
+| **Calendar** | All 8 methods verified present. |
+| **Timesheets** | All 13 methods verified present. |
+| **Users** | All methods present, some signature mismatches to verify. |
+| **Comments** | Methods present but signature ordering needs RPC layer testing. |
+
+---
+
+## `oderId` Typo Pattern
+
+The mobile app sends `oderId` as a parameter name in several places:
+- `projectApi.getProjectHierarchyAssignedToUser` → `{ oderId: userId }`
+- `projectApi.getProjectProgress` → `{ oderId: projectId }`
+- `projectApi.setCurrentProject` → `{ oderId: projectId }`
+- `userApi.updateUserSettings` → `{ oderId: userId, ...settings }`
+
+This appears to be a known Leantime backend parameter naming quirk (likely "orderId" misspelling that stuck). If the backend ever fixes this, the mobile app will break. Worth tracking.
+
+---
+
+## Forward-Port Checklist for Mobile Compatibility
+
+After forward-porting 4.0-dev onto v3.6.2:
+
+- [ ] **AdvancedAuth plugin present and functional** — `/advancedAuth/getToken` POST returns `{ id, token }`
+- [ ] **Bearer token auth works on `/api/jsonrpc`** — tokens bypass session, API middleware accepts `Authorization: Bearer`
+- [ ] **All 20 Tickets RPC methods respond** — especially `patch`, `quickAddTicket`, `getOpenUserTicketsThisWeekAndLater`
+- [ ] **All 18 Projects RPC methods respond** — especially `getProjectsAssignedToUser`, `changeCurrentSessionProject`
+- [ ] **All 8 Calendar RPC methods respond** — especially `getCalendar`, `getExternalCalendarEvents`
+- [ ] **All 5 Comments RPC methods respond** — test parameter ordering carefully
+- [ ] **All 13 Timesheets RPC methods respond** — especially `logTime`, `punchIn/punchOut`, `isClocked`
+- [ ] **All 15 Users RPC methods respond** — especially `getUser` (no params = current user), `getUsersWithProjectAccess`
+- [ ] **All 10 Notes RPC methods respond** — especially `patchCanvasItem`, `patchCanvas` (may be new)
+- [ ] **401 responses trigger properly** — when token expires, API should return 401 so mobile handles re-auth
+- [ ] **JSON-RPC error format consistent** — `{ jsonrpc: "2.0", error: { code, message } }` on failures
+
+---
+
+## Data Model Assumptions
+
+The mobile app expects these field names from the backend (any rename breaks the app):
+
+### Task fields consumed
+`id`, `headline`, `description`, `projectId`, `projectName`, `status` (numeric), `priority` (numeric 1-5), `storyPoints`, `hourRemaining`, `planHours`, `dueDate`, `dateToFinish`, `editFrom`, `editTo`, `authorId`, `editorId`, `editorFirstName`/`editorFirstname`, `editorLastName`/`editorLastname`, `milestoneId`/`milestoneid`, `milestoneHeadline`, `milestoneColor`, `tags`, `createdAt`, `updatedAt`
+
+### Project fields consumed
+`id`, `name`, `clientId`, `clientName`, `color`
+
+### User fields consumed
+`id`, `firstName`, `lastName`, `email`, `role`, `profileId`
+
+If 4.0-dev renamed any of these fields (e.g., camelCase → snake_case during Laravel migration), the mobile app will show blank data without errors.
+
+---
+
+*This document was compiled from static analysis of the leantime-mobile source code at `/Users/gloriafolaron/Herd/leantime-mobile/src/` and method signature verification against the Leantime v3.6.2 backend at `/Users/gloriafolaron/herd/leantime/app/`. RPC method existence was verified by grep against service class files; actual JSON-RPC routing behavior should be confirmed by live testing.*

--- a/Docs/leantime-mobile-backend-compatibility.md
+++ b/Docs/leantime-mobile-backend-compatibility.md
@@ -130,7 +130,7 @@ All methods verified present in v3.6.2:
 | `Comments.Comments.deleteComment` | `deleteComment($commentId)` | ✅ |
 | `Comments.Comments.pollComments` | `pollComments(?int $projectId, ?int $moduleId)` | ⚠️ |
 
-**Signature mismatch concern:** The mobile app sends `{ moduleId, module }` as named params, but the backend `getComments()` signature is `($module, $entityId, ...)` — parameter ORDER matters for JSON-RPC. The mobile sends `moduleId` but backend expects `entityId`. Similarly, `addComment` expects 4 positional params but mobile sends a `values` object. These may work if the RPC layer maps named params, but could break if it uses positional mapping. **Test thoroughly.**
+**Signature mismatch concern:** The mobile app sends `{ moduleId, module }` as named params, but the backend `getComments()` signature is `($module, $entityId, ...)` — the JSON-RPC controller maps request keys to parameter NAMES via reflection, so the risk is mismatched parameter names, not ordering. The mobile sends `moduleId` but the backend parameter is `$entityId` — that key never binds. Similarly `addComment` takes 4 named params while mobile sends a `values` object. **Test thoroughly.**
 
 ### ✅ Users — `app/Domain/Users/Services/Users.php`
 

--- a/Docs/leantime-naming-conventions.md
+++ b/Docs/leantime-naming-conventions.md
@@ -1,0 +1,430 @@
+# Leantime Design System — Naming Conventions Reference
+
+> Blade Components · CSS Tokens · Attribute API
+>
+> How to name things so humans and AI agents can read, write, and maintain Leantime code without guessing. This is the single source of truth for the naming system that connects Blade templates, CSS custom properties, and component attributes.
+
+---
+
+## 1. The Naming Philosophy
+
+Every name answers **"What is this for?"** — never "What does it look like?"
+
+```
+Bad:  bg-blue-500         →  Good: bg-primary
+Bad:  --lt-bg-2           →  Good: --color-surface-card
+Bad:  font-lg-bold        →  Good: --text-heading-2
+```
+
+This applies to three naming surfaces:
+
+1. **Blade component tags and attributes** — how you call components in templates
+2. **CSS custom properties (design tokens)** — how you style them
+3. **Component attribute values** — the shared vocabulary for role, state, and scale
+
+---
+
+## 2. Blade Component Tags
+
+### 2.1 Tag Name Grammar
+
+```blade
+<x-{scope}::{category}.{component}>
+```
+
+| Segment | Rule | Examples |
+|---------|------|----------|
+| `scope` | `globals` (shared) or domain name | `globals`, `tickets`, `projects` |
+| `category` | Functional group from tracker | `actions`, `elements`, `forms`, `navigation`, `feedback`, `layout` |
+| `component` | kebab-case, singular noun | `dropdown-menu`, `text-input`, `badge` |
+
+### 2.2 Complete Component Tag Registry
+
+#### Global Simple
+
+| Component | Tag Name | Category | Priority |
+|-----------|----------|----------|----------|
+| dropdown-menu | `<x-globals::actions.dropdown-menu>` | actions | P0 |
+| modal | `<x-globals::actions.modal>` | actions | P0 |
+| chip | `<x-globals::actions.chip>` | actions | P0 |
+| card | `<x-globals::elements.card>` | elements | P0 |
+| avatar | `<x-globals::elements.avatar>` | elements | P1 |
+| accordion | `<x-globals::elements.accordion>` | elements | P1 |
+| table | `<x-globals::elements.table>` | elements | P1 |
+| empty-state | `<x-globals::elements.empty-state>` | elements | P1 |
+| date-info | `<x-globals::elements.date-info>` | elements | P1 |
+| code | `<x-globals::elements.code>` | elements | P1 |
+| statistic | `<x-globals::elements.statistic>` | elements | P1 |
+| badge | `<x-globals::elements.badge>` | elements | P1 |
+| chat-bubble | `<x-globals::elements.chat-bubble>` | elements | P2 |
+| keyboard | `<x-globals::elements.keyboard>` | elements | P2 |
+| calendar | `<x-globals::elements.calendar>` | elements | P2 |
+| button | `<x-globals::forms.button>` | forms | P0 |
+| checkbox | `<x-globals::forms.checkbox>` | forms | P1 |
+| radio | `<x-globals::forms.radio>` | forms | P1 |
+| select | `<x-globals::forms.select>` | forms | P0 |
+| text-input | `<x-globals::forms.text-input>` | forms | P0 |
+| toggle | `<x-globals::forms.toggle>` | forms | P1 |
+| button-group | `<x-globals::forms.button-group>` | forms | P1 |
+| textarea | `<x-globals::forms.textarea>` | forms | P2 |
+| file-input | `<x-globals::forms.file-input>` | forms | P2 |
+| range | `<x-globals::forms.range>` | forms | P2 |
+| form-field | `<x-globals::forms.form-field>` | forms | P0 |
+| tabs | `<x-globals::navigation.tabs>` | navigation | P0 |
+| steps | `<x-globals::navigation.steps>` | navigation | P1 |
+| breadcrumbs | `<x-globals::navigation.breadcrumbs>` | navigation | P1 |
+| pagination | `<x-globals::navigation.pagination>` | navigation | P1 |
+| context-menu | `<x-globals::navigation.context-menu>` | navigation | P1 |
+| menu | `<x-globals::navigation.menu>` | navigation | P2 |
+| navbar | `<x-globals::navigation.navbar>` | navigation | P2 |
+| alert | `<x-globals::feedback.alert>` | feedback | P1 |
+| loading | `<x-globals::feedback.loading>` | feedback | P1 |
+| progress | `<x-globals::feedback.progress>` | feedback | P1 |
+| skeleton | `<x-globals::feedback.skeleton>` | feedback | P1 |
+| indicator | `<x-globals::feedback.indicator>` | feedback | P1 |
+
+#### Global Special
+
+| Component | Tag Name | Category | Priority |
+|-----------|----------|----------|----------|
+| text-editor | `<x-globals::forms.text-editor>` | forms | P0 |
+| date-picker | `<x-globals::forms.date-picker>` | forms | P0 |
+| color-picker | `<x-globals::forms.color-picker>` | forms | P1 |
+| emoji-input | `<x-globals::forms.emoji-input>` | forms | P2 |
+| select-panel | `<x-globals::action.select-panel>` | action | P1 |
+| page-header | `<x-globals::layout.page-header>` | layout | P1 |
+
+#### Domain Specific
+
+| Component | Tag Name | Category |
+|-----------|----------|----------|
+| list | `<x-globals::comments.list>` | comments |
+| ticket-card | `<x-globals::tickets.ticket-card>` | tickets |
+| milestone-card | `<x-globals::tickets.milestone-card>` | tickets |
+| ticket-state-label | `<x-globals::tickets.ticket-state-label>` | tickets |
+| project-card | `<x-globals::projects.project-card>` | projects |
+
+---
+
+## 3. Component Attribute API
+
+Every component shares a standard set of attributes. Learn it once, use it everywhere.
+
+### 3.1 IDL (Behavioral) Attributes
+
+These control what the component does and how it looks at a behavioral level.
+
+| Attribute | Options | Default | What It Controls |
+|-----------|---------|---------|------------------|
+| `content-role` | `primary`, `secondary`, `ghost`, `accent`, `link`, `default` | `primary` (actions), `default` (elements) | Visual weight / emphasis. Determines whether a button is the main CTA or a quiet secondary action. |
+| `state` | `default`, `info`, `warning`, `danger`, `success` | `default` | Semantic meaning. Maps directly to status colors. An alert with `state="danger"` gets red treatment. |
+| `variant` | (component-specific) | `""` | Behavioral mode. Changes how the component works, not just how it looks. e.g. chip `variant="filter"` vs `variant="action"`. |
+| `scale` | `xs`, `s`, `m`, `l`, `xl` | `m` | Size. Applies to the entire component uniformly — font, padding, icon size all scale together. |
+| `position` | `left`, `right`, `top`, `bottom`, `start`, `end`, `inner`, `outer` | `bottom` | Spatial placement of sub-elements like tooltips, dropdowns, labels. |
+| `element` | `a`, `input`, `button` | (semantic default) | HTML element override. A button that navigates uses `element="a"`. Rare but necessary. |
+| `align` | `start`, `end` | — | Content alignment within the component. |
+
+### 3.2 Content Attributes
+
+These pass content into component slots. Consistent pattern across all form-type components.
+
+| Attribute | Value | Used In | Notes |
+|-----------|-------|---------|-------|
+| `label-text` | string | All form components | The visible label above/beside the input. |
+| `label-position` | `top`, `left`, `right`, `bottom`, `inside` | All form components | Where the label renders relative to the control. |
+| `caption` | string | All form components | Helper text beneath the input. |
+| `validation-text` | string | All form components | Error/success message text. |
+| `validation-state` | `error`, `success`, `warning` | All form components | Which validation style to apply. |
+| `leading-visual` | icon name | dropdown-item, button, input | Icon before the content. |
+| `trailing-visual` | icon name | dropdown-item, button, input | Icon after the content. |
+| `items` | array | dropdown, select | Data source for list-based components. |
+| `link` / `href` | URL string | Any actionable component | Navigation target when the component is clicked. |
+
+### 3.3 The Form Component Pattern
+
+Every form component accepts the same base attribute set. This is the "form field contract" — if a component is in the `forms` category, it supports all of these:
+
+```blade
+<x-globals::forms.text-input
+    label-text="Email address"
+    caption="We'll never share your email"
+    validation-text="Please enter a valid email"
+    validation-state="error"
+    leading-visual="mail"
+    state="danger"
+    scale="m"
+/>
+```
+
+The same pattern works for `checkbox`, `radio`, `select`, `textarea`, `toggle`, `file-input`, and `range`. A developer who knows one knows all of them.
+
+---
+
+## 4. CSS Token Naming
+
+Leantime uses CSS custom properties as design tokens. The naming system has three layers, modeled after GitHub Primer's approach.
+
+### 4.1 The Three Layers
+
+| Layer | Purpose | Example | Who Uses It |
+|-------|---------|---------|-------------|
+| **Base (Primitive)** | Raw values. Never used in components. | `--lt-color-blue-500: #1B75BB` | Token file only. `theme.css` defines these. |
+| **Functional (Semantic)** | What it's for. Used in templates. | `--color-brand-primary: var(--lt-color-blue-500)` | Any template, any component. |
+| **Component** | Scoped to one component. Overridable. | `--btn-bg-primary: var(--color-brand-primary)` | Inside that component's CSS only. |
+
+### 4.2 Token Name Grammar
+
+```
+--{category}-{property}-{element}-{variant}-{state}
+```
+
+Read left to right: start broad, get specific. Not every segment is required — use only what's needed to be unambiguous.
+
+| Segment | What It Is | Values |
+|---------|-----------|--------|
+| `category` | What kind of token | `color`, `spacing`, `radius`, `shadow`, `text`, `z`, `size` |
+| `property` | What CSS property it maps to | `bg`, `border`, `text`, `surface`, `brand`, `focus`, `font`, `weight`, `line` |
+| `element` | What UI element it targets | `page`, `card`, `input`, `sidebar`, `header`, `modal`, `overlay` |
+| `variant` | Semantic variation | `primary`, `secondary`, `muted`, `danger`, `success`, `warning`, `info` |
+| `state` | Interaction state | `default`, `hover`, `focus`, `active`, `disabled` |
+
+### 4.3 Naming Shortcuts (Decision Tree)
+
+1. **Is it a raw value (hex, px, rem)?** → Base layer. Prefix with `--lt-`. Example: `--lt-color-green-600`
+2. **Is it used across many components?** → Functional layer. No prefix. Example: `--color-state-danger`
+3. **Is it only for one component?** → Component layer. Prefix with component name. Example: `--btn-bg-primary`
+
+### 4.4 Functional Token Quick Reference
+
+#### Colors
+
+| Token | Use It For | Maps To |
+|-------|-----------|---------|
+| `--color-brand-primary` | Main brand color, primary buttons, active states | `--lt-color-blue-500` |
+| `--color-brand-secondary` | Secondary accents, hover highlights | `--lt-color-green-500` |
+| `--color-surface-page` | Page background | `--lt-color-gray-50` |
+| `--color-surface-card` | Card/panel backgrounds | `#ffffff` |
+| `--color-surface-inset` | Recessed areas, code blocks, table stripes | `--lt-color-gray-100` |
+| `--color-surface-overlay` | Modal/dropdown backdrops | `rgba(0,0,0,0.5)` |
+| `--color-text-default` | Body text | `--lt-color-gray-800` |
+| `--color-text-muted` | Secondary text, captions, timestamps | `--lt-color-gray-500` |
+| `--color-text-link` | Hyperlinks | `--color-brand-primary` |
+| `--color-text-on-emphasis` | Text on colored backgrounds (buttons etc) | `#ffffff` |
+| `--color-border-default` | Standard borders | `--lt-color-gray-200` |
+| `--color-border-emphasis` | Active/focused borders | `--lt-color-gray-400` |
+| `--color-state-danger` | Errors, destructive actions | `--lt-color-red-500` |
+| `--color-state-warning` | Warnings, at-risk indicators | `--lt-color-yellow-500` |
+| `--color-state-success` | Confirmations, on-track indicators | `--lt-color-green-500` |
+| `--color-state-info` | Informational alerts, tips | `--lt-color-blue-400` |
+| `--color-focus-ring` | Keyboard focus outline (a11y critical) | `--lt-color-blue-300` |
+
+#### Spacing
+
+| Token | Value | Typical Use |
+|-------|-------|-------------|
+| `--spacing-xs` | `0.25rem` (4px) | Tight gaps, icon margins |
+| `--spacing-s` | `0.5rem` (8px) | Inner padding, compact lists |
+| `--spacing-m` | `1rem` (16px) | Default padding, card gutters |
+| `--spacing-l` | `1.5rem` (24px) | Section spacing |
+| `--spacing-xl` | `2rem` (32px) | Page margins, major separations |
+| `--spacing-2xl` | `3rem` (48px) | Hero spacing, layout gaps |
+
+#### Typography
+
+| Token | Value | Use For |
+|-------|-------|---------|
+| `--text-xs` | `0.75rem` | Badges, tiny labels |
+| `--text-s` | `0.875rem` | Captions, helper text |
+| `--text-m` | `1rem` | Body text (default) |
+| `--text-l` | `1.25rem` | Subheadings, emphasis |
+| `--text-xl` | `1.5rem` | Page titles |
+| `--text-2xl` | `2rem` | Hero headings |
+| `--font-family-base` | `system-ui, sans-serif` | All UI text |
+| `--font-family-mono` | `monospace` | Code blocks, pre |
+| `--font-weight-normal` | `400` | Body text |
+| `--font-weight-medium` | `500` | Labels, emphasis |
+| `--font-weight-bold` | `700` | Headings, strong emphasis |
+
+#### Radius, Shadow, Z-Index
+
+| Token | Value | Use For |
+|-------|-------|---------|
+| `--radius-s` | `0.25rem` | Buttons, badges, chips |
+| `--radius-m` | `0.5rem` | Cards, inputs, dropdowns |
+| `--radius-l` | `1rem` | Modals, large panels |
+| `--radius-full` | `9999px` | Avatars, pills |
+| `--shadow-s` | `0 1px 2px rgba(0,0,0,0.05)` | Subtle lift: buttons, chips |
+| `--shadow-m` | `0 4px 6px rgba(0,0,0,0.07)` | Cards, dropdowns |
+| `--shadow-l` | `0 10px 15px rgba(0,0,0,0.1)` | Modals, popovers |
+| `--z-dropdown` | `1000` | Dropdown menus |
+| `--z-sticky` | `1100` | Sticky headers |
+| `--z-modal` | `1300` | Modal dialogs |
+| `--z-toast` | `1400` | Toast notifications |
+
+---
+
+## 5. Component Token Patterns
+
+When a component needs its own token, prefix with the component's short name. The internal structure mirrors the attribute API: `content-role` maps to variant, `state` maps to state.
+
+### 5.1 Token ↔ Attribute Alignment
+
+The CSS token names and the Blade attribute values share vocabulary. This is intentional — if a button accepts `content-role="primary"`, its CSS token is `--btn-bg-primary`.
+
+| Blade Attribute | Attribute Value | CSS Token Pattern |
+|----------------|----------------|-------------------|
+| `content-role="primary"` | `primary` | `--{component}-bg-primary`, `--{component}-text-primary` |
+| `content-role="secondary"` | `secondary` | `--{component}-bg-secondary` |
+| `content-role="ghost"` | `ghost` | `--{component}-bg-ghost` (transparent) |
+| `state="danger"` | `danger` | `--{component}-bg-danger`, `--{component}-border-danger` |
+| `state="success"` | `success` | `--{component}-bg-success` |
+| `scale="s"` | `s` | `--{component}-padding-s`, `--{component}-font-s` |
+
+### 5.2 Button Tokens (Example)
+
+```css
+/* Button component tokens — defined in button.blade.php or component CSS */
+--btn-bg-primary:     var(--color-brand-primary);
+--btn-bg-secondary:   var(--color-surface-inset);
+--btn-bg-ghost:       transparent;
+--btn-text-primary:   var(--color-text-on-emphasis);
+--btn-text-secondary: var(--color-text-default);
+--btn-border-default: var(--color-border-default);
+--btn-padding-s:      var(--spacing-xs) var(--spacing-s);
+--btn-padding-m:      var(--spacing-s) var(--spacing-m);
+--btn-padding-l:      var(--spacing-m) var(--spacing-l);
+```
+
+Every component follows this same pattern. Replace `btn` with `card`, `input`, `alert`, `chip`, `badge`, `modal`, etc.
+
+### 5.3 Naming a New Component Token
+
+```
+--{short-name}-{property}-{variant}
+```
+
+| short-name | property | variant (optional) |
+|-----------|----------|-------------------|
+| `btn`, `card`, `input`, `alert` | `bg`, `text`, `border`, `shadow`, `padding`, `font`, `radius` | `primary`, `secondary`, `ghost`, `danger`, `success` |
+| `chip`, `badge`, `tab`, `modal` | `bg-hover`, `border-focus`, `text-muted` | `info`, `warning`, `active`, `disabled` |
+| `select`, `toggle`, `radio` | `ring` (focus ring width), `gap` (spacing between) | `checked`, `unchecked`, `indeterminate` |
+
+---
+
+## 6. The Rules
+
+1. **Tailwind + DaisyUI only.** No custom CSS without approval (per Guidelines checklist). Design tokens are the exception — they're defined in `theme.css`.
+
+2. **No magic numbers.** Every spacing, color, and font-size value must come from a token. Never hardcode px, hex, or rem in a template.
+
+3. **Kebab-case everything.** Component names, attribute names, CSS tokens. All kebab-case. No camelCase, no underscores.
+
+4. **Attributes describe content, not style.** A developer passes `content-role="primary"`, not `class="bg-blue-500 text-white"`. The component decides how to render `primary`.
+
+5. **Components handle their own data.** A developer should not need to reshape data for a component. Pass it from the controller as-is.
+
+6. **No business logic in components.** Components are presentation only. Logic lives in services and controllers.
+
+7. **Fail gracefully.** If an attribute is missing or wrong, the component should render with safe defaults, not throw.
+
+8. **ARIA and WCAG from day one.** Every component includes appropriate `aria-*` attributes. Keyboard navigation works. Focus ring is visible.
+
+9. **Responsive by default.** Every component works on mobile. No separate mobile components.
+
+---
+
+## 7. Copy-Paste Patterns
+
+### Primary Button
+
+```blade
+<x-globals::forms.button content-role="primary" leading-visual="plus">
+    Create New Task
+</x-globals::forms.button>
+```
+
+### Danger Button (Ghost)
+
+```blade
+<x-globals::forms.button content-role="ghost" state="danger">
+    Delete
+</x-globals::forms.button>
+```
+
+### Form Input with Validation
+
+```blade
+<x-globals::forms.text-input
+    label-text="Project Name"
+    caption="Choose something memorable"
+    validation-text="{{ $errors->first('name') }}"
+    validation-state="error"
+    :value="$project->name"
+/>
+```
+
+### Select with Remote Data
+
+```blade
+<x-globals::forms.select
+    label-text="Assign To"
+    variant="tags"
+    :items="$teamMembers"
+    search="true"
+/>
+```
+
+### Status Badge
+
+```blade
+<x-globals::elements.badge state="success" scale="s">
+    On Track
+</x-globals::elements.badge>
+```
+
+### Alert Toast
+
+```blade
+<x-globals::feedback.alert state="warning" variant="toast">
+    Your session will expire in 5 minutes.
+</x-globals::feedback.alert>
+```
+
+### Card with Dropdown
+
+```blade
+<x-globals::elements.card>
+    <x-globals::actions.dropdown-menu position="right">
+        <x-globals::actions.dropdown-item leading-visual="edit" href="/edit">
+            Edit
+        </x-globals::actions.dropdown-item>
+        <x-globals::actions.dropdown-item leading-visual="trash" state="danger">
+            Delete
+        </x-globals::actions.dropdown-item>
+    </x-globals::actions.dropdown-menu>
+    {{ $content }}
+</x-globals::elements.card>
+```
+
+---
+
+## 8. Notes for AI Coding Agents
+
+If you're an AI agent working on Leantime code:
+
+- **Tag names are predictable:** `<x-globals::{category}.{component}>`. If you know the component name and its category from Section 2, you can construct the tag.
+
+- **Token names are predictable:** `--color-{purpose}-{variant}` for colors, `--spacing-{size}` for spacing. Don't guess hex codes.
+
+- **The attribute vocabulary is shared:** `content-role`, `state`, `scale`, `variant`, `leading-visual`, `trailing-visual` work the same on every component.
+
+- **State values map to colors:** `danger`=red, `warning`=yellow, `success`=green, `info`=blue. Always use `state`, never a color class.
+
+- **Content-role values map to emphasis:** `primary`=filled/loud, `secondary`=outlined/medium, `ghost`=transparent/quiet, `accent`=brand secondary color.
+
+- **Theme safety:** Use tokens, not raw values. Tokens automatically adapt to dark mode, custom themes, and accessibility modes. Raw hex codes break.
+
+---
+
+*Leantime Design System · Naming Conventions Reference · v1.0 · February 2026*
+*Companion to: leantime-token-migration-spec.docx · Source: Component Updates Tracker spreadsheet*

--- a/Docs/leantime-plugin-changes-forward-port.md
+++ b/Docs/leantime-plugin-changes-forward-port.md
@@ -1,0 +1,403 @@
+# Leantime Plugin Ecosystem: Forward-Port Reference
+
+## Companion Document to `leantime-4.0-dev-unique-changes.md`
+
+**Scope:** 926 commits | 793 files changed (excl. vendor/node_modules/dist) | Plugins submodule + core plugin infrastructure
+**Comparison:** Plugins submodule commit `3156738` (4.0-dev) → `5ed0b93c` (v3.6.2)
+**Key Finding:** The plugins submodule did NOT diverge — 4.0-dev's commit is an **ancestor** of v3.6.2's. All 926 commits moved forward only on mainline.
+**Generated:** February 12, 2026
+
+---
+
+## How the Plugins Submodule Relates to the Main Repo
+
+The main Leantime repo includes `app/Plugins` as a git submodule pointing to `github.com/Leantime/plugins`. Each branch of the main repo pins a specific commit of this submodule:
+
+- **4.0-dev** pins commit `3156738` ("resolve merge conflicts") — an early snapshot
+- **v3.6.2** pins commit `5ed0b93c` ("fix recurring task issue") — 926 commits ahead
+
+Since 4.0-dev branched, mainline continued heavy plugin development while the 4.0-dev submodule pointer was never advanced. This means:
+
+1. **4.0-dev is missing 7 entirely new plugins** built since it branched
+2. **4.0-dev is missing 926 commits** of bug fixes, features, and refactoring to existing plugins
+3. **The core plugin infrastructure** (in the main repo, not the submodule) diverged on BOTH branches — this is where the real conflicts live
+
+---
+
+## Plugins at Time of 4.0-dev Branch (29 plugins)
+
+These plugins existed when 4.0-dev branched and have since been modified on mainline:
+
+| Plugin | Files Changed | Severity | Key Changes |
+|--------|:---:|:---:|---|
+| Llamadorian | 68 | 🔴 | Heavy refactoring, route updates, prioritization removed, Bedrock provider updates |
+| CustomFields | 40 | 🔴 | 7 files deleted, rewrite of composers/contracts, language registration added |
+| StrategyPro | 31 | 🟡 | Template updates, stakeholder editing fix, dashboard changes |
+| Billing | 26 | 🟡 | 20 new files (Blade templates, Jobs, credits system), cron/subscription rework |
+| Notes | 23 | 🟡 | Pin/star functionality, sort/filter, color management, widget restyle |
+| PgmPro | 20 | 🟡 | Template and service updates |
+| Whiteboardscanvas | 19 | 🟡 | Canvas/whiteboard template changes |
+| ProjectWizard | 15 | 🟢 | Template updates, 2 new files |
+| Accounts | 13 | 🟡 | Major register.php rewrite, controller updates, inline class removed |
+| Workflows | 10 | 🟢 | Model/service/listener updates |
+| ThemeBundle | 8 | 🟢 | 9 new files (assets, templates, listeners) |
+| Crisp | 8 | 🟢 | 5 new files, eventlistener/hxcontroller additions |
+| Pomodoro | 6 | 🟢 | Minor updates |
+| ClientConfigLoader | 6 | 🟢 | Cache-based config loading, service provider update |
+| SponsorLeantime | 5 | 🟢 | Minor updates |
+| Implementationintentions | 5 | 🟢 | Minor updates |
+| Freshsales | 5 | 🟢 | Minor updates |
+| Sentry | 4 | 🟢 | Minor updates |
+| GoogleAnalytics | 3 | 🟢 | Minor updates |
+| ApiRateLimiter | 3 | 🟢 | Minor updates |
+| Zapier | 2 | 🟢 | Controller update |
+| Subscriptions | — | 🟢 | Minimal changes |
+| WorkspaceManager | — | 🟢 | register.php rewrite |
+| Wootric | — | 🟢 | Minimal changes |
+
+---
+
+## 7 Entirely New Plugins (Not in 4.0-dev)
+
+These plugins were created after 4.0-dev branched and must be added to the forward-ported branch.
+
+### Copilot (141 new files) — 🔴 CRITICAL
+
+The AI copilot system, by far the largest new plugin. This is a full agent framework:
+
+**Architecture:**
+- `Agents/` — Multi-agent system with action agents (TaskBreakdown, TaskPrioritization, WritingAssistant), admin agents (Analysis, Orchestration, Synthesis), special agents (ACTCoach, EnvironmentOptimizer, ProjectManager, SystemGuide, WorkNavigator)
+- `AiProviders/Bedrock/` — AWS Bedrock integration (chat, streaming, structured output, message mapping)
+- `Chat/` — History management, structured outputs (30+ component classes for cognitive assessment, memory, motivation, patterns), token tracking
+- `Memory/` — MemoryServiceProvider for persistent AI context
+- `Prompts/` — Prompt management with sync command
+- `Tools/` — Tool integrations
+- `Observability/` — Monitoring/telemetry
+- Templates, controllers, hxcontrollers, listeners, middleware, models, repositories, services
+
+**Dependencies:** Own `composer.json`, `package.json`, `webpack.mix.js`, compiled dist assets
+
+**Forward-port concern:** This plugin hooks deeply into the core event system, template rendering, and task domain. Its templates will need componentization if 4.0-dev's DaisyUI/Blade component system is applied to plugins.
+
+### McpServer (35 new files) — 🔴 CRITICAL
+
+Model Context Protocol server for AI tool integration:
+
+- `Tools/` — CalendarTools, CommentTools, GoalTools, MilestoneTools, ProjectTools, TicketTools, TimerTools, TimesheetTools, WebSearchTools
+- `Services/` — McpServer, McpToolDiscovery, McpToolExecutor, WebSearchService
+- `Support/` — Custom attributes (`@UnifiedTool`, `@Parameter`), entity formatters, LLM string sanitizer
+- `Middleware/` — McpAuthMiddleware
+- `Command/` — McpDiscoverCommand, McpListCommand, McpStartCommand
+- Own `routes.php`, service provider, composer dependencies
+
+**Forward-port concern:** Uses `AITool` attribute from `app/Core/Support/Attributes/` (added in v3.6.2). The MCP routes are exempted from install/update checks. Relies on the v3.6.2 event system.
+
+### AdvancedAuth (28 new files) — 🟡 MEDIUM
+
+OAuth/SSO authentication with personal API tokens:
+
+- OAuth providers (Keycloak, etc.) with callback/redirect controllers
+- Personal access token management (CRUD controllers + templates)
+- Domain-based authentication routing
+- Company settings integration via listeners
+- Full i18n (35+ language files)
+- Uses `RegistrationService` for language file registration
+
+**Forward-port concern:** Hooks into `leantime.core.middleware.authcheck.*` events (the renamed middleware). Templates are Blade but not componentized.
+
+### Reactions (20 new files) — 🟢 LOW
+
+Emoji reaction system for tickets/comments:
+
+- Event-driven architecture with listeners
+- Own webpack build pipeline (`webpack.mix.js`, compiled assets)
+- HTMX-based UI with hxcontrollers
+- Full i18n support
+
+### CalDAV (18 new files) — 🟢 LOW
+
+Calendar sync via CalDAV protocol:
+
+- CalDAV server implementation with models/repositories/services
+- Database migrations
+- Settings UI with connect/edit/delete templates (Blade)
+- Menu integration via event listeners
+
+### RecurringTasks (16 new files) — 🟢 LOW
+
+Recurring task automation:
+
+- Hxcontrollers, listeners, middleware
+- Models/repositories/services
+- Own webpack build (`webpack.mix.js`, compiled dist)
+- Full i18n support
+
+### EnergyTracker (1 file) — 🟢 LOW
+
+Minimal plugin, services only.
+
+---
+
+## 3 Plugins Removed (Still in 4.0-dev)
+
+These plugins were deleted from mainline after 4.0-dev branched:
+
+| Plugin | Action Required |
+|--------|----------------|
+| **Mixpanel** | Delete from 4.0-dev. LICENSE was moved to AdvancedAuth. |
+| **VWO** | Delete from 4.0-dev. `composer.json` was repurposed for AdvancedAuth. |
+| **.idea** | Delete from 4.0-dev. IDE config files cleaned up. |
+
+---
+
+## ⚠️ CRITICAL: Event Hook Name Changes
+
+The most impactful change across all plugins is the **middleware rename** from `auth` to `authcheck` in event hook strings. This affects every plugin that registers public routes, login handlers, or API authentication.
+
+### Before (4.0-dev era)
+```php
+// These hook names exist in 4.0-dev's plugin register.php files
+EventDispatcher::add_filter_listener("leantime.core.middleware.auth.*.publicActions", ...);
+EventDispatcher::add_event_listener("leantime.core.middleware.auth.handle.logged_in", ...);
+EventDispatcher::add_event_listener("leantime.core.middleware.apiAuth.handle.before_api_request", ...);
+```
+
+### After (v3.6.2)
+```php
+// These are the current hook names
+EventDispatcher::add_filter_listener('leantime.core.middleware.authcheck.*.publicActions', ...);
+EventDispatcher::add_event_listener('leantime.core.middleware.authcheck.handle.logged_in', ...);
+EventDispatcher::add_event_listener('leantime.core.middleware.authcheck.handle.before_api_request', ...);
+```
+
+### Affected Plugins
+- **Accounts** — `publicActions` filter
+- **Billing** — `logged_in` event, `before_api_request` event
+- **ClientConfigLoader** — `loginRoute` filter
+- **AdvancedAuth** (new) — uses `authcheck` already
+- Any plugin registering public routes or auth hooks
+
+**If 4.0-dev's plugin code still uses the old `middleware.auth.*` hook names, those listeners will silently fail** — no errors, just non-functional authentication hooks.
+
+---
+
+## ⚠️ CRITICAL: DispatchesEvents Trait Rewrite on 4.0-dev
+
+The main repo's 4.0-dev branch rewrote `app/Core/Events/DispatchesEvents.php` significantly:
+
+### v3.6.2 (current mainline)
+```php
+// Calls go through EventDispatcher static class
+public static function dispatch_event(...): void {
+    EventDispatcher::dispatch_event($hook, $available_params, static::get_event_context($function));
+}
+```
+
+### 4.0-dev
+```php
+// Calls go through Laravel Event facade
+public static function dispatch_event(...): void {
+    Event::dispatch_event($hook, $available_params, static::getEventContext($function));
+}
+```
+
+Key differences in 4.0-dev:
+- Routes through `Illuminate\Support\Facades\Event` instead of `EventDispatcher` directly
+- Method renamed: `get_event_context()` → `getEventContext()`
+- Method renamed: `set_class_context()` → `setClassContext()`
+- New `dispatch()` method added (calls `Event::dispatchEvent()`)
+- `dispatchEvent()` signature changed — now accepts `$event` and dispatches via `Event::dispatch()`
+
+**Impact:** If plugins use the `DispatchesEvents` trait directly (rather than calling `EventDispatcher` statically), the behavior will differ between branches. Most plugins call `EventDispatcher` directly in `register.php`, so they're safe. But any plugin with services/controllers using the trait needs verification.
+
+---
+
+## ⚠️ Core Plugin Infrastructure Changes on 4.0-dev
+
+The main repo's 4.0-dev branch modified 14 files in the plugin domain. These changes exist ONLY on 4.0-dev and conflict with v3.6.2:
+
+### Plugins.php (Core)
+4.0-dev **removed** the `getEnabledPluginPaths()` method (68 lines) from `app/Core/Plugins/Plugins.php`. This method handles PHAR plugin loading and folder-based plugin path resolution. v3.6.2 added this method as part of its PHAR/marketplace plugin support.
+
+**Conflict resolution:** Favor v3.6.2 — PHAR support and `getEnabledPluginPaths()` are needed for the marketplace.
+
+### Registration Service
+4.0-dev **removed** several methods from `app/Domain/Plugins/Services/Registration.php`:
+- `getPluginBasePath()` — PHAR-aware path resolution
+- `addHeaderJs()` — JS injection via mix manifest
+- `registerManifestFolder()` — dist folder registration
+- `$distFolderRegistered` property
+
+**Conflict resolution:** These removals suggest 4.0-dev has a different asset loading strategy (likely through the webpack/ES module changes). Need to understand what replaced this functionality before deciding.
+
+### Template Renames
+4.0-dev renamed plugin templates:
+- `Templates/partials/pluginlist.blade.php` → `Templates/includes/pluginlist.blade.php`
+- `Templates/partials/plugintabs.blade.php` → `Templates/includes/plugintabs.blade.php`
+- Deleted `Templates/partials/latestPlugins.blade.php`
+
+### Other Modified Files
+- `Controllers/CssLoader.php`, `Controllers/Myapps.php`
+- `Hxcontrollers/Details.php`, `Hxcontrollers/Marketplaceplugins.php`
+- `Models/InstalledPlugin.php`, `Models/MarketplacePlugin.php`
+- `Repositories/Plugins.php`, `Services/Plugins.php`
+- `Templates/marketplace.blade.php`, `Templates/myapps.blade.php`, `Templates/plugindetails.blade.php`
+- `Templates/partials/marketplace/plugincontrols.blade.php`, `Templates/partials/plugin.blade.php`
+- `register.php`
+
+---
+
+## Plugin composer.json Pattern Change
+
+All plugins had their `"leantime/leantime": "3.0"` requirement **removed** from `composer.json`. This was a bulk cleanup — the version constraint was dropped because plugins are always loaded in-tree.
+
+4.0-dev plugins still have `"require": { "leantime/leantime": "3.0" }` — these should be removed during the forward-port.
+
+---
+
+## New Plugin Registration Patterns (v3.6.2)
+
+Several plugins adopted new registration patterns not present in 4.0-dev:
+
+### Language Registration via RegistrationService
+```php
+// New pattern (v3.6.2) — used by AdvancedAuth, CustomFields
+$registrationService = app()->makeWith(RegistrationService::class, ['pluginId' => 'PluginName']);
+$registrationService->registerLanguageFiles();
+```
+
+### Listener Class References (replacing inline closures)
+```php
+// Old pattern (4.0-dev era)
+EventDispatcher::add_event_listener("hook.name", new SomeClass());
+
+// New pattern (v3.6.2)
+EventDispatcher::add_event_listener('hook.name', SomeClass::class);
+```
+
+### Named Scheduled Tasks
+```php
+// Old pattern
+$scheduler->call(function () { ... })->everyFourHours();
+
+// New pattern (v3.6.2)
+$scheduler->call(function () { ... })->name('telemetry')->everyFourHours();
+```
+
+---
+
+## Template Evolution: .tpl.php vs .blade.php
+
+Since 4.0-dev branched, 39 new Blade templates (`.blade.php`) and only 2 new `.tpl.php` files were added to plugins. The trend is clearly toward Blade-only templates.
+
+4.0-dev's component system (DaisyUI + Blade components) will need to be applied to these new plugin templates. The largest template sets are:
+
+| Plugin | New Blade Templates | Notes |
+|--------|:---:|---|
+| Copilot | 12 | Chat panel, action feedback, dashboard, prioritization |
+| Billing | 10 | Subscription management, credit addons, confirmations |
+| AdvancedAuth | 6 | OAuth settings, personal tokens |
+| CalDAV | 4 | Connection management |
+| RecurringTasks | 4 | Task automation UI |
+| Notes | 3 | Pin/star features |
+| Reactions | 2 | Emoji reaction UI |
+| Crisp | 2 | Chat integration |
+
+---
+
+## Forward-Port Strategy for Plugins
+
+### Step 1: Advance the Submodule Pointer
+
+Since 4.0-dev's plugins commit is a direct ancestor of v3.6.2's, the simplest path is:
+
+```bash
+cd app/Plugins
+git checkout 5ed0b93c   # Point to v3.6.2's commit (or main HEAD)
+cd ../..
+git add app/Plugins
+git commit -m "Advance plugins submodule to v3.6.2 state"
+```
+
+This gives you all 926 commits of plugin work with zero conflicts in the submodule itself.
+
+### Step 2: Reconcile Core Plugin Infrastructure
+
+This is where conflicts live — in the **main repo**, not the submodule:
+
+| File | Strategy |
+|------|----------|
+| `app/Core/Plugins/Plugins.php` | **Favor v3.6.2** — keep `getEnabledPluginPaths()` for PHAR/marketplace |
+| `app/Core/Events/DispatchesEvents.php` | **Manual merge** — 4.0-dev's Laravel Event facade approach is directionally correct, but ensure `EventDispatcher` static calls still work for plugin `register.php` files |
+| `app/Core/Events/EventDispatcher.php` | **Manual merge** — ensure both branches' enhancements are preserved |
+| `app/Domain/Plugins/Services/Registration.php` | **Evaluate** — if 4.0-dev removed `addHeaderJs()`/`registerManifestFolder()`, what replaced them? If nothing, favor v3.6.2 |
+| `app/Domain/Plugins/Templates/*` | **Favor 4.0-dev** for `partials/` → `includes/` rename if it's part of the component system; otherwise favor v3.6.2 |
+| `app/Domain/Plugins/register.php` | **Manual merge** |
+
+### Step 3: Componentize New Plugin Templates
+
+After the submodule is advanced, the 39+ new Blade templates need to be converted to use 4.0-dev's DaisyUI component system. Priority order:
+
+1. **Copilot** — 12 templates, most user-facing, will define the AI experience
+2. **Billing** — 10 templates, revenue-critical
+3. **AdvancedAuth** — 6 templates, security-critical
+4. **CalDAV / RecurringTasks** — settings/management UIs
+
+### Step 4: Verify Event Hook Compatibility
+
+Run this check after merging to find any plugins still using old hook names:
+
+```bash
+cd app/Plugins
+grep -r "middleware\.auth\." --include="*.php" | grep -v "authcheck" | grep -v "authenticat"
+grep -r "middleware\.apiAuth\." --include="*.php"
+grep -r "new.*Class()" --include="register.php"  # old instantiation pattern
+```
+
+### Step 5: Validate Plugin Loading
+
+After forward-port:
+- [ ] All 35+ plugins load without errors
+- [ ] Copilot chat panel renders and AI responses work
+- [ ] MCP server starts (`php artisan mcp:start`) and tools are discoverable
+- [ ] AdvancedAuth OAuth flow completes (Keycloak callback)
+- [ ] Billing subscription management works
+- [ ] CalDAV sync connects
+- [ ] RecurringTasks scheduling fires
+- [ ] Reactions render on tickets/comments
+- [ ] CustomFields display and save correctly
+- [ ] Plugin marketplace loads and can install/update plugins
+- [ ] PHAR-format plugins load correctly
+- [ ] Plugin routes resolve via RouteLoader
+- [ ] Plugin webpack builds complete (`npm run dev` from plugin dirs with webpack.mix.js)
+
+---
+
+## Llamadorian → Copilot Relationship
+
+The Llamadorian plugin (68 files changed) and Copilot plugin (141 new files) are related but separate:
+
+- **Llamadorian** — the original AI integration, still present, heavily modified since 4.0-dev. Routes updated, prioritization removed, Bedrock provider updates, bot removed.
+- **Copilot** — the new full agent framework built alongside/on top of Llamadorian. Much larger, with structured outputs, multi-agent orchestration, memory, and observability.
+
+Both plugins exist in v3.6.2. The forward-port needs both — Llamadorian for backward compatibility/base AI features, Copilot for the full agent experience.
+
+---
+
+## Scale Summary
+
+| Metric | Value |
+|--------|-------|
+| Total commits on mainline not in 4.0-dev plugins | **926** |
+| Files changed (excl. vendor/node_modules/dist/Language) | **793** |
+| New plugins added | **7** (Copilot, McpServer, AdvancedAuth, Reactions, CalDAV, RecurringTasks, EnergyTracker) |
+| Plugins removed | **3** (Mixpanel, VWO, .idea) |
+| New Blade templates | **39** |
+| Plugins at 4.0-dev branch point | **29** |
+| Plugins at v3.6.2 | **33** |
+| Core plugin infrastructure files modified on 4.0-dev | **14** |
+| Event hook renames affecting plugins | **4+** (auth→authcheck pattern) |
+
+---
+
+*This document was compiled from local git analysis of the plugins submodule at `/Users/gloriafolaron/herd/leantime/app/Plugins` (commits `3156738` vs `5ed0b93c`), the main Leantime repo's `origin/4.0-dev` vs `v3.6.2` diff for core plugin infrastructure, and file-level inspection of new plugin architectures. It complements `leantime-4.0-dev-unique-changes.md` which covers the main repo's changes.*

--- a/Docs/phase-0-complete-summary.md
+++ b/Docs/phase-0-complete-summary.md
@@ -1,0 +1,601 @@
+# Leantime UI Modernization: Phase 0 Complete Summary
+
+## Claude Code Execution Prompt
+
+```
+You are executing Phase 0 of the Leantime UI Modernization project. This is a foundation-setup phase — no component migration yet, just upgrading the toolchain.
+
+BEFORE DOING ANYTHING: Read these documents in order:
+1. Docs/leantime-4.0-dev-unique-changes.md — What 4.0-dev changed
+2. Docs/leantime-plugin-changes-forward-port.md — Plugin ecosystem gaps
+3. Docs/leantime-mobile-backend-compatibility.md — Mobile API surface (DO NOT BREAK)
+4. Docs/phase-0-requirements.md — Detailed requirements with validation checklists
+
+PHASE 0 TASKS (execute in this exact order):
+
+0.1 LARAVEL 12 UPGRADE [2-4 hours]
+- Update composer.json: "laravel/framework": "^12.0"
+- Run composer update laravel/framework --with-all-dependencies
+- Verify Carbon 3.x (already at 3.10.1)
+- Run: php artisan test
+- Grep-verify no breaking changes hit us:
+  grep -rn "?.*\$.*= null" --include="*.php" app/ | grep "__construct"
+  grep -rn "Schema::getTables\|Schema::getTableListing\|Schema::getViews\|HasUuids" --include="*.php" app/
+- Test JSON-RPC endpoint still works (mobile app depends on it)
+
+0.2 BUILD PIPELINE: LARAVEL MIX → VITE [1-2 days]
+- npm install --save-dev vite laravel-vite-plugin
+- npm uninstall laravel-mix
+- Convert webpack.mix.js → vite.config.js (map all entry points)
+- Update package.json scripts: dev → vite, build → vite build
+- Replace all mix() calls in Blade with @vite():
+  grep -rn "mix(" --include="*.php" --include="*.blade.php" resources/ app/
+- Keep webpack.mix.js renamed as .webpack.mix.js.bak for rollback
+- Test: npm run dev (HMR), npm run build (production)
+
+0.3 TAILWIND CSS 3.4 → 4.x [4-8 hours]
+- npm install tailwindcss@latest
+- Convert tailwind.config.js to CSS-native @import/@plugin model
+- KEEP tw- prefix during Phase 0: @import "tailwindcss" prefix(tw-);
+- Verify existing tw-* classes still work across all pages
+
+0.4 DAISYUI 5 INSTALLATION [2-4 hours]
+- npm install daisyui@latest
+- Add @plugin "daisyui" to main CSS file
+- Set up dual-mode (DaisyUI alongside existing Bootstrap/custom CSS)
+- Create dev-only component preview route
+- CLASS NAME CHANGES from 4.0-dev era:
+  form-control → fieldset/label
+  card-compact → card-sm
+  bottom-nav → dock
+  avatar online → avatar avatar-online
+  dropdown → dropdown + popover attribute
+
+0.5 HTMX 1.9.12 → 2.0.8 + IDIOMORPH [4-8 hours]
+- npm install htmx.org@latest
+- Install idiomorph extension
+- Check for data-hx-* attributes (HTMX 2.x default changed):
+  grep -rn "data-hx-" --include="*.php" --include="*.blade.php" --include="*.tpl.php" resources/ app/
+- Test all 8 HxController domains still work
+- Test MyToDos infinite scroll
+
+0.6 COMPONENT INFRASTRUCTURE [2-4 hours]
+- Create app/Views/Components/ subdirectories: actions/, content/, elements/, forms/, navigations/
+- Establish anonymous component pattern with @props
+- Update CLAUDE.md with component conventions, DaisyUI 5 classes, HTMX 2.x patterns
+
+0.7 REFERENCE MODAL COMPONENT [2-4 hours]
+- Create app/Views/Components/modal.blade.php using native <dialog> + DaisyUI
+- Add HTMX open/close event pattern
+- Add to component preview page
+
+CRITICAL CONSTRAINTS:
+- DO NOT change any service method signatures in app/Domain/*/Services/
+- DO NOT rename any data model fields (mobile app depends on exact field names)
+- DO NOT remove the AdvancedAuth plugin or change its API
+- DO NOT change the JSON-RPC routing in app/Domain/Api/Controllers/Jsonrpc.php
+- DO NOT modify event hook names (auth→authcheck already happened on v3.6.2)
+- Mailer uses PHPMailer directly (app/Core/Mailer.php), not Laravel Mail — leave it alone
+- All 33+ plugins must continue loading after every change
+
+VALIDATION: After each step, run the checklist in Docs/phase-0-requirements.md.
+```
+
+---
+
+## What This Document Is
+
+This is a consolidated reference compiling ALL research, analysis, and decisions made during the Leantime UI Modernization planning sessions. It synthesizes:
+
+1. **Codebase assessment** — 4.0-dev branch analysis, v3.6.2 mainline state, component gap analysis
+2. **Technology stack review** — Version gaps, breaking changes, upgrade paths
+3. **Mobile backend compatibility audit** — API surface, auth flow, field name dependencies
+4. **Plugin ecosystem analysis** — 926-commit gap, 7 new plugins, event hook changes
+5. **Laravel 12 upgrade validation** — Breaking change impact, deployment surface review
+6. **Component design system** — From the Component_Updates_Tracker spreadsheet: component inventory, properties, frontend libraries, guidelines
+7. **Phase 0 requirements** — Detailed execution plan with validation checklists
+
+---
+
+## 1. Project Overview
+
+### Current State (v3.6.2 mainline)
+
+Leantime is an open-source project management app on Laravel 11. The codebase has two parallel efforts:
+
+- **Mainline (v3.6.2):** Production branch. 46% Blade migration complete (205 Blade vs 237 legacy .tpl.php). 15 shared components. 8 of 56 domains have HTMX controllers. 70MB JS bundles, 18.7MB per-page load.
+- **4.0-dev:** Feature branch, 693 commits behind master. Contains 65 well-structured Blade components and HTMX patterns. Serves as a design reference library, NOT mergeable code.
+
+### The 4.0-dev Forward-Port Strategy
+
+Rather than merging 4.0-dev (impossible — too many conflicts), we forward-port the *designs and patterns* from 4.0-dev onto the current mainline. This means:
+
+- Use 4.0-dev's 65 components as reference designs
+- Rebuild them using modern tooling (DaisyUI 5, HTMX 2.x, Tailwind 4)
+- Respect v3.6.2's current infrastructure (plugins, auth, API surface)
+
+### Timeline
+
+4 phases over 16 weeks (4-5 months part-time). Claude Code handles 60-80% mechanical work.
+
+| Phase | Weeks | Focus |
+|---|---|---|
+| **Phase 0** | 1-2 | Foundation: Laravel 12, Vite, Tailwind 4, DaisyUI 5, HTMX 2.x |
+| Phase 1 | 3-4 | Modal system replacement (37 files), HTMX hx-boost navigation |
+| Phase 2 | 5-8 | Core domain components (tickets, projects, dashboard, settings) |
+| Phase 3 | 9-12 | JS optimization (TinyMCE removal, bundle splitting), canvas domains |
+| Phase 4 | 13-16 | Remaining domains, CSS cleanup (Bootstrap removal) |
+
+---
+
+## 2. Architecture Constraints
+
+### 2.1 Mobile App API Surface — DO NOT BREAK
+
+The React Native/Expo mobile app communicates via:
+
+1. **JSON-RPC** at `/api/jsonrpc` — All data operations
+2. **Direct HTTP** — Authentication (`/advancedAuth/getToken`, `/advancedAuth/mobileStatus`)
+
+The JSON-RPC controller (`app/Domain/Api/Controllers/Jsonrpc.php`) resolves services via `app()->make($serviceName)->$methodName(...$preparedParams)`. It uses reflection to match named params to method parameters.
+
+**89 RPC methods across 7 domains:**
+
+| Domain | Methods | Critical Methods |
+|---|---|---|
+| Tickets | 20 | patch, quickAddTicket, getOpenUserTicketsThisWeekAndLater, getAllSubtasks |
+| Projects | 18 | getProjectsAssignedToUser, changeCurrentSessionProject, getProjectHierarchyAssignedToUser |
+| Calendar | 8 | getCalendar, getExternalCalendarEvents, addEvent, editEvent |
+| Comments | 5 | getComments, addComment (⚠️ parameter ordering concerns) |
+| Users | 15 | getUser, getUsersWithProjectAccess (⚠️ signature mismatches) |
+| Timesheets | 13 | logTime, punchIn/punchOut, isClocked, pollForNewTimesheets |
+| Notes | 10 | patchCanvasItem, patchCanvas (may be v3.6.2 additions) |
+
+**Known parameter quirks:**
+- `oderId` typo used as param name in multiple mobile app calls (legacy naming, do not "fix")
+- Comments `getComments()` expects `($module, $entityId, ...)` but mobile sends `{ moduleId, module }`
+- Users `getUsersWithProjectAccess` expects `($currentUser, $projectId)` but mobile sends `{ projectId }` only
+
+**Data model field names consumed by mobile app** (any rename = broken app):
+- Tasks: `id`, `headline`, `description`, `projectId`, `status` (numeric), `priority` (numeric 1-5), `storyPoints`, `hourRemaining`, `planHours`, `dateToFinish`, `editFrom`, `editTo`, `editorId`, `editorFirstName`/`editorFirstname`, `milestoneId`/`milestoneid`, `milestoneHeadline`, `milestoneColor`, `tags`, `createdAt`, `updatedAt`
+- Projects: `id`, `name`, `clientId`, `clientName`, `color`
+- Users: `id`, `firstName`, `lastName`, `email`, `role`, `profileId`
+
+### 2.2 Plugin Ecosystem
+
+**33+ plugins must continue working.** 7 new plugins added after 4.0-dev branched:
+
+| Plugin | Files | Risk | Notes |
+|---|---|---|---|
+| Copilot | 141 | CRITICAL | Full AI agent framework, AWS Bedrock, hooks into event system |
+| McpServer | 35 | CRITICAL | MCP server for AI tools, uses @UnifiedTool/@Parameter attributes |
+| AdvancedAuth | 28 | CRITICAL | OAuth/SSO + mobile app token auth — mobile app REQUIRES this |
+| Reactions | 20 | LOW | Emoji reactions |
+| CalDAV | 18 | LOW | Calendar sync |
+| RecurringTasks | 16 | LOW | Recurring task automation |
+| EnergyTracker | 1 | LOW | Minimal |
+
+**Event hook renames:** `leantime.core.middleware.auth.*` → `leantime.core.middleware.authcheck.*`. Plugins using old hook names silently fail.
+
+**Plugin submodule:** 4.0-dev pins commit 3156738, v3.6.2 pins 5ed0b93c (926 commits ahead). Clean fast-forward possible — no divergence.
+
+### 2.3 Deployment Surface
+
+| Method | Details | Laravel 12 Impact |
+|---|---|---|
+| Docker | PHP 8.3-fpm-alpine, nginx, supervisor | None (PHP 8.3 compatible) |
+| Docker Compose | MySQL 8.4 + Leantime | None |
+| Laravel Herd/Valet | Local dev | None |
+| Traditional hosting | Apache/nginx + PHP | None |
+| MySQL | Primary DB | None (Schema::create only) |
+| PostgreSQL | Supported via env var | None |
+
+**Email:** PHPMailer directly (`app/Core/Mailer.php`), NOT Laravel Mail. Configured via `LEAN_EMAIL_*` env vars. Completely unaffected by Laravel upgrades.
+
+**External integrations:** S3, OIDC, LDAP, Redis, CalDAV, AWS Bedrock, MCP, Google Calendar/iCal — all use standard Laravel APIs, no breaking changes.
+
+---
+
+## 3. Technology Stack: Current vs Target
+
+### 3.1 Version Gap Analysis
+
+| Dependency | Current (v3.6.2) | Target (Phase 0) | Breaking Changes |
+|---|---|---|---|
+| Laravel | ^11.44 | ^12.0 | Minimal — maintenance release. Nullable resolution, Schema method defaults. None affect Leantime. |
+| Carbon | 3.10.1 | 3.x | Already compatible ✅ |
+| PHP | 8.3 (Docker) | 8.3 | No change needed |
+| Tailwind CSS | ^3.4.1 | 4.x | Ground-up rewrite, CSS-native config. Class names backward compatible. |
+| DaisyUI | not installed | 5.5.x | New install. Class names differ from 4.0-dev era (see §3.2). |
+| HTMX | ^1.9.12 | ^2.0.8 | data- prefix default changed. Morph swap via Idiomorph added. |
+| Build tool | Laravel Mix ^6.0.49 | Vite (latest) | Complete migration. mix() → @vite() in Blade. |
+| TinyMCE | ^5.10.9 | ^5.10.9 (remove Phase 3) | EOL but keep for now. TipTap migration already covers highest-usage editors. |
+| MySQL | 8.4 | 8.4 | No change |
+
+### 3.2 DaisyUI Class Name Migration (4.0-dev → v5)
+
+4.0-dev components were built with DaisyUI 3.x/4.x conventions. DaisyUI 5 renamed several classes:
+
+| 4.0-dev Class | DaisyUI 5 Class | Notes |
+|---|---|---|
+| `form-control` | `fieldset` / `label` | Semantic HTML components |
+| `card-compact` | `card-sm` | Size modifier renamed |
+| `bottom-nav` | `dock` | Component renamed |
+| `avatar online` | `avatar avatar-online` | State modifier prefixed |
+| `avatar offline` | `avatar avatar-offline` | State modifier prefixed |
+| dropdown (CSS-only) | dropdown + `popover` attr | Native HTML popover |
+
+### 3.3 HTMX 2.x New Patterns
+
+```
+hx-on:click="..."              — Event attribute (replaces hx-on="click: ...")
+hx-swap="morph"                — Morph swap (preserves DOM state, requires Idiomorph)
+hx-swap="morph:innerHTML"      — Morph inner content only
+hx-sync="closest form:abort"   — Race condition prevention
+hx-trigger="revealed"          — Fire when scrolled into viewport
+hx-trigger="changed"           — Fire only if value changed
+hx-trigger="keyup delay:300ms" — Debounced input
+```
+
+**When to use morph swaps:** Form inputs (preserve focus), editors (TipTap), drag-drop areas, any element with interactive state.
+**When NOT to use:** Simple content updates, list replacements, static content refreshes.
+
+---
+
+## 4. Component Design System (from Spreadsheet)
+
+### 4.1 Component Inventory
+
+The Component_Updates_Tracker spreadsheet defines the complete design system. Components are organized into categories with priority levels, status, and property definitions.
+
+#### Global Simple Components (36 total)
+
+**P0 — Must Have (8 components):**
+
+| Component | Category | Status | Assigned | Key Properties |
+|---|---|---|---|---|
+| dropdown-menu | actions | Replacement in progress | Muhtasim | Child: dropdown-item |
+| modal | actions | Component dev in progress | Marcel | Needs design ✅ |
+| chip | actions | Not started | Marcel | type, variant[input/choice/action/select], color |
+| card | elements | Component dev in progress | Marcel | Glasmorphism option, replaces .maincontentinner |
+| button | forms | Replacement in progress | Marcel | type, leadingVisual, trailingVisual, state, element[a/input/button] |
+| select | forms | Replacement in progress | Tanveer | variation[tags/single/multiple], remoteUrl, search |
+| text-input | forms | Replacement in progress | Tanveer | label-text, caption, validation-text/state, leading/trailing-visual |
+| tabs | navigation | Replacement in progress | Tanveer | Child: tab. Needs design. |
+
+**P0 — Special Components (2):**
+
+| Component | Category | Status | Notes |
+|---|---|---|---|
+| text-editor | forms | Not started | TinyMCE replacement (TipTap migration in progress) |
+| date-picker | forms | Component dev in progress | Date picker + date ranges. Needs design. |
+
+**P1 — Should Have (18 components):**
+
+| Component | Category | Status |
+|---|---|---|
+| avatar | elements | Component dev in progress |
+| accordion | elements | Component dev in progress |
+| table | elements | Not started |
+| empty-state | elements | Component dev in progress |
+| date-info | elements | Replacement in progress |
+| code | elements | Component dev in progress |
+| statistic | elements | Component dev in progress |
+| badge | elements | Component dev in progress |
+| checkbox | forms | Replacement in progress |
+| radio | forms | Component dev in progress |
+| toggle | forms | Not started |
+| button-group | forms | — |
+| steps | navigation | Component dev in progress |
+| breadcrumbs | navigation | Not started |
+| pagination | navigation | Component dev in progress |
+| alert | feedback | Not started |
+| loading | feedback | Not started |
+| progress | feedback | Not started |
+| skeleton | feedback | Not started |
+| indicator | feedback | Not started |
+| color-picker | forms | Not started |
+| page-header | layout | Not started |
+| select-panel | action | Not started |
+| context-menu | navigation | Replacement in progress |
+| form-field | forms | Not started |
+
+**P2 — Nice to Have (7 components):**
+chat bubble, keyboard, calendar, range, textarea, file-input, emoji-input, menu, navbar
+
+#### Domain-Specific Components
+
+| Component | Domain | Notes |
+|---|---|---|
+| comment list | comments | — |
+| ticket-card | tickets | — |
+| milestone-card | tickets | — |
+| ticket-state-label | tickets | — |
+| projectCard | projects | — |
+
+### 4.2 Shared Component Properties (IDL Attributes)
+
+The design system defines a consistent property interface across all components:
+
+| Property | Options | Default | Purpose |
+|---|---|---|---|
+| `content-role` | default, primary, secondary, ghost/tertiary, accent, link | primary (actions) | Visual importance |
+| `state` | default, info, warning, danger, success | default | Semantic state |
+| `variant` | component-specific | "" | Behavior variations |
+| `scale` | xs, s, m, l, xl | m | Size |
+| `position` | left, right, top, bottom, inner, outer, start, end | bottom | Placement |
+| `element` | a, input, button | — | HTML element override |
+| `align` | start, end | — | Alignment |
+| `label-text` | text | "" | Label content |
+| `caption` | text | "" | Sub-label text |
+| `validation-text` | text | "" | Validation message |
+| `leading-visual` | icon | "" | Icon before content |
+| `trailing-visual` | icon | "" | Icon after content |
+| `items` | list | [] | Data items |
+| `link` | URL | "#" | Navigation target |
+
+### 4.3 Component Development Checklist (from Guidelines)
+
+Every component MUST satisfy:
+
+- [ ] Uses only valid HTML attribute names
+- [ ] Can be reused by various modules
+- [ ] Can accept any type of data/content
+- [ ] Merges attributes (`$attributes->merge()`)
+- [ ] Has default states
+- [ ] Fails gracefully if data or attributes are wrong
+- [ ] Does not require "design input" from component user (attributes focus on content type, not style)
+- [ ] No business logic
+- [ ] Is responsive
+- [ ] Only Tailwind CSS & DaisyUI CSS (no custom CSS without approval)
+- [ ] JS assets loaded as part of component
+- [ ] CSS assets loaded as part of component
+- [ ] Uses only approved JS libraries
+- [ ] Does not require developer to "prepare data for component" (handles data as provided by controller)
+- [ ] Has appropriate aria-* attributes
+- [ ] Follows WCAG guidelines
+- [ ] Works in modals and regular pages
+- [ ] All HTML elements replaced with component usage
+
+**Decision tree for "Do I need a component?":**
+1. Is this a one or two-off instance? → No component needed
+2. Can it be added as a variant to an existing component? → Create variant instead
+3. Otherwise → Create component
+
+---
+
+## 5. Frontend Libraries Inventory
+
+### 5.1 Keep (Approved)
+
+| Library | Version | Purpose |
+|---|---|---|
+| HTMX | ^1.9.12 → ^2.0.8 | Core interaction framework |
+| Tailwind CSS | ^3.4.1 → 4.x | CSS framework |
+| DaisyUI | NEW → 5.5.x | Component CSS library |
+| FullCalendar | ^6.1.11 | Calendar visualization |
+| Tippy.js | ^6.3.7 | Tooltips |
+| Popper.js | ^2.11.8 | Tooltip positioning (Tippy dep) |
+| Chart.js | ^3.6.0 | Report charts |
+| Lottie Player | ^2.0.4 | Lottie animations (AI robot) |
+| Canvas Confetti | ^1.9.3 | Confetti animation |
+| Croppie | ^2.6.5 | Profile picture cropping |
+| Shepherd.js | ^11.2.0 | Onboarding tours |
+| Uppy | ^3.25.3 | File uploads |
+| jQuery | 3.7.1 | Legacy dependency |
+| Gridstack | ^10.1.2 | Dashboard widget layout |
+| JSTree | ^3.3.16 | Wiki tree view |
+| Leader Line | ^1.0.7 | Kanban dependency arrows |
+| Luxon | ^3.4.4 | Date formatting |
+| Masonry/Isotope | ^4.2.2 / ^3.0.6 | Pinterest-style layouts |
+| Packery | ^2.1.2 | Idea board drag-drop grid |
+| Frappe Gantt | 0.6.1 | Gantt charts (heavily modified) |
+| Prism.js | — | Syntax highlighting |
+| Choices.js | — | Select dropdowns (forked) |
+| Excalidraw | v0.16.1 | Whiteboard plugin |
+| Sentry | ^7.116.0 | Error tracking |
+| FontAwesome Free | ^6.5.2 | Icons |
+
+### 5.2 Replace Soon
+
+| Library | Replace With | Notes |
+|---|---|---|
+| TinyMCE 5.10.9 | TipTap | EOL. TipTap migration covers todos, wikis, notes, comments. Remaining: canvas dialogs, file descriptions, ticket fields. |
+| NyroModal | Native `<dialog>` + DaisyUI | Phase 1 — 37 files use legacy jQuery modal. Heavily modified fork. |
+| Datatables | TBD | Sorting/paging tables |
+| Frappe Gantt | TBD | Heavily modified, needs more powerful replacement |
+| FontAwesome Iconpicker | Blade UI Icons | Wiki article icon picker |
+
+### 5.3 Replace with Existing Library
+
+| Library | Replace With |
+|---|---|
+| Chosen.js | Choices.js |
+| jQuery Tags | Choices.js |
+| SlimSelect | Choices.js |
+| Select2 | Choices.js |
+| Moment.js | Luxon |
+
+### 5.4 Remove
+
+| Library | Reason |
+|---|---|
+| Bootstrap Fileupload (3.0) | Legacy |
+| jQuery Forms | Not used |
+| Simple Color Picker | Use browser default |
+
+### 5.5 To Be Discussed
+
+| Library | Notes |
+|---|---|
+| jQuery UI | Used for datepickers, tabs, progress bars, accordion, drag-drop. Partially replaceable with DaisyUI components. |
+| jQuery Touch Punch | May not be needed anymore |
+| ajv (JSON schema) | Unclear if still used |
+| imagesloaded | Unclear if still needed |
+
+---
+
+## 6. 4.0-dev Remaining Task List Status
+
+### 6.1 Task Summary by Person
+
+| Person | Role | Status |
+|---|---|---|
+| Marcel | Lead — infrastructure, special components | Multiple in-progress (plugins, project selector, datepicker, ticket view, canvases, wiki, files) |
+| Muhtasim | UI components — forms, dropdowns, filters | Most tasks done. In-progress: goal add/edit, install route |
+| Tanveer | UI components — inputs, badges, filters | Most tasks done. PRs merged. |
+
+### 6.2 Not-Started Tasks (still need work)
+
+| Task | Location | Notes |
+|---|---|---|
+| First onboarding | — | P0, Marcel |
+| AI onboarding | — | P0, Marcel |
+| Project dashboard milestone cards | project dashboard | Should be a component |
+| Milestone cards not loading HTMX | project dashboard | — |
+| Project updates → comments component | project dashboard | Marcel |
+| Milestone calendar broken | milestone calendar | — |
+| Goal modal metric → regular input | goal modal | — |
+| Goal modal buttons (one secondary) | goal modal | — |
+| Blueprint card headlines → primary color | — | Marcel |
+| Canvases not working | canvas | Marcel |
+| Wiki not working | — | Marcel |
+| Files | — | Marcel |
+| Project settings 403 | project | Marcel |
+
+### 6.3 Known Bugs (from spreadsheet)
+
+| Module | Issue |
+|---|---|
+| Dashboard | Error — page does not load, only skeleton code |
+| Timesheets | Dropdown select options UI issue |
+| Timesheets | Week/List view out of page bounds |
+| Calendar | Button sizing, primary/secondary color |
+| Calendar | Add event — date-time input type fix |
+| Company → All Clients | Missing @endsection |
+| Company → User Mgmt | Missing @endsection |
+| Company → Integrations | Missing @endsection |
+| Home dashboard | Broken (Marcel) |
+| Project menu | Broken (Marcel) |
+| Task context menu | Not opening |
+| Delete | May not work |
+| View selector | Milestone gantt view |
+
+---
+
+## 7. TinyMCE → TipTap Migration Status
+
+TipTap migration already in progress (pending merge). Highest-usage editors done:
+
+| Area | Status |
+|---|---|
+| To-dos | ✅ Migrated to TipTap |
+| Wikis | ✅ Migrated to TipTap |
+| Notes | ✅ Migrated to TipTap |
+| Comments | ✅ Migrated to TipTap |
+
+**Still on TinyMCE (26 files):**
+- Canvas dialog (`canvasDialog.inc.php`) — shared by all 15+ canvas types
+- File descriptions
+- Ticket additional fields
+- Dashboard status updates
+
+**Infrastructure cleanup (after all editors migrated):**
+- `editors.js` (~400 lines TinyMCE config) → remove
+- `modals.js` (TinyMCE save/destroy on modal transitions) → remove coupling
+- `webpack.mix.js` (~30 TinyMCE plugin files) → remove from bundle
+- `EditorTypeEnum.php` → simplify
+- **3.5MB bundle savings** from removing TinyMCE
+
+**Critical coupling:** `modals.js` has `beforePostSubmit` and `beforeShowCont` callbacks that call `tinymce.get()`. Once TipTap is everywhere AND modals use native `<dialog>`, this coupling dissolves.
+
+---
+
+## 8. Key File Locations
+
+```
+# Build system
+webpack.mix.js                    — Current build config (→ vite.config.js)
+package.json                      — JS dependencies
+composer.json                     — PHP dependencies
+tailwind.config.js                — Current Tailwind config (→ CSS-native)
+
+# Core infrastructure
+app/Core/Mailer.php               — Email (PHPMailer, NOT Laravel Mail)
+app/Core/Events/DispatchesEvents.php — Event system trait
+app/Core/Events/EventDispatcher.php  — Static event dispatcher
+
+# API surface (mobile app — DO NOT TOUCH)
+app/Domain/Api/Controllers/Jsonrpc.php — JSON-RPC router
+app/Plugins/AdvancedAuth/             — Mobile app authentication
+
+# Installation
+app/Domain/Install/Repositories/Install.php — DB migrations
+app/Domain/Install/Services/SchemaBuilder.php — Schema creation
+
+# Docker
+.docker/Dockerfile                — Production image (PHP 8.3)
+.docker/docker-compose.yml        — MySQL 8.4 + Leantime
+.docker/config/                   — nginx, php-fpm, supervisor
+
+# Components
+app/Views/Components/             — Shared Blade components (15 → 65 target)
+
+# Plugins (must all keep working)
+app/Plugins/AdvancedAuth/         — OAuth/SSO + mobile tokens
+app/Plugins/Copilot/              — AI agent (141 files)
+app/Plugins/McpServer/            — MCP server (35 files)
+app/Plugins/Notes/                — Notes/notebooks (mobile app uses)
+```
+
+---
+
+## 9. Useful Grep Commands
+
+```bash
+# mix() references (need → @vite)
+grep -rn "mix(" --include="*.php" --include="*.blade.php" resources/ app/
+
+# HTMX data- prefix (2.x migration)
+grep -rn "data-hx-" --include="*.php" --include="*.blade.php" --include="*.tpl.php" resources/ app/
+
+# Laravel 12 breaking changes
+grep -rn "?.*\$.*= null" --include="*.php" app/ | grep "__construct"
+grep -rn "Schema::getTables\|Schema::getTableListing\|Schema::getViews\|HasUuids" --include="*.php" app/
+
+# TinyMCE references (Phase 3)
+grep -rn "tinymce\|TinyMCE\|tiny_mce" --include="*.php" --include="*.js" --include="*.blade.php" resources/ app/ | grep -v vendor | grep -v node_modules
+
+# Event hook compatibility
+grep -rn "middleware.auth\." --include="*.php" app/Plugins/
+
+# Tailwind prefix tracking
+grep -rn "tw-" --include="*.php" --include="*.blade.php" resources/ app/ | wc -l
+
+# HxControllers inventory
+find app/ -name "*.php" -path "*/Hxcontrollers/*" | sort
+
+# NyroModal usage (Phase 1)
+grep -rn "nyroModal\|nyromodal" --include="*.php" --include="*.js" --include="*.blade.php" resources/ app/ | grep -v vendor | grep -v node_modules
+```
+
+---
+
+## 10. Design System References
+
+From the spreadsheet's Helpful Resources:
+
+| Resource | URL | Use For |
+|---|---|---|
+| DaisyUI | https://daisyui.com/docs/install/ | Primary component CSS |
+| GitHub Primer | https://primer.style/ | Reference design system |
+| Material Design 3 | https://m3.material.io/components/chips/overview | Chip/chip patterns |
+| Atlassian Design | https://atlassian.design/components | PM-specific patterns |
+| Blade UI Kit | https://blade-ui-kit.com/ | Laravel Blade components |
+| BladewindUI | https://bladewindui.com/ | Blade component examples |
+| Razor UI | https://razorui.com/libraries/blade-application-ui/dropdowns | Blade dropdown patterns |
+| Material Tailwind | https://www.material-tailwind.com/ | Tailwind component patterns |
+| Component Decision Trees | https://www.smashingmagazine.com/2024/05/decision-trees-ui-components/ | When to componentize |
+| MDN HTML Attributes | https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes | Attribute reference |
+| WCAG Guidelines | https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG | Accessibility |
+| ARIA Guide | https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Guides | Accessibility |

--- a/Docs/phase-0-requirements.md
+++ b/Docs/phase-0-requirements.md
@@ -1,0 +1,363 @@
+# Phase 0: Foundation Setup — Requirements Document
+
+## For Claude Code Execution
+
+**Project:** Leantime UI Modernization Forward-Port
+**Branch:** `4.0-dev` forward-port onto `v3.6.2` mainline
+**Phase:** 0 of 4 — Foundation Setup
+**Estimated Duration:** ~1 week focused work
+**Risk Level:** MEDIUM-HIGH (build pipeline migration is riskiest item)
+**Generated:** February 12, 2026
+
+---
+
+## Context
+
+Leantime is an open-source project management application built on Laravel 11. A `4.0-dev` branch (693 commits behind master) contains 65 well-structured Blade components and HTMX patterns that serve as a design reference library. The mainline (`v3.6.2`) has continued evolving with 46% Blade migration complete, new plugins (Copilot, McpServer, AdvancedAuth, Reactions, CalDAV, RecurringTasks, EnergyTracker), and infrastructure improvements.
+
+Phase 0 establishes the modern foundation before any component forward-porting begins. Every subsequent phase depends on this work being solid.
+
+### Codebase Location
+- **Backend:** `/Users/gloriafolaron/Herd/leantime`
+- **Mobile App:** `/Users/gloriafolaron/Herd/leantime-mobile` (React Native/Expo)
+- **Docker:** `.docker/Dockerfile` and `.docker/docker-compose.yml`
+- **Dev Docker:** `.dev/docker-compose.yaml` and `.dev/dockerfile`
+
+### Companion Documents (READ THESE FIRST)
+- `Docs/leantime-4.0-dev-unique-changes.md` — What 4.0-dev changed and what to forward-port
+- `Docs/leantime-plugin-changes-forward-port.md` — Plugin ecosystem gap analysis
+- `Docs/leantime-mobile-backend-compatibility.md` — Mobile app API surface and breaking change risks
+
+---
+
+## Architecture Constraints
+
+### Mobile App API Surface — DO NOT BREAK
+
+The mobile app (React Native/Expo) communicates with the backend via two mechanisms:
+
+1. **JSON-RPC** at `/api/jsonrpc` — All data operations (tasks, projects, users, calendar, timesheets, notes, comments)
+2. **Direct HTTP** — Authentication only (`/advancedAuth/getToken`, `/advancedAuth/mobileStatus`)
+
+The JSON-RPC controller (`app/Domain/Api/Controllers/Jsonrpc.php`) uses reflection to resolve service methods: `app()->make($serviceName)->$methodName(...$preparedParams)`. It maps named params from the request to method parameters by name (not position), checks types, and casts as needed.
+
+**Critical: The JSON-RPC layer uses `app()->make()` (Laravel container resolution) to instantiate every service class.** Any change to service constructor signatures, method signatures, or return types will break the mobile app silently (returns RPC errors instead of data).
+
+The following RPC domains are actively used by the mobile app:
+- **Tickets** — 20 methods (CRUD, subtasks, milestones, status/priority/effort labels, scheduling, polling)
+- **Projects** — 18 methods (CRUD, hierarchy, roles, avatars, types, session switching)
+- **Calendar** — 8 methods (events CRUD, external calendars, iCal URL)
+- **Comments** — 5 methods (CRUD, polling) — has parameter ordering concerns
+- **Users** — 15 methods (CRUD, profile pictures, settings, password checks)
+- **Timesheets** — 13 methods (time logging, punch clock, polling)
+- **Notes** — 10 methods (plugin — canvas CRUD, notebooks)
+
+**Auth depends on AdvancedAuth plugin** (new in v3.6.2, does NOT exist in 4.0-dev). Login flow: `POST /advancedAuth/getToken` returns `{ id, token }`. All subsequent API calls use `Authorization: Bearer {token}` headers.
+
+**Data model field names the mobile app consumes** (any rename breaks the app):
+- Tasks: `id`, `headline`, `description`, `projectId`, `status`, `priority`, `storyPoints`, `hourRemaining`, `planHours`, `dateToFinish`, `editFrom`, `editTo`, `editorId`, `milestoneId`, `tags`, `createdAt`, `updatedAt`
+- Projects: `id`, `name`, `clientId`, `clientName`, `color`
+- Users: `id`, `firstName`, `lastName`, `email`, `role`, `profileId`
+
+### Installation & Deployment Surface
+
+1. **Docker** (`.docker/Dockerfile`) — PHP 8.3-fpm-alpine, nginx, supervisor.
+2. **Docker Compose** (`.docker/docker-compose.yml`) — MySQL 8.4 + Leantime container.
+3. **Dev Docker** (`.dev/docker-compose.yaml`) — Development environment.
+4. **Laravel Herd / Valet** — Local development.
+5. **Traditional hosting** — Apache/nginx + PHP + MySQL/PostgreSQL.
+
+Database: MySQL (primary), PostgreSQL (via `LEAN_DB_DEFAULT_CONNECTION = 'pgsql'`). Schema creation via `Schema::create()` (database-agnostic).
+
+### Email / SMTP
+
+**PHPMailer** directly (not Laravel Mail): `app/Core/Mailer.php`. Not affected by Laravel 12 upgrade.
+
+### External Integrations
+
+S3, OIDC/OAuth, LDAP, Redis, CalDAV, AWS Bedrock (Copilot), MCP Server, Google Calendar/iCal.
+
+### Event System
+
+WordPress-style hook system (`DispatchesEvents.php` / `EventDispatcher.php`), NOT Laravel events. 4.0-dev rewrote to use Laravel Event facade — forward-port must preserve backward compatibility. Event hook rename on v3.6.2: `auth.*` → `authcheck.*`.
+
+---
+
+## Phase 0 Requirements
+
+### 0.1 Laravel 12 Upgrade
+
+**Priority:** FIRST | **Risk:** LOW | **Effort:** 2-4 hours
+
+#### What to do
+1. Update `composer.json`: `"laravel/framework": "^12.0"`
+2. `composer update laravel/framework --with-all-dependencies`
+3. Verify Carbon v3 (already 3.10.1 ✅)
+4. `php artisan test`
+
+#### Breaking changes to check
+```bash
+# Nullable container resolution (MOST IMPORTANT)
+grep -rn "?.*\$.*= null" --include="*.php" app/ | grep "__construct"
+
+# Schema method changes
+grep -rn "Schema::getTables\|Schema::getTableListing\|Schema::getViews" --include="*.php" app/
+
+# HasUuids trait
+grep -rn "HasUuids" --include="*.php" app/
+
+# Grammar constructor changes
+grep -rn "Grammar::\|setConnection\|getPrefix\|withTablePrefix\|setTablePrefix" --include="*.php" app/
+```
+
+All verified: ZERO breaking changes affect Leantime.
+
+#### Validation checklist
+- [ ] `composer update` succeeds
+- [ ] `php artisan test` passes
+- [ ] JSON-RPC endpoint responds
+- [ ] Web installer works (fresh install)
+- [ ] DB migration runs
+- [ ] Login works (session + AdvancedAuth token)
+- [ ] SMTP, S3, OIDC, LDAP, Redis work (if configured)
+- [ ] Docker build + compose up work
+- [ ] PostgreSQL works (if testable)
+
+
+### 0.2 Build Pipeline Migration: Laravel Mix → Vite
+
+**Priority:** HIGH | **Risk:** MEDIUM-HIGH | **Effort:** 1-2 days
+
+#### What to do
+1. `npm install --save-dev vite laravel-vite-plugin && npm uninstall laravel-mix`
+2. Convert `webpack.mix.js` → `vite.config.js` (map all entry points)
+3. Update `package.json` scripts: `dev` → `vite`, `build` → `vite build`
+4. Replace `mix()` → `@vite()` in all Blade layouts:
+```bash
+grep -rn "mix(" --include="*.php" --include="*.blade.php" resources/ app/
+```
+5. Handle webpack patterns: `require()` → `import`, `module.exports` → `export default`, `process.env` → `import.meta.env`
+6. Keep `webpack.mix.js` renamed as `.webpack.mix.js.bak` for rollback
+
+#### Validation checklist
+- [ ] `npm run dev` starts Vite with HMR
+- [ ] `npm run build` produces production bundles
+- [ ] All pages render correctly
+- [ ] TipTap editor works
+- [ ] HTMX interactions work
+- [ ] Calendar/Gantt/Kanban/Canvas views render
+- [ ] Chart.js visualizations render
+- [ ] Build output size tracked
+- [ ] Docker build works
+
+
+### 0.3 Tailwind CSS Upgrade: 3.4 → 4.x
+
+**Priority:** HIGH | **Risk:** MEDIUM | **Effort:** 4-8 hours
+
+#### What to do
+1. `npm install tailwindcss@latest`
+2. Convert `tailwind.config.js` → CSS-native:
+```css
+@import "tailwindcss" prefix(tw-);
+@source "../views/**/*.blade.php";
+@source "../../app/Views/**/*.blade.php";
+@theme { --color-primary: #1a73e8; }
+```
+3. Keep `tw-` prefix during Phase 0
+
+#### Validation checklist
+- [ ] Compiles without errors
+- [ ] Existing `tw-*` classes work
+- [ ] No visual regressions
+- [ ] Custom theme values preserved
+
+
+### 0.4 DaisyUI 5 Installation
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 2-4 hours
+
+#### What to do
+1. `npm install daisyui@latest`
+2. Add `@plugin "daisyui"` to CSS config
+3. Configure themes, set up dual-mode (alongside Bootstrap)
+4. Create dev-only component preview page
+
+#### DaisyUI 5 class changes from 4.0-dev era
+| Old (4.0-dev) | New (DaisyUI 5) |
+|---|---|
+| `form-control` | `fieldset` / `label` |
+| `card-compact` | `card-sm` |
+| `bottom-nav` | `dock` |
+| `avatar online` | `avatar avatar-online` |
+| dropdown (CSS-only) | dropdown + `popover` attr |
+
+#### Validation checklist
+- [ ] DaisyUI classes render correctly
+- [ ] Theme switching works
+- [ ] No conflicts with Bootstrap
+- [ ] Preview page works
+- [ ] Modal renders with `<dialog>`
+
+
+### 0.5 HTMX Upgrade: 1.9.12 → 2.0.8 + Idiomorph
+
+**Priority:** MEDIUM | **Risk:** LOW-MEDIUM | **Effort:** 4-8 hours
+
+#### What to do
+1. `npm install htmx.org@latest` + install Idiomorph
+2. Check for `data-hx-*` attributes:
+```bash
+grep -rn "data-hx-" --include="*.php" --include="*.blade.php" --include="*.tpl.php" resources/ app/
+```
+3. Test all 8 HxController domains + MyToDos infinite scroll
+4. Add Idiomorph to base layout (don't add `hx-ext="morph"` yet)
+
+#### HTMX 2.x patterns for CLAUDE.md
+```
+hx-on:click="..."              — Event attribute
+hx-swap="morph"                — Morph swap (preserves DOM state)
+hx-sync="closest form:abort"   — Race condition prevention
+hx-trigger="revealed"          — Viewport trigger
+hx-trigger="keyup delay:300ms" — Debounced input
+```
+
+#### Validation checklist
+- [ ] Existing HTMX interactions work
+- [ ] MyToDos infinite scroll works
+- [ ] Form submissions work
+- [ ] Idiomorph loads without errors
+- [ ] No console errors
+
+
+### 0.6 Component Infrastructure Setup
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 2-4 hours
+
+#### What to do
+1. Create `app/Views/Components/` subdirs: `actions/`, `content/`, `elements/`, `forms/`, `navigations/`
+2. Establish anonymous component pattern with `@props`, `$attributes->merge()`, named slots
+3. Class-based ONLY for: computed logic, DB access, service injection, `shouldRender()`
+4. Update CLAUDE.md with conventions
+5. Verify existing 15 components still work
+
+#### Validation checklist
+- [ ] Directory structure created
+- [ ] CLAUDE.md updated (creation patterns, DaisyUI migration table, HTMX reference)
+- [ ] Existing 15 components render correctly
+
+
+### 0.7 Reference Modal Component
+
+**Priority:** LOW | **Risk:** LOW | **Effort:** 2-4 hours
+
+#### What to do
+1. Create `app/Views/Components/modal.blade.php` — native `<dialog>` + DaisyUI
+2. Props: `id`, `title`, `size` (sm/md/lg/xl), `closeable`
+3. HTMX trigger pattern: `hx-get` loads content → `showModal()` → close triggers refresh
+4. Add to component preview page
+
+#### Validation checklist
+- [ ] Opens/closes correctly (button, backdrop, Escape)
+- [ ] HTMX loads content into modal
+- [ ] Close triggers parent content refresh
+- [ ] Mobile viewport works
+- [ ] Nested modals work
+- [ ] Focus trap works
+
+---
+
+## Phase 0 Execution Order
+
+```
+0.1 Laravel 12 Upgrade                    [2-4 hours]
+0.2 Build Pipeline Migration (Mix → Vite)  [1-2 days]
+0.3 Tailwind CSS Upgrade (3.4 → 4.x)      [4-8 hours]
+0.4 DaisyUI 5 Installation                [2-4 hours]
+0.5 HTMX Upgrade (1.9 → 2.0.8)            [4-8 hours]
+0.6 Component Infrastructure Setup         [2-4 hours]
+0.7 Reference Modal Component              [2-4 hours]
+```
+**Total: ~5-7 working days**
+
+---
+
+## Phase 0 Deliverables
+
+- [ ] Laravel 12 running, all tests passing
+- [ ] Vite dev + production builds working
+- [ ] Tailwind 4 + DaisyUI 5 installed and rendering
+- [ ] HTMX 2.0.8 + Idiomorph loaded
+- [ ] All existing pages render (no regressions)
+- [ ] JSON-RPC + AdvancedAuth still work (mobile app)
+- [ ] Docker build + compose work
+- [ ] Fresh install + DB migration work
+- [ ] Component directory structure + CLAUDE.md updated
+- [ ] Reference modal component working
+- [ ] Build output size baseline recorded
+
+---
+
+## Version Reference
+
+| Dependency | Current (v3.6.2) | Target (Phase 0) |
+|---|---|---|
+| PHP | ^8.2 (Docker: 8.3) | ^8.2 (Docker: 8.3) |
+| Laravel | ^11.44 | ^12.0 |
+| Tailwind CSS | ^3.4.1 | 4.x |
+| DaisyUI | not installed | 5.5.x |
+| HTMX | ^1.9.12 | ^2.0.8 + Idiomorph |
+| Build tool | Laravel Mix ^6.0.49 | Vite + laravel-vite-plugin |
+| MySQL | 8.4 | 8.4 |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Vite migration breaks rendering | MEDIUM | HIGH | Keep webpack.mix.js as rollback |
+| Tailwind 4 changes class behavior | LOW | MEDIUM | v4 maintains v3 compatibility |
+| HTMX 2.x breaks interactions | LOW | MEDIUM | Backward compatible; test all domains |
+| Laravel 12 breaks service resolution | LOW | HIGH | Grep verified: zero breaking changes |
+| DaisyUI conflicts with Bootstrap | LOW | LOW | Dual-mode, unique namespace |
+| Docker build fails | MEDIUM | MEDIUM | Test after Vite migration |
+| Mobile app breaks | LOW | CRITICAL | JSON-RPC integration tests |
+| DB migrations fail | LOW | HIGH | Test fresh install + upgrade path |
+| Plugin loading breaks | LOW | MEDIUM | Verify all 33+ plugins load |
+
+---
+
+## What This Document Does NOT Cover
+
+- **Phase 1:** Modal system replacement (37 files), HTMX hx-boost
+- **Phase 2:** Core domain component forward-porting
+- **Phase 3:** JS optimization (bundle splitting), canvas domains
+- **Phase 4:** Remaining domains, CSS cleanup (Bootstrap removal)
+- Plugin submodule advancement (926 commits)
+- 4.0-dev merge conflicts (14 core files)
+
+---
+
+## Appendix: Useful Grep Commands
+
+```bash
+# mix() references (need → @vite)
+grep -rn "mix(" --include="*.php" --include="*.blade.php" resources/ app/
+
+# HTMX data- prefix (2.x migration)
+grep -rn "data-hx-" --include="*.php" --include="*.blade.php" --include="*.tpl.php" resources/ app/
+
+# Laravel 12 breaking changes
+grep -rn "?.*\$.*= null" --include="*.php" app/ | grep "__construct"
+grep -rn "Schema::getTables\|Schema::getTableListing\|Schema::getViews\|HasUuids" --include="*.php" app/
+
+# Event hook compatibility
+grep -rn "middleware.auth\." --include="*.php" app/Plugins/
+
+# Tailwind prefix tracking
+grep -rn "tw-" --include="*.php" --include="*.blade.php" resources/ app/ | wc -l
+
+# HxControllers inventory
+find app/ -name "*.php" -path "*/Hxcontrollers/*" | sort
+```

--- a/Docs/phase-0-requirements.md
+++ b/Docs/phase-0-requirements.md
@@ -18,8 +18,8 @@ Leantime is an open-source project management application built on Laravel 11. A
 Phase 0 establishes the modern foundation before any component forward-porting begins. Every subsequent phase depends on this work being solid.
 
 ### Codebase Location
-- **Backend:** `/Users/gloriafolaron/Herd/leantime`
-- **Mobile App:** `/Users/gloriafolaron/Herd/leantime-mobile` (React Native/Expo)
+- **Backend:** this repository's root
+- **Mobile App:** the `leantime-mobile` repository (React Native/Expo), checked out as a sibling
 - **Docker:** `.docker/Dockerfile` and `.docker/docker-compose.yml`
 - **Dev Docker:** `.dev/docker-compose.yaml` and `.dev/dockerfile`
 

--- a/Docs/phase-1-complete-summary.md
+++ b/Docs/phase-1-complete-summary.md
@@ -1,0 +1,364 @@
+# Phase 1: Modal System & Navigation — Complete Summary
+
+## Claude Code Execution Prompt
+
+```
+Read these documents in order before starting Phase 1:
+1. Docs/phase-0-complete-summary.md — Component inventory, frontend libraries, design system guidelines
+2. Docs/phase-0-requirements.md — Architecture constraints, mobile API surface, event system
+3. Docs/phase-1-complete-summary.md — THIS FILE: modal inventory, navigation patterns, canvas domain map
+4. Docs/phase-1-requirements.md — Step-by-step execution instructions with validation checklists
+5. Docs/leantime-4.0-dev-unique-changes.md — 4.0-dev component reference designs
+6. Docs/leantime-mobile-backend-compatibility.md — API surface (DO NOT BREAK)
+
+Phase 1 Tasks (execute in order):
+1.1 — Replace modals.js + nyroModal with native <dialog> modal system
+1.2 — Migrate hash-based modal triggers (href="#/...") to HTMX-powered <dialog>
+1.3 — Migrate formModal-class templates to Blade modal component
+1.4 — Add hx-boost to main navigation for SPA-like transitions
+1.5 — Convert high-priority core domain modals (Tickets, Calendar, Goals, Projects)
+1.6 — Establish canvas domain modal pattern (1 template serves 19 canvas domains)
+1.7 — Plugin modal compatibility layer
+
+CRITICAL CONSTRAINTS:
+- DO NOT change any service method signatures, field names, or return types
+- DO NOT break the JSON-RPC API surface (mobile app depends on it)
+- DO NOT remove nyroModal JS until ALL modal triggers are migrated
+- DO NOT change URL routing — modal endpoints must still respond to direct HTTP requests
+- Plugins that call leantime.modals.closeModal() need a shim until they're updated
+- The Frontcontroller already has is-modal header detection — USE this, don't reinvent
+- Canvas domains share a SINGLE template system (Canvas/Templates/) — fix once, fix 19 domains
+```
+
+---
+
+## 1. Current Modal Architecture
+
+### How Modals Work Today
+
+The current modal system is a **hash-based URL + jQuery nyroModal** pattern:
+
+1. User clicks `<a href="#/tickets/showTicket/123">` 
+2. `window.addEventListener("hashchange")` fires in `modals.js`
+3. `leantime.modals.openModal()` parses the hash, builds a URL from it
+4. `jQuery.nmManual(url, options)` opens nyroModal — an iframe/AJAX modal
+5. nyroModal fetches the full controller response and renders it in an overlay
+6. The Frontcontroller detects `is-modal` header and adjusts layout (no chrome)
+7. On close, `beforeClose` callback either runs `globalModalCallback` or `location.reload()`
+
+### Key Files
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `public/assets/js/app/core/modals.js` | Global modal open/close/hashchange listener | 117 |
+| `public/assets/js/libs/jquery.nyroModal/js/jquery.nyroModal.custom.js` | jQuery nyroModal library | ~800 |
+| `app/Core/Controller/Frontcontroller.php` | `is-modal` header detection, `redirect()` modal handling | key lines: 200-202, 395-430 |
+| `app/Core/UI/Template.php` | `closeModal()` → sets HTMX event header `HTMX.closemodal` | line 205 |
+| `resources/js/compiled-global-component.js` | Imports nyroModal into build bundle | line 21 |
+
+### modals.js Analysis
+
+```javascript
+// Core behavior:
+leantime.modals = (function () {
+    openModal()      // Reads window.location.hash, calls jQuery.nmManual()
+    closeModal()     // Calls jQuery.nmTop().close()
+    setCustomModalCallback(fn) // Sets window.globalModalCallback for close behavior
+})();
+
+// Lifecycle hooks in nyroModal options:
+beforePostSubmit → saves/destroys TinyMCE editors (DEAD CODE — TinyMCE migrated ✅)
+beforeShowCont   → saves/destroys TinyMCE editors (DEAD CODE — TinyMCE migrated ✅)  
+afterShowCont    → calls htmx.process() on modal content + re-init tippy tooltips
+beforeClose      → pushes history state, runs globalModalCallback OR location.reload()
+```
+
+**Important:** The `afterShowCont` callback calls `window.htmx.process('.nyroModalCont')` — this means HTMX attributes inside modals are already being activated. The new system just needs to ensure htmx.process() runs on `<dialog>` content too.
+
+### Frontcontroller Modal Detection
+
+```php
+// Frontcontroller.php line 200-202 — Routes to HxController OR regular Controller
+if ($this->incomingRequest instanceof HtmxRequest &&
+    $this->incomingRequest->header('is-modal') == false &&
+    $this->incomingRequest->header('hx-boosted') == false) {
+    $controllerType = 'Hxcontrollers';  // HTMX partial response
+} else {
+    $controllerType = 'Controllers';     // Full page OR modal response
+}
+
+// Frontcontroller.php line 402 — Redirect handling for modals
+if (app('request')->headers->get('is-modal')) {
+    Frontcontroller::redirectHtmx($url, $headers);
+}
+```
+
+**This means:** When `is-modal: true` header is sent, the Frontcontroller uses regular Controllers (full response) instead of HxControllers. The new `<dialog>` modal system should send this header with `hx-headers='{"is-modal": "true"}'` to maintain the same routing.
+
+### Template.php closeModal()
+
+```php
+public function closeModal(): void {
+    $this->setHTMXEvent('HTMX.closemodal');
+}
+```
+
+Controllers already call `$this->tpl->closeModal()` to signal modal close. The new system needs to listen for the `HTMX.closemodal` event.
+
+---
+
+## 2. Modal Trigger Inventory
+
+### Hash-Based Triggers (`href="#/..."`)
+
+**101 hash-based modal triggers** across core domains + **30+ in plugins**.
+
+#### By Domain (Core — 101 triggers)
+
+| Domain | Count | Key Modals |
+|--------|-------|------------|
+| Tickets | 25 | showTicket, newTicket, editMilestone, delTicket, moveTicket, delMilestone |
+| Canvas (shared) | 12 | editCanvasItem, delCanvasItem, boardDialog, delCanvas |
+| Goalcanvas | 14 | editCanvasItem, delCanvasItem, bigRock, delCanvas, editCanvasComment |
+| Ideas | 12 | ideaDialog, boardDialog, delCanvasItem |
+| Calendar | 8 | addEvent, editEvent, delEvent, export, connectCalendar, calendarSettings, editExternal, delExternalCal |
+| Dashboard | 5 | showTicket, newTicket, editMilestone, newUser |
+| Wiki | 6 | articleDialog, wikiModal, delWiki, delArticle |
+| Timesheets | 3 | showTicket (links to ticket modal) |
+| Widgets | 5 | showTicket, editMilestone, moveTicket, delete, widgetManager |
+| Setting | 3 | editBoxLabel, apiKey, newApiKey |
+| Projects | 1 | createnew |
+| Sprints | 4 | editSprint, delSprint |
+| Clients | 1 | newUser |
+| Plugins | 1 | details |
+
+#### By Domain (Plugins — 30+ triggers)
+
+| Plugin | Count | Key Modals |
+|--------|-------|------------|
+| Notes | 8 | notesDialog, notebookDialog, delNote, delNotebook |
+| StrategyPro | 6 | editCanvasItem, delCanvasItem, focusArea, delCanvas |
+| Whiteboardscanvas | 8 | whiteboardDialog, group, delCanvas, delCanvasItem, editCanvasItem |
+| Billing | 2 | changePlanModal, addCreditsModal |
+| AdvancedAuth | 1 | create (token) |
+| PgmPro | 1 | editBoxLabel |
+| Copilot | 1 | showTicket (link) |
+
+### formModal CSS Class Triggers
+
+**40 template files** use `class="formModal"` to trigger nyroModal on links/buttons. These work via jQuery event delegation:
+
+```javascript
+jQuery(".formModal, .modal").nyroModal(modalOptions);
+```
+
+These are in the `afterShowCont` callback, meaning nested modals also get wired up.
+
+### leantime.modals.closeModal() Callers
+
+Templates/JS that explicitly call the close function:
+
+| File | Context |
+|------|---------|
+| Notes/delNotebook.blade.php | Cancel button |
+| Notes/delNote.blade.php | Cancel button |
+| Notes/notesDialog.blade.php | Custom callback |
+| Whiteboardscanvas/whiteboardGroup.blade.php | Cancel button |
+| AdvancedAuth/token-created.blade.php | Done button |
+| Help/helperController.js | Close helper modal (5 calls) |
+| Billing/billingModals.js | Close billing modal |
+| Timesheets/timesheetsController.js | Close after save |
+
+### openModalManually() Pattern
+
+Used in canvas JS controllers to programmatically open modals. Found in **11 canvas domain JS files** + 2 plugins. Each canvas controller has its own copy — they all do the same thing: `jQuery.nmManual(url, options)`.
+
+---
+
+## 3. Canvas Domain Architecture
+
+### 19 Canvas Domains Share ONE Template System
+
+The `app/Domain/Canvas/` domain provides **shared templates** that all canvas-type domains inherit:
+
+```
+Canvas/Templates/
+├── boardDialog.php         — Create/edit board dialog
+├── canvasComment.inc.php   — Comment dialog
+├── canvasDialog.inc.php    — Main item edit dialog (CORE MODAL)
+├── element.inc.php         — Single canvas element (has modal triggers)
+├── modals.inc.php          — Modal includes
+├── showCanvasTop.inc.php   — Top header (has modal triggers)
+```
+
+**Every canvas domain** (Lean, SWOT, Business Model, Empathy, etc.) either uses these directly or has minimal overrides. Only Goalcanvas and Valuecanvas have their own dialog templates.
+
+| Canvas Domain | Has Own Dialog? | Uses Shared Templates? |
+|---|---|---|
+| Canvas (base) | ✅ canvasDialog.inc.php | — |
+| Goalcanvas | ✅ canvasDialog.blade.php, bigRockDialog.blade.php | Partially |
+| Valuecanvas | ✅ canvasDialog.tpl.php | Partially |
+| Ideas | ✅ ideaDialog.tpl.php, boardDialog.php | Own implementation |
+| Cpcanvas, Dbmcanvas, Eacanvas, Emcanvas, Insightscanvas, Lbmcanvas, Leancanvas, Logicmodelcanvas, Minempathycanvas, Obmcanvas, Retroscanvas, Riskscanvas, Sbcanvas, Smcanvas, Sqcanvas, Swotcanvas | ❌ | ✅ All use Canvas/Templates/ |
+
+**This means:** Fixing the modal system in `Canvas/Templates/canvasDialog.inc.php` and the shared JS controller pattern fixes modals for **16 canvas domains at once**.
+
+### Canvas JS Controller Pattern
+
+Each canvas domain has its own JS controller that duplicates modal logic:
+
+```javascript
+// Pattern repeated in 16+ files:
+var openModalManually = function (url) {
+    jQuery.nmManual(url, modalOptions);
+};
+```
+
+These need consolidation into a single canvas modal handler.
+
+---
+
+## 4. HxController Inventory
+
+**45 HxControllers** exist (20 core + 25 plugin). These handle HTMX partial responses and are NOT used for modal content (modals use regular Controllers).
+
+### Core Domain HxControllers
+
+| Domain | Controllers | Purpose |
+|--------|-------------|---------|
+| Help | HelperModal | Help overlay |
+| Menu | ProjectSelector | Project switcher |
+| Notifications | News, NewsBadge | Notification panel |
+| Plugins | Details, Marketplaceplugins | Plugin browser |
+| Projects | Checklist, ProjectCard, ProjectCardProgress, ProjectHubProjects | Project dashboard widgets |
+| Tickets | Milestones, Subtasks, TicketCard, TimerButton | Ticket partial updates |
+| Timesheets | Stopwatch | Timer widget |
+| Widgets | Calendar, MyProjects, MyToDos, Welcome | Dashboard widgets |
+
+### Plugin HxControllers
+
+AdvancedAuth (2), Copilot (3), Crisp (1), CustomFields (2), Implementationintentions (1), Llamadorian (2), Notes (5), Pomodoro (1), ProjectWizard (4), Reactions (2), RecurringTasks (1), ThemeBundle (1).
+
+---
+
+## 5. Existing Blade Components
+
+**31 component files** already exist across the codebase:
+
+### Global Components (`app/Views/Templates/components/`)
+
+| Component | Status |
+|-----------|--------|
+| accordion.blade.php | ✅ Exists |
+| actions/modal.blade.php | ✅ Exists (may need DaisyUI 5 update) |
+| badge.blade.php | ✅ Exists |
+| button.blade.php | ✅ Exists |
+| dropdownPill.blade.php | ✅ Exists |
+| emojiinput.blade.php | ✅ Exists |
+| inlineLinks.blade.php | ✅ Exists |
+| inlineSelect.blade.php | ✅ Exists |
+| kanban/* (8 files) | ✅ Kanban sub-components |
+| loader.blade.php | ✅ Exists |
+| loadingText.blade.php | ✅ Exists |
+| pageheader.blade.php | ✅ Exists |
+| selectable.blade.php | ✅ Exists |
+| tabs.blade.php + tabs/* | ✅ Tab components |
+| undrawSvg.blade.php | ✅ Exists |
+
+### Domain-Specific Components
+
+| Domain | Components |
+|--------|-----------|
+| Comments | input.blade.php, reply.blade.php |
+| Users | profile-box.blade.php, profile-image.blade.php |
+| Widgets | moveableWidget.blade.php |
+
+**Note:** `actions/modal.blade.php` already exists — Phase 1 should UPDATE this to use `<dialog>` + DaisyUI 5 rather than creating a new file.
+
+---
+
+## 6. Navigation Architecture
+
+### Current Full-Page Navigation
+
+Every page link is a full HTTP request. The main layout (`app/Views/Templates/layouts/app.blade.php`) includes:
+
+```
+mainwrapper
+├── header (logo, burger menu)
+├── leftmenu (@include menu::menu)
+├── maincontent
+│   ├── pageheader
+│   └── maincontentinner (@yield content)
+└── footer
+```
+
+### hx-boost Opportunity
+
+The Frontcontroller already handles `hx-boosted` requests:
+
+```php
+$this->incomingRequest->header('hx-boosted') == false
+```
+
+When `hx-boost="true"` is on a navigation link, HTMX sends the request with `HX-Boosted: true` header. The Frontcontroller routes to regular Controllers (not HxControllers) — same as modals. The response replaces just the content area, keeping the navigation shell.
+
+**Implementation:** Add `hx-boost="true"` to the `<body>` or main content wrapper. HTMX will intercept all `<a>` clicks and swap content. The layout template needs to handle boosted requests by returning only the content portion (not the full HTML shell).
+
+### Layout Detection Needed
+
+The app layout must detect HTMX boosted requests and return partial HTML:
+
+```php
+@if(request()->header('HX-Boosted'))
+    {{-- Just the page content, no shell --}}
+    @yield('content')
+@else
+    {{-- Full HTML page with nav, header, footer --}}
+    <!DOCTYPE html>...
+@endif
+```
+
+---
+
+## 7. Migration Metrics
+
+### Scope Summary
+
+| Category | Count | Phase 1 Target |
+|----------|-------|----------------|
+| nyroModal references | 97 occurrences in 42 files | Replace ALL |
+| Hash-based modal triggers | 131 (101 core + 30 plugin) | Core: all, Plugins: compatibility shim |
+| formModal class triggers | 40 files | Replace ALL |
+| leantime.modals.closeModal() calls | 13 files | Shim + migrate |
+| Canvas domains sharing templates | 19 domains, 1 template set | Fix templates once |
+| Core modal dialog templates | ~25 unique | Migrate to Blade components |
+| Plugin modal dialog templates | ~10 unique | Compatibility layer |
+| HxControllers (no changes needed) | 45 | Verify still work |
+
+### Files to Create/Modify
+
+**New files:**
+- Updated `app/Views/Templates/components/actions/modal.blade.php` — `<dialog>` + DaisyUI 5
+- `public/assets/js/app/core/modalManager.js` — Replacement for modals.js (hash listener + `<dialog>` bridge)
+- Layout partial for hx-boost responses
+
+**Core files to modify:**
+- `app/Views/Templates/layouts/app.blade.php` — hx-boost support, `<dialog>` container
+- `resources/js/compiled-global-component.js` — Remove nyroModal import, add modalManager
+- Every template with `href="#/"` patterns (101 in core)
+- Every template with `class="formModal"` (40 files)
+- `Canvas/Templates/*.inc.php` — Shared canvas modal templates (fixes 19 domains)
+
+---
+
+## 8. Design System References
+
+For modal and navigation component patterns, reference:
+- DaisyUI Modal: https://daisyui.com/components/modal/
+- DaisyUI Menu: https://daisyui.com/components/menu/
+- DaisyUI Navbar: https://daisyui.com/components/navbar/
+- HTMX hx-boost: https://htmx.org/attributes/hx-boost/
+- HTMX Modals: https://htmx.org/examples/modal-custom/
+- HTML `<dialog>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
+- GitHub Primer Dialog: https://primer.style/components/dialog

--- a/Docs/phase-1-requirements.md
+++ b/Docs/phase-1-requirements.md
@@ -1,0 +1,424 @@
+# Phase 1: Modal System & Navigation — Requirements Document
+
+## For Claude Code Execution
+
+**Project:** Leantime UI Modernization Forward-Port
+**Phase:** 1 of 4 — Modal System Replacement + SPA-like Navigation
+**Depends on:** Phase 0 complete (Laravel 12, Vite, Tailwind 4, DaisyUI 5, HTMX 2.0.8)
+**Estimated Duration:** 2 weeks
+**Risk Level:** MEDIUM-HIGH (touches every domain's user-facing interaction pattern)
+**Generated:** February 13, 2026
+
+---
+
+## Goal
+
+Replace the jQuery nyroModal system (hash-based URLs + iframe overlays) with native `<dialog>` elements powered by DaisyUI 5 and HTMX 2.x. Add hx-boost for SPA-like navigation. The modal system is the #1 pain point — 97 references across 42 files, 131 hash-based triggers, and a global `modals.js` that couples to dead TinyMCE code.
+
+---
+
+## Architecture Decision: The Bridge Pattern
+
+**Do NOT do a big-bang replacement.** Instead, build a **modalManager.js** that:
+
+1. Listens for the same `hashchange` events as the current `modals.js`
+2. Instead of opening nyroModal, fetches content via fetch() into a `<dialog>` element
+3. Sends `is-modal: true` header so the Frontcontroller routes to regular Controllers
+4. Handles `HTMX.closemodal` event to close the `<dialog>`
+5. Runs `htmx.process()` on dialog content (same as nyroModal's `afterShowCont`)
+6. Exposes `leantime.modals.openModal()` and `leantime.modals.closeModal()` API — **same interface** so plugins don't break
+
+This means the migration is **incremental**: old hash triggers work immediately through the bridge, and individual templates can be upgraded to direct HTMX triggers over time.
+
+---
+
+## 1.1 Build the Modal Component + Manager
+
+**Priority:** FIRST | **Risk:** MEDIUM | **Effort:** 4-8 hours
+
+### Update `app/Views/Templates/components/actions/modal.blade.php`
+
+The file already exists. Update it to use `<dialog>` + DaisyUI 5:
+
+```php
+@props([
+    'id' => null,
+    'size' => 'md',
+    'closeable' => true,
+])
+
+@php
+$sizeClass = match($size) {
+    'sm' => 'max-w-lg',
+    'md' => 'max-w-3xl',
+    'lg' => 'max-w-5xl',
+    'xl' => 'max-w-7xl',
+    'ticket' => 'max-w-7xl min-h-[80vh]',
+    default => 'max-w-3xl',
+};
+$modalId = $id ?? 'modal-' . uniqid();
+@endphp
+
+<dialog id="{{ $modalId }}" class="modal" {{ $attributes }}>
+    <div class="modal-box {{ $sizeClass }}">
+        @if($closeable)
+            <form method="dialog">
+                <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+            </form>
+        @endif
+        <div class="modal-content">
+            {{ $slot }}
+        </div>
+        @isset($actions)
+            <div class="modal-action">
+                {{ $actions }}
+            </div>
+        @endisset
+    </div>
+    @if($closeable)
+        <form method="dialog" class="modal-backdrop">
+            <button>close</button>
+        </form>
+    @endif
+</dialog>
+```
+
+### Create `public/assets/js/app/core/modalManager.js`
+
+This replaces `modals.js` with backward compatibility. Key behaviors:
+
+- Same `leantime.modals` namespace and API
+- Reads `window.location.hash`, fetches URL with `is-modal: true` header
+- Renders response in a `<dialog>` element
+- Sizes modal based on URL pattern (showTicket/ideaDialog → large)
+- Calls `htmx.process()` on loaded content
+- Calls `tippy()` for tooltips
+- Listens for `HTMX.closemodal` event from server
+- On close: pushes history state, runs `globalModalCallback` or `location.reload()`
+- Shows DaisyUI loading spinner while content loads
+
+### Update `resources/js/compiled-global-component.js`
+
+Replace nyroModal import with modalManager:
+```diff
+- import '../../public/assets/js/libs/jquery.nyroModal/js/jquery.nyroModal.custom.js';
++ import '../../public/assets/js/app/core/modalManager.js';
+```
+
+### Validation Checklist
+- [ ] Existing `href="#/tickets/showTicket/123"` links open a `<dialog>` modal
+- [ ] Modal content loads and renders correctly
+- [ ] HTMX attributes inside modal content are active
+- [ ] `leantime.modals.closeModal()` works (plugin compatibility)
+- [ ] `leantime.modals.setCustomModalCallback()` works
+- [ ] Modal closes on Escape key, backdrop click, and close button
+- [ ] `HTMX.closemodal` server event closes the modal
+- [ ] Hash is cleaned from URL when modal closes
+- [ ] Tippy tooltips work inside modal
+- [ ] Ticket modal opens at large size
+- [ ] Calendar modals open at default size
+- [ ] No console errors
+
+
+## 1.2 Add Global `<dialog>` Container to Layout
+
+**Priority:** HIGH | **Risk:** LOW | **Effort:** 1-2 hours
+
+Add to `app/Views/Templates/layouts/app.blade.php` before closing `</body>`:
+
+```html
+<dialog id="global-modal" class="modal">
+    <div class="modal-box max-w-5xl">
+        <form method="dialog">
+            <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+        </form>
+        <div class="modal-content" id="global-modal-content"></div>
+    </div>
+    <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+```
+
+### Validation Checklist
+- [ ] `<dialog>` element present in page DOM
+- [ ] Does not conflict with existing page layout
+- [ ] modalManager.js finds and uses this element
+
+
+## 1.3 Core Domain Modal Migration
+
+**Priority:** HIGH | **Risk:** MEDIUM | **Effort:** 1-2 days
+
+### Strategy
+
+The bridge pattern means all existing `href="#/"` triggers work IMMEDIATELY — no template changes needed for basic functionality. This step focuses on:
+
+1. **Removing the jQuery formModal initialization** (the `afterShowCont` callback)
+2. **Testing each domain's modals** work through the bridge
+3. **Fixing any templates** that make iframe/nyroModal assumptions
+
+### Priority Testing Order (by trigger count)
+
+| Priority | Domain | Triggers | Key Modals |
+|----------|--------|----------|------------|
+| 1 | Tickets | 25 | showTicket, newTicket, editMilestone, moveTicket, delTicket |
+| 2 | Goalcanvas | 14 | editCanvasItem, bigRock, delCanvasItem |
+| 3 | Canvas (shared) | 12 | editCanvasItem, boardDialog (fixes 16 domains) |
+| 4 | Ideas | 12 | ideaDialog, boardDialog |
+| 5 | Calendar | 8 | addEvent, editEvent, calendarSettings |
+| 6 | Wiki | 6 | articleDialog, wikiModal |
+| 7 | Dashboard | 5 | showTicket, newTicket, newUser |
+| 8 | Sprints | 4 | editSprint, delSprint |
+| 9 | Setting | 3 | editBoxLabel, apiKey |
+| 10 | Projects | 1 | createnew |
+
+### Template Compatibility Concerns
+
+Some modal templates may assume they're inside nyroModal's container (`.nyroModalCont`). Search for and update:
+
+```bash
+grep -rn "nyroModalCont\|nmTop\|nmManual\|nmObj" --include="*.php" --include="*.js" --include="*.blade.php" --include="*.tpl.php" app/ resources/ | grep -v vendor | grep -v node_modules
+```
+
+Replace `.nyroModalCont` selectors with `#global-modal-content` or `.modal-content`.
+
+### Validation Checklist
+- [ ] All hash-based triggers open modals for each domain above
+- [ ] Modal forms submit correctly (POST data reaches controller)
+- [ ] Controller redirects work inside modals
+- [ ] `$this->tpl->closeModal()` triggers dialog close
+- [ ] No `.nyroModalCont` references remain in active code paths
+
+
+## 1.4 Canvas Domain Modal Consolidation
+
+**Priority:** HIGH | **Risk:** MEDIUM | **Effort:** 4-8 hours
+
+### Why
+
+19 canvas domains share `Canvas/Templates/` files. Each has its own JS controller with duplicated `openModalManually()`. Fix the shared templates + create one handler = fix 19 domains.
+
+### What to Do
+
+1. **Verify `Canvas/Templates/canvasDialog.inc.php`** works inside `<dialog>` (no iframe assumptions)
+2. **Verify `Canvas/Templates/element.inc.php`** hash triggers work via bridge
+3. **Verify `Canvas/Templates/showCanvasTop.inc.php`** hash triggers work
+4. **Create shared `leantime.canvasModal.openModalManually()`** that delegates to hash trigger
+5. **Update 16+ canvas JS controllers** to use shared handler
+
+### Special Cases
+- **Goalcanvas** — has own `canvasDialog.blade.php` and `bigRockDialog.blade.php` (already Blade)
+- **Valuecanvas** — has own `canvasDialog.tpl.php`
+- **Ideas** — has own `ideaDialog.tpl.php` and `boardDialog.php`
+
+### Validation Checklist
+- [ ] 3+ canvas domains tested (e.g., Lean, SWOT, Retros)
+- [ ] Canvas item create/edit/delete modals work
+- [ ] Board create/edit dialogs work
+- [ ] Comment dialogs work
+- [ ] Goal canvas special dialogs work
+- [ ] Idea dialogs work
+
+
+## 1.5 Ticket Domain Deep Migration
+
+**Priority:** HIGH | **Risk:** MEDIUM | **Effort:** 4-8 hours
+
+### showTicketModal.blade.php
+
+Most complex modal. Contains subtask links, comments, timesheets, inline editing. Verify:
+
+- Renders correctly inside `<dialog>` (was inside nyroModal iframe)
+- Subtask `href="#/"` links open nested modals (modal-in-modal)
+- Comment submission via HTMX works
+- Ticket status/priority/effort inline changes work
+- `is-modal: true` header ensures Frontcontroller returns full controller response
+
+### Other Ticket Modals
+
+| Template | Format | Action |
+|----------|--------|--------|
+| newTicketModal.tpl.php | .tpl.php | Verify form submission |
+| milestoneDialog.tpl.php | .tpl.php | Verify save + close |
+| moveTicket.tpl.php | .tpl.php | Verify project selector |
+| delTicket.tpl.php | .tpl.php | Verify delete confirmation |
+
+### Validation Checklist
+- [ ] Show ticket modal opens with full content at large size
+- [ ] Subtask links open nested modals
+- [ ] Comment submission works
+- [ ] Ticket field changes save
+- [ ] Milestone dialog opens and saves
+- [ ] New ticket modal creates ticket
+- [ ] Move ticket works
+- [ ] Delete confirmation works
+- [ ] Modal close after save triggers list refresh
+
+
+## 1.6 hx-boost Navigation
+
+**Priority:** MEDIUM | **Risk:** MEDIUM | **Effort:** 4-8 hours
+
+### Implementation
+
+1. **Add `hx-boost` to content wrapper** in `app/Views/Templates/layouts/app.blade.php`:
+
+```html
+<div class="maincontent" 
+     hx-boost="true" 
+     hx-target="#maincontentinner" 
+     hx-swap="innerHTML show:window:top" 
+     hx-push-url="true">
+```
+
+2. **Detect boosted requests in layout:**
+
+```php
+@if(request()->header('HX-Boosted'))
+    @yield('content')
+@else
+    <!DOCTYPE html>
+    <html>
+    ... full page shell ...
+    @yield('content')
+    ... end shell ...
+    </html>
+@endif
+```
+
+3. **Exclude from boost:** hash links (automatic), external links, auth links, downloads. Add `hx-boost="false"` where needed.
+
+4. **Re-initialize page JS** after navigation:
+
+```javascript
+document.addEventListener('htmx:afterSettle', function(evt) {
+    // Re-initialize domain controllers, tooltips, etc.
+});
+```
+
+5. **Add loading indicator:**
+
+```html
+<div id="page-loading" class="htmx-indicator">
+    <progress class="progress w-full"></progress>
+</div>
+```
+
+### Frontcontroller Support
+
+Already exists — line 202 checks `hx-boosted`. Boosted requests route to regular Controllers (full page content), not HxControllers (fragments).
+
+### What NOT to Boost
+
+- External links, hash links, downloads, auth/logout, links with `hx-boost="false"`
+
+### Validation Checklist
+- [ ] Page navigation doesn't full-reload
+- [ ] Browser back/forward work
+- [ ] Page title updates
+- [ ] Left menu active state updates
+- [ ] Page-specific JS initializes after navigation
+- [ ] Modal links still work (not boosted)
+- [ ] External links open normally
+- [ ] Loading indicator shows during transitions
+
+
+## 1.7 Plugin Compatibility Verification
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 2-4 hours
+
+### Plugin Status
+
+| Plugin | Modal Pattern | Expected Status |
+|--------|--------------|-----------------|
+| Notes | closeModal(), setCustomModalCallback(), hash triggers | ✅ Bridge handles |
+| Billing | Direct jQuery('.nyroModal').nyroModal() | ⚠️ Needs shim or update |
+| StrategyPro | openModalManually(), hash triggers | ✅ Canvas consolidation handles |
+| Whiteboardscanvas | hash triggers, closeModal() | ✅ Bridge handles |
+| AdvancedAuth | hash triggers, closeModal() | ✅ Bridge handles |
+| Copilot | showTicket link | ✅ Bridge handles |
+| Help | closeModal() (5 calls) | ✅ Bridge handles |
+
+### Billing Plugin Shim
+
+```javascript
+// Shim for jQuery.fn.nyroModal — converts to hash trigger
+if (jQuery && jQuery.fn) {
+    jQuery.fn.nyroModal = function(options) {
+        this.each(function() {
+            jQuery(this).on('click', function(e) {
+                e.preventDefault();
+                var href = jQuery(this).attr('href');
+                if (href && href.startsWith('#')) {
+                    window.location.hash = href.substring(1);
+                }
+            });
+        });
+        return this;
+    };
+    jQuery.nmManual = function(url, options) {
+        window.location.hash = url.replace(leantime.appUrl, '');
+    };
+}
+```
+
+### Validation Checklist
+- [ ] Notes: notebook/note dialogs work
+- [ ] AdvancedAuth: token creation modal works
+- [ ] Help: helper modals work
+- [ ] No plugin console errors
+
+---
+
+## Execution Order
+
+```
+1.1 Modal component + modalManager.js           [4-8 hours]
+1.2 Global <dialog> in layout                    [1-2 hours]
+1.3 Core domain modal testing + fixes            [1-2 days]
+1.4 Canvas domain consolidation                  [4-8 hours]
+1.5 Ticket domain deep migration                 [4-8 hours]
+1.6 hx-boost navigation                          [4-8 hours]
+1.7 Plugin compatibility verification            [2-4 hours]
+```
+**Total: ~2 weeks**
+
+---
+
+## Phase 1 Deliverables
+
+- [ ] modalManager.js replaces modals.js (same API, `<dialog>` backend)
+- [ ] All 131 hash-based modal triggers work through bridge
+- [ ] `<dialog>` modals render with DaisyUI 5 styling
+- [ ] Modals accessible (Escape, focus trap, aria attributes)
+- [ ] Nested modals work
+- [ ] Canvas modal code consolidated (16 files → 1 shared handler)
+- [ ] hx-boost SPA-like navigation working
+- [ ] All plugins' modal interactions verified
+- [ ] Mobile API (JSON-RPC) completely unaffected
+- [ ] No TinyMCE references in modal code
+- [ ] nyroModal JS still in codebase but unused (remove after Phase 2 verification)
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Modal content doesn't render in `<dialog>` | MEDIUM | HIGH | is-modal header ensures full response; test each type |
+| Hash-based triggers break | LOW | HIGH | Bridge pattern — same listener, different backend |
+| Nested modals break | MEDIUM | MEDIUM | Test showTicket → subtask → delete chain |
+| hx-boost breaks page JS | MEDIUM | MEDIUM | htmx:afterSettle re-init; disable boost per-link |
+| Plugin modals break | LOW | MEDIUM | Same API; shim for direct nyroModal calls |
+| Canvas modals break | LOW | HIGH | Fix shared template once, test 3 canvas types |
+| Form submission fails in `<dialog>` | MEDIUM | HIGH | Verify POST/redirect cycle per domain |
+| CSS conflicts | LOW | MEDIUM | DaisyUI modal classes namespaced |
+
+---
+
+## What This Document Does NOT Cover
+
+- Phase 2: Core domain component forward-porting
+- Phase 3: JS optimization, canvas domain componentization
+- Phase 4: Remaining domains, Bootstrap removal
+- Converting .tpl.php to .blade.php (happens in Phase 2-4)
+- nyroModal library file removal (after Phase 2 verification)

--- a/Docs/phase-2-complete-summary.md
+++ b/Docs/phase-2-complete-summary.md
@@ -1,0 +1,329 @@
+# Phase 2: Core Domain Componentization — Complete Summary
+
+## Claude Code Execution Prompt
+
+```
+Read these documents in order before starting Phase 2:
+1. Docs/phase-0-complete-summary.md — Component inventory, frontend library decisions, design guidelines
+2. Docs/phase-1-complete-summary.md — Modal system architecture, navigation patterns
+3. Docs/phase-2-complete-summary.md — THIS FILE: domain template inventory, jQuery dependency map
+4. Docs/phase-2-requirements.md — Step-by-step execution instructions with validation checklists
+5. Docs/leantime-4.0-dev-unique-changes.md — 4.0-dev component reference designs
+
+Phase 2 Tasks (execute in order):
+2.1 — Build shared Blade component library (form inputs, cards, tables, page layouts)
+2.2 — Tickets domain: convert .tpl.php → Blade components (38 templates, highest traffic)
+2.3 — Projects domain: convert .tpl.php → Blade components (15 templates)
+2.4 — Dashboard domain: enhance existing Blade templates with components (3 templates)
+2.5 — Calendar domain: convert .tpl.php → Blade components (11 templates)
+2.6 — Settings domain: convert .tpl.php → Blade components (2 templates)
+2.7 — Users domain: convert .tpl.php → Blade components (8 templates)
+2.8 — Timesheets domain: convert .tpl.php → Blade components (7 templates)
+2.9 — Menu domain: update existing Blade templates with DaisyUI 5 components (14 templates)
+
+CRITICAL CONSTRAINTS:
+- DO NOT change service method signatures, field names, or return types
+- DO NOT break the JSON-RPC API surface (mobile app depends on it)
+- DO NOT change Controller logic — only template files change
+- Every .tpl.php → .blade.php conversion must render identical UI output
+- Test each converted template in browser before proceeding to next
+- Preserve all HTMX attributes and HxController interactions
+- Preserve all existing CSS classes during conversion (add DaisyUI classes alongside)
+```
+
+---
+
+## 1. Core Domain Template Inventory
+
+### Templates by Format (Core Domains Only)
+
+| Domain | Total | .blade.php | .tpl.php | .inc.php/.sub.php | .js | Priority |
+|--------|-------|-----------|---------|-------------------|-----|----------|
+| Tickets | 38 | 8 | 15 | 15 | 3 | 🔴 P1 |
+| Help | 44 | 15 | 29 | 0 | 5 | 🟡 P3 (content-only) |
+| Projects | 15 | 6 | 7 | 2 | 1 | 🔴 P1 |
+| Menu | 14 | 14 | 0 | 0 | 2 | 🟡 P2 (already Blade) |
+| Calendar | 11 | 4 | 7 | 0 | 1 | 🔴 P1 |
+| Auth | 11 | 7 | 4 | 0 | 1 | 🟢 P4 (low traffic) |
+| Plugins | 10 | 10 | 0 | 0 | 0 | ✅ Already Blade |
+| Widgets | 9 | 9 | 0 | 0 | 1 | ✅ Already Blade |
+| Canvas | 9 | 0 | 0 | 9 | 1 | Phase 3 |
+| Users | 8 | 3 | 5 | 0 | 3 | 🟡 P2 |
+| Goalcanvas | 8 | 8 | 0 | 0 | 1 | ✅ Already Blade |
+| Timesheets | 7 | 1 | 6 | 0 | 1 | 🟡 P2 |
+| Wiki | 6 | 0 | 6 | 0 | 1 | Phase 3 |
+| Clients | 5 | 0 | 5 | 0 | 1 | Phase 4 |
+| Sprints | 2 | 0 | 2 | 0 | 0 | Phase 2 (with Tickets) |
+| Setting | 2 | 0 | 2 | 0 | 3 | 🟡 P2 |
+| Comments | 4 | 2 | 1 | 1 | 1 | 🟡 P2 (cross-cutting) |
+| Dashboard | 3 | 3 | 0 | 0 | 1 | ✅ Already Blade |
+| Notifications | 2 | 2 | 0 | 0 | 0 | ✅ Already Blade |
+| Files | 3 | 0 | 2 | 1 | 0 | Phase 4 |
+
+### Phase 2 Scope: 108 Templates to Convert/Update
+
+| Category | Template Count | Already Blade | Need Conversion |
+|----------|---------------|---------------|-----------------|
+| Tickets + Sprints | 40 | 8 | 32 |
+| Projects | 15 | 6 | 9 |
+| Calendar | 11 | 4 | 7 |
+| Setting | 2 | 0 | 2 |
+| Users | 8 | 3 | 5 |
+| Timesheets | 7 | 1 | 6 |
+| Comments | 4 | 2 | 2 |
+| Menu (update only) | 14 | 14 | 0 (update) |
+| Dashboard (update only) | 3 | 3 | 0 (update) |
+| **Total** | **104** | **41** | **63 to convert** |
+
+---
+
+## 2. Tickets Domain — Detailed Template Map
+
+The most complex domain with 38 templates, 3 JS controllers, and the most user traffic.
+
+### Main Views (full pages)
+
+| Template | Format | Complexity | Notes |
+|----------|--------|-----------|-------|
+| showKanban.tpl.php | .tpl.php | 🔴 HIGH | Kanban board — drag-drop, swimlanes, ticket cards |
+| showAll.tpl.php | .tpl.php | 🔴 HIGH | Table list view — DataTables, filters |
+| showList.tpl.php | .tpl.php | 🟡 MED | Simple list view |
+| showTicket.tpl.php | .tpl.php | 🔴 HIGH | Full-page ticket detail (non-modal version) |
+| showAllMilestones.tpl.php | .tpl.php | 🟡 MED | Milestones Gantt view |
+| showAllMilestonesOverview.tpl.php | .tpl.php | 🟡 MED | Milestones table view |
+| roadmap.tpl.php | .tpl.php | 🟡 MED | Project roadmap view |
+| roadmapAll.tpl.php | .tpl.php | 🟡 MED | All-projects roadmap |
+| calendar.tpl.php | .tpl.php | 🟡 MED | Ticket calendar view |
+| newTicket.tpl.php | .tpl.php | 🟡 MED | Full-page new ticket form |
+
+### Modal Dialogs
+
+| Template | Format | Notes |
+|----------|--------|-------|
+| showTicketModal.blade.php | ✅ Blade | Ticket detail in modal (already migrated) |
+| newTicketModal.tpl.php | .tpl.php | Quick ticket creation modal |
+| milestoneDialog.tpl.php | .tpl.php | Milestone create/edit |
+| moveTicket.tpl.php | .tpl.php | Move ticket between projects |
+| delTicket.tpl.php | .tpl.php | Delete confirmation |
+| delMilestone.tpl.php | .tpl.php | Delete milestone confirmation |
+
+### Partials (already mostly Blade)
+
+| Template | Format | Notes |
+|----------|--------|-------|
+| partials/ticketCard.blade.php | ✅ Blade | Kanban card component |
+| partials/subtasks.blade.php | ✅ Blade | Subtask list (HTMX) |
+| partials/ticketsubmenu.blade.php | ✅ Blade | Context menu |
+| partials/milestoneCard.blade.php | ✅ Blade | Milestone card |
+| partials/timerButton.blade.php | ✅ Blade | Timer widget |
+| partials/timerLink.blade.php | ✅ Blade | Timer link |
+| partials/quickadd-form.inc.php | .inc.php | Inline ticket creation |
+| componentTest.blade.php | ✅ Blade | Component test page |
+
+### Submodules (shared across views)
+
+| Template | Format | Used By |
+|----------|--------|---------|
+| submodules/ticketHeader.sub.php | .sub.php | showAll, showKanban, showList |
+| submodules/ticketFilter.sub.php | .sub.php | All ticket views |
+| submodules/ticketBoardTabs.sub.php | .sub.php | Kanban, list views |
+| submodules/ticketNewBtn.sub.php | .sub.php | All ticket views |
+| submodules/ticketNewButton.sub.php | .sub.php | All ticket views |
+| submodules/ticketDetails.sub.php | .sub.php | showTicket full page |
+| submodules/subTasks.sub.php | .sub.php | showTicket full page |
+| submodules/attachments.sub.php | .sub.php | showTicket |
+| submodules/comments.sub.php | .sub.php | showTicket |
+| submodules/timesheet.sub.php | .sub.php | showTicket |
+| submodules/additionalFields.sub.php | .sub.php | showTicket |
+| submodules/portfolioHeader.sub.php | .sub.php | Roadmap views |
+| submodules/timelineHeader.sub.php | .sub.php | Milestone views |
+| submodules/timelineTabs.sub.php | .sub.php | Milestone views |
+
+### Ticket JS Controllers
+
+| File | Purpose | jQuery Usage |
+|------|---------|-------------|
+| ticketsController.js | Main ticket interactions | Heavy jQuery |
+| kanbanController.js | Kanban drag-drop, board logic | Heavy jQuery |
+| ticketsRepository.js | AJAX data layer | jQuery.ajax |
+
+---
+
+## 3. jQuery Dependency Map
+
+**1,493 jQuery references** across domain JS controllers. This breaks down by pattern:
+
+### By Usage Pattern (estimated)
+
+| Pattern | Count | Replacement |
+|---------|-------|-------------|
+| `jQuery("selector")` / `$("selector")` — DOM queries | ~600 | `document.querySelector()` / HTMX |
+| `jQuery.ajax()` / `$.get()` / `$.post()` | ~200 | `fetch()` / HTMX `hx-get`/`hx-post` |
+| `jQuery(el).on("event")` — event handlers | ~250 | `addEventListener()` / HTMX events |
+| `jQuery(el).addClass/removeClass/toggleClass` | ~150 | `el.classList.add/remove/toggle` |
+| `jQuery(el).show/hide/toggle` | ~100 | CSS classes / HTMX swap |
+| `jQuery(el).val()` / `.text()` / `.html()` | ~100 | Native DOM properties |
+| jQuery UI (sortable, draggable, datepicker) | ~50 | Phase 3/4 — needs alternatives |
+| jQuery plugins (nyroModal, growl, chosen, etc.) | ~43 | Phase 1 (modal), Phase 3 (rest) |
+
+### jQuery Removal Strategy
+
+Phase 2 does NOT remove jQuery. Instead:
+1. New Blade components use vanilla JS + HTMX (no new jQuery)
+2. Converted templates preserve existing jQuery in JS controllers
+3. jQuery removal happens incrementally in Phase 3-4 as JS controllers are modernized
+
+---
+
+## 4. Bootstrap CSS Dependency Map
+
+**1,099 Bootstrap references** across templates:
+
+| Bootstrap Pattern | Count | DaisyUI/Tailwind Replacement |
+|-------------------|-------|------------------------------|
+| Grid: `col-md-*`, `col-lg-*`, `col-sm-*`, `col-xs-*` | 789 | Tailwind grid/flex utilities |
+| Buttons: `btn-default`, `btn-success`, `btn-danger`, etc. | 97 | DaisyUI `btn`, `btn-primary`, etc. |
+| Forms: `form-group`, `form-control` | 175 | DaisyUI `form-control`, `input`, `select` |
+| Panels, wells, alerts | ~38 | DaisyUI `card`, `alert` |
+
+### Bootstrap Removal Strategy
+
+Phase 2 uses a **dual-class approach**:
+1. Add DaisyUI/Tailwind classes alongside Bootstrap classes
+2. Verify visual parity
+3. Remove Bootstrap classes in Phase 4 (final cleanup)
+4. Remove Bootstrap CSS files in Phase 4
+
+---
+
+## 5. JS Bundle Architecture
+
+### Current Bundles (13 compiled files)
+
+| Bundle | Size Factor | Content | Phase 2 Action |
+|--------|------------|---------|----------------|
+| compiled-frameworks.js | LARGE | jQuery, jQuery UI core | Keep (Phase 3 removes jQuery UI) |
+| compiled-framework-plugins.js | LARGE | jQuery UI, chosen, growl, form, tags | Keep (Phase 3 modernizes) |
+| compiled-global-component.js | LARGE | 22 imports: luxon, tippy, slimselect, nyroModal, croppie, etc. | Phase 1 replaces nyroModal |
+| compiled-app.js | MEDIUM | Core app + modals + domain JS (glob import) | Update modals import |
+| compiled-calendar-component.js | MEDIUM | FullCalendar | Keep |
+| compiled-chart-component.js | SMALL | Chart.js | Keep |
+| compiled-editor-component.js | LARGE | TipTap editor (36 imports) | Keep |
+| compiled-table-component.js | MEDIUM | DataTables | Keep (Phase 3 evaluates replacement) |
+| compiled-gantt-component.js | MEDIUM | Frappe Gantt | Keep |
+| compiled-htmx.js | SMALL | HTMX core | Keep |
+| compiled-htmx-extensions.js | SMALL | HTMX extensions | Keep |
+| compiled-footer.js | TINY | Footer scripts | Keep |
+| compiled-lottieplayer.js | SMALL | Lottie animations | Keep |
+
+### Domain JS Auto-Import
+
+`compiled-app.js` uses Vite's `import.meta.glob()` to auto-import ALL domain JS:
+
+```javascript
+const domainModules = import.meta.glob('../../app/Domain/**/*.js', { eager: true });
+```
+
+This means **every domain JS controller is loaded on every page**. Phase 3 should convert this to lazy loading.
+
+---
+
+## 6. Shared Component Library Plan
+
+### Components to Build in Phase 2.1
+
+These components serve as the foundation for ALL domain conversions:
+
+| Component | DaisyUI Base | Purpose | Priority |
+|-----------|-------------|---------|----------|
+| `<x-form.input>` | input, textarea | Text/number/email inputs with labels + errors | P1 |
+| `<x-form.select>` | select | Dropdown with label + errors | P1 |
+| `<x-form.checkbox>` | checkbox, toggle | Checkboxes and toggles | P1 |
+| `<x-form.radio>` | radio | Radio groups | P1 |
+| `<x-form.date>` | — | Date picker wrapper | P1 |
+| `<x-form.editor>` | — | TipTap editor wrapper | P2 |
+| `<x-form.file>` | file-input | File upload | P2 |
+| `<x-form.color>` | — | Color picker | P3 |
+| `<x-card>` | card | Content card with header/body/footer | P1 |
+| `<x-table>` | table | Data table with sorting | P1 |
+| `<x-table.row>` | — | Table row | P1 |
+| `<x-alert>` | alert | Status messages | P1 |
+| `<x-dropdown>` | dropdown | Dropdown menus | P1 |
+| `<x-avatar>` | avatar | User avatar display | P1 |
+| `<x-badge>` | badge | Status badges | P1 (exists, update) |
+| `<x-progress>` | progress, radial-progress | Progress indicators | P2 |
+| `<x-tooltip>` | tooltip | Tippy.js wrapper | P1 |
+| `<x-page-header>` | — | Page title + actions bar | P1 (exists, update) |
+| `<x-breadcrumbs>` | breadcrumbs | Navigation breadcrumbs | P2 |
+| `<x-empty-state>` | — | Empty content placeholder | P2 |
+| `<x-confirm-delete>` | — | Delete confirmation dialog | P1 |
+| `<x-status-indicator>` | — | Red/yellow/green status dot | P1 |
+| `<x-filter-bar>` | — | Filter controls row | P2 |
+
+### Existing Components to Update
+
+| Component | Current State | Action |
+|-----------|-------------|--------|
+| `actions/modal.blade.php` | Phase 1 updated | ✅ Done |
+| `badge.blade.php` | Exists | Update to DaisyUI 5 |
+| `button.blade.php` | Exists | Update to DaisyUI 5 |
+| `accordion.blade.php` | Exists | Update to DaisyUI 5 |
+| `tabs.blade.php` | Exists | Update to DaisyUI 5 |
+| `pageheader.blade.php` | Exists | Update to DaisyUI 5 |
+| `loader.blade.php` | Exists | Update to DaisyUI 5 |
+| `kanban/*.blade.php` | Exists (8 files) | Update to DaisyUI 5 |
+
+---
+
+## 7. CSS Files to Eventually Remove
+
+### Phase 4 Removal Targets
+
+| CSS File | Lines | Replacement |
+|----------|-------|-------------|
+| bootstrap.css | 6,782 | Tailwind 4 + DaisyUI 5 |
+| bootstrap-grid.min.css | — | Tailwind grid |
+| bootstrap-responsive.min.css | — | Tailwind responsive |
+| bootstrap-timepicker.min.css | — | DaisyUI date input |
+| bootstrap-fileupload.min.css | — | DaisyUI file-input |
+| nyroModal.css | — | DaisyUI modal (Phase 1) |
+| jquery-ui-*.css | — | DaisyUI components |
+| jquery.chosen.css | — | SlimSelect (already present) |
+| jquery.alerts.css | — | DaisyUI alert |
+| style.default.css | 2,969 | Migrate custom styles to Tailwind |
+| structure.css | — | Tailwind layout |
+| forms.css | — | DaisyUI form components |
+| overwrites.css | — | Remove after components cover all cases |
+| tinymceSkin/** | — | Remove (TinyMCE migrated ✅) |
+
+---
+
+## 8. Domain-Specific Notes
+
+### Tickets Domain
+- `showKanban.tpl.php` uses jQuery UI Sortable for drag-drop — keep jQuery UI in Phase 2, evaluate replacement in Phase 3
+- `showAll.tpl.php` uses DataTables jQuery plugin — keep in Phase 2
+- `showTicketModal.blade.php` already Blade — update to use new form components
+- Submodules (.sub.php) are PHP includes — convert to Blade `@include` or components
+
+### Projects Domain
+- `projectHub.blade.php` already Blade — widget-based dashboard
+- `showProject.tpl.php` uses chart components and submodules
+- `editProject.tpl.php` / `newProject.tpl.php` — form-heavy, good candidates for form components
+
+### Calendar Domain
+- `showMyCalendar.tpl.php` integrates FullCalendar JS — keep FC integration
+- Multiple modal dialogs (add/edit/delete event) — use Phase 1 modal pattern
+- `calendarSettings.blade.php` already Blade
+
+### Settings Domain
+- `editCompanySettings.tpl.php` — large form, tab-based, API key management
+- `editBoxDialog.tpl.php` — label editing modal
+
+### Users Domain
+- `newUser.tpl.php` — invite user form
+- Profile components already exist as Blade
+
+### Menu Domain
+- Already 100% Blade (14 templates)
+- Update to DaisyUI 5 classes (sidebar, drawer, menu components)

--- a/Docs/phase-2-requirements.md
+++ b/Docs/phase-2-requirements.md
@@ -1,0 +1,467 @@
+# Phase 2: Core Domain Componentization — Requirements Document
+
+## For Claude Code Execution
+
+**Project:** Leantime UI Modernization Forward-Port
+**Phase:** 2 of 4 — Core Domain Template Conversion + Shared Component Library
+**Depends on:** Phase 0 (build pipeline) + Phase 1 (modal system + navigation)
+**Estimated Duration:** 3-4 weeks
+**Risk Level:** MEDIUM (template-level changes, no business logic)
+**Generated:** February 13, 2026
+
+---
+
+## Goal
+
+Convert the highest-traffic core domain templates from `.tpl.php` / `.inc.php` / `.sub.php` to Blade components using DaisyUI 5 + Tailwind 4 + HTMX. Build a shared component library that standardizes forms, cards, tables, and page layouts. Convert **63 templates** across 9 core domains.
+
+---
+
+## 2.1 Build Shared Component Library
+
+**Priority:** FIRST | **Risk:** LOW | **Effort:** 2-3 days
+
+### What to Build
+
+Create reusable Blade components in `app/Views/Templates/components/`. Every subsequent domain conversion depends on these.
+
+### Form Components (`components/form/`)
+
+**`input.blade.php`** — Text, number, email, password, hidden inputs:
+```php
+@props(['name', 'label' => null, 'type' => 'text', 'value' => '', 'required' => false, 'error' => null])
+
+<div class="form-control w-full">
+    @if($label)
+        <label class="label" for="{{ $name }}">
+            <span class="label-text">{{ $label }} @if($required)<span class="text-error">*</span>@endif</span>
+        </label>
+    @endif
+    <input type="{{ $type }}" name="{{ $name }}" id="{{ $name }}"
+           value="{{ old($name, $value) }}"
+           {{ $required ? 'required' : '' }}
+           {{ $attributes->merge(['class' => 'input input-bordered w-full' . ($error ? ' input-error' : '')]) }} />
+    @if($error)
+        <label class="label"><span class="label-text-alt text-error">{{ $error }}</span></label>
+    @endif
+</div>
+```
+
+**`select.blade.php`** — Dropdowns with label and error support.
+
+**`checkbox.blade.php`** — Checkboxes and toggles.
+
+**`textarea.blade.php`** — Multi-line text with optional TipTap editor integration.
+
+**`date.blade.php`** — Date picker wrapper (preserves existing datepicker JS).
+
+**`file.blade.php`** — File upload with DaisyUI styling.
+
+**`color.blade.php`** — Color picker wrapper.
+
+### Layout Components (`components/`)
+
+**`card.blade.php`** — Content card with optional header, body, and footer:
+```php
+@props(['title' => null, 'compact' => false])
+
+<div {{ $attributes->merge(['class' => 'card bg-base-100 shadow-sm' . ($compact ? ' card-compact' : '')]) }}>
+    @if($title)
+        <div class="card-body">
+            <h2 class="card-title">{{ $title }}</h2>
+            {{ $slot }}
+            @isset($actions)
+                <div class="card-actions justify-end">{{ $actions }}</div>
+            @endisset
+        </div>
+    @else
+        <div class="card-body">
+            {{ $slot }}
+        </div>
+    @endif
+</div>
+```
+
+**`table.blade.php`** — Data table wrapper preserving DataTables integration.
+
+**`alert.blade.php`** — Status messages (success, error, warning, info).
+
+**`dropdown.blade.php`** — Dropdown menus using DaisyUI dropdown.
+
+**`confirm-delete.blade.php`** — Delete confirmation dialog pattern.
+
+**`empty-state.blade.php`** — Empty content placeholder with illustration.
+
+**`status-indicator.blade.php`** — Red/yellow/green dot.
+
+**`filter-bar.blade.php`** — Filter controls row (sprint filter, status filter, etc.).
+
+### Update Existing Components
+
+Update these to use DaisyUI 5 classes:
+- `badge.blade.php`
+- `button.blade.php`
+- `accordion.blade.php`
+- `tabs.blade.php` + `tabs/heading.blade.php` + `tabs/content.blade.php`
+- `pageheader.blade.php`
+- `loader.blade.php`
+
+### Validation Checklist
+- [ ] All form components render correctly with labels, values, errors
+- [ ] Card component renders with title, body, actions
+- [ ] Table component works with existing DataTables initialization
+- [ ] Alert component shows all 4 variants
+- [ ] Dropdown component opens/closes properly
+- [ ] Updated existing components maintain visual compatibility
+- [ ] Components work inside modals (Phase 1 `<dialog>`)
+- [ ] Components work with HTMX attributes (hx-get, hx-post, hx-target)
+
+---
+
+## 2.2 Tickets Domain Conversion
+
+**Priority:** HIGHEST | **Risk:** MEDIUM | **Effort:** 5-7 days
+
+This is the largest and most complex domain. Convert in sub-phases:
+
+### Phase 2.2a: Submodules First (shared across views)
+
+Convert `.sub.php` includes to Blade `@include` or components. These are used by multiple parent templates, so converting them first means parent templates can reference Blade includes.
+
+| Submodule | Lines | Complexity | Key Dependencies |
+|-----------|-------|-----------|-----------------|
+| ticketHeader.sub.php | — | MED | Sprint filter, view tabs |
+| ticketFilter.sub.php | — | MED | Filter dropdowns (chosen.js) |
+| ticketBoardTabs.sub.php | — | LOW | Tab navigation |
+| ticketNewBtn.sub.php | — | LOW | New ticket button |
+| ticketNewButton.sub.php | — | LOW | New ticket button (variant) |
+| ticketDetails.sub.php | — | HIGH | Full ticket detail panel |
+| subTasks.sub.php | — | MED | Subtask list + add form |
+| attachments.sub.php | — | MED | File upload (Uppy) |
+| comments.sub.php | — | MED | Comment thread |
+| timesheet.sub.php | — | MED | Time logging |
+| additionalFields.sub.php | — | LOW | Custom fields |
+| portfolioHeader.sub.php | — | LOW | Portfolio view header |
+| timelineHeader.sub.php | — | MED | Timeline controls |
+| timelineTabs.sub.php | — | LOW | Timeline tab navigation |
+
+**Conversion pattern:**
+```php
+// Before (.sub.php included via PHP include):
+<?php include __DIR__ . '/submodules/ticketHeader.sub.php'; ?>
+
+// After (Blade include):
+@include('tickets::partials.ticketHeader')
+```
+
+### Phase 2.2b: Modal Dialogs
+
+| Template | Action |
+|----------|--------|
+| newTicketModal.tpl.php → newTicketModal.blade.php | Convert form to use `<x-form.*>` components |
+| milestoneDialog.tpl.php → milestoneDialog.blade.php | Convert form, date pickers |
+| moveTicket.tpl.php → moveTicket.blade.php | Convert project selector |
+| delTicket.tpl.php → delTicket.blade.php | Use `<x-confirm-delete>` component |
+| delMilestone.tpl.php → delMilestone.blade.php | Use `<x-confirm-delete>` component |
+
+### Phase 2.2c: Main Views
+
+| Template | Complexity | Key Concerns |
+|----------|-----------|-------------|
+| showKanban.tpl.php | 🔴 HIGH | jQuery UI Sortable drag-drop — preserve JS, convert HTML structure |
+| showAll.tpl.php | 🔴 HIGH | DataTables integration — preserve table structure, use `<x-table>` |
+| showTicket.tpl.php | 🔴 HIGH | Full page ticket — uses many submodules |
+| showAllMilestones.tpl.php | 🟡 MED | Gantt chart integration |
+| showAllMilestonesOverview.tpl.php | 🟡 MED | DataTables milestone list |
+| showList.tpl.php | 🟡 MED | Simple ticket list |
+| roadmap.tpl.php | 🟡 MED | Gantt chart |
+| roadmapAll.tpl.php | 🟡 MED | All-project Gantt |
+| calendar.tpl.php | 🟡 MED | FullCalendar integration |
+| newTicket.tpl.php | 🟡 MED | Full-page ticket form |
+
+### Kanban Special Handling
+
+`showKanban.tpl.php` is the most complex template. Key concerns:
+1. jQuery UI Sortable for drag-drop — **preserve all sortable initialization**
+2. Swimlane grouping (by milestone, sprint, priority) — preserve `data-*` attributes
+3. Ticket cards already use `partials/ticketCard.blade.php` — just update the container
+4. The kanbanController.js handles all drag-drop AJAX — **do not change this JS**
+5. Convert HTML structure to use DaisyUI card/grid utilities alongside existing classes
+
+### Sprint Templates (with Tickets)
+
+| Template | Action |
+|----------|--------|
+| Sprints/sprintdialog.tpl.php → sprintdialog.blade.php | Convert form, use date components |
+| Sprints/delSprint (if exists) | Convert |
+
+### Validation Checklist
+- [ ] Kanban board renders with correct layout and drag-drop works
+- [ ] Table list view renders with sorting, pagination (DataTables)
+- [ ] Full-page ticket detail shows all tabs (details, subtasks, comments, time, files)
+- [ ] Ticket modal shows correctly (already Blade, verify with new components)
+- [ ] New ticket form creates tickets
+- [ ] Milestone dialog creates/edits milestones
+- [ ] Delete confirmations work
+- [ ] Move ticket between projects works
+- [ ] Sprint dialog creates/edits sprints
+- [ ] Roadmap/timeline views render Gantt charts
+- [ ] All HTMX interactions still work (subtask add, comment submit, etc.)
+- [ ] Ticket filters work (sprint, status, milestone, user)
+- [ ] Quick-add form works
+
+---
+
+## 2.3 Projects Domain Conversion
+
+**Priority:** HIGH | **Risk:** LOW-MEDIUM | **Effort:** 2-3 days
+
+| Template | Format | Action |
+|----------|--------|--------|
+| projectHub.blade.php | ✅ Blade | Update to use DaisyUI components |
+| partials/projectCard.blade.php | ✅ Blade | Update card styling |
+| partials/projectCardProgressBar.blade.php | ✅ Blade | Update progress bar |
+| partials/projectHubProjects.blade.php | ✅ Blade | Update grid layout |
+| partials/checklist.blade.php | ✅ Blade | Update to DaisyUI |
+| createnew.blade.php | ✅ Blade | Update form components |
+| showAll.tpl.php → showAll.blade.php | Convert | DataTables project list |
+| showProject.tpl.php → showProject.blade.php | Convert | Project detail + charts |
+| editProject.tpl.php → editProject.blade.php | Convert | Edit form → use `<x-form.*>` |
+| newProject.tpl.php → newProject.blade.php | Convert | New form → use `<x-form.*>` |
+| editAccount.tpl.php → editAccount.blade.php | Convert | Account settings form |
+| delProject.tpl.php → delProject.blade.php | Convert | Use `<x-confirm-delete>` |
+| duplicateProject.tpl.php → duplicateProject.blade.php | Convert | Duplicate form |
+| submodules/projectDetails.sub.php | Convert | Include to Blade partial |
+| submodules/tickets.sub.php | Convert | Include to Blade partial |
+
+### Validation Checklist
+- [ ] Project hub renders with project cards and progress bars
+- [ ] Project list (DataTables) renders with sorting
+- [ ] Project detail page shows charts and details
+- [ ] Create/edit/delete project workflows work
+- [ ] Duplicate project works
+- [ ] Project settings save correctly
+
+---
+
+## 2.4 Dashboard Domain Update
+
+**Priority:** HIGH | **Risk:** LOW | **Effort:** 0.5-1 day
+
+Already 100% Blade. Update to use shared components:
+
+| Template | Action |
+|----------|--------|
+| show.blade.php | Update cards, buttons, links to DaisyUI |
+| home.blade.php | Update layout to DaisyUI |
+| partials/createEntityButton.blade.php | Update dropdown to DaisyUI |
+
+### Validation Checklist
+- [ ] Dashboard renders with widgets
+- [ ] Create entity button works (ticket, milestone)
+- [ ] Widget grid layout preserved
+
+---
+
+## 2.5 Calendar Domain Conversion
+
+**Priority:** MEDIUM | **Risk:** LOW-MEDIUM | **Effort:** 1-2 days
+
+| Template | Format | Action |
+|----------|--------|--------|
+| showMyCalendar.tpl.php → showMyCalendar.blade.php | Convert | FullCalendar integration — preserve FC init |
+| calendarSettings.blade.php | ✅ Blade | Update to DaisyUI |
+| connectCalendar.blade.php | ✅ Blade | Update form |
+| editExternalCalendar.blade.php | ✅ Blade | Update form |
+| importGCal.blade.php | ✅ Blade | Update form |
+| addEvent.tpl.php → addEvent.blade.php | Convert | Modal form → use `<x-form.*>` |
+| editEvent.tpl.php → editEvent.blade.php | Convert | Modal form |
+| delEvent.tpl.php → delEvent.blade.php | Convert | Use `<x-confirm-delete>` |
+| delExternalCal.tpl.php → delExternalCal.blade.php | Convert | Use `<x-confirm-delete>` |
+| export.tpl.php → export.blade.php | Convert | Export options form |
+
+### Validation Checklist
+- [ ] Calendar renders with FullCalendar
+- [ ] Add/edit/delete events work
+- [ ] Calendar settings save
+- [ ] External calendar connection works
+- [ ] Export function works
+
+---
+
+## 2.6 Settings Domain Conversion
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 1 day
+
+| Template | Format | Action |
+|----------|--------|--------|
+| editCompanySettings.tpl.php → editCompanySettings.blade.php | Convert | Large tabbed form |
+| editBoxDialog.tpl.php → editBoxDialog.blade.php | Convert | Label editing modal |
+
+### Validation Checklist
+- [ ] Company settings page renders all tabs
+- [ ] All settings save correctly
+- [ ] API key section works (create, view, delete)
+- [ ] Label editing dialog works
+
+---
+
+## 2.7 Users Domain Conversion
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 1-2 days
+
+| Template | Format | Action |
+|----------|--------|--------|
+| profile-box.blade.php | ✅ Blade | Update to DaisyUI |
+| profile-image.blade.php | ✅ Blade | Update avatar component |
+| showAll.tpl.php → showAll.blade.php | Convert | User list (DataTables) |
+| newUser.tpl.php → newUser.blade.php | Convert | Invite form → `<x-form.*>` |
+| editOwn.tpl.php → editOwn.blade.php | Convert | Profile edit form |
+| editUser.tpl.php → editUser.blade.php | Convert | Admin user edit |
+| delUser.tpl.php → delUser.blade.php | Convert | Use `<x-confirm-delete>` |
+
+### Validation Checklist
+- [ ] User list renders with DataTables
+- [ ] Invite user form works
+- [ ] Profile edit saves
+- [ ] Admin user edit works
+- [ ] Delete user confirmation works
+
+---
+
+## 2.8 Timesheets Domain Conversion
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 1-2 days
+
+| Template | Format | Action |
+|----------|--------|--------|
+| partials/stopwatch.blade.php | ✅ Blade | Update to DaisyUI |
+| showMy.tpl.php → showMy.blade.php | Convert | Personal timesheet view |
+| showMyList.tpl.php → showMyList.blade.php | Convert | List view |
+| showAll.tpl.php → showAll.blade.php | Convert | All timesheets (admin) |
+| addTime.tpl.php → addTime.blade.php | Convert | Time entry form |
+| editTime.tpl.php → editTime.blade.php | Convert | Edit time entry |
+| delTime.tpl.php → delTime.blade.php | Convert | Delete confirmation |
+
+### Validation Checklist
+- [ ] Timesheet views render with correct data
+- [ ] Add/edit/delete time entries work
+- [ ] Stopwatch widget works
+- [ ] Admin all-timesheets view works
+
+---
+
+## 2.9 Menu Domain Update
+
+**Priority:** MEDIUM | **Risk:** LOW | **Effort:** 1 day
+
+Already 100% Blade (14 templates). Update to DaisyUI 5:
+
+- Sidebar menu → DaisyUI `menu` component
+- Project selector → DaisyUI `dropdown`
+- Top navigation → DaisyUI `navbar`
+- Mobile menu → DaisyUI `drawer`
+
+### Validation Checklist
+- [ ] Desktop sidebar renders correctly
+- [ ] Project selector dropdown works
+- [ ] Top navigation shows correctly
+- [ ] Mobile responsive menu works
+- [ ] Menu state (open/closed) persists
+- [ ] Active menu item highlights correctly
+
+---
+
+## Execution Order
+
+```
+2.1  Shared component library               [2-3 days]   — Foundation for all conversions
+2.2a Tickets submodules                      [2-3 days]   — Shared includes first
+2.2b Tickets modal dialogs                   [1 day]      — Forms → components
+2.2c Tickets main views                      [3-4 days]   — Largest templates
+2.3  Projects domain                         [2-3 days]   — Second highest traffic
+2.4  Dashboard update                        [0.5-1 day]  — Already Blade
+2.5  Calendar domain                         [1-2 days]   — FullCalendar integration
+2.6  Settings domain                         [1 day]      — Large form
+2.7  Users domain                            [1-2 days]   — User management
+2.8  Timesheets domain                       [1-2 days]   — Time tracking
+2.9  Menu domain update                      [1 day]      — Navigation styling
+```
+**Total: ~3-4 weeks**
+
+---
+
+## Conversion Rules
+
+### .tpl.php → .blade.php Conversion Patterns
+
+```php
+// PHP echo
+<?= $variable ?>              → {{ $variable }}
+<?php echo $variable; ?>       → {{ $variable }}
+
+// PHP escaped
+<?php $tpl->e($var); ?>        → {{ $tpl->escape($var) }}
+<?= $tpl->e($var) ?>           → {{ $tpl->escape($var) }}
+
+// PHP unescaped
+<?= $tpl->__('key') ?>         → {!! __('key') !!}
+
+// PHP control structures
+<?php if($condition): ?>        → @if($condition)
+<?php endif; ?>                 → @endif
+<?php foreach($items as $item): ?> → @foreach($items as $item)
+<?php endforeach; ?>            → @endforeach
+
+// Include
+<?php include __DIR__ . '/submodules/file.sub.php'; ?> → @include('domain::partials.file')
+
+// Template variables
+$tpl->get('varName')           → $varName (passed via controller)
+$tpl->assign('key', $value)    → Pass via view data
+```
+
+### Dual-Class Approach
+
+During conversion, keep Bootstrap classes alongside DaisyUI to prevent visual regressions:
+
+```html
+<!-- Before -->
+<div class="col-md-6">
+    <input class="form-control" />
+</div>
+
+<!-- During Phase 2 (both classes) -->
+<div class="col-md-6 md:w-1/2">
+    <input class="form-control input input-bordered" />
+</div>
+
+<!-- Phase 4 cleanup (Bootstrap removed) -->
+<div class="md:w-1/2">
+    <input class="input input-bordered" />
+</div>
+```
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| DataTables breaks after conversion | MEDIUM | HIGH | Preserve exact table HTML structure, test with DataTables init |
+| Kanban drag-drop breaks | MEDIUM | HIGH | Keep all jQuery UI Sortable attributes and init code unchanged |
+| FullCalendar breaks | LOW | HIGH | Keep FC init unchanged, only change surrounding HTML |
+| Form submissions fail | LOW | HIGH | Verify every form action URL and field names match |
+| HTMX interactions break | LOW | HIGH | Preserve all hx-* attributes exactly |
+| Visual regressions | MEDIUM | MEDIUM | Dual-class approach, visual comparison testing |
+| Chosen.js dropdowns break | LOW | MEDIUM | Keep chosen-js imports, test filter dropdowns |
+| Submodule include paths break | MEDIUM | MEDIUM | Test every include path, use Blade @include properly |
+
+---
+
+## What This Document Does NOT Cover
+
+- Phase 3: Canvas domains, Wiki, JS optimization, jQuery removal
+- Phase 4: Remaining domains, Bootstrap removal, final cleanup
+- jQuery controller modernization (preserving all existing JS in Phase 2)
+- Backend/service layer changes (none needed)

--- a/Docs/phase-3-combined.md
+++ b/Docs/phase-3-combined.md
@@ -1,0 +1,250 @@
+# Phase 3: Canvas Domains, Wiki & JS Optimization — Complete Summary & Requirements
+
+## Claude Code Execution Prompt
+
+```
+Read these documents in order before starting Phase 3:
+1. Docs/phase-0-complete-summary.md — Component inventory, frontend library decisions
+2. Docs/phase-1-complete-summary.md — Modal system, canvas domain architecture
+3. Docs/phase-2-complete-summary.md — Shared component library, jQuery dependency map
+4. Docs/phase-3-combined.md — THIS FILE: canvas domain plan, JS optimization strategy
+5. Docs/phase-2-requirements.md — Conversion patterns (reuse for canvas/wiki templates)
+
+Phase 3 Tasks (execute in order):
+3.1 — Canvas domain template conversion (shared templates → Blade, fixes 19 domains)
+3.2 — Goalcanvas DaisyUI 5 update (already Blade)
+3.3 — Ideas domain conversion (.tpl.php → Blade)
+3.4 — Wiki domain conversion (.tpl.php → Blade)
+3.5 — JS bundle splitting (eager → lazy loading for domain controllers)
+3.6 — jQuery reduction pass 1 (remove jQuery from new components, modernize key controllers)
+3.7 — Remove dead JS libraries (nyroModal, TinyMCE skin CSS, unused jQuery plugins)
+
+CRITICAL CONSTRAINTS:
+- Canvas shared templates affect 19 domains — test 3+ canvas types after changes
+- DO NOT break jQuery UI Sortable (kanban) — that stays until Phase 4
+- DO NOT remove jQuery itself — reduce usage, don't eliminate
+- Domain JS glob import (import.meta.glob eager) → convert to dynamic import()
+- Keep DataTables, FullCalendar, Frappe Gantt untouched
+```
+
+---
+
+## 1. Canvas Domain Template Architecture
+
+### Shared Templates (Canvas/Templates/)
+
+These 9 files serve 16 canvas domains directly + 3 with custom overrides:
+
+| Template | Purpose | Modal Triggers | Complexity |
+|----------|---------|---------------|-----------|
+| canvasDialog.inc.php | Item create/edit dialog (main modal) | None (is the modal) | 🔴 HIGH |
+| canvasComment.inc.php | Comment on canvas item | None (is the modal) | 🟡 MED |
+| boardDialog.php | Board create/edit | None (is the modal) | 🟡 MED |
+| element.inc.php | Single canvas element display | 3 hash triggers | 🟡 MED |
+| showCanvasTop.inc.php | Canvas header with controls | 4 hash triggers | 🟡 MED |
+| modals.inc.php | Modal includes container | — | 🟢 LOW |
+| showCanvasBottom.inc.php | Canvas footer | — | 🟢 LOW |
+| showCanvas.inc.php | Main canvas grid layout | — | 🟡 MED |
+| canvasChart.inc.php | Canvas chart view | — | 🟡 MED |
+
+### Canvas Domains Using Shared Templates
+
+These 16 domains have NO custom templates — they rely entirely on Canvas/Templates/:
+
+```
+Cpcanvas, Dbmcanvas, Eacanvas, Emcanvas, Insightscanvas, Lbmcanvas,
+Leancanvas, Logicmodelcanvas, Minempathycanvas, Obmcanvas, Retroscanvas,
+Riskscanvas, Sbcanvas, Smcanvas, Sqcanvas, Swotcanvas
+```
+
+Each has: 5 .tpl.php files (showCanvas, editCanvasItem, editCanvasComment, delCanvas, delCanvasItem) + 1 JS controller.
+
+**These .tpl.php files are thin wrappers** that include the shared templates. Conversion pattern:
+```php
+// Current (e.g., Leancanvas/Templates/showCanvas.tpl.php):
+<?php $canvasName = 'lean'; include __DIR__ . '/../../Canvas/Templates/showCanvas.inc.php'; ?>
+
+// After (Leancanvas/Templates/showCanvas.blade.php):
+@include('canvas::showCanvas', ['canvasName' => 'lean'])
+```
+
+### Domains with Custom Templates
+
+| Domain | Custom Templates | Action |
+|--------|-----------------|--------|
+| Goalcanvas | canvasDialog.blade.php, bigRockDialog.blade.php, showCanvas.blade.php, dashboard.blade.php (all Blade ✅) | Update to DaisyUI 5 components |
+| Valuecanvas | canvasDialog.tpl.php (custom) | Convert to Blade |
+| Ideas | ideaDialog.tpl.php, boardDialog.php, showBoards.tpl.php, advancedBoards.tpl.php | Convert to Blade |
+
+### Canvas JS Controller Consolidation
+
+16 canvas JS controllers duplicate the same code. Phase 1 started consolidation with `canvasModal.js`. Phase 3 completes it:
+
+**Create `public/assets/js/app/core/canvasController.js`** — shared canvas logic:
+- `initSortable()` — canvas item drag-drop
+- `initCanvasFilters()` — filter controls
+- `openModalManually()` — already done in Phase 1
+
+**Each domain controller** reduces to configuration-only:
+```javascript
+leantime.leanCanvasController = leantime.canvasController.init('lean');
+```
+
+---
+
+## 2. Wiki Domain
+
+| Template | Format | Action |
+|----------|--------|--------|
+| show.tpl.php | .tpl.php | Convert — main wiki view with article tree |
+| articleDialog.tpl.php | .tpl.php | Convert — article editor modal |
+| wikiDialog.tpl.php | .tpl.php | Convert — wiki create/edit modal |
+| delWiki.tpl.php | .tpl.php | Convert — use `<x-confirm-delete>` |
+| delArticle.tpl.php | .tpl.php | Convert — use `<x-confirm-delete>` |
+| wikiModal.tpl.php | .tpl.php | Convert — wiki create modal |
+
+Key concern: `show.tpl.php` uses jstree for the article navigation tree. Preserve jstree integration.
+
+---
+
+## 3. JS Bundle Optimization
+
+### Current Problem
+
+`compiled-app.js` eagerly imports ALL domain JS controllers:
+```javascript
+const domainModules = import.meta.glob('../../app/Domain/**/*.js', { eager: true });
+```
+
+This loads 45+ JS files on every page, regardless of which domain the user is viewing.
+
+### Solution: Dynamic Imports
+
+Convert to lazy loading:
+```javascript
+// Before (loads everything eagerly):
+const domainModules = import.meta.glob('../../app/Domain/**/*.js', { eager: true });
+
+// After (loads on demand):
+const domainModules = import.meta.glob('../../app/Domain/**/*.js');
+// Each module is now a function: () => import('...')
+// Load based on current page/route
+```
+
+**Vite will automatically code-split** dynamic imports into separate chunks. Each domain's JS loads only when that domain's page is visited.
+
+### Page-Specific Loading Pattern
+
+```javascript
+// In compiled-app.js:
+const currentModule = document.body.dataset.module; // Set by layout template
+const domainModules = import.meta.glob('../../app/Domain/**/*.js');
+
+// Load only the current domain's JS
+for (const [path, loader] of Object.entries(domainModules)) {
+    if (path.includes(`/${currentModule}/`)) {
+        loader(); // Dynamic import — Vite creates a chunk
+    }
+}
+```
+
+Layout template adds: `<body data-module="{{ $currentModule }}">`
+
+### Libraries to Lazy-Load
+
+| Library | Current Bundle | Load When |
+|---------|---------------|-----------|
+| FullCalendar | compiled-calendar-component.js | Calendar pages only |
+| Chart.js | compiled-chart-component.js | Dashboard, project detail |
+| Frappe Gantt | compiled-gantt-component.js | Roadmap/timeline views |
+| DataTables | compiled-table-component.js | List views |
+| Lottie Player | compiled-lottieplayer.js | Welcome/onboarding |
+
+These are already separate bundles — ensure they're loaded conditionally via `@vite` in templates that need them, not globally.
+
+### Expected Bundle Size Improvement
+
+| State | Main Bundle | Total Page Load |
+|-------|------------|----------------|
+| Current (eager) | ~800KB+ | Everything on every page |
+| After splitting | ~200KB core | +50-100KB per domain chunk |
+
+---
+
+## 4. jQuery Reduction Pass 1
+
+### Strategy
+
+Phase 3 does NOT remove jQuery. It reduces new jQuery usage and modernizes the most-called patterns:
+
+1. **New code: zero jQuery** — all Phase 3 Blade components use vanilla JS + HTMX
+2. **Canvas controllers: consolidate** — 16 duplicated controllers → 1 shared + config
+3. **Key patterns: modernize** — Replace `jQuery.ajax()` calls in high-traffic controllers with `fetch()`
+
+### High-Priority jQuery Replacement Targets
+
+| File | jQuery Calls | Action |
+|------|-------------|--------|
+| ticketsController.js | ~120 | Phase 4 (too risky in Phase 3) |
+| kanbanController.js | ~100 | Phase 4 (jQuery UI Sortable dependency) |
+| 16x canvas controllers | ~400 total | Consolidate to 1 shared controller |
+| dashboardController.js | ~30 | Modernize — mostly event handlers |
+| menuController.js | ~40 | Modernize — DOM queries + toggle |
+| projectsController.js | ~30 | Modernize where safe |
+
+### Dead Library Removal
+
+| Library | Location | Reason for Removal |
+|---------|----------|-------------------|
+| jquery.nyroModal | public/assets/js/libs/jquery.nyroModal/ | Replaced by modalManager.js (Phase 1) |
+| nyroModal.css | public/assets/css/components/nyroModal.css | No longer used |
+| TinyMCE skin CSS | public/assets/css/libs/tinymceSkin/ | TinyMCE migrated to TipTap ✅ |
+| TinyMCE plugins | public/assets/js/libs/tinymce-plugins/ | TinyMCE migrated ✅ |
+| jquery.alerts.css | public/assets/css/libs/jquery.alerts.css | Replaced by DaisyUI alert |
+
+### Validation Checklist
+- [ ] No page loads nyroModal JS
+- [ ] No page loads TinyMCE CSS/JS
+- [ ] Bundle size measurably smaller
+- [ ] All canvas domains still function
+- [ ] Dashboard, menu, project pages still function
+
+---
+
+## 5. Execution Order
+
+```
+3.1  Canvas shared templates → Blade          [2-3 days]   — Fixes 16 domains at once
+3.2  Goalcanvas DaisyUI update                [0.5 day]    — Already Blade
+3.3  Ideas domain conversion                  [1-2 days]   — Custom templates
+3.4  Wiki domain conversion                   [1-2 days]   — jstree integration
+3.5  JS bundle splitting                      [1-2 days]   — Vite code splitting
+3.6  jQuery reduction + controller consolidation [2-3 days] — Canvas JS, key controllers
+3.7  Dead library removal                     [0.5 day]    — Cleanup
+```
+**Total: ~2 weeks**
+
+---
+
+## 6. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Canvas shared template change breaks domains | MEDIUM | HIGH | Test Lean, SWOT, Retros after changes |
+| jstree breaks in wiki | LOW | MEDIUM | Preserve jstree init code exactly |
+| Dynamic imports cause flash/delay | LOW | MEDIUM | Preload hints, loading states |
+| jQuery removal breaks unexpected dependency | MEDIUM | MEDIUM | Only remove from new code + dead libraries |
+| Vite code splitting increases request count | LOW | LOW | HTTP/2 handles parallel requests well |
+
+---
+
+## 7. Phase 3 Deliverables
+
+- [ ] All 19 canvas domains use Blade templates
+- [ ] Canvas JS consolidated (16 controllers → 1 shared + config)
+- [ ] Wiki domain fully converted to Blade
+- [ ] Ideas domain fully converted to Blade
+- [ ] Domain JS lazy-loaded (not eager)
+- [ ] Dead libraries removed (nyroModal, TinyMCE assets)
+- [ ] Bundle size reduced by 30-40%
+- [ ] Zero new jQuery introduced

--- a/Docs/phase-4-combined.md
+++ b/Docs/phase-4-combined.md
@@ -1,0 +1,346 @@
+# Phase 4: Final Cleanup — Bootstrap Removal, Remaining Domains & jQuery Elimination
+
+## Claude Code Execution Prompt
+
+```
+Read these documents in order before starting Phase 4:
+1. Docs/phase-0-complete-summary.md — Component inventory, frontend library decisions
+2. Docs/phase-2-complete-summary.md — Shared component library, Bootstrap dependency map
+3. Docs/phase-3-combined.md — Canvas/Wiki done, JS optimization done, jQuery reduction started
+4. Docs/phase-4-combined.md — THIS FILE: remaining domain inventory, Bootstrap removal plan
+
+Phase 4 Tasks (execute in order):
+4.1 — Remaining domain template conversions (Auth, Clients, Files, Errors, Comments, Help, Connector)
+4.2 — Plugin template modernization (StrategyPro, PgmPro, Whiteboardscanvas, Llamadorian, Billing, Accounts)
+4.3 — Bootstrap class removal (strip dual-class patterns from ALL templates)
+4.4 — Bootstrap CSS file removal (delete bootstrap.css, bootstrap-grid, etc.)
+4.5 — jQuery UI replacement (Sortable → native drag API or SortableJS)
+4.6 — jQuery elimination (modernize remaining controllers, remove jQuery dependency)
+4.7 — Dead CSS cleanup (remove unused component CSS, consolidate custom styles)
+4.8 — Final build optimization (tree-shaking, asset hash verification, bundle audit)
+
+CRITICAL CONSTRAINTS:
+- DO NOT break the JSON-RPC API surface
+- jQuery UI Sortable → SortableJS migration needs careful testing of kanban drag-drop
+- Bootstrap removal must be verified page-by-page (789 grid classes, 97 button classes, 175 form classes)
+- Plugin templates: update core plugins, provide migration guide for third-party
+- Test EVERY page after Bootstrap CSS removal — visual regression is the #1 risk
+```
+
+---
+
+## 1. Remaining Domain Template Inventory
+
+### Domains NOT Yet Converted (After Phase 3)
+
+| Domain | Total | .tpl.php | .blade.php | Priority | Notes |
+|--------|-------|---------|-----------|----------|-------|
+| Help | 44 | 29 | 15 | LOW | Static content pages, tours, onboarding |
+| Auth | 11 | 4 | 7 | LOW | Login, register, password reset |
+| Connector | 9 | 8 | 0 | LOW | API connectors, rarely viewed |
+| Clients | 5 | 5 | 0 | LOW | Client management |
+| Errors | 4 | 4 | 0 | LOW | 404, 500, maintenance pages |
+| Files | 3 | 2 | 0 | LOW | File browser, upload |
+| Comments | 4 | 1 | 2 | MED | Cross-cutting concern, used in tickets/canvas |
+| Api | 3 | 3 | 0 | LOW | API key management |
+| TwoFA | 2 | 2 | 0 | LOW | Two-factor setup |
+| Install | 2 | 2 | 0 | LOW | Installation wizard |
+| CsvImport | 1 | 1 | 0 | LOW | CSV import dialog |
+| Reports | 1 | 1 | 0 | LOW | Report view |
+| Strategy | 1 | 1 | 0 | LOW | Strategy overview |
+| **Total** | **90** | **63** | **24** | — | — |
+
+### Plugin Templates to Modernize
+
+| Plugin | Total | .tpl.php | .blade.php | Priority |
+|--------|-------|---------|-----------|----------|
+| ProjectWizard | 15 | 0 | 15 | ✅ Already Blade |
+| StrategyPro | 13 | 12 | 1 | MED — canvas-based plugin |
+| Billing | 13 | 2 | 11 | LOW — mostly Blade |
+| Copilot | 11 | 0 | 11 | ✅ Already Blade |
+| Notes | 10 | 0 | 10 | ✅ Already Blade |
+| Llamadorian | 9 | 9 | 0 | MED — AI features |
+| Whiteboardscanvas | 7 | 6 | 1 | MED — canvas plugin |
+| PgmPro | 7 | 6 | 1 | MED — portfolio management |
+| AdvancedAuth | 6 | 0 | 6 | ✅ Already Blade |
+| Accounts | 6 | 4 | 2 | LOW |
+| CustomFields | 4 | 0 | 4 | ✅ Already Blade |
+| CalDAV | 4 | 0 | 4 | ✅ Already Blade |
+| Others (8 plugins) | ~12 | 0 | ~12 | ✅ Already Blade |
+
+**Total plugin .tpl.php to convert: ~39 files** (StrategyPro, Llamadorian, Whiteboardscanvas, PgmPro, Accounts, Billing)
+
+---
+
+## 2. Bootstrap Removal Plan
+
+### Phase 4.3: Strip Bootstrap Classes from Templates
+
+After Phases 2-3 added DaisyUI/Tailwind classes alongside Bootstrap (dual-class approach), Phase 4 removes the Bootstrap classes.
+
+**Scope: 1,099 Bootstrap references across all templates**
+
+| Pattern | Count | Replacement Already Added |
+|---------|-------|--------------------------|
+| `col-md-*`, `col-lg-*`, `col-sm-*`, `col-xs-*` | 789 | Tailwind `md:w-*`, `lg:w-*`, grid/flex |
+| `btn-default`, `btn-success`, `btn-danger`, etc. | 97 | DaisyUI `btn-primary`, `btn-error`, etc. |
+| `form-group`, `form-control` | 175 | DaisyUI `form-control`, `input` |
+| `panel-*`, `well`, `alert-*` | ~38 | DaisyUI `card`, `alert` |
+
+### Removal Process
+
+```bash
+# Step 1: Find all remaining Bootstrap grid classes
+grep -rn "col-md-\|col-lg-\|col-sm-\|col-xs-\|row" --include="*.blade.php" app/ resources/
+
+# Step 2: For each file, verify DaisyUI/Tailwind equivalent exists
+# Step 3: Remove Bootstrap class, keep Tailwind class
+# Step 4: Visual test the page
+```
+
+### Phase 4.4: Remove Bootstrap CSS Files
+
+| File to Remove | Lines |
+|----------------|-------|
+| public/assets/css/libs/bootstrap.css | 6,782 |
+| public/assets/css/libs/bootstrap.min.css | (minified) |
+| public/assets/css/libs/bootstrap-grid.min.css | — |
+| public/assets/css/libs/bootstrap-responsive.min.css | — |
+| public/assets/css/libs/bootstrap-timepicker.min.css | — |
+| public/assets/css/libs/bootstrap-fileupload.min.css | — |
+| public/assets/js/libs/bootstrap.min.js | — |
+| public/assets/js/libs/bootstrap-fileupload.min.js | — |
+| public/assets/js/libs/bootstrap-timepicker.min.js | — |
+
+Also remove from Vite config / CSS imports.
+
+---
+
+## 3. jQuery Elimination Plan
+
+### Phase 4.5: jQuery UI Replacement
+
+jQuery UI is used for:
+- **Sortable** — Kanban board drag-drop, canvas item reordering, widget grid
+- **Datepicker** — Date inputs (partially replaced by native + flatpickr)
+- **Dialog** — Replaced by `<dialog>` in Phase 1
+- **Draggable/Droppable** — Kanban cards
+
+**Replacement: SortableJS** (no jQuery dependency, modern API, touch support)
+
+```javascript
+// Before (jQuery UI Sortable):
+jQuery('.kanbanColumn').sortable({
+    connectWith: '.kanbanColumn',
+    update: function(event, ui) { ... }
+});
+
+// After (SortableJS):
+import Sortable from 'sortablejs';
+document.querySelectorAll('.kanbanColumn').forEach(el => {
+    Sortable.create(el, {
+        group: 'kanban',
+        onEnd: function(evt) { ... }
+    });
+});
+```
+
+### Phase 4.6: jQuery Core Removal
+
+**After jQuery UI is replaced**, systematically remove jQuery from controllers:
+
+| Controller | jQuery Calls | Complexity | Strategy |
+|-----------|-------------|-----------|----------|
+| kanbanController.js | ~100 | 🔴 HIGH | Rewrite with vanilla JS + HTMX |
+| ticketsController.js | ~120 | 🔴 HIGH | Rewrite core interactions |
+| menuController.js | ~40 | 🟡 MED | querySelector + classList |
+| usersController.js | ~30 | 🟡 MED | Modernize |
+| settingController.js | ~20 | 🟢 LOW | Modernize |
+| calendarController.js | ~30 | 🟡 MED | FullCalendar handles most |
+| commentsController.js | ~20 | 🟢 LOW | HTMX replaces most |
+| dashboardController.js | ~30 | 🟡 MED | Modernize |
+
+**Key library dependencies to address:**
+- chosen.js (dropdown) → SlimSelect (already in codebase)
+- jquery.growl.js → DaisyUI toast/alert
+- jquery.form.js → native FormData + fetch
+- jquery.tagsinput.js → modern tag input
+- jquery-is-in-viewport → IntersectionObserver
+
+### Removal Order
+
+1. Remove jQuery UI → SortableJS
+2. Remove jQuery plugins (chosen → SlimSelect, growl → toast, etc.)
+3. Remove jQuery from compiled-framework-plugins.js
+4. Modernize domain controllers (one at a time, test after each)
+5. Remove jQuery from compiled-frameworks.js
+6. Remove jQuery from package.json
+
+---
+
+## 4. Dead CSS Cleanup
+
+### CSS Files to Remove After Full Migration
+
+| File | Lines | Why Remove |
+|------|-------|-----------|
+| components/nyroModal.css | — | Modal replaced (Phase 1) |
+| components/forms.css | — | DaisyUI form components |
+| components/overwrites.css | — | No more overrides needed |
+| components/reset.css | — | Tailwind preflight handles reset |
+| components/progressbars.css | — | DaisyUI progress |
+| components/toast-notifications.css | — | DaisyUI toast |
+| libs/jquery.alerts.css | — | DaisyUI alert |
+| libs/jquery.chosen.css | — | SlimSelect |
+| libs/jquery.simple-color-picker.css | — | DaisyUI/Tailwind |
+| libs/jquery.tagsinput.css | — | Modern tag input |
+| libs/jquery-ui-*.css | — | jQuery UI removed |
+| libs/switchery/*.css | — | DaisyUI toggle |
+| libs/loading-btn.css | — | DaisyUI loading state |
+| libs/loading.css | — | DaisyUI loading |
+| libs/isotope.css | — | CSS Grid replaces |
+| libs/shepherd-theme-arrows.css | — | Evaluate if tours still use Shepherd |
+| libs/tinymceSkin/** | — | TinyMCE removed ✅ |
+
+### Custom CSS to Consolidate
+
+| File | Lines | Action |
+|------|-------|--------|
+| components/style.default.css | 2,969 | Audit: extract needed styles to Tailwind utilities |
+| components/structure.css | — | Migrate layout rules to Tailwind |
+| components/nav.css | — | DaisyUI navbar/menu handles this |
+| components/kanban.css | — | Migrate to Tailwind utilities |
+| components/tables.css | — | DaisyUI table + DataTables CSS only |
+| components/text-styles.css | — | Tailwind typography |
+| components/mobile.css | 2,511 | Tailwind responsive utilities |
+| components/print.css | — | Keep (print styles) |
+| components/accessibility.css | — | Keep (a11y overrides) |
+
+### Target: Single CSS Entry Point
+
+After cleanup, the CSS architecture should be:
+```
+resources/css/
+├── app.css          ← Main entry: Tailwind directives + custom utilities
+├── editor.css       ← TipTap editor styles
+└── print.css        ← Print styles
+```
+
+All component styling handled by DaisyUI classes inline. No separate component CSS files.
+
+---
+
+## 5. Final Build Optimization
+
+### Phase 4.8 Checklist
+
+- [ ] Vite build produces hashed asset filenames
+- [ ] CSS tree-shaking removes unused Tailwind classes
+- [ ] JS tree-shaking removes dead code
+- [ ] No jQuery in final bundle
+- [ ] No Bootstrap in final bundle
+- [ ] Bundle analyzer shows clean dependency tree
+- [ ] Gzipped main CSS < 50KB (down from ~200KB+)
+- [ ] Gzipped main JS < 150KB (down from ~800KB+)
+- [ ] Domain JS chunks < 30KB each
+- [ ] All pages load in < 3 seconds on 3G simulation
+
+### Bundle Audit Commands
+
+```bash
+# Build with analysis
+npx vite build --mode production
+npx vite-bundle-analyzer
+
+# Check for jQuery remnants
+grep -r "jQuery\|jquery" dist/assets/*.js
+
+# Check for Bootstrap remnants
+grep -r "bootstrap\|col-md-\|btn-default" dist/assets/*.css
+
+# Verify hashed filenames
+ls -la public/build/assets/
+```
+
+---
+
+## 6. Execution Order
+
+```
+4.1  Remaining domain conversions               [3-4 days]
+4.2  Plugin template modernization              [2-3 days]
+4.3  Bootstrap class removal from templates     [2-3 days]
+4.4  Bootstrap CSS/JS file removal              [0.5 day]
+4.5  jQuery UI → SortableJS                     [2-3 days]
+4.6  jQuery elimination from controllers        [3-5 days]
+4.7  Dead CSS cleanup + consolidation           [1-2 days]
+4.8  Final build optimization + audit           [1 day]
+```
+**Total: ~3 weeks**
+
+---
+
+## 7. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Bootstrap removal causes visual regressions | HIGH | HIGH | Page-by-page visual testing, dual-class was preparation |
+| Kanban drag-drop breaks with SortableJS | MEDIUM | HIGH | Parallel implementation, keep jQuery UI as fallback |
+| jQuery removal breaks obscure interaction | MEDIUM | MEDIUM | Remove one controller at a time, test thoroughly |
+| Plugin templates break | LOW | MEDIUM | Core plugins updated, migration guide for third-party |
+| CSS too aggressive removal | MEDIUM | MEDIUM | Keep backup of removed files, test each page |
+| Help/onboarding tours break | LOW | LOW | Test Shepherd.js integration separately |
+| Bundle size doesn't improve enough | LOW | LOW | Analyze before/after, identify remaining bloat |
+
+---
+
+## 8. Phase 4 Deliverables (= Project Complete)
+
+### Template Conversion
+- [ ] 100% of core domain templates are Blade
+- [ ] 100% of core plugin templates are Blade
+- [ ] Zero .tpl.php, .inc.php, .sub.php files in active use
+
+### CSS
+- [ ] Bootstrap CSS completely removed
+- [ ] All styling via Tailwind 4 + DaisyUI 5 + minimal custom CSS
+- [ ] Single CSS entry point (app.css)
+- [ ] Gzipped CSS < 50KB
+
+### JavaScript
+- [ ] jQuery completely removed
+- [ ] jQuery UI completely removed
+- [ ] All interactions via vanilla JS + HTMX
+- [ ] Domain JS lazy-loaded
+- [ ] Gzipped main JS < 150KB
+
+### Architecture
+- [ ] Consistent Blade component library
+- [ ] DaisyUI 5 theming throughout
+- [ ] `<dialog>` modals (no nyroModal)
+- [ ] hx-boost SPA-like navigation
+- [ ] HTMX-driven partial updates
+- [ ] WCAG 2.1 AA compliance
+- [ ] Mobile-responsive all pages
+- [ ] Mobile app API completely intact
+
+### Performance
+- [ ] < 3 second initial page load (3G)
+- [ ] < 500ms navigation transitions (hx-boost)
+- [ ] < 200ms modal opens
+- [ ] No unused CSS/JS in production build
+
+---
+
+## 9. Post-Phase 4: Maintenance Guidelines
+
+After Phase 4, all new development should follow:
+
+1. **Templates:** Blade only. Use shared components from `app/Views/Templates/components/`
+2. **Styling:** DaisyUI 5 classes + Tailwind 4 utilities only. No custom CSS unless truly needed
+3. **Interactivity:** HTMX attributes for server communication. Vanilla JS for client-side logic
+4. **Modals:** `<dialog>` via modal component. No hash-based triggers for new features
+5. **Forms:** `<x-form.*>` components with validation
+6. **Navigation:** All new pages work with hx-boost
+7. **Plugins:** Follow component patterns. Reference component library docs
+8. **Testing:** Visual regression test after any component change

--- a/Docs/plugin-migration-strategy.md
+++ b/Docs/plugin-migration-strategy.md
@@ -1,0 +1,517 @@
+# Leantime Plugin Migration Strategy — Per-Plugin Approach
+
+## Companion Document to Phase 4.2
+
+**Scope:** 32 active plugin directories (31 with code, 1 dead) in `app/Plugins`
+**Branch:** Current working branch (v3.6.2 mainline, post-Phase 0–4 planning)
+**Generated:** February 13, 2026
+
+---
+
+## 1. Current Plugin Inventory (Live Audit)
+
+### Full Plugin List (32 directories)
+
+| Plugin | Templates (.tpl.php / .blade.php) | Own Build Pipeline | composer.json | DispatchesEvents Trait | Event Hooks |
+|--------|:-:|:-:|:-:|:-:|:-:|
+| **Copilot** | 0 / 11 | ✅ webpack.mix.js + package.json | ✅ | — | 9 EventDispatcher calls |
+| **McpServer** | 0 / 1 | — | ✅ (+ vendor/) | ✅ (2 services) | ServiceProvider + EventDispatcher |
+| **AdvancedAuth** | 0 / 6 | — | ✅ | — | 7 EventDispatcher calls |
+| **Billing** | 2 / 11 | — | ✅ | — | 10 EventDispatcher calls |
+| **Llamadorian** | 9 / 0 | — | ✅ | ✅ (5 files) | 12 EventDispatcher calls |
+| **StrategyPro** | 12 / 1 | — | ✅ | — | EventDispatcher calls |
+| **PgmPro** | 6 / 1 | — | ✅ | — | EventDispatcher calls |
+| **Whiteboardscanvas** | 6 / 1 | — | ✅ | — | EventDispatcher calls |
+| **Accounts** | 4 / 2 | — | ✅ | ✅ (2 files) | EventDispatcher + authcheck |
+| **CustomFields** | 0 / 4 | — | ✅ | — | EventDispatcher calls |
+| **Notes** | 0 / 10 | — | ✅ | — | EventDispatcher calls |
+| **Reactions** | 0 / 2 | ✅ webpack.mix.js (no package.json) | ✅ | ✅ (1 file) | EventDispatcher calls |
+| **RecurringTasks** | 0 / 2 | ✅ webpack.mix.js + package.json | ✅ | — | EventDispatcher calls |
+| **CalDAV** | 0 / 4 | — | ✅ | — | EventDispatcher calls |
+| **ProjectWizard** | 0 / 15 | — | ✅ | — | EventDispatcher calls |
+| **Crisp** | 0 / 1 | — | ✅ | — | EventDispatcher calls |
+| **ThemeBundle** | 0 / 2 | — | ✅ | — | EventDispatcher calls |
+| **Implementationintentions** | 0 / 3 | — | ✅ | ✅ (1 file) | EventDispatcher calls |
+| **Pomodoro** | 0 / 1 | — | ✅ | — | EventDispatcher calls |
+| **Workflows** | 0 / 0 | — | ✅ | — | Services only |
+| **ClientConfigLoader** | 0 / 0 | — | ✅ | — | authcheck hook |
+| **ApiRateLimiter** | 0 / 0 | — | ✅ | — | authcheck hook |
+| **Subscriptions** | 0 / 0 | — | ✅ | — | Minimal |
+| **WorkspaceManager** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **Freshsales** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **GoogleAnalytics** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **SponsorLeantime** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **Wootric** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **Sentry** | 0 / 0 | — | ✅ | — | EventDispatcher calls |
+| **Zapier** | 0 / 1 | — | ✅ | — | Minimal |
+| **EnergyTracker** | 0 / 0 | — | — | — | Services only |
+| **GoogleCalendar** | 0 / 0 | — | — (lock only) | — | ⚠️ DEAD — No register.php, no PHP files |
+
+### Key Findings vs. Documentation
+
+1. **GoogleCalendar is dead** — Has vendor/ directory with Google API libs but no register.php, no PHP files, no templates. Not in original docs. Should be removed or flagged.
+2. **Event hook migration is COMPLETE** — `grep` for `middleware.auth.` (old pattern) returns zero results. All 5 plugins using authcheck hooks (ClientConfigLoader, ApiRateLimiter, Accounts, AdvancedAuth, Billing) are already on the correct `middleware.authcheck` pattern. This was flagged as a risk in the forward-port doc but has already been resolved on the current branch.
+3. **11 files use DispatchesEvents trait** — Across Llamadorian (5), McpServer (2), Accounts (2), Reactions (1), Implementationintentions (1). These need verification against the trait's method signatures after any core Event system reconciliation.
+4. **3 plugins have own webpack.mix.js** — Copilot, Reactions, RecurringTasks. Core migrated to Vite in Phase 0. These are now orphaned on Laravel Mix.
+5. **39 .tpl.php files remain** across 6 plugins (StrategyPro: 12, Llamadorian: 9, PgmPro: 6, Whiteboardscanvas: 6, Accounts: 4, Billing: 2).
+
+---
+
+## 2. Tier Classification
+
+### Tier 1 — Dedicated Migration Strategy Required
+
+| Plugin | Why | Risk |
+|--------|-----|------|
+| **Copilot** | 141+ files, own build pipeline, 999-line custom CSS, jQuery dependency, 8 JS files (2,851 lines), deep event system integration, AI-critical | 🔴 CRITICAL |
+| **McpServer** | ServiceProvider architecture, own vendor/, custom attributes (`@UnifiedTool`, `@Parameter`), route exemptions, CLI commands, DispatchesEvents in 2 services | 🔴 CRITICAL |
+| **AdvancedAuth** | Security-critical (OAuth/SSO + mobile app auth), 6 Blade templates with Bootstrap classes, authcheck hooks, 35+ language files | 🟡 HIGH |
+
+### Tier 2 — Focused Checklist Required
+
+| Plugin | Why | Risk |
+|--------|-----|------|
+| **Billing** | Revenue-critical, 2 legacy .tpl.php + 11 Blade, heavy Bootstrap usage in old templates, inline HTML in register.php, authcheck hooks | 🟡 HIGH |
+| **Llamadorian** | 9 legacy .tpl.php (100% unconverted), 5 files using DispatchesEvents trait, jQuery.nmManual modal calls, StoryTime popup architecture | 🟡 MEDIUM |
+| **StrategyPro** | 12 legacy .tpl.php (most of any plugin), canvas-based UI | 🟡 MEDIUM |
+| **PgmPro** | 6 legacy .tpl.php, portfolio management UI | 🟢 MEDIUM |
+| **Whiteboardscanvas** | 6 legacy .tpl.php, canvas-based UI | 🟢 MEDIUM |
+| **Accounts** | 4 legacy .tpl.php, 2 DispatchesEvents files, authcheck hook | 🟢 LOW |
+
+### Tier 3 — Batch Pass (Remaining 22 plugins)
+
+All already on Blade or have no templates. Require only: DaisyUI class audit, Bootstrap class removal, build pipeline check, DispatchesEvents verification (where applicable).
+
+---
+
+## 3. Tier 1: Copilot Migration Strategy
+
+### 3.1 Overview
+
+Copilot is the largest and most complex plugin. It has its own build pipeline (webpack.mix.js), 999 lines of custom CSS, 2,851 lines of JS across 8 files, jQuery UI dependencies (resizable/draggable), and deep integration with the core event system via 9+ event hooks.
+
+### 3.2 Build Pipeline Migration (Mix → Vite)
+
+**Current state:** Copilot uses its own `webpack.mix.js` that compiles 8 JS files and 1 CSS file to `dist/`. It externalizes jQuery via `externals: { jquery: 'jQuery' }`.
+
+**Problem:** Core migrated to Vite in Phase 0. Plugin still uses Mix. This creates two parallel build systems, prevents tree-shaking of Copilot's JS, and means Copilot's assets aren't part of the core build's hash-versioning.
+
+**Strategy:**
+
+1. **Create `vite.config.js` for Copilot** — Multi-entry Vite config producing the same 8+1 output files to `dist/`.
+2. **Update asset registration** — Copilot's `register.php` calls `$registrationService->addFooterJs()` and `$registrationService->addCss()` with relative paths. Verify these resolve correctly with Vite's hashed output. If `RegistrationService` doesn't support Vite manifests yet, this needs a core-side adapter.
+3. **Remove jQuery externalization** — Instead of `externals: { jquery: 'jQuery' }`, refactor the 15+ jQuery calls in `copilot.js` to vanilla JS (see 3.4).
+4. **Remove `webpack.mix.js`, `package.json`, `node_modules/`** from Copilot. Assets compile via Vite.
+5. **Verify `dist/mix-manifest.json`** is no longer read anywhere.
+
+**Decision needed:** Should Copilot's Vite config be standalone (plugin-level `vite.config.js`) or integrated into the core Vite config as additional entry points? Standalone is cleaner for plugin architecture but core integration enables shared chunk deduplication.
+
+### 3.3 CSS Migration (Custom → Tailwind/DaisyUI)
+
+**Current state:** `copilot.css` is 999 lines of fully custom CSS. Uses CSS custom properties (`var(--neutral)`, `var(--primary)`) that align with DaisyUI's theme variables, which is good. However, it defines its own layout system, spacing, animations, and component styles entirely outside DaisyUI.
+
+**Strategy:**
+
+1. **Audit for DaisyUI equivalents** — Many patterns map directly:
+   - `.copilot-chat-message-bubble { background: var(--neutral); border-radius: 8px; }` → DaisyUI `chat-bubble` component
+   - `.copilot-panel-header` → DaisyUI `navbar` or card header pattern
+   - Button styles → DaisyUI `btn btn-ghost`, `btn btn-sm`
+   - Loading/skeleton states → DaisyUI `loading` and `skeleton`
+
+2. **Keep Copilot-specific layout CSS** — The chat panel positioning, fullscreen toggle, resizable panel, and streaming animation are unique to Copilot and have no DaisyUI equivalent. These should remain as custom CSS but be migrated from a standalone file to Tailwind `@apply` directives or `@layer components` in a Copilot-specific CSS module.
+
+3. **Replace Bootstrap grid in `dashboard.blade.php`** — Currently uses `col-md-12`, `col-md-8`, `col-md-4`. Replace with Tailwind grid utilities.
+
+4. **Target:** Reduce from 999 lines to ~300-400 lines of truly Copilot-specific CSS (panel layout, streaming animation, chat scroll behavior). Everything else maps to DaisyUI classes inline in templates.
+
+### 3.4 JavaScript: jQuery Elimination
+
+**Current state:** `copilot.js` (1,178 lines) uses jQuery for:
+- `jQuery(panel).resizable()` and `jQuery(panel).draggable()` — jQuery UI
+- `jQuery('#' + messageId).find(...)` — DOM queries
+- `jQuery('#' + messageId).data("id", data.id)` — Data attributes
+- `jQuery(this).attr("hx-vals", ...)` — HTMX attribute manipulation
+- `jQuery('.tool-message').remove()` — DOM removal
+
+**Strategy:**
+
+1. **jQuery UI resizable/draggable → CSS `resize` + vanilla JS drag** — The chat panel's resize and drag behavior can be implemented with CSS `resize: both` for simple resize, or a lightweight drag library if needed. Since Phase 4.5 is bringing in SortableJS for kanban, evaluate if SortableJS or a sibling lib handles drag.
+
+2. **jQuery DOM queries → `document.querySelector`** — All `jQuery('#' + id).find(...)` patterns become `document.querySelector('#' + id + ' .selector')`.
+
+3. **jQuery `.data()` → `dataset`** — `jQuery(el).data("id", val)` → `el.dataset.id = val`.
+
+4. **jQuery `.attr("hx-vals")` → `setAttribute`** — Direct equivalent.
+
+5. **jQuery `.remove()` → `el.remove()`** — Native.
+
+6. **Execution order:** Refactor `copilot.js` first (1,178 lines, most jQuery), then `direct-actions.js` (388 lines), then `task-prioritization.js` (401 lines). The remaining files (`markdown-parser.js`, `marked-extensions.js`, `mermaid-init.js`, `stream-processor.js`, `tiptap-integration.js`) likely don't use jQuery.
+
+### 3.5 Template Componentization
+
+**Current state:** All 11 templates are Blade (good), but they use raw HTML/CSS classes rather than the shared component library.
+
+**Templates to update:**
+
+| Template | Priority | Key Changes |
+|----------|----------|-------------|
+| `dashboard.blade.php` | HIGH | Replace Bootstrap grid (`col-md-*`) with Tailwind |
+| `partials/chatPanel.blade.php` | HIGH | Buttons → `<x-globals::forms.button>`, panel structure |
+| `partials/chat.blade.php` | MED | Message bubbles → evaluate DaisyUI chat component |
+| `partials/feedbackButtons.blade.php` | MED | Buttons → `<x-globals::forms.button>` |
+| `partials/prioritizationToggle.blade.php` | MED | Toggle → `<x-globals::forms.toggle>` |
+| `partials/taskDashboardActions.blade.php` | LOW | Action buttons → component |
+| `partials/taskPriorityActions.blade.php` | LOW | Badge/chip usage → `<x-globals::actions.chip>` |
+| `partials/actionFeedback.blade.php` | LOW | Alert → `<x-globals::feedback.alert>` |
+| `partials/chatHistory.blade.php` | LOW | List items |
+| `partials/dailyWelcome.blade.php` | LOW | Static content |
+| `partials/inlineMessage.blade.php` | LOW | Inline alert/message |
+
+### 3.6 Event System Verification
+
+Copilot registers 9 event hooks. None use the old `middleware.auth` pattern (confirmed). Hooks to verify still fire correctly after Phase 4:
+
+1. `leantime.core.middleware.loadplugins.handle.pluginsEvents` — Config extension
+2. `leantime.*.beforeBodyClose` — Chat panel injection
+3. `leantime.core.console.consolekernel.schedule.cron` — Prompt sync cron
+4. `leantime.domain.tickets.templates.dashboard.afterHeadline` — Dashboard actions
+5. `leantime.domain.tickets.templates.showTicketModal.beforeSubtasks` — Task breakdown
+6. `leantime.*.submenuSection` — Submenu items
+7. `leantime.domain.widgets.templates.partials.myToDos.beforeTodoWidgetGroupByDropdown` — Prioritization toggle
+8. `leantime.domain.tickets.services.tickets.getToDoWidgetHierarchicalAssignments.myTodoWidgetTasks` — Task filter
+9. `leantime.domain.*.todoWidgetSortableEnabled` — Sortable management
+
+**Risk:** Hooks 4–9 reference specific template hook points. If Phase 4.1 (remaining domain conversions) changes the template structure in tickets/widgets domains, these hooks may silently stop firing. **Verify each hook has a matching `@event` or `EventDispatcher::dispatch_event()` call in the converted template.**
+
+### 3.7 Copilot Execution Order
+
+```
+1. Build pipeline: webpack.mix.js → vite.config.js          [0.5 day]
+2. jQuery elimination from copilot.js                         [1 day]
+3. jQuery elimination from remaining JS files                 [0.5 day]
+4. CSS audit: identify DaisyUI replacements                   [0.5 day]
+5. Template componentization (dashboard + chatPanel first)    [1 day]
+6. CSS reduction: replace custom with DaisyUI/Tailwind        [1 day]
+7. Event hook verification (all 9 hooks fire)                 [0.5 day]
+8. End-to-end test: chat panel renders, AI responds, streaming works  [0.5 day]
+```
+**Total: ~5.5 days**
+
+---
+
+## 4. Tier 1: McpServer Migration Strategy
+
+### 4.1 Overview
+
+McpServer is architecturally unique — it's the only plugin using a full Laravel ServiceProvider (`McpServerServiceProvider extends McpServiceProvider`), its own Composer vendor/ directory (php-mcp/laravel), custom PHP attributes, artisan CLI commands, and route exemptions. It has minimal UI (1 Blade template) but deep infrastructure coupling.
+
+### 4.2 ServiceProvider Compatibility
+
+**Current state:** `McpServerServiceProvider` extends `PhpMcp\Laravel\McpServiceProvider` and registers:
+- Singletons: `McpRegistrar`, `McpToolExecutor`, `McpToolDiscovery`, `McpPromptService`
+- Middleware: `mcp.auth`
+- CLI commands: `McpStartCommand`, `McpListCommand`, `McpDiscoverCommand`
+- Route exemptions for Installed/Updated middleware via EventDispatcher
+
+**Migration concern:** The ServiceProvider uses `EventDispatcher::add_filter_listener()` directly in `registerMcpRouteExemptions()`. This is the static call pattern (correct for v3.6.2). If the DispatchesEvents trait reconciliation in Phase 4 changes how EventDispatcher works internally, verify these filter listeners still register.
+
+**Strategy:**
+1. **No template work needed** — Single Blade template (`timer.blade.php`) has only 2 Bootstrap button classes (`btn btn-default`). Quick replacement with DaisyUI `btn`.
+2. **Verify ServiceProvider boots after Phase 4** — Test `php artisan mcp:start`, `php artisan mcp:list`, `php artisan mcp:discover`.
+3. **Verify route exemptions work** — MCP routes must bypass Installed/Updated middleware.
+4. **Test all 9 tool domains** — CalendarTools, CommentTools, GoalTools, MilestoneTools, ProjectTools, TicketTools, TimerTools, TimesheetTools, WebSearchTools. Each tool uses reflection and `@UnifiedTool`/`@Parameter` attributes from `app/Core/Support/Attributes/`.
+
+### 4.3 DispatchesEvents Trait Verification
+
+Two services use the trait: `McpPromptService` and `McpServer`. Need to verify:
+- Method signatures match (`dispatch_event` vs `dispatchEvent`, `get_event_context` vs `getEventContext`)
+- Events actually fire (not silently swallowed)
+
+**Test:** After DispatchesEvents reconciliation, run `php artisan mcp:list` and verify all tools are discovered.
+
+### 4.4 Vendor Dependency
+
+McpServer bundles its own `vendor/` with `php-mcp/laravel`. This is independent of the core Composer vendor/ and won't be affected by the Laravel 12 upgrade (Phase 0). However:
+- Verify `php-mcp/laravel` is compatible with Laravel 12
+- The `autoload.php` is required directly in `register.php` — this pattern bypasses core's autoloader
+
+### 4.5 McpServer Execution Order
+
+```
+1. Replace 2 Bootstrap button classes in timer.blade.php        [0.1 day]
+2. Verify ServiceProvider boots (artisan commands)               [0.25 day]
+3. Verify route exemptions (MCP routes bypass middleware)        [0.25 day]
+4. Test all 9 tool domains                                       [0.5 day]
+5. DispatchesEvents trait verification (2 services)              [0.25 day]
+6. php-mcp/laravel Laravel 12 compatibility check                [0.25 day]
+```
+**Total: ~1.5 days**
+
+---
+
+## 5. Tier 1: AdvancedAuth Migration Strategy
+
+### 5.1 Overview
+
+AdvancedAuth handles OAuth/SSO authentication and personal API tokens. It's the auth provider for the mobile app (`POST /advancedAuth/getToken`). It has 6 Blade templates all using Bootstrap classes, 8 event listeners, and 35+ language files.
+
+### 5.2 Template Migration
+
+**Current state:** All 6 templates are Blade but use Bootstrap classes heavily:
+
+| Template | Bootstrap Usage | Component Replacements |
+|----------|----------------|----------------------|
+| `new.blade.php` | `form-group`, `form-control`, `btn btn-default` | `<x-globals::forms.form-field>`, `<x-globals::forms.text-input>`, `<x-globals::forms.button>` |
+| `settings.blade.php` | `col-md-12`, `col-md-8`, `form-group` (×4) | Tailwind grid, `<x-globals::forms.form-field>` |
+| `token-created.blade.php` | `form-group`, `form-control`, `btn btn-default` | Form components |
+| `tokens.blade.php` | `col-md-12` | Tailwind width |
+| `partials/personalTokens.blade.php` | Review needed | — |
+| `partials/showButtons.blade.php` | Review needed | — |
+
+**Strategy:** Straightforward component replacement. These are simple form-based templates.
+
+### 5.3 Mobile App Auth Verification
+
+**CRITICAL:** AdvancedAuth provides `POST /advancedAuth/getToken` which returns Bearer tokens for the mobile app's JSON-RPC API. The auth flow is:
+1. Mobile app → `POST /advancedAuth/getToken` with credentials
+2. AdvancedAuth validates, returns Bearer token
+3. Mobile app uses token for all subsequent `/api/jsonrpc` calls
+
+**Test matrix:**
+- [ ] Token generation endpoint returns valid token
+- [ ] Token auth works for JSON-RPC calls
+- [ ] OAuth callback redirect works (Keycloak)
+- [ ] `publicActions` filter correctly exempts auth routes
+- [ ] Domain-based auth routing (CheckDomain listener) works
+
+### 5.4 Event Hook Verification
+
+8 event hooks, all using `EventDispatcher` static calls (correct pattern):
+1. `loadplugins.handle.pluginsEvents` — SetConfig listener
+2. `users.templates.editOwn.tabs` — Personal token tab
+3. `setting.templates.editCompanySettings.tabs` — Settings tab
+4. `setting.templates.editCompanySettings.tabsContent` — Settings content
+5. `users.templates.editOwn.tabsContent` — Personal token content
+6. `*.beforeRegcontentClose` — Provider buttons
+7. `auth.controllers.login.post.beforeAuthServiceCall` — Domain check
+8. `middleware.authcheck.*.publicActions` — Public route filter
+
+**Risk:** Hooks 2–5 inject into specific template locations. If those templates are restructured during Phase 4.1 (Auth domain conversion), the hooks must be re-verified.
+
+### 5.5 AdvancedAuth Execution Order
+
+```
+1. Template componentization (6 templates)                       [0.5 day]
+2. Bootstrap class removal                                       [0.25 day]
+3. Mobile app auth flow verification                             [0.5 day]
+4. OAuth callback test (Keycloak)                                [0.25 day]
+5. Event hook verification (8 hooks)                             [0.25 day]
+```
+**Total: ~1.75 days**
+
+---
+
+## 6. Tier 2: Focused Checklists
+
+### 6.1 Billing
+
+**Template work:** 2 `.tpl.php` files to convert (`subscriptions_old.tpl.php` is heavily Bootstrap), 11 `.blade.php` to audit for Bootstrap classes.
+
+**Special concerns:**
+- `register.php` contains inline HTML in event listeners (menu items, announcement banner with `btn-fancy`). These need DaisyUI class updates.
+- Loads JS via `<script>` tag in event listener (`billingModals.js`) — should use `$registrationService->addFooterJs()`.
+- Uses `authcheck.handle.logged_in` and `authcheck.handle.before_api_request` hooks (verified correct pattern).
+
+**Checklist:**
+- [ ] Convert 2 `.tpl.php` → `.blade.php`
+- [ ] Audit 11 `.blade.php` for Bootstrap classes
+- [ ] Update inline HTML in `register.php` (menu, announcements)
+- [ ] Migrate `billingModals.js` script tag to proper registration
+- [ ] Verify subscription limit check still fires on login
+- [ ] Verify API request billing check still fires
+- [ ] Test Stripe checkout flow end-to-end
+
+### 6.2 Llamadorian
+
+**Template work:** 9 `.tpl.php` files, ALL need conversion to Blade. This is the most template-heavy conversion.
+
+**Special concerns:**
+- Uses `jQuery.nmManual()` (nyroModal) for StoryTime popup — must migrate to `<dialog>` modal system
+- 5 files use `DispatchesEvents` trait — highest trait usage of any plugin
+- Uses legacy function-based event listeners (`function addStatusReportLink(...)`) rather than class-based
+- Several event listeners are commented out (task prioritization features, now superseded by Copilot)
+
+**Checklist:**
+- [ ] Convert 9 `.tpl.php` → `.blade.php` with DaisyUI components
+- [ ] Replace `jQuery.nmManual()` StoryTime modal with `<dialog>`
+- [ ] Verify 5 DispatchesEvents trait files after core reconciliation
+- [ ] Modernize function-based listeners to class-based (or leave as-is if stable)
+- [ ] Remove commented-out code (dead task prioritization features)
+- [ ] Test StoryTime popup, status updates, AI settings tab, dashboard notifications
+
+### 6.3 StrategyPro
+
+**Template work:** 12 `.tpl.php` files. Largest count of any plugin.
+
+**Special concerns:**
+- Canvas-based UI — shares patterns with core Canvas domain (Phase 3 converted shared canvas templates). StrategyPro likely has custom overrides of `canvasDialog.tpl.php` and `canvasComment.tpl.php`.
+- Check if StrategyPro's canvas templates can use the shared Blade canvas components created in Phase 3, or if they need custom versions.
+
+**Checklist:**
+- [ ] Audit which templates can use shared canvas components from Phase 3
+- [ ] Convert remaining custom `.tpl.php` → `.blade.php`
+- [ ] Apply DaisyUI/component patterns
+- [ ] Test canvas CRUD operations, kanban view, roadmap view
+
+### 6.4 PgmPro
+
+**Template work:** 6 `.tpl.php` + 1 `.blade.php`.
+
+**Checklist:**
+- [ ] Convert 6 `.tpl.php` → `.blade.php`
+- [ ] Apply shared component library
+- [ ] Test portfolio management views
+
+### 6.5 Whiteboardscanvas
+
+**Template work:** 6 `.tpl.php` + 1 `.blade.php`.
+
+**Special concerns:** Canvas/whiteboard templates — similar to StrategyPro, check shared component reuse from Phase 3.
+
+**Checklist:**
+- [ ] Audit shared canvas component reuse
+- [ ] Convert 6 `.tpl.php` → `.blade.php`
+- [ ] Test whiteboard/canvas operations
+
+### 6.6 Accounts
+
+**Template work:** 4 `.tpl.php` + 2 `.blade.php`.
+
+**Special concerns:**
+- 2 files use `DispatchesEvents` trait (`InviteTeamStep`, `ScheduleSyncStep`)
+- Uses `authcheck` hook for public actions
+
+**Checklist:**
+- [ ] Convert 4 `.tpl.php` → `.blade.php`
+- [ ] Verify DispatchesEvents in 2 service files
+- [ ] Test registration, invite, onboarding flows
+
+---
+
+## 7. Tier 3: Batch Pass
+
+For the remaining 22 plugins (all already Blade or template-less), run these automated checks:
+
+### 7.1 Bootstrap Class Removal (Automated)
+
+```bash
+cd app/Plugins
+grep -rn "btn-default\|btn-success\|btn-danger\|btn-warning\|btn-info\|btn-primary" \
+  --include="*.blade.php" --include="*.php" | grep -v vendor | grep -v node_modules
+
+grep -rn "col-md-\|col-lg-\|col-sm-\|col-xs-\|form-group\|form-control\|panel-" \
+  --include="*.blade.php" --include="*.php" | grep -v vendor | grep -v node_modules
+```
+
+**Known hits (from audit):**
+- McpServer `timer.blade.php`: 2 × `btn btn-default` → DaisyUI `btn`
+- Any templates rendered via `echo` in register.php listener callbacks
+
+### 7.2 DaisyUI 5 Class Audit
+
+If any plugins reference DaisyUI 4-era class names (from the 4.0-dev component era):
+
+```bash
+grep -rn "form-control\|card-compact\|bottom-nav\|avatar online\|avatar offline" \
+  --include="*.blade.php" | grep -v vendor
+```
+
+Replace with DaisyUI 5 equivalents: `form-control` → `fieldset`/`label`, `card-compact` → `card-sm`, `bottom-nav` → `dock`, etc.
+
+### 7.3 DispatchesEvents Trait Verification
+
+11 files across 6 plugins use the trait. After core Event system reconciliation:
+
+```bash
+# Verify method signatures match
+grep -rn "dispatch_event\|get_event_context\|set_class_context\|dispatchEvent\|getEventContext\|setClassContext" \
+  --include="*.php" app/Plugins/ | grep -v vendor | grep -v node_modules
+```
+
+Ensure whichever method naming convention the reconciled trait uses is reflected in all 11 plugin files.
+
+### 7.4 Build Pipeline Orphans
+
+3 plugins have `webpack.mix.js`:
+- **Copilot** — Addressed in Tier 1 strategy (section 3.2)
+- **Reactions** — Has `webpack.mix.js` but NO `package.json`. Check if it uses root-level node_modules or is a dead config.
+- **RecurringTasks** — Has both `webpack.mix.js` and `package.json`. Needs Vite migration or verification that Mix still works independently.
+
+### 7.5 Dead Plugin Cleanup
+
+- **GoogleCalendar** — No register.php, no PHP files outside vendor/. Remove or document as placeholder.
+
+### 7.6 composer.json Cleanup
+
+Per the forward-port doc, all plugins had `"leantime/leantime": "3.0"` removed. Verify:
+
+```bash
+grep -rn '"leantime/leantime"' app/Plugins/*/composer.json
+```
+
+If any still have it, remove the constraint.
+
+---
+
+## 8. Cross-Cutting Concerns
+
+### 8.1 RegistrationService + Vite Compatibility
+
+Multiple plugins use `$registrationService->addFooterJs()` and `$registrationService->addCss()` to register assets. After the core Mix → Vite migration (Phase 0), verify:
+1. `RegistrationService` can resolve assets from plugin `dist/` directories
+2. Hash-versioned filenames (if Vite is used for plugins) are handled
+3. The `mix-manifest.json` pattern (used by Copilot's dist/) is still read OR migrated to Vite manifests
+
+### 8.2 Inline HTML in register.php Files
+
+Several plugins echo HTML directly in event listeners (Billing menu items, Llamadorian buttons, etc.). These inline HTML snippets contain Bootstrap classes that will break after Bootstrap CSS removal in Phase 4.4. Audit ALL `register.php` files:
+
+```bash
+grep -rn "echo.*class=" app/Plugins/*/register.php | grep -v vendor
+```
+
+### 8.3 Plugin Testing Order
+
+After all migrations, test plugins in dependency order:
+
+1. **AdvancedAuth** first — Other plugins depend on auth working
+2. **McpServer** — Independent, can test in isolation
+3. **Copilot** — Depends on AdvancedAuth for user context
+4. **Billing** — Depends on auth
+5. **Llamadorian** — Depends on project/ticket data
+6. **StrategyPro / PgmPro / Whiteboardscanvas** — Depend on canvas system (Phase 3)
+7. **Everything else** — Batch test
+
+---
+
+## 9. Timeline Summary
+
+| Tier | Plugins | Effort | Dependencies |
+|------|---------|--------|-------------|
+| **Tier 1: Copilot** | 1 | 5.5 days | Phase 4.1 template hooks, Phase 4.5 jQuery UI removal |
+| **Tier 1: McpServer** | 1 | 1.5 days | Core DispatchesEvents reconciliation |
+| **Tier 1: AdvancedAuth** | 1 | 1.75 days | Phase 4.1 Auth domain conversion |
+| **Tier 2: Billing** | 1 | 1.5 days | — |
+| **Tier 2: Llamadorian** | 1 | 2 days | Phase 1 modal system (for nyroModal replacement) |
+| **Tier 2: StrategyPro** | 1 | 1.5 days | Phase 3 canvas components |
+| **Tier 2: PgmPro + Whiteboardscanvas** | 2 | 1.5 days | Phase 3 canvas components |
+| **Tier 2: Accounts** | 1 | 0.75 days | — |
+| **Tier 3: Batch pass** | 22 | 1.5 days | — |
+| **Cross-cutting verification** | All | 1 day | All phases complete |
+| **Total** | **32** | **~18.5 days** | — |
+
+This replaces the original Phase 4.2 estimate of 2-3 days, which was significantly underscoped. The original estimate only covered template modernization and didn't account for build pipeline migration, jQuery elimination within plugins, CSS migration, DispatchesEvents verification, or mobile auth testing.
+
+---
+
+*This document was compiled from live analysis of `/Users/gloriafolaron/herd/leantime/app/Plugins` on the current working branch, cross-referenced with `leantime-plugin-changes-forward-port.md`, `phase-4-combined.md`, and `project-summary-and-claude-code-prompt.md`.*

--- a/Docs/pr-stack-status-2026-06-04.md
+++ b/Docs/pr-stack-status-2026-06-04.md
@@ -1,0 +1,88 @@
+# PR Stack Status — 2026-06-04
+
+Working notes for Marcel's review queue. Six PRs in flight, all green where CI runs, two coordinated pairs.
+
+## Open PRs
+
+### Core (Leantime/leantime)
+
+| PR | Title | Branch | Scope |
+|---|---|---|---|
+| [#3481](https://github.com/Leantime/leantime/pull/3481) | feat(stageflow): spotlight non-hovered stages on row hover | `feat/stageflow-spotlight-hover` | Pure CSS. Hover any stage → others fade to 40%, hovered card lifts with shadow. Logic Model and any other stageflow consumer. |
+| [#3482](https://github.com/Leantime/leantime/pull/3482) | feat(libs): npm-manage html2canvas + jsPDF | `feat/logicmodel-export-libs` | Pivoted from "commit minified blobs" to "npm + Mix build". Lazy-loaded at runtime by export consumers. **Must merge with plugin #47.** |
+| [#3484](https://github.com/Leantime/leantime/pull/3484) | fix(logicmodelcanvas): left-align status filter dropdown menu | `fix/logicmodel-status-filter-positioning` | Logic Model "All status" filter was rendering 134px to the left, behind the sidebar, getting clipped by `.primaryContent` overflow. Inline override on this template only — Blueprints/Canvas templates left alone (their `pull-right` placement makes the right-align rule correct). |
+| [#3491](https://github.com/Leantime/leantime/pull/3491) | chore(logicmodelcanvas): drop unused snapshot mount div | `chore/remove-snapshot-mount-div` | Empty `<div id="snapshotListContainer">` in core template was the HTMX target for the snapshot feature being removed from the plugin. **Pairs with plugin #46.** |
+
+### Plugins (Leantime/plugins, private)
+
+| PR | Title | Branch | Scope |
+|---|---|---|---|
+| [#46](https://github.com/Leantime/plugins/pull/46) | fix(strategypro): wizard UX fixes from end-to-end walkthrough | `fix/wizard-ux-issues` | Large bundle: 16+ commits. See breakdown below. **Pairs with core #3491.** |
+| [#47](https://github.com/Leantime/plugins/pull/47) | fix(strategypro): make Logic Model PNG/PDF export render correctly | `fix/logicmodel-export-png-wrap` | Three fixes: item-title wrap during export, color-mix → 8-digit hex for html2canvas, loader path update for the npm pivot. **Must merge with core #3482.** |
+
+## Merge order
+
+Two pairs must land together; the other three are independent.
+
+**Coordinated pairs (atomic):**
+- core #3482 ⇄ plugin #47 — both point at the new `/dist/js/` lib paths. Merging either alone breaks exports until the other lands.
+- core #3491 ⇄ plugin #46 — the snapshot removal lives in #46; the empty mount div in #3491 has no consumer once snapshots are gone.
+
+**Standalone:**
+- core #3481 — spotlight is pure CSS, no dependency on anything else.
+- core #3484 — local template override, no cross-PR impact.
+- plugin #46 is also internally complete (no further plugin PR depends on it).
+
+## What's in plugin #46 (the big one)
+
+Sixteen commits, all coordinated around the StrategyPro Logic Model feature work. Grouped by concern:
+
+**Bug fixes (visible to user):**
+- Milestone entity-link pills routed to `/tickets/showTicket/` → 500 because milestones have their own modal. Now routes to `/tickets/editMilestone/`.
+- Milestone classification: WorkGenerator was recording milestones as `entityBType='Ticket'`. Now `'Milestone'`. Legacy rows reclassified at render time.
+- Status / relates label lookups in dashboard and showCanvas tpl files were crashing on empty values. Guarded with `isset()`.
+- Health badge anchored inside the column header (was straddling the corner at `top:-4px`).
+- PNG export item title wrap fix (also in #47).
+- E2E pass on the sector-template HxController surfaced four edge cases: cancel was loading, invalid fixtureKey was silent, invalid canvasId was 500, view-vars assignment was duplicated. All fixed.
+
+**Feature behaviour:**
+- StrategyPro Logic Model features now gate to `type=strategy` projects only — narrative, health badges, wizard, entity pills disappear on regular project blueprints.
+- Generated goals now have a real `title` (Goal: …) and a real `description` (Metric: …). Was previously `title=''` with the canvas bold text shoved into description.
+
+**Removal:**
+- Snapshot feature ripped out. Storage worked, consumption side (view, restore, compare) was never built — the feature was write-only. Schema cleaned up via `dropIfExists` in update path. (See [Architectural question](#open-architectural-question) below — the templates / sample-content system replaces some of what snapshots was reaching for.)
+
+**Code review responses (Copilot inline comments on #46):**
+- WorkGenerator `(int) $result` was coercing bool `true` to ticket #1. Replaced with explicit `match (true)` accepting array-with-id or numeric only.
+- register.php entity-link renderer: nullsafe `?->` on `first()` lookups so orphaned `entity_relationship` rows don't raise PHP 8 warnings.
+- Health-badge popover max-height (`Math.max(available, 280)`) — **kept intentionally**, see [Known tradeoffs](#known-tradeoffs).
+
+## Known tradeoffs (intentional, flagged for Marcel)
+
+1. **Snapshot table drop on plugin update.** `zp_logicmodel_snapshots` is dropped via `dropIfExists` in the plugin's `update()` method. This destroys any saved snapshots on existing installs. The feature was effectively unusable (no view, restore, compare, export), so the risk of losing meaningful production data is near zero. Flagged here in case any pilot user did rely on it.
+
+2. **Healthbadge popover max-height kept at `Math.max(available, 280)`.** Copilot suggested clamping to `available`. The current behaviour ("minimum 280px usable, scroll internally if the badge is near the viewport bottom") is documented inline and is the intentional choice — sub-280px popovers near the viewport bottom would make the content too cramped to read. If you disagree, flip to `Math.min(available, …)` and it's a one-line change.
+
+3. **Plugin features gated to `type=strategy` projects only.** The architectural call was: StrategyPro's smart features (narrative, health badges, wizard, entity pills) only make sense in a strategic-planning context. Regular project blueprints get a plain OSS canvas. Helper is `logicModelIsStrategyProject($canvasId)`, used by 8 render listeners. If you want any of those features available on non-strategy projects, remove the gate from the specific listener.
+
+4. **Generated goal titles inherit from canvas item `description` field (the bold line on the card), with `conclusion` flowing into goal `description` ("Metric:"). The dashboard label "Metric:" is hardcoded as a translation string. When the conclusion is more "measurement method" than "metric" (e.g. "Measured by pre/post DIBELS comparison"), the label reads slightly off. Relabeling spans 40+ translation files — flagged as a separate decision later, not blocking this PR.
+
+5. **The "All status" dropdown label** in the Logic Model header is grammatically rough but unchanged in this PR — relabel decision deferred (same translation cost as #4).
+
+## Open architectural question
+
+The sector templates work in StrategyPro is a NEW system parallel to Blueprints' `TemplateRegistry`. Both load file-based definitions via a registry service. Conceptually overlapping but with different data shapes (YAML structure-schema vs. JSON content-fixture) and on different sides of the core/plugin boundary.
+
+Three options laid out for Marcel:
+- **A.** Extend Blueprints' `TemplateRegistry` to also handle content fixtures. Cleaner. Touches core. Multi-day refactor.
+- **B.** Keep the parallel implementation but rename it ("sector starters") to clarify the boundary.
+- **C.** Drop sector starters as a separate concept; rely on the wizard for pre-fill.
+
+**Pending Marcel's call before further sector-template work proceeds.** A separate icon-polish edit (per-sector Font Awesome icons in the selector partial) is sitting uncommitted locally so we don't accumulate work on this surface until the direction is decided.
+
+## Status check (as of writing)
+
+- Core CI: all four open PRs are green (acceptance, phpstan, pint, unit, security audit).
+- Plugins repo: no CI configured.
+- Copilot reviews on #3481 (2 inline comments) and #46 (4 inline comments) — three addressed in code, one (popover height) intentionally left, two on #3481 (opacity multiplication + hardcoded shadow) addressed.
+- No human reviewer feedback yet.

--- a/Docs/project-summary-and-claude-code-prompt.md
+++ b/Docs/project-summary-and-claude-code-prompt.md
@@ -1,0 +1,304 @@
+# Leantime 4.0 UI Modernization — Complete Project Summary
+
+## For Claude Code Execution
+
+**Project:** Leantime UI Modernization Forward-Port
+**Scope:** Forward-port 4.0-dev component work onto v3.6.2 mainline + modernize infrastructure
+**Total Timeline:** 16 weeks (4 phases), ~4-5 months part-time
+**Generated:** February 12, 2026
+
+---
+
+## 1. What This Project Is
+
+Leantime has two diverged branches:
+
+- **v3.6.2 (mainline)** — Production. 693 commits ahead of 4.0-dev. Has new plugins (Copilot AI, MCP Server, AdvancedAuth, CalDAV, Reactions, RecurringTasks), mobile app API, and infrastructure improvements.
+- **4.0-dev** — Design reference. 65 well-structured Blade components, HTMX patterns, DaisyUI integration, native `<dialog>` modals, ES module JS. NOT mergeable — too far behind.
+
+The project forward-ports the **design and component patterns** from 4.0-dev onto v3.6.2's codebase while simultaneously upgrading the infrastructure stack.
+
+---
+
+## 2. Current State Assessment
+
+### Template Migration Progress
+- 46% Blade migration complete: 205 `.blade.php` vs 237 legacy `.tpl.php`
+- 15 shared components on mainline vs 65 on 4.0-dev (50 component gap)
+- 8 of 56 domains have HTMX controllers
+
+### Critical Pain Points
+1. **Modal system** — 37 files use legacy jQuery/nyroModal. 4.0-dev has native `<dialog>` reference.
+2. **Full page reloads** — HTMX hx-boost can solve; morph swaps (HTMX 2.x) prevent content staleness.
+3. **JS bundle size** — 70MB total, 18.7MB per-page load. TipTap 6.8MB, TinyMCE 3.5MB (redundant/EOL), global components 5.1MB.
+4. **CSS complexity** — Bootstrap 2.x + custom CSS + Tailwind (tw- prefix) coexist.
+
+### 4.0-dev Remaining Task List (from Component Tracker)
+
+**Workload summary:**
+- Muhtasim: 26 tasks, 24 done
+- Tanveer: 13 tasks, 13 done
+- Marcel: 14 tasks, 0 done ← these are the unfinished items
+
+**Marcel's unfinished tasks (carried forward to this project):**
+- Ensure all plugins work
+- First onboarding + AI onboarding
+- Project selector (menu tree)
+- Project updates (replace with comments component)
+- Goal chip for status
+- Ticket view improvements
+- Datepicker (everywhere)
+- Blueprint cards headlines
+- Canvases not working
+- Wiki not working
+- Files
+- Project settings 403
+- Home dashboard broken
+- Project menu broken
+
+**Outstanding bugs:**
+- Dashboard: page does not load, only skeleton code
+- Timesheets: dropdown select options UI issue; week/list views out of page
+- Calendar: button sizing, primary/secondary color; add event date-time input
+- Company pages (All Clients, User Mgmt, Integrations): missing `@endsection`
+- Milestone calendar broken
+- Task context menu not opening
+- Delete may not work
+- View selector on milestone gantt view
+
+---
+
+## 3. Component Design System
+
+### Component Inventory (from Component Updates Tracker)
+
+**Global Simple Components (35 total):**
+
+| Component | Category | Tag | Priority | Status | Assigned |
+|---|---|---|---|---|---|
+| dropdown-menu | actions | `globals::actions.dropdown-menu` | P0 | Replacement in progress | Muhtasim |
+| modal | actions | `globals::actions.modal` | P0 | Component dev in progress | Marcel |
+| chip | actions | `globals::actions.chip` | P0 | Not started | Marcel |
+| card | elements | `globals::elements.card` | P0 | Component dev in progress | Marcel |
+| button | forms | `globals::forms.button` | P0 | Replacement in progress | Marcel |
+| select | forms | `globals::forms.select` | P0 | Replacement in progress | Tanveer |
+| text-input | forms | `globals::forms.text-input` | P0 | Replacement in progress | Tanveer |
+| tabs | navigation | `globals::navigation.tabs` | P0 | Replacement in progress | Tanveer |
+| form-field | forms | `globals::forms.form-field` | P0 | Not started | Tanveer |
+| avatar | elements | `globals::elements.avatar` | P1 | Component dev in progress | Muhtasim |
+| accordion | elements | `globals::elements.accordion` | P1 | Component dev in progress | Muhtasim |
+| table | elements | `globals::elements.table` | P1 | Not started | Joe |
+| empty-state | elements | `globals::elements.empty-state` | P1 | Component dev in progress | Marcel |
+| date-info | elements | `globals::elements.date-info` | P1 | Replacement in progress | Marcel |
+| code | elements | `globals::elements.code` | P1 | Component dev in progress | Tanveer |
+| statistic | elements | `globals::elements.statistic` | P1 | Component dev in progress | Tanveer |
+| badge | elements | `globals::elements.badge` | P1 | Component dev in progress | Tanveer |
+| checkbox | forms | `globals::forms.checkbox` | P1 | Replacement in progress | Tanveer |
+| radio | forms | `globals::forms.radio` | P1 | Component dev in progress | Tanveer |
+| toggle | forms | `globals::forms.toggle` | P1 | Not started | Marcel |
+| button-group | forms | `globals::forms.button-group` | P1 | — | Marcel |
+| steps | navigation | `globals::navigation.steps` | P1 | Component dev in progress | Tanveer |
+| breadcrumbs | navigation | `globals::navigation.breadcrumbs` | P1 | Not started | — |
+| pagination | navigation | `globals::navigation.pagination` | P1 | Component dev in progress | Tanveer |
+| alert | feedback | `globals::feedback.alert` | P1 | Not started | — |
+| loading | feedback | `globals::feedback.loading` | P1 | Not started | — |
+| progress | feedback | `globals::feedback.progress` | P1 | Not started | — |
+| skeleton | feedback | `globals::feedback.skeleton` | P1 | Not started | — |
+| indicator | feedback | `globals::feedback.indicator` | P1 | Not started | — |
+| chat bubble | elements | `globals::elements.chat bubble` | P2 | Not started | — |
+| keyboard | elements | `globals::elements.keyboard` | P2 | Not started | — |
+| calendar | elements | `globals::elements.calendar` | P2 | Not started | — |
+| range | forms | `globals::forms.range` | P2 | Not started | — |
+| textarea | forms | `globals::forms.textarea` | P2 | Not started | — |
+| file-input | forms | `globals::forms.file-input` | P2 | Not started | — |
+| menu | navigation | `globals::navigation.menu` | P2 | Not started | — |
+| navbar | navigation | `globals::navigation.navbar` | P2 | Not started | — |
+
+**Global Special Components:**
+
+| Component | Category | Tag | Priority | Status | Assigned |
+|---|---|---|---|---|---|
+| text-editor | forms | `globals::forms.text-editor` | P0 | Not started | Marcel |
+| date-picker | forms | `globals::forms.date-picker` | P0 | Component dev in progress | Marcel |
+| color-picker | forms | `globals::forms.color-picker` | P1 | Not started | — |
+| page-header | layout | `globals::layout.pageheader` | P1 | Not started | — |
+| emoji-input | forms | `globals::forms.emoji-input` | P2 | Not started | — |
+| select-panel | action | `globals::action.select-panel` | P1 | Not started | — |
+| context-menu | navigation | `globals::navigation.context-menu` | P1 | Replacement in progress | Muhtasim |
+
+**Domain-Specific Components:**
+
+| Component | Domain | Tag |
+|---|---|---|
+| list | comments | `globals::comments.list` |
+| ticket-card | tickets | `globals::tickets.ticket-card` |
+| milestone-card | tickets | `globals::tickets.milestone-card` |
+| ticket-state-label | tickets | `globals::tickets.ticket-state-label` |
+| projectCard | projects | — |
+
+
+### Component Attribute System
+
+Components use a standardized attribute system with these IDL (Interface Definition Language) attributes:
+
+| Attribute | Options | Default | Purpose |
+|---|---|---|---|
+| `content-role` | default, primary, secondary, ghost/tertiary, accent, link | primary (actions) | Semantic role of the component |
+| `state` | default, info, warning, danger, success | default | Visual state indicator |
+| `variant` | component-specific | "" | Different behavior modes (e.g., chip: filter/action/select) |
+| `scale` | xs, s, m, l, xl | m | Size scale |
+| `position` | left, right, top, bottom, inner, outer, start, end | bottom | Placement relative to parent |
+| `element` | a, input, button | — | HTML element override (e.g., cancel button → `<a>`) |
+| `align` | start, end | — | Content alignment |
+
+Content attributes shared across form components:
+- `label-text`, `label-position` (top/left/right/bottom/inside)
+- `caption` (descriptive text underneath)
+- `validation-text`, `validation-state`
+- `leading-visual`, `trailing-visual` (icons)
+- `items` (data list for selects/dropdowns)
+
+### Component Development Checklist (from Guidelines sheet)
+
+Every component must satisfy:
+- [ ] Uses only valid attribute names
+- [ ] Can be re-used by various modules
+- [ ] Can accept any type of data/content
+- [ ] Merges attributes (via `$attributes->merge()`)
+- [ ] Has default states
+- [ ] Fails gracefully with wrong data/attributes
+- [ ] No design input required from component user (content-focused attributes, not style)
+- [ ] No business logic
+- [ ] Is responsive
+- [ ] Only Tailwind CSS & DaisyUI CSS (no additional CSS without approval)
+- [ ] JS assets loaded as part of component
+- [ ] CSS assets loaded as part of component
+- [ ] Uses only approved JS components
+- [ ] Does not require data preparation by developer (handles controller data directly)
+- [ ] Has appropriate `aria-*` attributes
+- [ ] Follows WCAG guidelines
+- [ ] Works in modals and regular pages
+- [ ] All legacy HTML elements replaced
+
+---
+
+## 4. Frontend Library Audit
+
+### Libraries to KEEP (approved for component use)
+
+| Library | Version | Used For |
+|---|---|---|
+| FullCalendar | ^6.1.11 | Calendar visualization |
+| Lottie Player | ^2.0.4 | Animations (AI robot) |
+| Tippy.js | ^6.3.7 | Tooltips |
+| Popper.js | ^2.11.8 | Tooltip dependency |
+| Canvas Confetti | ^1.9.3 | Confetti animation |
+| Chart.js | ^3.6.0 | Report charts |
+| Chart.js Luxon Adapter | ^1.3.1 | Chart date support |
+| HTMX | ^1.9.12 → **^2.0.8** | HTMX support (upgrading) |
+| Tailwind | ^3.4.1 → **4.x** | CSS framework (upgrading) |
+| Uppy | ^3.25.3 | File uploads |
+| Choices.js | forked | Select dropdowns (THE standard) |
+| Frappe Gantt | 0.6.1 (modified) | Gantt charts |
+| jQuery Growl | 1.3.5 | Notification tooltips |
+| Croppie | ^2.6.5 | Profile picture cropping |
+
+### Libraries to REPLACE SOON
+
+| Library | Replace With | Notes |
+|---|---|---|
+| TinyMCE | TipTap | EOL. Migration in progress. Most high-usage editors already migrated. |
+| NyroModal | Native `<dialog>` + DaisyUI | Heavy jQuery modal. 37 files to migrate. |
+| FontAwesome Icon Picker | Blade UI Icons | Wiki articles only |
+| Datatables | TBD | Tables across system with sorting/paging |
+| Frappe Gantt | TBD (more powerful) | Heavily modified, functional but limited |
+
+### Libraries to REMOVE
+
+| Library | Notes |
+|---|---|
+| Bootstrap 3 fileupload | Legacy |
+| jQuery Forms (jquery.form.js) | Not used |
+| Simple Color Picker | Use browser default |
+
+### Libraries to CONSOLIDATE (replace with Choices.js)
+
+| Library | Current Use |
+|---|---|
+| Chosen JS | Select dropdowns |
+| jQuery Tags | Tags input |
+| SlimSelect | Another dropdown library |
+| Select2 | Yet another dropdown library |
+
+### Libraries to EVALUATE
+
+| Library | Version | Question |
+|---|---|---|
+| jQuery UI | 1.13.2 | Used for datepickers, tabs, progress bars, accordion, drag-drop. Replace with DaisyUI/HTMX? |
+| jQuery UI Touch Punch | ^0.2.3 | Still needed? |
+| Ajv JSON validator | ^8.13.0 | Still in use? |
+| imagesloaded | ^5.0.0 | Still needed? |
+| Moment.js | ^2.29.4 | Replace with Luxon (already present) |
+
+### Libraries to KEEP but NOT component-approved
+
+jQuery (3.7.1), Gridstack (^10.1.2), Masonry (^4.2.2), Isotope (^3.0.6), Packery (^2.1.2), Leader Line (^1.0.7), JSTree (^3.3.16), Shepherd.js (^11.2.0), Prism.js, Sentry, Luxon (^3.4.4), iCal.js (^1.5.0), Excalidraw (v0.16.1)
+
+---
+
+## 5. Version Upgrades Required (Phase 0)
+
+| Dependency | Current | Target | Risk | Notes |
+|---|---|---|---|---|
+| Laravel | ^11.44 | ^12.0 | LOW | Maintenance release. All breaking changes verified as non-impactful. |
+| Carbon | 3.10.1 | 3.x | NONE | Already compatible |
+| Build pipeline | Laravel Mix ^6.0.49 | Vite | MEDIUM-HIGH | Enables Tailwind 4 + ESM + tree-shaking |
+| Tailwind CSS | ^3.4.1 | 4.x | MEDIUM | CSS-native config model. DaisyUI 5 requires this. |
+| DaisyUI | not installed | 5.5.x | LOW | Additive. 63 components. Pure CSS. |
+| HTMX | ^1.9.12 | ^2.0.8 + Idiomorph | LOW-MEDIUM | Morph swaps preserve DOM state during partial updates |
+| TinyMCE | ^5.10.9 | REMOVE (Phase 3) | MEDIUM | EOL. TipTap migration mostly done. |
+
+### DaisyUI 5 Class Name Changes (from 4.0-dev reference)
+
+| Old (4.0-dev era) | New (DaisyUI 5) |
+|---|---|
+| `form-control` | `fieldset` / `label` |
+| `card-compact` | `card-sm` |
+| `bottom-nav` | `dock` |
+| `avatar online` | `avatar avatar-online` |
+| `avatar offline` | `avatar avatar-offline` |
+
+---
+
+## 6. Architecture Constraints — DO NOT BREAK
+
+### Mobile App (React Native/Expo)
+
+Communicates via JSON-RPC at `/api/jsonrpc`. The controller uses `app()->make()` to resolve services and reflection to map params by name.
+
+**89 RPC methods** across 7 domains (Tickets: 20, Projects: 18, Users: 15, Timesheets: 13, Notes: 10, Calendar: 8, Comments: 5).
+
+Auth requires AdvancedAuth plugin (v3.6.2 only, NOT in 4.0-dev): `POST /advancedAuth/getToken` → Bearer token for all API calls.
+
+**Field names consumed by mobile** (renaming breaks the app silently):
+- Tasks: `id`, `headline`, `description`, `projectId`, `status`, `priority`, `storyPoints`, `planHours`, `dateToFinish`, `editFrom`, `editTo`, `editorId`, `milestoneId`, `tags`
+- Projects: `id`, `name`, `clientId`, `clientName`, `color`
+- Users: `id`, `firstName`, `lastName`, `email`, `role`, `profileId`
+
+Full method inventory: `Docs/leantime-mobile-backend-compatibility.md`
+
+### Plugin Ecosystem (33+ plugins)
+
+- Plugins submodule: 4.0-dev is 926 commits behind v3.6.2. Clean fast-forward.
+- 7 new plugins not in 4.0-dev: Copilot (141 files), McpServer (35), AdvancedAuth (28), Reactions (20), CalDAV (18), RecurringTasks (16), EnergyTracker (1)
+- Event hook rename: `middleware.auth.*` → `middleware.authcheck.*` (silent failure if wrong)
+- DispatchesEvents: 4.0-dev uses Laravel Event facade, v3.6.2 uses EventDispatcher static. Must preserve backward compat.
+
+### Deployment Surface
+
+- Docker (PHP 8.3-fpm-alpine, nginx, MySQL 8.4)
+- PostgreSQL support (via `LEAN_DB_DEFAULT_CONNECTION = 'pgsql'`)
+- SMTP via PHPMailer (not Laravel Mail)
+- S3, OIDC/OAuth, LDAP, Redis, CalDAV, AWS Bedrock (Copilot), MCP Server
+- Installation via SchemaBuilder (`Schema::create()` — database-agnostic)
+

--- a/Docs/remediation strategy/leantime-sweeps.md
+++ b/Docs/remediation strategy/leantime-sweeps.md
@@ -1,0 +1,188 @@
+# Leantime Remediation Sweeps
+
+Each sweep is a self-contained unit of work. Every sweep follows the pattern: **discover → implement → replace → verify**. Sweeps are ordered by dependency — later sweeps assume earlier ones are complete.
+
+---
+
+## Sweep 01: Component Audit & Duplicate Map
+
+**Outcome:** A machine-readable manifest of every file in `app/Views/Templates/components/` with duplicates flagged, so all subsequent sweeps know exactly which files to delete and which to keep.
+
+1. **Scan the components directory.** Recursively list every `.blade.php` file under `app/Views/Templates/components/`. For each file, extract: filename, subdirectory path, the component tag name (from the folder/file convention), and a hash of its content.
+2. **Identify duplicates by function.** Group files that serve the same purpose (e.g., all files containing "dropdown" in name or rendering `<select>`, `<ul>` menus, or DaisyUI `dropdown` classes). Produce a grouped list showing: canonical name from the component tracker (e.g., `globals::actions.dropdown-menu`), all files that implement a version of it, and which file — if any — is closest to the tracker spec.
+3. **Output a deprecation manifest.** Write a JSON file `component-audit.json` with the structure: `{ "canonical_name": "globals::actions.dropdown-menu", "keep": "path/to/best/version.blade.php", "delete": ["path/to/dupe1.blade.php", "path/to/dupe2.blade.php"], "references_count": 14 }` for each group. Include a `references_count` by grepping the codebase for usages of each file.
+4. **Verify:** The manifest must account for every `.blade.php` in the components directory. No file should be unclassified. Run `find app/Views/Templates/components -name "*.blade.php" | wc -l` and confirm it matches the sum of all entries in the manifest.
+
+---
+
+## Sweep 02: Legacy File Cleanup
+
+**Outcome:** All `.tpl` files that have a `.blade.php` equivalent are deleted. All test files (e.g., `componentTest`) are removed from template directories. Zero legacy template files remain in active template paths.
+
+1. **Find all `.tpl` files.** Run `find` across the entire project for `*.tpl` files. For each one, check if a `.blade.php` file with the same base name exists in the same directory or the equivalent Blade directory.
+2. **Delete matched `.tpl` files.** For every `.tpl` that has a Blade equivalent, delete the `.tpl` file. Log each deletion with the path pair (deleted `.tpl` → existing `.blade.php`).
+3. **Remove test files from template directories.** Search all directories under `app/Views/Templates/` for files matching `*test*`, `*Test*`, `componentTest*`, or similar patterns. Delete them. These belong in a `tests/` directory, not in template paths.
+4. **Verify:** `find app/Views/Templates -name "*.tpl" | wc -l` returns 0 (or only returns `.tpl` files with no Blade equivalent, which should be listed for manual review). `find app/Views/Templates -iname "*test*" | wc -l` returns 0.
+
+---
+
+## Sweep 03: Event Folder Rename (htmx → events)
+
+**Outcome:** Every domain that has an `htmx/` folder now has an `events/` folder instead. All internal references (imports, autoloaders, namespace declarations) are updated. The application boots and routes resolve without errors.
+
+1. **Find all `htmx` folders across domains.** Search the domain directories (likely under `app/Domain/*/` or similar) for folders named `htmx`. List every occurrence.
+2. **Rename each `htmx/` to `events/`.** Use `git mv` (or `mv` + git add) to rename. This preserves git history.
+3. **Update all references.** Grep the entire codebase for the old path segments (e.g., `Htmx\\`, `htmx/`, `htmx.`) and replace with the `events` equivalent. This includes PHP namespace declarations, `use` statements, autoloader configs, and any Blade `@include` or `@component` references.
+4. **Verify:** Run the application's route cache clear (`php artisan route:clear && php artisan route:cache`) and confirm no errors. Run `grep -r "htmx" app/Domain/ --include="*.php" | grep -v "hx-"` to confirm no stale references remain (excluding legitimate `hx-` HTMX attributes in Blade templates).
+
+---
+
+## Sweep 04: Icon Library Consolidation
+
+**Outcome:** The project uses only Material Icons via Blade UI. All Glyphicon and FontAwesome class references are replaced. A single icon rendering approach exists across the entire codebase.
+
+1. **Audit current icon usage.** Grep for `glyphicon`, `fa-`, `fa `, `fas `, `far `, `fab `, `fontawesome` across all `.blade.php`, `.php`, `.js`, and `.css` files. Produce a list of every icon reference with file path and line number.
+2. **Build a mapping table.** For each unique icon found (e.g., `fa-trash`, `glyphicon-plus`), map it to the equivalent Material Icon name (e.g., `delete`, `add`). Use the Material Icons reference at fonts.google.com/icons.
+3. **Replace all icon references.** For each file, replace the old icon markup (e.g., `<i class="fa fa-trash"></i>` or `<span class="glyphicon glyphicon-plus"></span>`) with the Blade UI Material Icon syntax used in 4.0-beta (e.g., `<x-icon name="delete" />` or the project's established convention). Do this file-by-file, not with a single global regex, to handle edge cases in markup structure.
+4. **Remove old icon library imports.** Find and delete any `<link>` or `@import` references to FontAwesome or Glyphicon CSS files in layout files, `<head>` partials, or asset build configs (webpack, vite, etc.).
+5. **Verify:** `grep -r "glyphicon\|fa-\|fontawesome" app/Views/ --include="*.blade.php" | wc -l` returns 0. Load 5 representative pages (ticket list, ticket detail modal, project dashboard, goal screen, settings) and confirm all icons render visually.
+
+---
+
+## Sweep 05: form-field Component (Label + Input Wrapper)
+
+**Outcome:** A single `<x-globals::forms.form-field>` Blade component exists that wraps any input with a label, caption, validation message, and consistent spacing. It accepts `label-text`, `label-position` (top/left), `caption`, `validation-text`, `validation-state`, `leading-visual`, `trailing-visual` props.
+
+1. **Create the component.** Build `globals::forms.form-field` as a Blade component. It renders a wrapper `<div>` with the label above or beside the input (controlled by `label-position`, defaulting to `top`). The `{{ $slot }}` receives the actual input element. Below the input: optional `caption` text in muted small type, and optional `validation-text` styled by `validation-state` (error = red, warning = amber, success = green). Spacing between label, input, and validation must be fixed values — not page-dependent.
+2. **Reference the 4.0-beta implementation.** Check the 4.0-beta branch for the existing form-field component. Port its spacing values (margin/padding between label and input, between input and validation text) directly. If 4.0-beta used specific DaisyUI form-control classes, use the same ones.
+3. **Apply to the ticket detail view as proof.** Replace the form markup in the ticket detail sidebar (where labels are on top and inputs below) to use `<x-globals::forms.form-field label-text="Status">` wrapping the existing status select. Do the same for 3–5 other fields on that view (milestone, author, due date, priority).
+4. **Apply to the milestone modal.** The milestone modal currently has fields stacked with zero spacing between them. Wrap each field in `<x-globals::forms.form-field>`. This should fix the "fields right on top of each other" issue.
+5. **Verify:** Open the ticket detail view — labels and inputs should have identical spacing for every field. Open the milestone modal — fields should have consistent vertical rhythm (no cramming). Compare against the timesheet tab — if timesheet forms also use `form-field`, they should match. If not, note for a later sweep.
+
+---
+
+## Sweep 06: Unified dropdown-menu Component
+
+**Outcome:** A single `<x-globals::actions.dropdown-menu>` component replaces all 4+ dropdown implementations. It handles action menus, filter menus, sprint selectors, and "new" button dropdowns with consistent item spacing, icon rendering, and background opacity.
+
+1. **Create the component.** Build `globals::actions.dropdown-menu` with props: `trigger` (slot for the button/link that opens it), `position` (left/right/bottom, defaulting to bottom-left), `width` (auto/fixed), `background` (solid white by default — not transparent). Child `<x-globals::actions.dropdown-item>` accepts: `href`, `leading-visual` (icon name), `trailing-visual`, and renders each item with consistent padding (e.g., `px-4 py-2`), proper icon sizing, and text that never shows raw HTML.
+2. **Replace the ticket page "New" button dropdown.** This is the dropdown that currently shows `<span...` raw HTML for icons. Replace its markup with `<x-globals::actions.dropdown-menu>` and `<x-globals::actions.dropdown-item leading-visual="add">` for each option. Icons should render as actual icons, not HTML strings.
+3. **Replace the sprint selector dropdown.** This dropdown has different spacing than all others. Replace with the same component. Verify item spacing matches the "New" button dropdown exactly.
+4. **Replace the 3-dot page header menu** (the one that opens off-screen to the right and shows blue icons as HTML). Use `position="bottom-left"` or `position="bottom-end"` to ensure it stays on-screen. Icons must render via the Material Icons approach from Sweep 04.
+5. **Verify:** Open tickets page. The "New" button dropdown, sprint selector dropdown, and 3-dot header menu should all have: identical item padding, properly rendered icons (no raw HTML), opaque white/solid background (not transparent), and menus that stay within the viewport. Also verify the project dropdown (previously transparent/hard to read) — if it uses the old component, replace it with this one.
+
+---
+
+## Sweep 07: Unified modal Component
+
+**Outcome:** A single `<x-globals::actions.modal>` component is used for all modals. Ticket modal and milestone modal have identical overlay transparency, X button size, and header styling.
+
+1. **Create the component.** Build `globals::actions.modal` with props: `title` (heading text), `size` (sm/md/lg/xl), `show` (boolean or Alpine.js binding). The overlay must use a single fixed `bg-black/50` (or equivalent) — not page-specific transparency. The X close button must be a consistent size (e.g., `w-8 h-8`) using a Material Icon `close`. The header area renders the `title` prop at a fixed heading size. An optional `actions` slot provides the footer area for buttons.
+2. **Remove the trash icon from the milestone modal header.** The milestone modal currently has a trash icon in the top-right that "makes no sense." Remove it from the header. If delete functionality is needed, it should be in the modal footer as a button with `state="danger"`.
+3. **Replace the ticket detail modal.** Swap its current modal wrapper markup to use `<x-globals::actions.modal title="Task Details" size="lg">`. The content stays as-is inside the slot. The overlay and X button now come from the component.
+4. **Replace the milestone modal.** Same approach. After replacement, the headline size should match the ticket modal exactly because both now use the same `title` rendering.
+5. **Verify:** Open a ticket modal, then close it and open a milestone modal. The overlay darkness, X button size, and title font size must be identical. The milestone modal should no longer have a trash icon in the header. Closing either modal should not trigger a full page reload (this connects to hx-boost in Sweep 11).
+
+---
+
+## Sweep 08: button Component with Icon Support
+
+**Outcome:** A single `<x-globals::forms.button>` component renders buttons, links-as-buttons, and icon-only circle buttons. The 3-dot menu triggers, widget header icons, and modal action buttons all use this component.
+
+1. **Create the component.** Build `globals::forms.button` with props: `content-role` (primary/secondary/ghost/accent/link), `state` (default/info/warning/danger/success), `element` (button/a/input — controls the rendered HTML tag), `leading-visual` (icon name), `trailing-visual` (icon name), `scale` (xs/s/m/l/xl), `variant` (default/icon-only/circle). When `variant="circle"`, render as a round icon button (for 3-dot menus and widget headers). When `element="a"`, render as an `<a>` tag with button styling.
+2. **Replace 3-dot menu trigger buttons.** Across the app, the 3-dot (`more_vert` or `ellipsis`) buttons are currently blue links with no background. Replace each with `<x-globals::forms.button variant="circle" content-role="ghost" leading-visual="more_vert" />`. This gives them consistent sizing and a hover background.
+3. **Replace gridstack widget header icons.** These are currently inconsistent (blue, no background, link-styled). Replace with the same `variant="circle"` button. This ensures widget header icons match modal header icons match 3-dot menu icons.
+4. **Apply to the filter button's badge area.** The filter button on tickets currently has a floating "1" with no background. The button itself should use this component, and the badge count should use the badge component (Sweep 10).
+5. **Verify:** On the ticket kanban view, the 3-dot menu triggers, widget header icons, and filter button should all have consistent sizing and hover states. None should appear as raw blue text links. Icon-only buttons should be circular with appropriate padding.
+
+---
+
+## Sweep 09: chip Component (Status, Milestone, Author)
+
+**Outcome:** Status labels, milestone indicators, and author tags across ticket views all render through `<x-globals::actions.chip>` with correct colors and no white-on-white text.
+
+1. **Create the component.** Build `globals::actions.chip` with props: `variant` (input/choice/action/select), `content-role` (primary/secondary/tertiary), `color` (custom hex — used for milestone colors and status colors), `leading-visual`, `trailing-visual`, `scale`. The component must calculate text color based on the background `color` prop — if the background is light, use dark text; if dark, use light text. This directly fixes the white-on-white milestone chip issue.
+2. **Replace milestone chips in dropdowns.** Find where milestone options render in dropdown selectors. Replace with `<x-globals::actions.chip color="{{ $milestone->color }}">{{ $milestone->headline }}</x-globals::actions.chip>`. The automatic contrast logic ensures readable text regardless of milestone color.
+3. **Replace status labels on ticket cards/lists.** Where statuses currently render inconsistently (sometimes as chips, sometimes as unstyled text in a dropdown), replace with the chip component using the status color.
+4. **Replace author/user tags.** Where author names appear as selectable chips (e.g., in assignment dropdowns), use `<x-globals::actions.chip variant="select" leading-visual="person">`.
+5. **Verify:** On the ticket kanban board, milestone chips must show readable text on their colored backgrounds (no white-on-white). Status chips must look identical whether displayed on a card, in a list row, or inside a dropdown. Open the milestone selector dropdown — items should be consistently sized (not "too large" as reported).
+
+---
+
+## Sweep 10: badge, select, checkbox, and radio Fixes
+
+**Outcome:** Filter count badges have visible backgrounds. Single-select dropdowns don't show an X clear button. Checkboxes and radios use the correct theme color (not purple) at consistent sizes.
+
+1. **Build the badge component.** Create `globals::elements.badge` with props: `content-role` (primary/secondary/accent), `scale` (xs/s/m). It renders a small pill with a background color and contrasting text. Default is the theme's primary color with white text.
+2. **Fix the filter button badge.** On the tickets filter button, find where the "1" count is rendered. Wrap it in `<x-globals::elements.badge>1</x-globals::elements.badge>`. The floating number now has a visible background pill.
+3. **Fix single-select X button.** In the `globals::forms.select` component (or wherever the select is implemented), add logic: if `variant="single"` (or if the component is not multi-select), do not render the clear/X button. The X should only appear on `variant="tags"` or `variant="multiple"`.
+4. **Fix checkbox and radio theming.** Find the checkbox component (`globals::forms.checkbox`) and radio component (`globals::forms.radio`). Replace any `purple` or `violet` color classes with the app's primary theme color (likely DaisyUI's `primary` class, e.g., `checkbox-primary`, `radio-primary`). Ensure both use a consistent size — the notification page checkboxes should not be oversized, and widget grouping radios should match the todo screen radios in size. Set a default scale via the component rather than inheriting page-level styles.
+5. **Verify:** Tickets page filter button shows a pill badge with "1" on a colored background. Any single-select dropdown (status, milestone, sprint) does not show an X. Notification settings page checkboxes are theme-colored and standard-sized. Widget grouping radios on dashboards and the todo screen are the same color and same size.
+
+---
+
+## Sweep 11: hx-boost Restoration & Page Loader
+
+**Outcome:** Main menu navigation uses `hx-boost="true"`. Navigating between major sections (tickets, projects, goals, etc.) does not trigger full page reloads. Closing a modal does not reload the page. A global page loader (progress bar or spinner) appears during HTMX navigation transitions.
+
+1. **Port hx-boost config from 4.0-beta.** Identify where `hx-boost` was applied in the 4.0-beta branch (likely on the `<body>`, `<main>`, or the nav menu `<a>` tags). Apply the same attribute to the current build's layout file.
+2. **Port the global page loader.** In 4.0-beta, an element (likely a top progress bar or spinner overlay) was shown during `htmx:beforeRequest` and hidden on `htmx:afterSettle`. Copy that element and its JS event listeners into the current layout. This is likely a `<div>` with a CSS animation that listens to HTMX lifecycle events.
+3. **Fix modal close behavior.** Currently, closing a ticket modal triggers a full page reload. After hx-boost is active, the modal close should trigger an HTMX event (e.g., `htmx:trigger` to refresh the ticket list behind the modal) rather than a `window.location.reload()` or form submission that causes navigation. Check if the modal close button has `onclick="location.reload()"` or similar — remove it and replace with an HTMX-compatible approach.
+4. **Verify:** Click "Tickets" in the main menu — the page content should swap without a full browser navigation (URL updates via pushState, no white flash, page loader appears briefly). Open a ticket modal, make an edit, close it — the ticket list should update behind the modal without a full page reload. Open browser DevTools Network tab — main menu clicks should show XHR/fetch requests, not full document loads.
+
+---
+
+## Sweep 12: tabs Component & View Tab Spacing
+
+**Outcome:** `<x-globals::navigation.tabs>` provides consistent tab rendering. The ticket kanban view tabs no longer have excess bottom padding. The project selector's tabs no longer close the dropdown when clicked.
+
+1. **Create/finalize the tabs component.** Build `globals::navigation.tabs` with a `<x-globals::navigation.tab>` child. Each tab accepts: `label`, `href` (for page tabs) or `target` (for in-page tab panels), `active` (boolean). The component renders with consistent padding — specifically, bottom padding/margin should be a fixed value (e.g., `pb-2 mb-4`) that doesn't vary by page context.
+2. **Replace ticket view tabs.** The kanban/list/timeline view selector at the top of the tickets page currently has "a large margin/padding on the bottom." Replace with the tabs component. The consistent bottom spacing from the component eliminates the per-page override.
+3. **Fix project selector tabs closing the dropdown.** The project selector has tabs inside a dropdown, and clicking a tab closes the dropdown (event propagation issue). In the tabs component, when rendered inside a dropdown context, add `@click.stop` (Alpine.js) or `event.stopPropagation()` to tab click handlers so clicks don't bubble up to the dropdown's close handler.
+4. **Verify:** On tickets page, the view tabs (kanban/list/etc.) should have a reasonable, consistent bottom margin — no excessive gap before the content below. In the project selector dropdown, clicking between tabs (e.g., switching between "Recent" and "All Projects") should keep the dropdown open. The selected tab should visually highlight.
+
+---
+
+## Sweep 13: Domain Template Migration (Partials → Components)
+
+**Outcome:** The `partials/` and `submodules/` folders inside domain template directories are converted to properly namespaced Blade components. Domain-specific components (ticket-card, milestone-card, ticket-state-label, comment list, project card) exist and compose the global primitives from previous sweeps.
+
+1. **Convert ticket domain partials.** In the Tickets domain template directory, identify all files in `partials/` and `submodules/`. For each partial that renders a self-contained UI block (e.g., a ticket card, a milestone chip row, a comment thread), convert it to a Blade component under `globals::tickets.*` (e.g., `globals::tickets.ticket-card`). The component should use the global primitives internally — `<x-globals::actions.chip>` for status, `<x-globals::forms.button>` for actions, `<x-globals::elements.card>` for the card wrapper.
+2. **Convert project domain partials.** Same process for the Projects domain. The project card partial becomes `globals::projects.project-card` using `<x-globals::elements.card>` and `<x-globals::elements.avatar>`.
+3. **Convert goals domain partials.** The goal card that currently has "icons outside the card" should become `globals::goals.goal-card`. When built with `<x-globals::elements.card>`, the icons render inside the card's bounds because the card component controls its own overflow/positioning.
+4. **Update all referencing Blade files.** In each domain's main view files, replace `@include('partials.ticket-card')` style references with `<x-globals::tickets.ticket-card :ticket="$ticket" />` component calls.
+5. **Verify:** For each domain (tickets, projects, goals), confirm that the `partials/` folder is empty or deleted. Load the ticket list — ticket cards should render using the new component with consistent styling. Load the goals screen — goal card icons should be inside the card boundaries. Load the project dashboard — project cards should use the card component.
+
+---
+
+## Sweep 14: Page-Specific Form Fixes (Timesheets, Profile, Wiki, Theme)
+
+**Outcome:** Every page that has forms uses the `form-field` component from Sweep 05. No page has unique/custom spacing between labels and inputs. The docs/wiki page uses the same input styling and background as the rest of the app.
+
+1. **Fix timesheet tab forms.** The timesheet tab currently shows "a cluster of labels and inputs, no organization." Wrap every label+input pair in `<x-globals::forms.form-field>`. Group related fields visually using the card component if needed.
+2. **Fix profile and company settings forms.** These pages have "yet another level of whitespace around forms and labels." Replace their form markup with `form-field` wrappers. Remove any page-specific CSS that overrides form spacing (look for scoped `<style>` blocks or page-specific CSS classes adding extra padding/margin).
+3. **Fix docs/wiki input styling.** The wiki/docs editor uses "a completely different input setup and background." Identify what wrapper or layout creates the different background. Replace it with the standard `<x-globals::elements.card>` for the content area, and `<x-globals::forms.form-field>` for any input elements. The background should match the rest of the app.
+4. **Fix theme page label alignment.** The theme page has "labels that show up to the left of color pickers and font pickers." Wrap these in `<x-globals::forms.form-field label-position="top">` so labels appear above pickers, matching the standard layout. If the color-picker component exists, ensure it works inside the form-field wrapper.
+5. **Verify:** Open each page (timesheets, profile, company settings, docs/wiki, theme) side by side with the ticket detail view. The vertical spacing between label → input → next label should be visually identical across all of them. The docs/wiki page background should match the main app background. The theme page labels should be above their pickers, not floating to the left.
+
+---
+
+## Sweep 15: Goal Screen Bug Fixes
+
+**Outcome:** Creating a new goal does not throw errors. Goal metrics dashboard has proper bottom margin. Goal card icons are inside cards (if not already fixed by Sweep 13).
+
+1. **Debug goal creation errors.** Navigate to the goals screen, open the "create new goal" flow, and trigger the error. Check Laravel logs (`storage/logs/laravel.log`) and browser console for the specific error messages. Common causes: missing required fields in the form submission, a migration that wasn't run, or a controller referencing an old route/view. Fix the root cause — this is likely a backend issue, not a component issue.
+2. **Fix goal metrics bottom margin.** On the goals dashboard, the metrics/statistics at the top have "no margin to the bottom." Find the container that wraps the goal metrics (likely a `<div>` with statistic components). Add a bottom margin class (`mb-6` or similar). If using the `<x-globals::elements.statistic>` component, the margin should be built into the component's wrapper or a layout grid.
+3. **Verify goal cards.** If Sweep 13 already converted goal cards to use the card component, verify that icons are now inside the card. If they're still outside, the issue is likely an absolutely-positioned icon that's relative to the wrong parent — move the icon element inside the card component's content area.
+4. **Verify:** Create a new goal end-to-end — fill form, submit, see it appear on the goal board with no errors in console or logs. The metrics row at the top of the goals dashboard should have visible spacing between it and the content below. Goal card icons should be visually inside their cards.
+
+---
+
+## Sweep 16: Final Cross-Page Consistency Audit
+
+**Outcome:** Every page in the application uses the same component set with no visual outliers. A before/after screenshot set documents the changes.
+
+1. **Systematic page walk-through.** Visit each major page: Ticket Kanban, Ticket List, Ticket Detail (modal), Project Dashboard, Project Cards, Goals Dashboard, Goal Detail, Milestones, Timesheets, My Profile, Company Settings, Notifications, Theme Settings, Docs/Wiki. For each page, check: are all dropdowns using the unified component? Are all form fields wrapped in form-field? Are all icons Material Icons? Are all buttons using the button component? Are modals using the modal component?
+2. **Fix any remaining one-off issues.** If any page still has inline/custom implementations, replace them with the canonical components. This sweep is the catch-all for anything missed in previous sweeps.
+3. **DaisyUI alignment check.** For each component built, verify that it uses DaisyUI utility classes where they exist (e.g., `btn`, `btn-primary`, `modal`, `dropdown`, `badge`, `checkbox`, `radio`). Components should extend DaisyUI, not fight against it.
+4. **Verify:** No `grep -r` for deprecated component files returns results. A clean `php artisan view:cache` completes without errors. The application loads end-to-end with no console errors related to missing components or undefined variables.


### PR DESCRIPTION
## What & why

The **entire `Docs/` knowledge base** (46 files: implementation guides 00-17, WorkStructure architecture, design tokens, RA + stakeholder-report requirements/prompts, phase summaries, QA walkthroughs) existed **only inside a git stash** (`wip-resources-screenshots`, 2026-07-14) — flagged by the Jul-28 forensics (`Docs/PR-FORENSICS-ANALYSIS.md` §5.4) as content existing nowhere else. One laptop failure from gone.

This commits it. Root-level debug artifacts from the same stash (b64 dumps, snapshots) intentionally not rescued.

(The other flagged stash — the Jul-16 user-capacity WIP — turned out fully superseded by the merged #3653; no rescue needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85
