### PR TITLE
fix(install): self-heal a missing zp_access_tokens so 30504 can't block upgrades

### DIFF
--- a/app/Domain/Install/Repositories/Install.php
+++ b/app/Domain/Install/Repositories/Install.php
@@ -2004,7 +2004,7 @@ class Install
         $errors = [];
 
         $sql = [
-            'CREATE TABLE `zp_access_tokens` (
+            'CREATE TABLE IF NOT EXISTS `zp_access_tokens` (
                     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
                     `tokenable_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
                     `tokenable_id` bigint unsigned NOT NULL,
@@ -2019,7 +2019,7 @@ class Install
                     UNIQUE KEY `personal_access_tokens_token_unique` (`token`),
                     KEY `personal_access_tokens_tokenable_type_tokenable_id_index` (`tokenable_type`,`tokenable_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;',
-            'CREATE TABLE `zp_jobs` (
+            'CREATE TABLE IF NOT EXISTS `zp_jobs` (
                     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
                     `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
                     `payload` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -2055,7 +2055,16 @@ class Install
             } catch (\Exception $e) {
                 Log::error($statement.' Failed:'.$e->getMessage());
                 Log::error($e);
+                $errors[] = 'Migration 30400 failed: '.$e->getMessage();
             }
+        }
+
+        // Report failures instead of returning true regardless. Swallowing them here is what
+        // let installs record 3.4.0 as applied while zp_access_tokens did not exist, which
+        // then broke every subsequent upgrade at 30504 (#3706). The creates above are
+        // IF NOT EXISTS, so a re-run on a healthy install is still a no-op.
+        if ($errors !== []) {
+            return $errors;
         }
 
         return true;
@@ -2654,6 +2663,18 @@ class Install
     public function update_sql_30504(): bool|array
     {
         try {
+            // Self-heal a missing table rather than dying on it (#3706). zp_access_tokens is
+            // created by update_sql_30400, but that migration wrapped its statements in a
+            // swallow-everything try/catch and still returned success — so an install whose
+            // CREATE TABLE failed recorded 3.4.0 as applied with no table to show for it, and
+            // every later upgrade died here on "1146 Table 'zp_access_tokens' doesn't exist"
+            // with no way forward. Recreating it is safe: the table only holds API tokens, and
+            // an install that never had one has none to lose.
+            if (! Schema::hasTable('zp_access_tokens')) {
+                Log::warning('Migration 30504: zp_access_tokens missing, recreating it before adding push columns.');
+                app()->make(SchemaBuilder::class)->createAccessTokensTable();
+            }
+
             Schema::table('zp_access_tokens', function (Blueprint $table) {
                 if (! Schema::hasColumn('zp_access_tokens', 'push_token')) {
                     $table->string('push_token', 255)->nullable()->after('expires_at');

--- a/app/Domain/Install/Services/SchemaBuilder.php
+++ b/app/Domain/Install/Services/SchemaBuilder.php
@@ -882,8 +882,13 @@ class SchemaBuilder
 
     /**
      * Create zp_access_tokens table (Laravel Sanctum personal access tokens).
+     *
+     * Public because update_sql_30504() reuses it to self-heal installs that
+     * reached that migration without the table (see #3706). Keeping one
+     * definition here also keeps the create database-agnostic, unlike the raw
+     * MySQL in update_sql_30400().
      */
-    private function createAccessTokensTable(): void
+    public function createAccessTokensTable(): void
     {
         Schema::create('zp_access_tokens', function (Blueprint $table) {
             $table->id();

--- a/tests/Unit/app/Domain/Install/UpdateSql30504Test.php
+++ b/tests/Unit/app/Domain/Install/UpdateSql30504Test.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Unit\app\Domain\Install;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Leantime\Domain\Install\Repositories\Install;
+use Leantime\Domain\Install\Services\SchemaBuilder;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Unit\TestCase;
+
+/**
+ * Regression tests for migration update_sql_30504 (#3706) — the push-notification
+ * columns on zp_access_tokens.
+ *
+ * The migration used to ALTER the table unguarded. Installs whose zp_access_tokens
+ * was never created (update_sql_30400 swallowed a failed CREATE and still returned
+ * success, so 3.4.0 was recorded as applied) then hit
+ * "1146 Table 'zp_access_tokens' doesn't exist" here and could not upgrade at all.
+ *
+ * These pin the self-heal: create the table when it is missing, and leave it alone
+ * when it is not — no DB, facades faked.
+ */
+class UpdateSql30504Test extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * Run update_sql_30504 with the Schema/DB facades faked.
+     *
+     * @param  bool  $tableExists  what Schema::hasTable reports for zp_access_tokens
+     * @return array{result: mixed, recreated: bool}
+     */
+    private function runMigration(bool $tableExists): array
+    {
+        // swap() rather than shouldReceive(): the latter resolves the real facade root
+        // first, and unit tests run with `database.default => []`, so building the
+        // DatabaseManager blows up before any expectation is set.
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasTable')->with('zp_access_tokens')->andReturn($tableExists);
+        // The column/index work is not under test here: accept the calls and skip the
+        // closures so no Blueprint is needed.
+        $schema->shouldReceive('table')->andReturnNull();
+        $schema->shouldReceive('hasColumn')->andReturn(true);
+        Schema::swap($schema);
+
+        $db = Mockery::mock();
+        $db->shouldReceive('select')->andReturn([]);
+        DB::swap($db);
+
+        $recreated = false;
+        $builder = Mockery::mock(SchemaBuilder::class);
+        $builder->shouldReceive('createAccessTokensTable')
+            ->andReturnUsing(function () use (&$recreated): void {
+                $recreated = true;
+            });
+        app()->instance(SchemaBuilder::class, $builder);
+
+        $install = (new \ReflectionClass(Install::class))->newInstanceWithoutConstructor();
+
+        return ['result' => $install->update_sql_30504(), 'recreated' => $recreated];
+    }
+
+    public function test_recreates_the_table_when_it_is_missing_instead_of_failing(): void
+    {
+        $run = $this->runMigration(tableExists: false);
+
+        $this->assertTrue(
+            $run['recreated'],
+            'A missing zp_access_tokens must be recreated, not left for the ALTER to die on (#3706)'
+        );
+        $this->assertTrue(
+            $run['result'],
+            'The migration must succeed on an install that reached 30504 without the table'
+        );
+    }
+
+    public function test_leaves_an_existing_table_alone(): void
+    {
+        $run = $this->runMigration(tableExists: true);
+
+        $this->assertFalse(
+            $run['recreated'],
+            'An install that already has zp_access_tokens must not have it recreated'
+        );
+        $this->assertTrue($run['result'], 'The migration must still report success');
+    }
+}


### PR DESCRIPTION
Fixes #3706 — an **upgrade blocker**. Worth prioritising for this release, since the cut carries six new migrations (dbVersion 3.5.20 → 3.5.26) and anyone in this state can't take any of them.

## The failure

```
Migration 30504: SQLSTATE[42S02]: Base table or view not found: 1146
Table 'leantime.zp_access_tokens' doesn't exist
```

There is no way past it. The install is stuck on its old version permanently.

## Why the table can be missing

`update_sql_30400` creates `zp_access_tokens`, but it ran every statement inside a try/catch that logged the exception, **swallowed it, and then returned `true` unconditionally**:

```php
} catch (\Exception $e) {
    Log::error($statement.' Failed:'.$e->getMessage());
    Log::error($e);
}
...
return true;   // success, even though the CREATE TABLE failed
```

So a failed `CREATE TABLE` recorded db version 3.4.0 as **successfully applied** with no table to show for it. Two of its three creates also lacked `IF NOT EXISTS` (the third had it), so a partially-applied 30400 couldn't be repaired by re-running either.

`update_sql_30504` then ALTERs that table. It guards every *column* with `Schema::hasColumn` but never guarded the *table* — unlike its neighbours 30500, 30518 and 30524, which all check `Schema::hasTable`. So it hard-fails.

## The fix

- **30504 recreates the table when missing**, then proceeds. It reuses `SchemaBuilder::createAccessTokensTable()` instead of adding a fourth copy of the schema, which also keeps the create **database-agnostic** — the raw SQL in 30400 is MySQL-only, which matters now that the docker image ships `pdo_pgsql`. Recreating is safe: the table holds API tokens, and an install that never had it has none to lose.
- **30400's two bare creates become `IF NOT EXISTS`**, matching the third.
- **30400 returns its errors** instead of reporting success regardless, so a failed create can never again be recorded as an applied version. Only installs below 3.4.0 re-run it, and the creates are now idempotent, so a healthy re-run stays a no-op.

`SchemaBuilder::createAccessTokensTable()` becomes public for the reuse.

## Verification

`tests/Unit/app/Domain/Install/UpdateSql30504Test.php` pins both paths — missing table is recreated, existing table is left alone.

I confirmed the test actually catches the bug rather than just passing: against the **unfixed** migration it fails with *"A missing zp_access_tokens must be recreated, not left for the ALTER to die on"*, and passes with the fix.

- Full unit suite: **894 tests, 2239 assertions, 0 failures**
- `pint --test --config .pint/pint.json`: clean

Note the tests fake the Schema/DB facades via `swap()` rather than `shouldReceive()` — the latter resolves the real facade root first, and unit tests run with `database.default => []`, so building the DatabaseManager blows up before any expectation is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)