### PR TITLE
fix: batch of five reported bugs (#3738, #3632, #3685, #3636, #3692)

### DIFF
--- a/app/Core/UI/Template.php
+++ b/app/Core/UI/Template.php
@@ -730,7 +730,13 @@ class Template
         if (! is_null($content)) {
             $content = $this->convertRelativePaths($content);
 
-            return htmlentities($content);
+            // htmlspecialchars, not htmlentities: both escape every character that matters for
+            // XSS (< > & " ') identically, but htmlentities ALSO converts non-ASCII to named
+            // entities, so "Müller" became "M&uuml;ller". Most call sites sit inside {{ }},
+            // which escapes the ampersand again, and the user was shown a literal "M&uuml;ller"
+            // in dropdowns, filters and Ideas (#3636). Escaping strength is unchanged for the
+            // call sites that render through {!! !!} and rely on this for safety.
+            return htmlspecialchars($content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         }
 
         return '';

--- a/app/Domain/Files/Templates/showAll.blade.php
+++ b/app/Domain/Files/Templates/showAll.blade.php
@@ -10,7 +10,7 @@
             <div class='mediamgr_left'>
                 <div class="mediamgr_category">
 
-                    <form action='{{ BASE_URL }}/files/showAll@if(isset($_GET['modalPopUp']))?modalPopUp=true @endif' method='post' enctype="multipart/form-data" class="fileModal" >
+                    <form action='{{ BASE_URL }}/files/showAll{{ isset($_GET['modalPopUp']) ? '?modalPopUp=true' : '' }}' method='post' enctype="multipart/form-data" class="fileModal" >
                         <div class="par f-left" style="margin-right: 15px;">
 
                             <div class='fileupload fileupload-new' data-provides='fileupload'>

--- a/app/Domain/Ideas/Repositories/Ideas.php
+++ b/app/Domain/Ideas/Repositories/Ideas.php
@@ -90,6 +90,15 @@ class Ideas
 
             if ($result !== null) {
                 foreach (safe_unserialize($result->value, []) as $key => $label) {
+                    // Ignore keys we have no status class for. Idea labels are keyed by the
+                    // canvasTypes strings, but a bug in the rename dialog used to persist an
+                    // integer 0 key, and reading it back threw "Undefined array key 0" on every
+                    // render — permanently 500ing the board with no way to undo it from the UI
+                    // (#3685). Skipping unknown keys lets an already-broken board heal itself.
+                    if (! isset($this->statusClasses[$key])) {
+                        continue;
+                    }
+
                     $labels[$key] = [
                         'name' => $label,
                         'class' => $this->statusClasses[$key],

--- a/app/Domain/Setting/Controllers/EditBoxLabel.php
+++ b/app/Domain/Setting/Controllers/EditBoxLabel.php
@@ -29,7 +29,7 @@ class EditBoxLabel extends Controller
 
         if (isset($params['module']) && isset($params['label'])) {
             $module = htmlspecialchars($params['module'], ENT_QUOTES, 'UTF-8');
-            $label = (int) filter_var($params['label'], FILTER_SANITIZE_NUMBER_INT);
+            $label = $this->sanitizeLabelKey($params['label']);
 
             $currentLabel = $this->settingsSvc->getProjectLabel($module, $label, (int) session('currentProject'));
         }
@@ -49,7 +49,7 @@ class EditBoxLabel extends Controller
         $sanitizedString = '';
         if (isset($_GET['module']) && isset($_GET['label'])) {
             $module = htmlspecialchars($_GET['module'], ENT_QUOTES, 'UTF-8');
-            $labelKey = (int) filter_var($_GET['label'], FILTER_SANITIZE_NUMBER_INT);
+            $labelKey = $this->sanitizeLabelKey($_GET['label']);
             $sanitizedString = htmlspecialchars(strip_tags($params['newLabel'] ?? ''), ENT_QUOTES, 'UTF-8');
 
             $this->settingsSvc->saveProjectLabel($module, $labelKey, $sanitizedString, (int) session('currentProject'));
@@ -60,6 +60,28 @@ class EditBoxLabel extends Controller
         $this->tpl->assign('currentLabel', $sanitizedString);
 
         return $this->tpl->displayPartial('setting.editBoxDialog');
+    }
+
+    /**
+     * Normalize a label key without destroying it.
+     *
+     * Ticket labels are keyed by integers, but idea labels are keyed by the canvasTypes
+     * strings ('idea', 'validation', …). The previous
+     * `(int) filter_var(..., FILTER_SANITIZE_NUMBER_INT)` turned every idea key into 0,
+     * which then got persisted and permanently 500'd the board (#3685). Numeric keys are
+     * returned as ints so ticket labels behave exactly as before; anything else is passed
+     * through as a trimmed string for the service to look up. An unknown key simply
+     * matches nothing, so this cannot be used to write an arbitrary label.
+     */
+    private function sanitizeLabelKey(mixed $label): int|string
+    {
+        if (! is_scalar($label)) {
+            return '';
+        }
+
+        $label = trim((string) $label);
+
+        return is_numeric($label) ? (int) $label : $label;
     }
 
     /**

--- a/app/Domain/Setting/Services/Setting.php
+++ b/app/Domain/Setting/Services/Setting.php
@@ -189,7 +189,7 @@ class Setting
      * @api
      */
     #[RequiresPermission(SettingPermissions::PROJECT_LABELS, projectIdParam: 'projectId')]
-    public function getProjectLabel(string $module, int $labelKey, int $projectId): string
+    public function getProjectLabel(string $module, int|string $labelKey, int $projectId): string
     {
         if ($module === 'ticketlabels') {
             $stateLabels = $this->ticketsRepo->getStateLabels();
@@ -228,7 +228,7 @@ class Setting
      * @api
      */
     #[RequiresPermission(SettingPermissions::PROJECT_LABELS, projectIdParam: 'projectId')]
-    public function saveProjectLabel(string $module, int $labelKey, string $newLabel, int $projectId): void
+    public function saveProjectLabel(string $module, int|string $labelKey, string $newLabel, int $projectId): void
     {
         if ($module === 'ticketlabels') {
             $currentStateLabels = $this->ticketsRepo->getStateLabels();
@@ -249,6 +249,14 @@ class Setting
 
         if ($module === 'idealabels') {
             $stateLabels = $this->ideaRepo->getCanvasLabels();
+
+            // Only rename a label that actually exists, mirroring the ticketlabels branch
+            // above. Writing an unknown key persisted junk into the project setting, which is
+            // how the board ended up permanently broken (#3685).
+            if (! isset($stateLabels[$labelKey])) {
+                return;
+            }
+
             $newStateLabels = [];
             foreach ($stateLabels as $key => $label) {
                 $newStateLabels[$key] = $label['name'];

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -1781,17 +1781,28 @@ class Tickets
     {
         $this->addTicketChange(session('userdata.id'), $id, $params);
 
+        // Match field names case-insensitively, then write the CANONICAL column name.
+        // PATCHABLE_COLUMNS is mostly camelCase but 'milestoneid' matches the real column, so a
+        // caller sending the documented 'milestoneId' fell through the case-sensitive isset()
+        // and was silently dropped while the call still reported success (#3692). Resolving to
+        // the canonical name (rather than aliasing) also keeps the UPDATE correct on
+        // PostgreSQL, where a quoted "milestoneId" would not match the milestoneid column.
+        $canonicalColumns = [];
+        foreach (array_keys(self::PATCHABLE_COLUMNS) as $column) {
+            $canonicalColumns[strtolower($column)] = $column;
+        }
+
         $updates = [];
         foreach ($params as $key => $value) {
-            $sanitizedKey = DbCore::sanitizeToColumnString($key);
+            $sanitizedKey = strtolower(DbCore::sanitizeToColumnString($key));
 
-            if (! isset(self::PATCHABLE_COLUMNS[$sanitizedKey])) {
+            if (! isset($canonicalColumns[$sanitizedKey])) {
                 continue;
             }
 
-            $updates[$sanitizedKey] = $value;
+            $updates[$canonicalColumns[$sanitizedKey]] = $value;
 
-            if ($key == 'status') {
+            if ($sanitizedKey === 'status') {
                 TicketStatusUpdated::dispatch(ticketId: (int) $id, status: $value, legacyHook: __FUNCTION__);
             }
         }

--- a/app/Domain/Timesheets/Repositories/Timesheets.php
+++ b/app/Domain/Timesheets/Repositories/Timesheets.php
@@ -594,7 +594,16 @@ class Timesheets extends Repository
         $onTheClock['id'] = $result->id;
         $onTheClock['since'] = $result->punchIn;
         $onTheClock['headline'] = $result->headline;
-        $start_date = new Carbon($result->punchIn, 'UTC');
+        // punchIn is an integer column and punchIn() writes time(), so the stored value is a
+        // Unix timestamp. PDO hands integer columns back as STRINGS, and Carbon's constructor
+        // parses an int epoch but throws InvalidFormatException on the string form
+        // ("Failed to parse time string (1786766470) at position 8") — 500ing every page that
+        // renders the timer (#3632). punchOut() already reads it as an epoch, so the epoch is
+        // the intended storage and only this read was wrong. A legacy datetime string is still
+        // accepted so no install trades one crash for another.
+        $start_date = is_numeric($result->punchIn)
+            ? Carbon::createFromTimestamp((int) $result->punchIn, 'UTC')
+            : new Carbon($result->punchIn, 'UTC');
         $since_start = $start_date->diff(Carbon::now(session('usersettings.timezone'))->setTimezone('UTC'));
 
         $r = $since_start->format('%H:%I');

--- a/tests/Unit/app/Core/UI/TemplateEscapeTest.php
+++ b/tests/Unit/app/Core/UI/TemplateEscapeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Unit\app\Core\UI;
+
+use Leantime\Core\UI\Template;
+use Unit\TestCase;
+
+/**
+ * Regression tests for Template::escape() (#3636).
+ *
+ * escape() used htmlentities(), which converts non-ASCII to named entities on top of the
+ * XSS-relevant characters. Nearly every call site renders through {{ }}, which escapes the
+ * resulting ampersand a second time, so users with non-English data saw a literal
+ * "M&uuml;ller" in dropdowns, filters and Ideas.
+ *
+ * These pin both halves of the contract: non-ASCII survives, and the escaping is still as
+ * strong as it was for the call sites that render through {!! !!}.
+ */
+class TemplateEscapeTest extends TestCase
+{
+    private function escape(?string $value): string
+    {
+        // Built without the constructor: escape() only reaches convertRelativePaths(), which
+        // depends on the BASE_URL constant rather than any instance state, so none of
+        // Template's collaborators (session, db, theme) need to exist here.
+        $template = (new \ReflectionClass(Template::class))->newInstanceWithoutConstructor();
+
+        return $template->escape($value);
+    }
+
+    public function test_non_ascii_is_left_alone(): void
+    {
+        $this->assertSame('Müller', $this->escape('Müller'));
+        $this->assertSame('Ä Ö Ü ä ö ü ß', $this->escape('Ä Ö Ü ä ö ü ß'));
+        $this->assertStringNotContainsString(
+            '&uuml;',
+            $this->escape('Müller'),
+            'Umlauts must not be turned into named entities (#3636)'
+        );
+    }
+
+    public function test_xss_relevant_characters_are_still_escaped(): void
+    {
+        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $this->escape('<script>alert(1)</script>'));
+        $this->assertSame('&quot; onerror=&quot;alert(1)', $this->escape('" onerror="alert(1)'));
+        $this->assertSame('&#039; onmouseover=&#039;x', $this->escape("' onmouseover='x"));
+        $this->assertSame('a &lt; b &amp; c &gt; d', $this->escape('a < b & c > d'));
+    }
+
+    public function test_ampersand_is_escaped_exactly_once(): void
+    {
+        // The double-escape the user actually saw came from & being encoded here and again
+        // by Blade. One pass here must produce exactly one &amp;.
+        $this->assertSame('Müller &amp; Söhne', $this->escape('Müller & Söhne'));
+    }
+
+    public function test_null_is_an_empty_string(): void
+    {
+        $this->assertSame('', $this->escape(null));
+    }
+}

--- a/tests/Unit/app/Domain/Tickets/Repositories/PatchTicketColumnsTest.php
+++ b/tests/Unit/app/Domain/Tickets/Repositories/PatchTicketColumnsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Unit\app\Domain\Tickets\Repositories;
+
+use Illuminate\Database\ConnectionInterface;
+use Leantime\Domain\Tickets\Repositories\Tickets;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Unit\TestCase;
+
+/**
+ * Regression tests for patchTicket() field-name matching (#3692).
+ *
+ * PATCHABLE_COLUMNS is mostly camelCase, but 'milestoneid' matches the real column name.
+ * The lookup was a case-sensitive isset(), so the documented API/MCP field 'milestoneId'
+ * never matched and was dropped — while patchTicket() still reported success, which is the
+ * part that makes it dangerous for automation.
+ *
+ * These call patchTicket() for real against a faked connection and assert on the payload
+ * it would have written — no DB.
+ */
+class PatchTicketColumnsTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * Run patchTicket() and capture the column => value payload handed to update().
+     *
+     * @param  array<string, mixed>  $params
+     * @return array{result: bool, updates: array<string, mixed>}
+     */
+    private function runPatch(array $params): array
+    {
+        $updates = [];
+
+        $builder = Mockery::mock();
+        $builder->shouldReceive('where')->andReturnSelf();
+        $builder->shouldReceive('update')->andReturnUsing(function ($payload) use (&$updates) {
+            $updates = $payload;
+
+            return 1;
+        });
+        // addTicketChange() reads the previous row before logging the change; an empty
+        // result short-circuits it without touching anything under test.
+        $builder->shouldReceive('select')->andReturnSelf();
+        $builder->shouldReceive('limit')->andReturnSelf();
+        $builder->shouldReceive('first')->andReturn(null);
+        $builder->shouldReceive('insert')->andReturn(true);
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $conn = Mockery::mock(ConnectionInterface::class);
+        $conn->shouldReceive('table')->andReturn($builder);
+
+        $repo = (new \ReflectionClass(Tickets::class))->newInstanceWithoutConstructor();
+        $prop = new \ReflectionProperty(Tickets::class, 'connection');
+        $prop->setAccessible(true);
+        $prop->setValue($repo, $conn);
+
+        $result = $repo->patchTicket(42, $params);
+
+        return ['result' => $result, 'updates' => $updates];
+    }
+
+    public function test_documented_milestone_id_casing_actually_patches(): void
+    {
+        $run = $this->runPatch(['milestoneId' => 7]);
+
+        $this->assertArrayHasKey(
+            'milestoneid',
+            $run['updates'],
+            'The documented milestoneId field must reach the update as the real column (#3692)'
+        );
+        $this->assertSame(7, $run['updates']['milestoneid']);
+        $this->assertTrue($run['result']);
+    }
+
+    public function test_lowercase_milestoneid_still_works(): void
+    {
+        $run = $this->runPatch(['milestoneid' => 9]);
+
+        $this->assertSame(9, $run['updates']['milestoneid'] ?? null);
+    }
+
+    public function test_unknown_fields_are_still_ignored(): void
+    {
+        $run = $this->runPatch(['bogusColumn' => 'x', 'headline' => 'kept']);
+
+        $this->assertArrayNotHasKey('bogusColumn', $run['updates']);
+        $this->assertArrayNotHasKey('boguscolumn', $run['updates']);
+        $this->assertSame('kept', $run['updates']['headline'] ?? null);
+    }
+
+    public function test_a_patch_of_only_unknown_fields_reports_failure(): void
+    {
+        $run = $this->runPatch(['bogusColumn' => 'x']);
+
+        $this->assertFalse(
+            $run['result'],
+            'Nothing patchable means nothing was written, and the caller must be told'
+        );
+    }
+}


### PR DESCRIPTION
Five independent, small fixes triaged as release candidates. Each verified against master before fixing; details on the non-obvious ones below.

Fixes #3738
Fixes #3632
Fixes #3685
Fixes #3636
Fixes #3692

## #3738 — deleting a file attachment threw a template syntax error

Blade only compiles a directive when the `@` is **not** preceded by a word character (`\B@`). The form action was:

```blade
action='{{ BASE_URL }}/files/showAll@if(isset($_GET['modalPopUp']))?modalPopUp=true @endif'
```

So `showAll@if(` stayed literal text while the space-preceded ` @endif` **did** compile — leaving an orphan `<?php endif; ?>` and a PHP fatal. That is exactly the compiled output the reporter pasted.

Replaced with a plain ternary. Verified by running the Blade compiler on the line: no orphan `endif`, and both branches emit the correct URL.

## #3632 — a running timer 500s every page

`punchIn` is an **integer** column, `punchIn()` writes `time()`, and `punchOut()` already reads it as an epoch — so the epoch is the intended storage and only this read was wrong.

The subtle part: **PDO hands integer columns back as strings**, and Carbon parses an int epoch fine but throws on the string form:

```
1786766470   (integer): parsed -> 2026-08-15 04:01:10
'1786766470' (string):  InvalidFormatException: Failed to parse time string at position 8
```

Now uses `createFromTimestamp` for numeric values, still accepting a legacy datetime string so no install trades one crash for another.

## #3685 — renaming an idea kanban column permanently 500s the board

Idea labels are keyed by the `canvasTypes` **strings**, but `EditBoxLabel` int-cast the key with `FILTER_SANITIZE_NUMBER_INT` → `0`. `saveProjectLabel` persisted that `0` key into the project setting, and `getCanvasLabels()` then hit `Undefined array key 0` on every render — permanent, with no way to undo it from the UI.

Fixed at all three points:
- the controller keeps non-numeric keys instead of coercing them (numeric keys still become ints, so ticket labels behave exactly as before);
- `saveProjectLabel` refuses unknown keys, matching the `ticketlabels` branch directly beside it that already did;
- `getCanvasLabels()` skips keys it has no status class for, so **an already-broken board heals itself** rather than needing manual DB surgery.

## #3636 — umlauts rendered as raw HTML entities

`Template::escape()` used `htmlentities()`, which converts non-ASCII to named entities *on top of* the XSS-relevant characters. Nearly every call site renders through `{{ }}`, which escapes the resulting `&` again — so users saw a literal `M&uuml;ller`.

11 call sites render through `{!! !!}` and rely on `escape()` for actual safety, so I verified the swap character-by-character rather than assuming:

| input | htmlentities (before) | htmlspecialchars (after) |
|---|---|---|
| `<script>alert(1)</script>` | `&lt;script&gt;…` | `&lt;script&gt;…` |
| `" onerror="alert(1)` | `&quot; onerror=&quot;…` | `&quot; onerror=&quot;…` |
| `' onmouseover='x` | `&#039; onmouseover=&#039;x` | `&#039; onmouseover=&#039;x` |
| `Müller & Söhne` | `M&uuml;ller &amp; S&ouml;hne` | `Müller &amp; Söhne` |

Identical on every character that matters for XSS; only the non-ASCII mangling goes away.

## #3692 — bulkEditTasks silently ignored milestoneId

`PATCHABLE_COLUMNS` is mostly camelCase but `'milestoneid'` matches the real column name, and the lookup was a case-sensitive `isset()` — so the **documented** `milestoneId` was dropped while the call still returned success. Silent success is the dangerous half for agent automation.

`patchTicket()` now matches case-insensitively and writes the **canonical** column name. Resolving rather than aliasing matters: an added `'milestoneId' => true` alias would put a quoted `"milestoneId"` into the UPDATE, which does not match the `milestoneid` column on PostgreSQL — newly relevant now that the docker image ships `pdo_pgsql`.

## Verification

- **Full unit suite: 902 tests, 2256 assertions, 0 failures.** Pint clean (762 files).
- Two regression tests added — `TemplateEscapeTest` and `PatchTicketColumnsTest` — and **both were confirmed to fail against the unfixed code**, not merely to pass against the fixed code. The first draft of the patch test passed either way (it re-implemented the lookup instead of calling the method), so it was rewritten to exercise `patchTicket()` for real against a faked connection.
- #3738 was verified by compiling the template line directly; #3632 by reproducing the Carbon throw on the string epoch.
- **#3738 and #3685 have no unit test.** The first is a template-compilation fix and the second needs session + DB state; both were verified manually as described. Worth a browser pass on the Ideas board before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
