### PR TITLE
fix(goals): harden the goal↔milestone edge model (audit follow-up)

### DIFF
--- a/app/Core/Configuration/AppSettings.php
+++ b/app/Core/Configuration/AppSettings.php
@@ -9,5 +9,5 @@ class AppSettings
 {
     public string $appVersion = '3.9.8';
 
-    public string $dbVersion = '3.5.25';
+    public string $dbVersion = '3.5.26';
 }

--- a/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
@@ -156,14 +156,22 @@ class EditCanvasItem extends Controller
             $itemId = (int) $params['id'];
             $this->goalService->removeMilestoneFromGoal($itemId, (int) $params['removeMilestone']);
 
+            // getGoalItem() always stamps the goal's REAL projectId on success;
+            // false only for a missing/foreign/unauthorized goal — fail closed
+            // rather than fall back to the SESSION project, which could load
+            // another project's milestone options into the re-rendered picker.
             $canvasItem = $this->goalService->getGoalItem($itemId);
+            if (! $canvasItem) {
+                return $this->tpl->displayPartial('errors.error404');
+            }
+
             $goalMilestones = $this->goalService->getGoalMilestones($itemId);
             $this->tpl->assign('id', $itemId);
             $this->tpl->assign('goalMilestones', $goalMilestones['milestones']);
             $this->tpl->assign('milestoneSummary', $goalMilestones['summary']);
             $this->tpl->assign('milestones', $this->ticketService->getAllMilestones([
                 'sprint' => '', 'type' => 'milestone',
-                'currentProject' => $canvasItem['projectId'] ?? session('currentProject'),
+                'currentProject' => $canvasItem['projectId'],
             ]));
 
             return $this->tpl->displayPartial('goalcanvas::partials.milestonesSection');

--- a/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
+++ b/app/Domain/Goalcanvas/Controllers/EditCanvasItem.php
@@ -149,12 +149,24 @@ class EditCanvasItem extends Controller
         // Detach a milestone edge. State-changing, so it goes through POST (not a
         // GET link) with a CSRF token — the chip's remove control is an hx-post.
         // Authorized by the service (EDIT against the item's real project; a
-        // view-only user is denied). Returns an empty 200 so the caller's
-        // hx-swap="delete" removes just that chip.
+        // view-only user is denied). Returns the re-rendered milestones section
+        // (hx-target="#goalMsSection" outerHTML) so the summary counts and
+        // scroll arrow update with the removed chip, not just the chip node.
         if (isset($params['removeMilestone']) && isset($params['id'])) {
-            $this->goalService->removeMilestoneFromGoal((int) $params['id'], (int) $params['removeMilestone']);
+            $itemId = (int) $params['id'];
+            $this->goalService->removeMilestoneFromGoal($itemId, (int) $params['removeMilestone']);
 
-            return $this->tpl->emptyResponse();
+            $canvasItem = $this->goalService->getGoalItem($itemId);
+            $goalMilestones = $this->goalService->getGoalMilestones($itemId);
+            $this->tpl->assign('id', $itemId);
+            $this->tpl->assign('goalMilestones', $goalMilestones['milestones']);
+            $this->tpl->assign('milestoneSummary', $goalMilestones['summary']);
+            $this->tpl->assign('milestones', $this->ticketService->getAllMilestones([
+                'sprint' => '', 'type' => 'milestone',
+                'currentProject' => $canvasItem['projectId'] ?? session('currentProject'),
+            ]));
+
+            return $this->tpl->displayPartial('goalcanvas::partials.milestonesSection');
         }
 
         if (isset($params['comment']) && isset($params['id'])) {

--- a/app/Domain/Goalcanvas/Repositories/Goalcanvas.php
+++ b/app/Domain/Goalcanvas/Repositories/Goalcanvas.php
@@ -484,6 +484,26 @@ class Goalcanvas extends Blueprints
     }
 
     /**
+     * Resolve a milestone's project id. Null when the id is not a live
+     * milestone-type ticket — the read-auth counterpart of the same-project
+     * validation in addGoalMilestoneLink().
+     */
+    public function getMilestoneProjectId(int $milestoneId): ?int
+    {
+        if ($milestoneId <= 0) {
+            return null;
+        }
+
+        $projectId = $this->dbConnection->table('zp_tickets')
+            ->where('id', $milestoneId)
+            ->where('type', 'milestone')
+            ->where('status', '<>', -1)
+            ->value('projectId');
+
+        return $projectId === null ? null : (int) $projectId;
+    }
+
+    /**
      * Remove a single goal↔milestone link: delete the tracked_by edge and clear
      * the legacy milestoneId column if it still points at this milestone.
      *
@@ -937,12 +957,24 @@ class Goalcanvas extends Blueprints
     /**
      * {@inheritDoc}
      *
-     * Goal boards additionally record metric value changes to zp_goal_history.
+     * Goal boards additionally record metric value changes to zp_goal_history,
+     * and preserve the legacy milestoneId column on payloads that omit it.
      */
     public function editCanvasItem(array $values): void
     {
         $itemId = (int) ($values['itemId'] ?? $values['id'] ?? 0);
         $previousValue = $this->getCurrentGoalValue($itemId);
+
+        // Blueprints::editCanvasItem writes milestoneId unconditionally with
+        // `?? ''`, so a payload that simply omits the key (the edges-driven
+        // goal dialog does, by design) would blank the goal's legacy column on
+        // every save and break the dual-write invariant for column readers.
+        // Absent key = "don't touch", matching the service's edge-sync guard.
+        if (! array_key_exists('milestoneId', $values) && $itemId > 0) {
+            $values['milestoneId'] = (string) ($this->dbConnection->table('zp_canvas_items')
+                ->where('id', $itemId)
+                ->value('milestoneId') ?? '');
+        }
 
         parent::editCanvasItem($values);
 

--- a/app/Domain/Goalcanvas/Services/Goalcanvas.php
+++ b/app/Domain/Goalcanvas/Services/Goalcanvas.php
@@ -32,6 +32,9 @@ class Goalcanvas extends BaseService
 
     private ProjectService $projectService;
 
+    /** @var array<int, int>|null Memoized accessibleProjectIds() result. */
+    private ?array $accessibleProjectIdsCache = null;
+
     public array $reportingSettings = [
         'linkonly',
         'linkAndReport',
@@ -67,7 +70,7 @@ class Goalcanvas extends BaseService
                 array_map(static fn ($g) => (int) $g['id'], $goals)
             );
             foreach ($goals as &$goal) {
-                $goal['milestones'] = $milestonesByGoal[(int) $goal['id']] ?? [];
+                $goal['milestones'] = $this->filterAccessibleMilestones($milestonesByGoal[(int) $goal['id']] ?? []);
                 $progressValue = 0;
                 $goal['goalProgress'] = 0;
                 $total = $goal['endValue'] - $goal['startValue'];
@@ -213,14 +216,19 @@ class Goalcanvas extends BaseService
     }
 
     /**
-     * Goals linked to a milestone. Internal read used by the milestone UI; the data-access is
-     * the milestone the caller is already viewing.
+     * Goals linked to a milestone, authorized for VIEW against the milestone's
+     * project. Reachable beyond the milestone UI (MCP getGoalsByMilestone wraps
+     * it verbatim), so the caller's access to the milestone cannot be assumed —
+     * a missing/foreign/unauthorized milestone returns [] (neutral, no oracle).
      */
     public function getGoalsByMilestone($milestoneId): array
     {
-        $goals = $this->goalRepository->getGoalsByMilestone($milestoneId);
+        $projectId = $this->goalRepository->getMilestoneProjectId((int) $milestoneId);
+        if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
+            return [];
+        }
 
-        return $goals;
+        return $this->goalRepository->getGoalsByMilestone($milestoneId);
     }
 
     /**
@@ -242,7 +250,12 @@ class Goalcanvas extends BaseService
             return ['milestones' => [], 'summary' => $empty];
         }
 
-        $milestones = $this->goalRepository->getMilestonesForGoals([$goalId])[$goalId] ?? [];
+        // Same defensive strip the rollup reads apply — keeps the editor chips
+        // consistent with getMilestonesByGoal/getGoalRollup for any legacy
+        // cross-project rows, and the summary counts what is actually shown.
+        $milestones = $this->filterAccessibleMilestones(
+            $this->goalRepository->getMilestonesForGoals([$goalId])[$goalId] ?? []
+        );
 
         $summary = ['total' => count($milestones)] + $empty;
         foreach ($milestones as $m) {
@@ -302,9 +315,15 @@ class Goalcanvas extends BaseService
         // — status labels + progress — is batched inside the repository). Fill
         // an empty entry for every authorized goal so an @api caller gets a
         // predictable key set, not just the goals that happen to have chips.
+        // Each goal's chips get the same defensive cross-project strip as the
+        // single-goal reads (accessibleProjectIds is memoized, so this stays
+        // one projects lookup for the whole batch).
         return array_replace(
             array_fill_keys($authorized, []),
-            $this->goalRepository->getMilestonesForGoals($authorized)
+            array_map(
+                fn (array $milestones) => $this->filterAccessibleMilestones($milestones),
+                $this->goalRepository->getMilestonesForGoals($authorized)
+            )
         );
     }
 
@@ -481,19 +500,25 @@ class Goalcanvas extends BaseService
     }
 
     /**
-     * Project ids the current user may access.
+     * Project ids the current user may access. Memoized per request — the
+     * filter now runs per goal in batched reads, and the underlying projects
+     * lookup is expensive.
      *
      * @return array<int, int>
      */
     private function accessibleProjectIds(): array
     {
+        if ($this->accessibleProjectIdsCache !== null) {
+            return $this->accessibleProjectIdsCache;
+        }
+
         $projects = $this->projectService->getProjectsUserHasAccessTo();
 
         if (! is_array($projects)) {
-            return [];
+            return $this->accessibleProjectIdsCache = [];
         }
 
-        return array_values(array_filter(
+        return $this->accessibleProjectIdsCache = array_values(array_filter(
             array_map(static fn ($p) => (int) ($p['id'] ?? 0), $projects),
             static fn ($id) => $id > 0
         ));

--- a/app/Domain/Goalcanvas/Services/Goalcanvas.php
+++ b/app/Domain/Goalcanvas/Services/Goalcanvas.php
@@ -223,7 +223,11 @@ class Goalcanvas extends BaseService
      */
     public function getGoalsByMilestone($milestoneId): array
     {
-        $projectId = $this->goalRepository->getMilestoneProjectId((int) $milestoneId);
+        // One cast, used for BOTH the authorization resolve and the read —
+        // authorizing one value and reading another invites drift.
+        $milestoneId = (int) $milestoneId;
+
+        $projectId = $this->goalRepository->getMilestoneProjectId($milestoneId);
         if ($projectId === null || ! $this->can(GoalcanvasPermissions::VIEW, $projectId)) {
             return [];
         }

--- a/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
+++ b/app/Domain/Goalcanvas/Templates/canvasDialog.blade.php
@@ -37,13 +37,11 @@
         .gv-unit{font-size:11px;font-weight:700;color:var(--gv-acc);opacity:.85;}
 
         /* tab bar — report deck style (gradient bar + translucent group + white active pill) */
-        .gv-tabs{display:flex;align-items:center;margin:0 0 22px;background:linear-gradient(90deg,var(--gv-acc),var(--gv-acc2));border-radius:14px;padding:7px 12px;}
-        .gv-tab-group{display:flex;align-items:center;gap:2px;padding:3px;border-radius:11px;background:rgba(255,255,255,.14);border:1px solid rgba(255,255,255,.3);}
-        .gv-tab{background:none;border:none;font-family:inherit;font-size:14px;font-weight:500;color:rgba(255,255,255,.85);padding:8px 15px;cursor:pointer;border-radius:9px;display:inline-flex;align-items:center;gap:7px;transition:color .15s,background .15s;}
+        /* Tab visuals come from the shared floating-pill standard
+           (tab-group.css: .lt-tabs--floating + --onlight for this white
+           modal surface); only the dialog-specific spacing stays here. */
+        .gv-tabs{margin:0 0 22px;}
         .gv-tab i,.gv-tab span[class*="fa"]{font-size:12px;}
-        .gv-tab:hover{color:#fff;background:rgba(255,255,255,.16);}
-        .gv-tab.is-active{color:var(--gv-acc);font-weight:600;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.12);}
-        .gv-tab:focus-visible{outline:2px solid #fff;outline-offset:2px;}
         .gv-panel{min-height:210px;}
         .gv-row{margin-bottom:20px;}
 
@@ -108,12 +106,12 @@
             <input type="hidden" name="changeItem" value="1">
 
             {{-- ── Tabs ── --}}
-            <div class="gv-tabs" role="tablist" aria-label="{{ __('goalcanvas.tabs_label') }}">
-                <div class="gv-tab-group">
-                    <button type="button" class="gv-tab" role="tab" id="gvTab-goal" aria-controls="gvPanel-goal" aria-selected="false" data-tab="goal"><i class="fa-solid fa-bullseye" aria-hidden="true"></i> {{ __('goalcanvas.tab_goal') }}</button>
-                    <button type="button" class="gv-tab" role="tab" id="gvTab-progress" aria-controls="gvPanel-progress" aria-selected="false" data-tab="progress"><i class="fa-solid fa-ranking-star" aria-hidden="true"></i> {{ __('goalcanvas.tab_progress') }}</button>
+            <div class="gv-tabs lt-tabs lt-tabs--floating lt-tabs--onlight" role="tablist" aria-label="{{ __('goalcanvas.tabs_label') }}">
+                <div class="gv-tab-group lt-tabs-group">
+                    <button type="button" class="gv-tab lt-tab" role="tab" id="gvTab-goal" aria-controls="gvPanel-goal" aria-selected="false" data-tab="goal"><i class="fa-solid fa-bullseye" aria-hidden="true"></i> {{ __('goalcanvas.tab_goal') }}</button>
+                    <button type="button" class="gv-tab lt-tab" role="tab" id="gvTab-progress" aria-controls="gvPanel-progress" aria-selected="false" data-tab="progress"><i class="fa-solid fa-ranking-star" aria-hidden="true"></i> {{ __('goalcanvas.tab_progress') }}</button>
                     @if ($id !== '')
-                        <button type="button" class="gv-tab" role="tab" id="gvTab-milestones" aria-controls="gvPanel-milestones" aria-selected="false" data-tab="milestones"><span class="fa fa-flag-checkered" aria-hidden="true"></span> {{ __("headlines.milestones") }}</button>
+                        <button type="button" class="gv-tab lt-tab" role="tab" id="gvTab-milestones" aria-controls="gvPanel-milestones" aria-selected="false" data-tab="milestones"><span class="fa fa-flag-checkered" aria-hidden="true"></span> {{ __("headlines.milestones") }}</button>
                     @endif
                 </div>
             </div>
@@ -215,68 +213,10 @@
             {{-- ── Tab: Milestones ── --}}
             @if ($id !== '')
                 <div class="gv-panel" data-panel="milestones" role="tabpanel" id="gvPanel-milestones" aria-labelledby="gvTab-milestones" tabindex="0">
-                    <div class="gv-ms-head">
-                        @if (($milestoneSummary['total'] ?? 0) > 0)
-                            <span class="gv-ms-summary"><b>{{ $milestoneSummary['total'] }}</b> {{ $milestoneSummary['total'] == 1 ? __("goalcanvas.summary_milestone_one") : __("goalcanvas.summary_milestones") }}
-                                @if ($milestoneSummary['inProgress'] > 0)&middot; {{ $milestoneSummary['inProgress'] }} {{ __("goalcanvas.summary_in_progress") }} @endif
-                                @if ($milestoneSummary['notStarted'] > 0)&middot; {{ $milestoneSummary['notStarted'] }} {{ __("goalcanvas.summary_not_started") }} @endif
-                                @if ($milestoneSummary['done'] > 0)&middot; {{ $milestoneSummary['done'] }} {{ __("goalcanvas.summary_done") }} @endif
-                            </span>
-                        @endif
-                        <span class="gv-ms-actions">
-                            @if ($login::userIsAtLeast($roles::$editor))
-                                <button type="button" class="gv-ms-act helperTooltip" onclick="leantime.goalCanvasController.toggleMilestoneSelectors('new');" data-tippy-content="{{ __('goalcanvas.ms_new') }}" title="{{ __('goalcanvas.ms_new') }}" aria-label="{{ __('goalcanvas.ms_new') }}"><i class="fa fa-plus" aria-hidden="true"></i></button>
-                                @if (count($milestones) > 0)
-                                    <button type="button" class="gv-ms-act helperTooltip" onclick="leantime.goalCanvasController.toggleMilestoneSelectors('existing');" data-tippy-content="{{ __('goalcanvas.ms_link') }}" title="{{ __('goalcanvas.ms_link') }}" aria-label="{{ __('goalcanvas.ms_link') }}"><i class="fa fa-link" aria-hidden="true"></i></button>
-                                @endif
-                            @endif
-                            <i class="fa fa-question-circle-o helperTooltip" aria-hidden="true" data-tippy-content="{{ __("tooltip.link_milestones_tooltip") }}"></i>
-                        </span>
-                    </div>
-
-                    @if (count($goalMilestones) > 0)
-                        <style>
-                            .goalMsWrap{position:relative;}
-                            .goalMsRow{display:flex;gap:8px;overflow-x:auto;overflow-y:hidden;padding-bottom:9px;scroll-snap-type:x proximity;-webkit-overflow-scrolling:touch;}
-                            .goalMsRow::-webkit-scrollbar{height:10px;}
-                            .goalMsRow::-webkit-scrollbar-thumb{background:#9aa7ad;border-radius:10px;border:2px solid transparent;background-clip:padding-box;}
-                            .goalMsRow::-webkit-scrollbar-thumb:hover{background:#7d8b92;}
-                            .goalMsRow::-webkit-scrollbar-track{background:var(--secondary-background,#eef1f2);border-radius:10px;}
-                            .goalMsRow > .goalMsChip{scroll-snap-align:start;transition:border-color .12s;}
-                            .goalMsChip:hover{border-color:var(--primary-color,#004666)!important;}
-                            .goalMsChip .msLink{text-decoration:none;color:inherit;cursor:pointer;display:flex;align-items:center;min-width:0;flex:1;}
-                            .goalMsChip .msLink:hover .msName{color:var(--primary-color,#004666);}
-                            .goalMsNext{position:absolute;right:-3px;top:5px;width:29px;height:29px;border-radius:50%;border:1px solid var(--main-border-color,#e4e7ec);background:var(--primary-background,#fff);color:var(--primary-color,#004666);display:flex;align-items:center;justify-content:center;font-size:19px;line-height:1;cursor:pointer;box-shadow:0 2px 8px rgba(20,40,50,.16);z-index:5;}
-                            .goalMsNext:hover{background:var(--secondary-background,#f2f4f7);}
-                        </style>
-                        <div class="goalMsWrap">
-                            <div class="goalMsRow">
-                                @foreach ($goalMilestones as $ms)
-                                    <div class="goalMsChip" style="position:relative;flex:0 0 auto;min-width:150px;max-width:220px;height:42px;border-radius:9px;border:1px solid var(--main-border-color,#e4e7ec);background:var(--secondary-background,#f2f4f7);overflow:hidden;display:flex;align-items:center;padding:0 10px;">
-                                        <span style="position:absolute;left:0;top:0;bottom:0;width:{{ (int) $ms['percentDone'] }}%;background:{{ $ms['color'] }};opacity:.18;border-right:2px solid {{ $ms['color'] }};"></span>
-                                        <a href="#/tickets/editMilestone/{{ (int) $ms['id'] }}" class="msLink" style="position:relative;z-index:1;" title="{{ __('links.edit_milestone') }}: {{ $ms['headline'] }}">
-                                            <span class="msName" style="flex:1;min-width:0;font-size:12.5px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ $ms['headline'] }}</span>
-                                            <span style="flex:none;font-size:11px;font-weight:600;opacity:.7;margin-left:6px;">{{ (int) $ms['percentDone'] }}%</span>
-                                        </a>
-                                        @if ($login::userIsAtLeast($roles::$editor))
-                                            <button type="button"
-                                                    hx-post="{{ BASE_URL }}/goalcanvas/editCanvasItem/{{ $id }}"
-                                                    hx-vals='{"removeMilestone": {{ (int) $ms['id'] }}}'
-                                                    hx-headers='{"X-CSRF-TOKEN": "{{ csrf_token() }}"}'
-                                                    hx-target="closest .goalMsChip"
-                                                    hx-swap="delete"
-                                                    class="delete"
-                                                    style="position:relative;z-index:1;margin-left:8px;opacity:.6;background:transparent;border:none;cursor:pointer;padding:0;flex:none;"
-                                                    aria-label="{{ __("links.remove") }}: {{ $ms['headline'] }}" title="{{ __("links.remove") }}"><i class="fa fa-close" aria-hidden="true"></i></button>
-                                        @endif
-                                    </div>
-                                @endforeach
-                            </div>
-                            @if (count($goalMilestones) > 2)
-                                <button type="button" class="goalMsNext" onclick="this.parentElement.querySelector('.goalMsRow').scrollBy({left:210,behavior:'smooth'});" aria-label="{{ __('goalcanvas.scroll_more_milestones') }}" title="{{ __('goalcanvas.scroll_more_milestones') }}"><i class="fa fa-angle-right" aria-hidden="true"></i></button>
-                            @endif
-                        </div>
-                    @endif
+                    {{-- Summary + chips live in a partial so the chip-remove
+                         hx-post re-renders the whole section (counts + arrow
+                         stay correct — deleting only the chip left them stale). --}}
+                    @include('goalcanvas::partials.milestonesSection')
 
                     @if ($login::userIsAtLeast($roles::$editor))
                         <div class="row" id="newMilestone" style="display:none;">

--- a/app/Domain/Goalcanvas/Templates/partials/milestonesSection.blade.php
+++ b/app/Domain/Goalcanvas/Templates/partials/milestonesSection.blade.php
@@ -1,0 +1,75 @@
+{{--
+    Goal editor — linked-milestones section (summary line + chip row).
+
+    Lives in its own partial so the chip-remove hx-post can re-render the WHOLE
+    section (hx-target="#goalMsSection" outerHTML): deleting only the chip node
+    left the "N milestones · X in progress" summary and the scroll arrow stale
+    until the modal reopened.
+
+    Expects: $id, $goalMilestones, $milestoneSummary, $milestones (project
+    milestone options — drives the "link existing" button visibility).
+--}}
+<div id="goalMsSection">
+    <div class="gv-ms-head">
+        @if (($milestoneSummary['total'] ?? 0) > 0)
+            <span class="gv-ms-summary"><b>{{ $milestoneSummary['total'] }}</b> {{ $milestoneSummary['total'] == 1 ? __("goalcanvas.summary_milestone_one") : __("goalcanvas.summary_milestones") }}
+                @if ($milestoneSummary['inProgress'] > 0)&middot; {{ $milestoneSummary['inProgress'] }} {{ __("goalcanvas.summary_in_progress") }} @endif
+                @if ($milestoneSummary['notStarted'] > 0)&middot; {{ $milestoneSummary['notStarted'] }} {{ __("goalcanvas.summary_not_started") }} @endif
+                @if ($milestoneSummary['done'] > 0)&middot; {{ $milestoneSummary['done'] }} {{ __("goalcanvas.summary_done") }} @endif
+            </span>
+        @endif
+        <span class="gv-ms-actions">
+            @if ($login::userIsAtLeast($roles::$editor))
+                <button type="button" class="gv-ms-act helperTooltip" onclick="leantime.goalCanvasController.toggleMilestoneSelectors('new');" data-tippy-content="{{ __('goalcanvas.ms_new') }}" title="{{ __('goalcanvas.ms_new') }}" aria-label="{{ __('goalcanvas.ms_new') }}"><i class="fa fa-plus" aria-hidden="true"></i></button>
+                @if (count($milestones) > 0)
+                    <button type="button" class="gv-ms-act helperTooltip" onclick="leantime.goalCanvasController.toggleMilestoneSelectors('existing');" data-tippy-content="{{ __('goalcanvas.ms_link') }}" title="{{ __('goalcanvas.ms_link') }}" aria-label="{{ __('goalcanvas.ms_link') }}"><i class="fa fa-link" aria-hidden="true"></i></button>
+                @endif
+            @endif
+            <i class="fa fa-question-circle-o helperTooltip" aria-hidden="true" data-tippy-content="{{ __("tooltip.link_milestones_tooltip") }}"></i>
+        </span>
+    </div>
+
+    @if (count($goalMilestones) > 0)
+        <style>
+            .goalMsWrap{position:relative;}
+            .goalMsRow{display:flex;gap:8px;overflow-x:auto;overflow-y:hidden;padding-bottom:9px;scroll-snap-type:x proximity;-webkit-overflow-scrolling:touch;}
+            .goalMsRow::-webkit-scrollbar{height:10px;}
+            .goalMsRow::-webkit-scrollbar-thumb{background:#9aa7ad;border-radius:10px;border:2px solid transparent;background-clip:padding-box;}
+            .goalMsRow::-webkit-scrollbar-thumb:hover{background:#7d8b92;}
+            .goalMsRow::-webkit-scrollbar-track{background:var(--secondary-background,#eef1f2);border-radius:10px;}
+            .goalMsRow > .goalMsChip{scroll-snap-align:start;transition:border-color .12s;}
+            .goalMsChip:hover{border-color:var(--primary-color,#004666)!important;}
+            .goalMsChip .msLink{text-decoration:none;color:inherit;cursor:pointer;display:flex;align-items:center;min-width:0;flex:1;}
+            .goalMsChip .msLink:hover .msName{color:var(--primary-color,#004666);}
+            .goalMsNext{position:absolute;right:-3px;top:5px;width:29px;height:29px;border-radius:50%;border:1px solid var(--main-border-color,#e4e7ec);background:var(--primary-background,#fff);color:var(--primary-color,#004666);display:flex;align-items:center;justify-content:center;font-size:19px;line-height:1;cursor:pointer;box-shadow:0 2px 8px rgba(20,40,50,.16);z-index:5;}
+            .goalMsNext:hover{background:var(--secondary-background,#f2f4f7);}
+        </style>
+        <div class="goalMsWrap">
+            <div class="goalMsRow">
+                @foreach ($goalMilestones as $ms)
+                    <div class="goalMsChip" style="position:relative;flex:0 0 auto;min-width:150px;max-width:220px;height:42px;border-radius:9px;border:1px solid var(--main-border-color,#e4e7ec);background:var(--secondary-background,#f2f4f7);overflow:hidden;display:flex;align-items:center;padding:0 10px;">
+                        <span style="position:absolute;left:0;top:0;bottom:0;width:{{ (int) $ms['percentDone'] }}%;background:{{ $ms['color'] }};opacity:.18;border-right:2px solid {{ $ms['color'] }};"></span>
+                        <a href="#/tickets/editMilestone/{{ (int) $ms['id'] }}" class="msLink" style="position:relative;z-index:1;" title="{{ __('links.edit_milestone') }}: {{ $ms['headline'] }}">
+                            <span class="msName" style="flex:1;min-width:0;font-size:12.5px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ $ms['headline'] }}</span>
+                            <span style="flex:none;font-size:11px;font-weight:600;opacity:.7;margin-left:6px;">{{ (int) $ms['percentDone'] }}%</span>
+                        </a>
+                        @if ($login::userIsAtLeast($roles::$editor))
+                            <button type="button"
+                                    hx-post="{{ BASE_URL }}/goalcanvas/editCanvasItem/{{ $id }}"
+                                    hx-vals='{"removeMilestone": {{ (int) $ms['id'] }}}'
+                                    hx-headers='{"X-CSRF-TOKEN": "{{ csrf_token() }}"}'
+                                    hx-target="#goalMsSection"
+                                    hx-swap="outerHTML"
+                                    class="delete"
+                                    style="position:relative;z-index:1;margin-left:8px;opacity:.6;background:transparent;border:none;cursor:pointer;padding:0;flex:none;"
+                                    aria-label="{{ __("links.remove") }}: {{ $ms['headline'] }}" title="{{ __("links.remove") }}"><i class="fa fa-close" aria-hidden="true"></i></button>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+            @if (count($goalMilestones) > 2)
+                <button type="button" class="goalMsNext" onclick="this.parentElement.querySelector('.goalMsRow').scrollBy({left:210,behavior:'smooth'});" aria-label="{{ __('goalcanvas.scroll_more_milestones') }}" title="{{ __('goalcanvas.scroll_more_milestones') }}"><i class="fa fa-angle-right" aria-hidden="true"></i></button>
+            @endif
+        </div>
+    @endif
+</div>

--- a/app/Domain/Goalcanvas/Tools/GetAllGoalsTool.php
+++ b/app/Domain/Goalcanvas/Tools/GetAllGoalsTool.php
@@ -51,8 +51,19 @@ class GetAllGoalsTool extends Tool
             return ToolResult::text("No goals found for project ID: {$projectId}");
         }
 
+        // Milestone links come from the tracked_by edge model (many-to-many),
+        // hydrated in ONE batched call — the legacy milestoneId column goes
+        // stale after edits and misses every link beyond the first.
+        $milestonesByGoal = $this->goalcanvasService->getMilestonesForGoals(
+            array_map(static fn ($g) => (int) $g['id'], $goals)
+        );
+
         $response = "## Goals\n";
         foreach ($goals as $goal) {
+            $milestones = array_map(
+                static fn (array $m) => ($m['headline'] ?? '').' ('.((int) ($m['percentDone'] ?? 0)).'%)',
+                $milestonesByGoal[(int) $goal['id']] ?? []
+            );
             $result = [
                 'id' => $goal['id'],
                 'title' => Str::sanitizeForLLM($goal['title']),
@@ -62,7 +73,7 @@ class GetAllGoalsTool extends Tool
                 'endValue' => $goal['endValue'],
                 'metricType' => $goal['metricType'],
                 'canvasId' => $goal['canvasId'],
-                'milestoneId' => $goal['milestoneId'] ?: 'None',
+                'milestones' => $milestones !== [] ? Str::sanitizeForLLM(implode('; ', $milestones)) : 'None',
                 'startDate' => $goal['startDate'],
                 'endDate' => $goal['endDate'],
                 'status' => $goal['status'],

--- a/app/Domain/Goalcanvas/Tools/GetGoalTool.php
+++ b/app/Domain/Goalcanvas/Tools/GetGoalTool.php
@@ -48,6 +48,14 @@ class GetGoalTool extends Tool
             return ToolResult::error("Goal with ID {$goalId} not found.");
         }
 
+        // Milestones come from the tracked_by edge model (many-to-many), not
+        // the frozen legacy milestoneId column — a goal can have several, and
+        // the column goes stale after edits.
+        $milestones = array_map(
+            static fn (array $m) => ($m['headline'] ?? '').' ('.((int) ($m['percentDone'] ?? 0)).'%, '.($m['statusType'] ?? 'NEW').')',
+            $this->goalcanvasService->getGoalMilestones($goalId)['milestones']
+        );
+
         $response = "## Goal Details\n";
         $result = [
             'id' => $goal['id'],
@@ -61,7 +69,7 @@ class GetGoalTool extends Tool
             'status' => $goal['status'],
             'startDate' => $goal['startDate'],
             'endDate' => $goal['endDate'],
-            'milestone' => Str::sanitizeForLLM($goal['milestoneHeadline'] ?? ''),
+            'milestones' => $milestones !== [] ? Str::sanitizeForLLM(implode('; ', $milestones)) : 'None',
             'author' => $goal['authorFirstname'].' '.$goal['authorLastname'],
             'created' => $goal['created'],
         ];

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3012,6 +3012,7 @@ class Install
             $connection = $this->connection;
             $schema = $connection->getSchemaBuilder();
             if (! $schema->hasTable('zp_canvas_items')
+                || ! $schema->hasTable('zp_canvas')
                 || ! $schema->hasTable('zp_entity_relationship')
                 || ! $schema->hasTable('zp_tickets')
                 || ! $schema->hasColumn('zp_canvas_items', 'milestoneId')) {
@@ -3203,7 +3204,12 @@ class Install
                     $join->on('er.entityA', '=', 'ci.id')->where('ci.box', '=', 'goal');
                 })
                 ->leftJoin('zp_tickets as t', function ($join): void {
-                    $join->on('er.entityB', '=', 't.id')->where('t.type', '=', 'milestone');
+                    // "Live" = milestone-type AND not soft-deleted — matches
+                    // the addGoalMilestoneLink chokepoint's definition, so an
+                    // edge to a deleted milestone counts as orphaned.
+                    $join->on('er.entityB', '=', 't.id')
+                        ->where('t.type', '=', 'milestone')
+                        ->where('t.status', '<>', -1);
                 })
                 ->where('er.relationship', EntityRelationshipEnum::TrackedBy->value)
                 ->where('er.entityAType', 'GoalItem')

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -3016,6 +3016,10 @@ class Install
                 || ! $schema->hasTable('zp_entity_relationship')
                 || ! $schema->hasTable('zp_tickets')
                 || ! $schema->hasColumn('zp_canvas_items', 'milestoneId')) {
+                // Surface the skip in the update log — a partial install
+                // silently no-oping would be invisible otherwise.
+                Log::info('Migration 30524 skipped: required tables/columns missing (partial install?)');
+
                 return true;
             }
 
@@ -3182,6 +3186,10 @@ class Install
                 || ! $schema->hasTable('zp_canvas_items')
                 || ! $schema->hasTable('zp_canvas')
                 || ! $schema->hasTable('zp_tickets')) {
+                // Surface the skip in the update log — a partial install
+                // silently no-oping would be invisible otherwise.
+                Log::info('Migration 30526 skipped: required tables missing (partial install?)');
+
                 return true;
             }
 

--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -98,6 +98,7 @@ class Install
         30523,
         30524,
         30525,
+        30526,
     ];
 
     /**
@@ -3036,6 +3037,7 @@ class Install
                     // varchar, so trim before the digit check.
                     $pairs = [];
                     $milestoneIds = [];
+                    $canvasIds = [];
                     foreach ($goals as $g) {
                         $raw = trim((string) $g->milestoneId);
                         if (! ctype_digit($raw)) {
@@ -3045,8 +3047,9 @@ class Install
                         if ($mid <= 0) {
                             continue;
                         }
-                        $pairs[] = ['goalId' => (int) $g->id, 'milestoneId' => $mid, 'author' => $g->author];
+                        $pairs[] = ['goalId' => (int) $g->id, 'milestoneId' => $mid, 'author' => $g->author, 'canvasId' => (int) $g->canvasId];
                         $milestoneIds[$mid] = true;
+                        $canvasIds[(int) $g->canvasId] = true;
                     }
 
                     if ($pairs === []) {
@@ -3057,10 +3060,23 @@ class Install
 
                     // Drop edges to deleted milestones + dedup existing edges,
                     // both scoped to this chunk's ids — O(1) lookups, no N+1.
-                    $liveTickets = array_flip(array_map(
-                        'intval',
-                        $this->connection->table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->where('type', 'milestone')->where('status', '<>', -1)->pluck('id')->all()
-                    ));
+                    // The milestone lookup keeps projectId: links are
+                    // same-project only (product rule), so a legacy
+                    // cross-project row must NOT be promoted to an edge.
+                    $liveTickets = [];
+                    foreach (
+                        $this->connection->table('zp_tickets')->whereIn('id', array_keys($milestoneIds))->where('type', 'milestone')->where('status', '<>', -1)->get(['id', 'projectId']) as $t
+                    ) {
+                        $liveTickets[(int) $t->id] = (int) $t->projectId;
+                    }
+
+                    // Goal projects, resolved via each goal's canvas (chunk-scoped).
+                    $projectByCanvas = [];
+                    foreach (
+                        $this->connection->table('zp_canvas')->whereIn('id', array_keys($canvasIds))->get(['id', 'projectId']) as $c
+                    ) {
+                        $projectByCanvas[(int) $c->id] = (int) $c->projectId;
+                    }
 
                     $existingEdges = [];
                     foreach (
@@ -3078,6 +3094,12 @@ class Install
                     $rows = [];
                     foreach ($pairs as $p) {
                         if (! isset($liveTickets[$p['milestoneId']])) {
+                            continue;
+                        }
+                        // Same-project only: skip legacy rows pointing at a
+                        // milestone in a different project than the goal's.
+                        if (! isset($projectByCanvas[$p['canvasId']])
+                            || $liveTickets[$p['milestoneId']] !== $projectByCanvas[$p['canvasId']]) {
                             continue;
                         }
                         if (isset($existingEdges[$p['goalId'].':'.$p['milestoneId']])) {
@@ -3132,5 +3154,76 @@ class Install
         }
 
         return $result;
+    }
+
+    /**
+     * update_sql_30526 — database update for v3.5.26.
+     *
+     * Hygiene pass over the goal↔milestone `tracked_by` edges:
+     *  1. Removes CROSS-PROJECT edges — links are same-project only (product
+     *     rule), but the original 30524/30525 backfill promoted legacy
+     *     cross-project `milestoneId` rows into edges before the guard existed.
+     *  2. Removes ORPHANED edges — a milestone deleted through the generic
+     *     ticket-delete path (which historically skipped the goal-detach
+     *     cascade) or a goal removed out-of-band leaves edges pointing at
+     *     rows that no longer exist.
+     *
+     * Query-builder only (portable) and naturally idempotent: a clean graph
+     * yields zero deletions.
+     */
+    public function update_sql_30526(): bool|array
+    {
+        try {
+            /** @var \Illuminate\Database\Connection $connection */
+            $connection = $this->connection;
+            $schema = $connection->getSchemaBuilder();
+            if (! $schema->hasTable('zp_entity_relationship')
+                || ! $schema->hasTable('zp_canvas_items')
+                || ! $schema->hasTable('zp_canvas')
+                || ! $schema->hasTable('zp_tickets')) {
+                return true;
+            }
+
+            // Cross-project edges: goal's canvas project != milestone's project.
+            $crossProject = $this->connection->table('zp_entity_relationship as er')
+                ->join('zp_canvas_items as ci', 'er.entityA', '=', 'ci.id')
+                ->join('zp_canvas as cb', 'ci.canvasId', '=', 'cb.id')
+                ->join('zp_tickets as t', 'er.entityB', '=', 't.id')
+                ->where('er.relationship', EntityRelationshipEnum::TrackedBy->value)
+                ->where('er.entityAType', 'GoalItem')
+                ->where('er.entityBType', 'Ticket')
+                ->whereColumn('t.projectId', '<>', 'cb.projectId')
+                ->pluck('er.id')
+                ->all();
+
+            // Orphans: entityA no longer a goal item, or entityB no longer a
+            // live milestone ticket.
+            $orphaned = $this->connection->table('zp_entity_relationship as er')
+                ->leftJoin('zp_canvas_items as ci', function ($join): void {
+                    $join->on('er.entityA', '=', 'ci.id')->where('ci.box', '=', 'goal');
+                })
+                ->leftJoin('zp_tickets as t', function ($join): void {
+                    $join->on('er.entityB', '=', 't.id')->where('t.type', '=', 'milestone');
+                })
+                ->where('er.relationship', EntityRelationshipEnum::TrackedBy->value)
+                ->where('er.entityAType', 'GoalItem')
+                ->where('er.entityBType', 'Ticket')
+                ->where(function ($q): void {
+                    $q->whereNull('ci.id')->orWhereNull('t.id');
+                })
+                ->pluck('er.id')
+                ->all();
+
+            $ids = array_values(array_unique(array_map('intval', array_merge($crossProject, $orphaned))));
+            foreach (array_chunk($ids, 500) as $chunk) {
+                $this->connection->table('zp_entity_relationship')->whereIn('id', $chunk)->delete();
+            }
+        } catch (\Exception $e) {
+            Log::error('Migration 30526: '.$e->getMessage());
+
+            return ['Migration 30526 failed: '.$e->getMessage()];
+        }
+
+        return true;
     }
 }

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -3680,6 +3680,14 @@ class Tickets extends BaseService
             return ['msg' => 'notifications.ticket_delete_error', 'type' => 'error'];
         }
 
+        // Milestones carry goal tracked_by edges (and child-ticket links) that
+        // only deleteMilestone() cascades — deleting one through the generic
+        // path would strand orphaned edges. Route by actual type, not by which
+        // entry point the caller happened to use.
+        if (($ticket->type ?? '') === 'milestone') {
+            return $this->deleteMilestone($id);
+        }
+
         // Editor+ in the ticket's project AND access to it (was access-only, no role gate).
         $this->authorize(TicketsPermissions::DELETE, (int) $ticket->projectId);
 

--- a/tests/Unit/app/Domain/Goalcanvas/Services/GoalcanvasServiceTest.php
+++ b/tests/Unit/app/Domain/Goalcanvas/Services/GoalcanvasServiceTest.php
@@ -658,23 +658,49 @@ class GoalcanvasServiceTest extends TestCase
 
     public function test_get_goal_milestones_returns_chips_and_summarizes_by_status(): void
     {
+        // Chips carry their projectId and pass the accessible-projects strip.
         $repo = $this->make(GoalcanvaRepository::class, [
             'getCanvasItemProjectId' => fn () => 9,
             'getMilestonesForGoals' => fn () => [
                 7 => [
-                    ['id' => 1, 'headline' => 'A', 'statusType' => 'DONE'],
-                    ['id' => 2, 'headline' => 'B', 'statusType' => 'INPROGRESS'],
-                    ['id' => 3, 'headline' => 'C', 'statusType' => 'NEW'],
-                    ['id' => 4, 'headline' => 'D', 'statusType' => 'NEW'],
+                    ['id' => 1, 'headline' => 'A', 'statusType' => 'DONE', 'projectId' => 9],
+                    ['id' => 2, 'headline' => 'B', 'statusType' => 'INPROGRESS', 'projectId' => 9],
+                    ['id' => 3, 'headline' => 'C', 'statusType' => 'NEW', 'projectId' => 9],
+                    ['id' => 4, 'headline' => 'D', 'statusType' => 'NEW', 'projectId' => 9],
                 ],
             ],
         ]);
 
-        $result = $this->service($repo)->getGoalMilestones(7);
+        $result = $this->service($repo, projects: $this->projectsWithAccess([9]))->getGoalMilestones(7);
 
         $this->assertCount(4, $result['milestones']);
         $this->assertSame(
             ['total' => 4, 'done' => 1, 'inProgress' => 1, 'notStarted' => 2],
+            $result['summary'],
+        );
+    }
+
+    public function test_get_goal_milestones_strips_legacy_cross_project_chips_and_counts_only_shown(): void
+    {
+        // Same defensive strip as the rollup reads: a legacy cross-project row
+        // (milestone in project 8, caller can only access 9) must not surface
+        // in the editor chips, and the summary counts what is actually shown.
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getCanvasItemProjectId' => fn () => 9,
+            'getMilestonesForGoals' => fn () => [
+                7 => [
+                    ['id' => 1, 'headline' => 'Mine', 'statusType' => 'DONE', 'projectId' => 9],
+                    ['id' => 2, 'headline' => 'Foreign', 'statusType' => 'INPROGRESS', 'projectId' => 8],
+                ],
+            ],
+        ]);
+
+        $result = $this->service($repo, projects: $this->projectsWithAccess([9]))->getGoalMilestones(7);
+
+        $this->assertCount(1, $result['milestones']);
+        $this->assertSame('Mine', $result['milestones'][0]['headline']);
+        $this->assertSame(
+            ['total' => 1, 'done' => 1, 'inProgress' => 0, 'notStarted' => 0],
             $result['summary'],
         );
     }
@@ -724,18 +750,67 @@ class GoalcanvasServiceTest extends TestCase
         $repo = $this->make(GoalcanvaRepository::class, [
             'getCanvasItemProjectIds' => fn () => [1 => 7, 2 => 8],
             'getMilestonesForGoals' => fn (array $ids) => in_array(1, $ids, true)
-                ? [1 => [['id' => 10, 'headline' => 'M1']]]
+                ? [1 => [['id' => 10, 'headline' => 'M1', 'projectId' => 7]]]
                 : [],
         ]);
         $perms = $this->make(PermissionService::class, [
             'currentUserCan' => fn (string $permission, ?int $projectId = null) => $projectId === 7,
         ]);
 
-        $result = $this->service($repo, $perms)->getMilestonesForGoals([1, 2]);
+        $result = $this->service($repo, $perms, $this->projectsWithAccess([7]))->getMilestonesForGoals([1, 2]);
 
         $this->assertArrayHasKey(1, $result, 'authorized goal is present');
         $this->assertArrayNotHasKey(2, $result, 'unauthorized goal is omitted');
-        $this->assertSame([['id' => 10, 'headline' => 'M1']], $result[1]);
+        $this->assertSame([['id' => 10, 'headline' => 'M1', 'projectId' => 7]], $result[1]);
+    }
+
+    public function test_get_goals_by_milestone_soft_denies_unknown_or_foreign_milestone(): void
+    {
+        // The MCP getGoalsByMilestone tool wraps this verbatim, so the service
+        // itself must gate: an unknown/non-milestone id returns [] without
+        // reading any goals (no oracle).
+        $read = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getMilestoneProjectId' => fn () => null,
+            'getGoalsByMilestone' => function () use (&$read) {
+                $read++;
+
+                return [['id' => 1]];
+            },
+        ]);
+
+        $this->assertSame([], $this->service($repo)->getGoalsByMilestone(999));
+        $this->assertSame(0, $read, 'goals must not be read for an unresolvable milestone');
+    }
+
+    public function test_get_goals_by_milestone_soft_denies_when_view_not_permitted(): void
+    {
+        $read = 0;
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getMilestoneProjectId' => fn () => 8,
+            'getGoalsByMilestone' => function () use (&$read) {
+                $read++;
+
+                return [['id' => 1]];
+            },
+        ]);
+        $perms = $this->make(PermissionService::class, ['currentUserCan' => fn () => false]);
+
+        $this->assertSame([], $this->service($repo, $perms)->getGoalsByMilestone(5));
+        $this->assertSame(0, $read, 'VIEW-denied returns [] without reading goals');
+    }
+
+    public function test_get_goals_by_milestone_returns_goals_for_an_accessible_milestone(): void
+    {
+        $repo = $this->make(GoalcanvaRepository::class, [
+            'getMilestoneProjectId' => fn () => 9,
+            'getGoalsByMilestone' => fn () => [['id' => 1, 'title' => 'G']],
+        ]);
+
+        $this->assertSame(
+            [['id' => 1, 'title' => 'G']],
+            $this->service($repo)->getGoalsByMilestone(5)
+        );
     }
 
     public function test_get_milestones_for_goals_is_empty_safe(): void

--- a/tests/Unit/app/Domain/Install/UpdateSql30524Test.php
+++ b/tests/Unit/app/Domain/Install/UpdateSql30524Test.php
@@ -17,24 +17,31 @@ use Unit\TestCase;
  * pinned here with a faked connection — no DB.
  *
  * Covers: correct edge direction, junk/non-numeric skipped, deleted /
- * non-milestone tickets skipped, NULL author for unknown, idempotent re-run
- * (existing edge not duplicated), and the table-guard no-op.
+ * non-milestone tickets skipped, SAME-PROJECT enforcement (a legacy
+ * cross-project row is never promoted to an edge), NULL author for unknown,
+ * idempotent re-run (existing edge not duplicated), and the table-guard no-op.
  */
 class UpdateSql30524Test extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
     /**
-     * Run update_sql_30524 against a fully-faked connection.
+     * Run update_sql_30524 against a fully-faked, TABLE-AWARE connection.
      *
-     * @param  array<int, object>  $canvasGoals  rows shaped {id, milestoneId, author}
-     * @param  int[]  $liveMilestoneIds  ticket ids that are live milestones
+     * @param  array<int, object>  $canvasGoals  rows shaped {id, milestoneId, author, canvasId}
+     * @param  array<int, int>  $liveMilestones  ticket id => projectId for live milestones
+     * @param  array<int, int>  $canvasProjects  canvas id => projectId
      * @param  array<int, array{0:int,1:int}>  $existingEdges  [goalId, milestoneId] pairs already linked
      * @param  bool  $tablesExist  Schema-guard toggle: false makes hasTable/hasColumn report missing tables (the no-op path)
      * @return array{result: mixed, inserted: array<int, array<string, mixed>>}
      */
-    private function runMigration(array $canvasGoals, array $liveMilestoneIds, array $existingEdges, bool $tablesExist = true): array
-    {
+    private function runMigration(
+        array $canvasGoals,
+        array $liveMilestones,
+        array $canvasProjects,
+        array $existingEdges,
+        bool $tablesExist = true
+    ): array {
         $inserted = [];
         $capture = function ($rows) use (&$inserted): void {
             foreach ($rows as $row) {
@@ -49,7 +56,7 @@ class UpdateSql30524Test extends TestCase
         $conn = Mockery::mock(ConnectionInterface::class);
         $conn->shouldReceive('getSchemaBuilder')->andReturn($schema);
         $conn->shouldReceive('table')->andReturnUsing(
-            fn (string $table) => $this->fakeBuilder($canvasGoals, $liveMilestoneIds, $existingEdges, $capture)
+            fn (string $table) => $this->fakeBuilder($table, $canvasGoals, $liveMilestones, $canvasProjects, $existingEdges, $capture)
         );
 
         $install = (new \ReflectionClass(Install::class))->newInstanceWithoutConstructor();
@@ -61,17 +68,26 @@ class UpdateSql30524Test extends TestCase
     }
 
     /**
-     * One fake builder serves all three tables — the migration uses a distinct
-     * terminal on each (chunkById on zp_canvas_items, pluck on zp_tickets,
-     * get/insert on zp_entity_relationship), so there is no cross-talk.
+     * The builder is table-aware: the migration reads goal rows (chunkById on
+     * zp_canvas_items), live milestones with their project (get on zp_tickets),
+     * goal projects via canvases (get on zp_canvas), and existing edges
+     * (get on zp_entity_relationship) — each table serves its own shape.
      */
-    private function fakeBuilder(array $canvasGoals, array $liveMilestoneIds, array $existingEdges, callable $capture): object
-    {
-        return new class($canvasGoals, $liveMilestoneIds, $existingEdges, $capture)
+    private function fakeBuilder(
+        string $table,
+        array $canvasGoals,
+        array $liveMilestones,
+        array $canvasProjects,
+        array $existingEdges,
+        callable $capture
+    ): object {
+        return new class($table, $canvasGoals, $liveMilestones, $canvasProjects, $existingEdges, $capture)
         {
             public function __construct(
+                private string $table,
                 private array $canvasGoals,
-                private array $liveMilestoneIds,
+                private array $liveMilestones,
+                private array $canvasProjects,
                 private array $existingEdges,
                 private $capture
             ) {}
@@ -108,13 +124,24 @@ class UpdateSql30524Test extends TestCase
                 return true;
             }
 
-            public function pluck($column)
-            {
-                return collect($this->liveMilestoneIds);
-            }
-
             public function get($columns = ['*'])
             {
+                if ($this->table === 'zp_tickets') {
+                    return collect(array_map(
+                        fn ($id, $projectId) => (object) ['id' => $id, 'projectId' => $projectId],
+                        array_keys($this->liveMilestones),
+                        array_values($this->liveMilestones)
+                    ));
+                }
+                if ($this->table === 'zp_canvas') {
+                    return collect(array_map(
+                        fn ($id, $projectId) => (object) ['id' => $id, 'projectId' => $projectId],
+                        array_keys($this->canvasProjects),
+                        array_values($this->canvasProjects)
+                    ));
+                }
+
+                // zp_entity_relationship — the existing-edge dedup read.
                 return collect(array_map(
                     fn ($e) => (object) ['entityA' => $e[0], 'entityB' => $e[1]],
                     $this->existingEdges
@@ -130,16 +157,17 @@ class UpdateSql30524Test extends TestCase
         };
     }
 
-    private function goal(int $id, ?string $milestoneId, ?int $author): object
+    private function goal(int $id, ?string $milestoneId, ?int $author, int $canvasId = 1): object
     {
-        return (object) ['id' => $id, 'milestoneId' => $milestoneId, 'author' => $author];
+        return (object) ['id' => $id, 'milestoneId' => $milestoneId, 'author' => $author, 'canvasId' => $canvasId];
     }
 
     public function test_backfills_a_tracked_by_edge_in_the_correct_direction(): void
     {
         $out = $this->runMigration(
             canvasGoals: [$this->goal(5, '42', 7)],
-            liveMilestoneIds: [42],
+            liveMilestones: [42 => 1],
+            canvasProjects: [1 => 1],
             existingEdges: [],
         );
 
@@ -158,7 +186,8 @@ class UpdateSql30524Test extends TestCase
     {
         $out = $this->runMigration(
             canvasGoals: [$this->goal(6, 'abc', 1), $this->goal(7, '   ', 1), $this->goal(8, '4x', 1)],
-            liveMilestoneIds: [42],
+            liveMilestones: [42 => 1],
+            canvasProjects: [1 => 1],
             existingEdges: [],
         );
 
@@ -171,18 +200,52 @@ class UpdateSql30524Test extends TestCase
         // (deleted, or demoted to a task).
         $out = $this->runMigration(
             canvasGoals: [$this->goal(9, '99', 1)],
-            liveMilestoneIds: [],
+            liveMilestones: [],
+            canvasProjects: [1 => 1],
             existingEdges: [],
         );
 
         $this->assertSame([], $out['inserted'], 'a milestone that is not live is not backfilled');
     }
 
+    public function test_skips_cross_project_legacy_rows(): void
+    {
+        // Product rule: goal↔milestone links are SAME-PROJECT only. A legacy
+        // column row pointing at another project's milestone must not be
+        // promoted into a first-class edge (goal's canvas 1 -> project 1;
+        // milestone 42 lives in project 2).
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(5, '42', 7, canvasId: 1)],
+            liveMilestones: [42 => 2],
+            canvasProjects: [1 => 1],
+            existingEdges: [],
+        );
+
+        $this->assertSame([], $out['inserted'], 'a cross-project legacy row is never promoted to an edge');
+    }
+
+    public function test_migrates_same_project_rows_alongside_skipped_cross_project_ones(): void
+    {
+        // Mixed chunk: goal 5's milestone is same-project (migrates), goal 6's
+        // is cross-project (skipped) — the guard is per-pair, not per-chunk.
+        $out = $this->runMigration(
+            canvasGoals: [$this->goal(5, '42', 7, canvasId: 1), $this->goal(6, '43', 7, canvasId: 1)],
+            liveMilestones: [42 => 1, 43 => 2],
+            canvasProjects: [1 => 1],
+            existingEdges: [],
+        );
+
+        $this->assertCount(1, $out['inserted']);
+        $this->assertSame(5, $out['inserted'][0]['entityA']);
+        $this->assertSame(42, $out['inserted'][0]['entityB']);
+    }
+
     public function test_is_idempotent_when_the_edge_already_exists(): void
     {
         $out = $this->runMigration(
             canvasGoals: [$this->goal(5, '42', 7)],
-            liveMilestoneIds: [42],
+            liveMilestones: [42 => 1],
+            canvasProjects: [1 => 1],
             existingEdges: [[5, 42]],
         );
 
@@ -193,7 +256,8 @@ class UpdateSql30524Test extends TestCase
     {
         $out = $this->runMigration(
             canvasGoals: [$this->goal(9, '42', null)],
-            liveMilestoneIds: [42],
+            liveMilestones: [42 => 1],
+            canvasProjects: [1 => 1],
             existingEdges: [],
         );
 
@@ -205,7 +269,8 @@ class UpdateSql30524Test extends TestCase
     {
         $out = $this->runMigration(
             canvasGoals: [$this->goal(5, '42', 7)],
-            liveMilestoneIds: [42],
+            liveMilestones: [42 => 1],
+            canvasProjects: [1 => 1],
             existingEdges: [],
             tablesExist: false,
         );

--- a/tests/Unit/app/Domain/Install/UpdateSql30526Test.php
+++ b/tests/Unit/app/Domain/Install/UpdateSql30526Test.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Unit\app\Domain\Install;
+
+use Illuminate\Database\ConnectionInterface;
+use Leantime\Domain\Install\Repositories\Install;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Unit\TestCase;
+
+/**
+ * Regression tests for migration update_sql_30526 — the hygiene pass that
+ * deletes goal↔milestone `tracked_by` edges violating the same-project product
+ * rule (promoted by the pre-guard 30524/30525 backfill) and edges orphaned by
+ * the pre-cascade generic ticket delete. Behavior pinned with a faked
+ * connection — no DB.
+ *
+ * The migration issues two pluck reads on the aliased edge table (cross-project
+ * first, then orphans) and one chunked whereIn-delete on the plain table; the
+ * fake serves them in that order.
+ */
+class UpdateSql30526Test extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @param  int[]  $crossProjectIds  edge ids the cross-project read returns
+     * @param  int[]  $orphanIds  edge ids the orphan read returns
+     * @return array{result: mixed, deleted: int[]}
+     */
+    private function runMigration(array $crossProjectIds, array $orphanIds, bool $tablesExist = true): array
+    {
+        $deleted = [];
+        // The two aliased pluck reads arrive in a fixed order (cross-project,
+        // then orphans) — serve them from a queue shared across builder
+        // instances.
+        $pluckQueue = new \ArrayObject([$crossProjectIds, $orphanIds]);
+
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasTable')->andReturn($tablesExist);
+
+        $conn = Mockery::mock(ConnectionInterface::class);
+        $conn->shouldReceive('getSchemaBuilder')->andReturn($schema);
+        $conn->shouldReceive('table')->andReturnUsing(
+            function (string $table) use ($pluckQueue, &$deleted) {
+                return new class($pluckQueue, $deleted)
+                {
+                    private array $whereInIds = [];
+
+                    public function __construct(private \ArrayObject $pluckQueue, private array &$deleted) {}
+
+                    public function join(...$a): static
+                    {
+                        return $this;
+                    }
+
+                    public function leftJoin(...$a): static
+                    {
+                        return $this;
+                    }
+
+                    public function where(...$a): static
+                    {
+                        return $this;
+                    }
+
+                    public function whereColumn(...$a): static
+                    {
+                        return $this;
+                    }
+
+                    public function whereIn($column, $ids): static
+                    {
+                        $this->whereInIds = $ids;
+
+                        return $this;
+                    }
+
+                    public function pluck($column)
+                    {
+                        $sets = $this->pluckQueue->getArrayCopy();
+                        $next = array_shift($sets);
+                        $this->pluckQueue->exchangeArray($sets);
+
+                        return collect($next ?? []);
+                    }
+
+                    public function delete(): int
+                    {
+                        foreach ($this->whereInIds as $id) {
+                            $this->deleted[] = (int) $id;
+                        }
+
+                        return count($this->whereInIds);
+                    }
+                };
+            }
+        );
+
+        $install = (new \ReflectionClass(Install::class))->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(Install::class, 'connection');
+        $prop->setAccessible(true);
+        $prop->setValue($install, $conn);
+
+        return ['result' => $install->update_sql_30526(), 'deleted' => $deleted];
+    }
+
+    public function test_deletes_cross_project_and_orphaned_edges(): void
+    {
+        $out = $this->runMigration(crossProjectIds: [11, 12], orphanIds: [13]);
+
+        $this->assertTrue($out['result']);
+        $this->assertSame([11, 12, 13], $out['deleted']);
+    }
+
+    public function test_deduplicates_an_edge_that_is_both_cross_project_and_orphaned(): void
+    {
+        $out = $this->runMigration(crossProjectIds: [11], orphanIds: [11, 12]);
+
+        $this->assertTrue($out['result']);
+        $this->assertSame([11, 12], $out['deleted'], 'an id in both sets is deleted once');
+    }
+
+    public function test_a_clean_graph_deletes_nothing(): void
+    {
+        $out = $this->runMigration(crossProjectIds: [], orphanIds: []);
+
+        $this->assertTrue($out['result']);
+        $this->assertSame([], $out['deleted']);
+    }
+
+    public function test_is_a_no_op_when_the_required_tables_are_absent(): void
+    {
+        $out = $this->runMigration(crossProjectIds: [11], orphanIds: [12], tablesExist: false);
+
+        $this->assertTrue($out['result']);
+        $this->assertSame([], $out['deleted'], 'missing schema short-circuits before any delete');
+    }
+}


### PR DESCRIPTION
Follow-up to the multi-agent audit of the goal↔milestone many-to-many feature (#3690 + #3725). The core of the feature checked out healthy — fail-closed edge chokepoint, clean live graph, 49/49 tests — but the audit confirmed a set of boundary gaps. This PR closes the core-repo ones (the plugin surface lands separately in Leantime/plugins#95).

## Security
- **`getGoalsByMilestone` authorizes the caller** against the milestone's real project (new `getMilestoneProjectId` resolver, VIEW-gated, neutral `[]` on deny). The MCP `getGoalsByMilestone` tool wraps this method verbatim and previously let any authenticated user read goal titles/descriptions/KPI values from projects they cannot access. (The JSON-RPC leg was already safe — no `@api` tag.)
- **Read-side filter consistency**: the editor chips, batch hydration, and board chip-attach now apply the same accessible-projects strip as the mobile/rollup reads, so a legacy cross-project row can't surface a foreign milestone anywhere. `accessibleProjectIds()` memoized.

## Dual-write repair
- The Goalcanvas repo's `editCanvasItem` **preserves the legacy `milestoneId` column when the payload omits the key** — the edges-driven dialog omits it by design, and the base repo's unconditional `?? ''` write was blanking the column on *every* goal save, rotting every column-based reader in real time.
- **Generic `Tickets::delete()` on a milestone routes through `deleteMilestone()`**, so the goal-detach cascade always runs — the generic path previously stranded orphaned `tracked_by` edges.

## Readers → edges
- MCP `GetGoalTool` / `GetAllGoalsTool` now report milestones from the edge model (one batched call) instead of the frozen column — edge-only links and second..Nth milestones were invisible to AI tools.

## UX
- Goal dialog chip removal re-renders the whole milestones section (new `goalcanvas::partials.milestonesSection`), so the "N milestones · X in progress" summary and scroll arrow update with the removal instead of going stale until the modal reopens. Verified live round-trip.

## Migrations
- The 30524/30525 backfill now enforces the **same-project product rule** — a legacy cross-project `milestoneId` row is never promoted to an edge.
- New **`update_sql_30526`** (dbVersion → 3.5.26): deletes cross-project `tracked_by` edges minted before the guard and edges orphaned by the pre-cascade delete path. Query-builder only, idempotent; a clean graph deletes nothing (verified live on a dev install).

## Tests
Migration harness rewritten table-aware with cross-project scenarios; new `UpdateSql30526Test`; new service tests for the milestone auth gate and the chip strip. 66 unit tests green, Pint + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYSPNgLdUwEnxgYqTxMc85