### PR TITLE
fix(assets): cache-bust the css bundles with the build mtime

### DIFF
--- a/app/Views/Templates/sections/header.blade.php
+++ b/app/Views/Templates/sections/header.blade.php
@@ -18,11 +18,19 @@
 <link rel="shortcut icon" href="{!! BASE_URL !!}/dist/images/favicon.png"/>
 <link rel="apple-touch-icon" href="{!! BASE_URL !!}/dist/images/apple-touch-icon.png">
 
-<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/main.{!! $version !!}.min.css"/>
-<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/app.{!! $version !!}.min.css"/>
+@php
+    // Cache-buster: the filenames only change per app version, so rebuilds of
+    // the SAME version were served stale from browser cache (no query hash in
+    // the mix manifest — core mix does not version() the css). The bundle's
+    // mtime changes on every build, which busts exactly when needed.
+    $mainCssPath = APP_ROOT.'/public/dist/css/main.'.$version.'.min.css';
+    $cssBust = is_file($mainCssPath) ? filemtime($mainCssPath) : $version;
+@endphp
+<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/main.{!! $version !!}.min.css?v={!! $cssBust !!}"/>
+<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/app.{!! $version !!}.min.css?v={!! $cssBust !!}"/>
 @if($tpl->needsComponent('tiptap'))
-<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/tiptap-editor.{!! $version !!}.min.css"/>
-<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/katex.min.css"/>
+<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/tiptap-editor.{!! $version !!}.min.css?v={!! $cssBust !!}"/>
+<link rel="stylesheet" href="{!! BASE_URL !!}/dist/css/katex.min.css?v={!! $cssBust !!}"/>
 @endif
 
 @dispatchEvent('afterLinkTags')


### PR DESCRIPTION
Replaces #3722 (closed by an accidental branch deletion on my side — apologies for the noise). Same change with the review feedback already applied: rebuilds of the same app version served **stale css from browser cache** (bit twice in the Jul-28/29 cleanup); the bundle mtime is appended as \`?v=\`, with an explicit \`is_file()\` guard instead of \`@\`-suppression per Copilot's comment.

Live-verified rendering: \`main.3.9.8.min.css?v=1785333857\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85