### PR TITLE
fix(telegram): handle status 0 (Done) without empty() evaluation bug

### DIFF
--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -312,11 +312,11 @@ class Messengers
 
         // 2. Status
         $statusName = '';
-        if (! empty($status)) {
+        if ($status !== '' && $status !== null) {
             if ($ticketService !== null) {
                 try {
                     $statusLabelsArray = $ticketService->getStatusLabels($notification->projectId);
-                    if (! empty($statusLabelsArray[$status]['name'])) {
+                    if (isset($statusLabelsArray[$status]['name']) && $statusLabelsArray[$status]['name'] !== '') {
                         $statusName = $statusLabelsArray[$status]['name'];
                     } else {
                         $statusName = (string) $status;
@@ -396,7 +396,7 @@ class Messengers
         if (! empty($taskTitle)) {
             $lines[] = '📌 <b>'.e($this->language->__('label.title')).':</b> '.e($taskTitle);
         }
-        if (! empty($statusName) && $statusName !== 'N/A') {
+        if ($statusName !== '' && $statusName !== 'N/A') {
             $lines[] = '🏷 <b>'.e($this->language->__('label.todo_status')).':</b> '.e($statusName);
         }
         if (! empty($priorityName)) {

--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -312,7 +312,7 @@ class Messengers
 
         // 2. Status
         $statusName = '';
-        if ($status !== '' && $status !== null) {
+        if ((is_int($status) || is_string($status)) && $status !== '') {
             if ($ticketService !== null) {
                 try {
                     $statusLabelsArray = $ticketService->getStatusLabels($notification->projectId);


### PR DESCRIPTION
### Description

Fixes an issue in Telegram notification card generation where tasks marked as **Done** (`status 0`) omitted the status line due to PHP's `empty(0)` evaluating to `true`.

In `app/Domain/Notifications/Services/Messengers.php`, the status resolution logic checked `if (! empty($status))`. In PHP, `empty(0)` and `empty("0")` evaluate to `true`, causing `!empty($status)` to evaluate to `false`. As a result, `$statusName` remained empty and the status line was omitted from the generated Telegram notification card when tasks transitioned to `Done`.

We replaced loose `! empty($status)` checks with explicit empty-string/null checks (`$status !== '' && $status !== null`) in `prepareTelegramMessage()`. This ensures all project statuses (including `0` / `Done` and custom project status labels like `Blocked`, `Waiting for Approval`, etc.) dynamically render as expected (`🏷 Status: Done`).

### Link to ticket

N/A

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshots of the result

<img width="375" height="123" alt="image" src="https://github.com/user-attachments/assets/afb1af64-bbf6-495d-b968-c798642c3fa7" />
<img width="375" height="123" alt="image" src="https://github.com/user-attachments/assets/b2b3c0d2-d6a9-4cab-b721-505f6f69c9b4" />
