### PR TITLE
fix(tickets): restore board tabs styling and two-row toolbar layout (#3748)

### DIFF
--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -21,11 +21,17 @@
 
     <div class="maincontentinner">
 
-        {{-- Board actions (New / Filter / Group By) moved into the nav bar
-             (ticketBoardTabs). Only the table-specific DataTables buttons remain
-             here, right-aligned above the table. --}}
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-4">
+                @dispatchEvent('filters.afterLefthandSectionOpen')
+                @include('tickets::submodules.ticketNewBtn')
+                @include('tickets::submodules.ticketFilter')
+                @dispatchEvent('filters.beforeLefthandSectionClose')
+            </div>
+
+            <div class="col-md-4 center">
+            </div>
+            <div class="col-md-4">
                 <div class="pull-right">
                     @dispatchEvent('filters.afterRighthandSectionOpen')
                     <div id="tableButtons" style="display:inline-block"></div>

--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -22,23 +22,16 @@
     <div class="maincontentinner">
 
         <div class="row">
-            <div class="col-md-4">
-                @dispatchEvent('filters.afterLefthandSectionOpen')
-                @include('tickets::submodules.ticketNewBtn')
-                @include('tickets::submodules.ticketFilter')
-                @dispatchEvent('filters.beforeLefthandSectionClose')
+            <div class="col-md-6 col-sm-12">
+                @include('tickets::submodules.ticketBoardActions')
             </div>
-
-            <div class="col-md-4 center">
-            </div>
-            <div class="col-md-4">
+            <div class="col-md-6 col-sm-12">
                 <div class="pull-right">
                     @dispatchEvent('filters.afterRighthandSectionOpen')
                     <div id="tableButtons" style="display:inline-block"></div>
                     @dispatchEvent('filters.beforeRighthandSectionClose')
                 </div>
             </div>
-
         </div>
 
         <div class="clearfix" style="margin-bottom: 20px;"></div>

--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -28,8 +28,20 @@
 
     <div class="maincontentinner kanban-board-wrapper" >
 
-        {{-- Board actions (New / Filter / Group By) moved into the nav bar
-             (ticketBoardTabs) so there's no separate toolbar row here. --}}
+        <div class="row">
+            <div class="col-md-4">
+                @dispatchEvent('filters.afterLefthandSectionOpen')
+                @include('tickets::submodules.ticketNewBtn')
+                @include('tickets::submodules.ticketFilter')
+                @dispatchEvent('filters.beforeLefthandSectionClose')
+            </div>
+
+            <div class="col-md-4 center">
+            </div>
+            <div class="col-md-4">
+            </div>
+        </div>
+
         <div class="clearfix"></div>
 
         @if ($programBoard)

--- a/app/Domain/Tickets/Templates/showKanban.blade.php
+++ b/app/Domain/Tickets/Templates/showKanban.blade.php
@@ -29,16 +29,8 @@
     <div class="maincontentinner kanban-board-wrapper" >
 
         <div class="row">
-            <div class="col-md-4">
-                @dispatchEvent('filters.afterLefthandSectionOpen')
-                @include('tickets::submodules.ticketNewBtn')
-                @include('tickets::submodules.ticketFilter')
-                @dispatchEvent('filters.beforeLefthandSectionClose')
-            </div>
-
-            <div class="col-md-4 center">
-            </div>
-            <div class="col-md-4">
+            <div class="col-md-12">
+                @include('tickets::submodules.ticketBoardActions')
             </div>
         </div>
 

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -21,8 +21,20 @@
 
     <div class="maincontentinner">
 
-        {{-- Board actions (New / Filter / Group By) moved into the nav bar
-             (ticketBoardTabs) so there's no separate toolbar row here. --}}
+        <div class="row">
+            <div class="col-md-4">
+                @dispatchEvent('filters.afterLefthandSectionOpen')
+                @include('tickets::submodules.ticketNewBtn')
+                @include('tickets::submodules.ticketFilter')
+                @dispatchEvent('filters.beforeLefthandSectionClose')
+            </div>
+
+            <div class="col-md-4 center">
+            </div>
+            <div class="col-md-4">
+            </div>
+        </div>
+
         <div class="clearfix"></div>
 
         @dispatchEvent('allTicketsTable.before', ['tickets' => $allTickets])

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -22,16 +22,8 @@
     <div class="maincontentinner">
 
         <div class="row">
-            <div class="col-md-4">
-                @dispatchEvent('filters.afterLefthandSectionOpen')
-                @include('tickets::submodules.ticketNewBtn')
-                @include('tickets::submodules.ticketFilter')
-                @dispatchEvent('filters.beforeLefthandSectionClose')
-            </div>
-
-            <div class="col-md-4 center">
-            </div>
-            <div class="col-md-4">
+            <div class="col-md-12">
+                @include('tickets::submodules.ticketBoardActions')
             </div>
         </div>
 

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardActions.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardActions.blade.php
@@ -1,0 +1,6 @@
+<div class="board-actions">
+    @dispatchEvent('filters.afterLefthandSectionOpen')
+    @include('tickets::submodules.ticketNewBtn')
+    @include('tickets::submodules.ticketFilter')
+    @dispatchEvent('filters.beforeLefthandSectionClose')
+</div>

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardActions.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardActions.blade.php
@@ -1,4 +1,4 @@
-<div class="board-actions">
+<div class="board-actions hideOnPrint">
     @dispatchEvent('filters.afterLefthandSectionOpen')
     @include('tickets::submodules.ticketNewBtn')
     @include('tickets::submodules.ticketFilter')

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -2,12 +2,9 @@
     use Leantime\Core\Controller\Frontcontroller;
 
     if (!function_exists('findActive')) {
-        function findActive($route): string
+        function findActive($route): bool
         {
-            if (str_contains(Frontcontroller::getCurrentRoute(), $route)) {
-                return 'active';
-            }
-            return '';
+            return str_contains(Frontcontroller::getCurrentRoute(), $route);
         }
     }
 
@@ -18,39 +15,33 @@
         'table'  => ['url' => BASE_URL . '/tickets/showAll',    'active' => 'showAll'],
         'list'   => ['url' => BASE_URL . '/tickets/showList',   'active' => 'showList'],
     ];
+
+    $plainKanban = strip_tags(__('links.kanban'));
+    $plainTable  = strip_tags(__('links.table'));
+    $plainList   = strip_tags(__('links.list'));
+    $navLabel    = trim("{$plainKanban} / {$plainTable} / {$plainList}");
 @endphp
 
-<div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
-    <nav class="lt-tabs-group" aria-label="{{ __('links.kanban') }} / {{ __('links.table') }} / {{ __('links.list') }}">
-    <ul>
-        <li class="{{ findActive($boardTabs['kanban']['active']) }}">
-            <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.kanban') !!}
-            </a>
-        </li>
-        <li class="{{ findActive($boardTabs['table']['active']) }}">
-            <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.table') !!}
-            </a>
-        </li>
-        <li class="{{ findActive($boardTabs['list']['active']) }}">
-            <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.list') !!}
-            </a>
-        </li>
-    </ul>
-    </nav>
+<link rel="stylesheet" href="{{ BASE_URL }}/assets/css/components/tab-group.css" />
 
-    {{-- Board actions (New / Filter / Group By) live on the right of the nav bar
-         — like the report's period picker — so the bar is balanced and the board
-         needs no separate toolbar row below it. Guarded on $searchCriteria so the
-         partial stays safe if the nav is ever reused without the board context. --}}
-    @isset($searchCriteria)
-        <div class="lt-tabs-actions">
-            @dispatchEvent('filters.afterLefthandSectionOpen')
-            @include('tickets::submodules.ticketNewBtn')
-            @include('tickets::submodules.ticketFilter')
-            @dispatchEvent('filters.beforeLefthandSectionClose')
-        </div>
-    @endisset
+<div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
+    <nav class="lt-tabs-group" aria-label="{{ $navLabel }}">
+        <ul>
+            <li class="{{ findActive($boardTabs['kanban']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['kanban']['active']) ? 'on' : '' }}" preload="mouseover">
+                    {!! __('links.kanban') !!}
+                </a>
+            </li>
+            <li class="{{ findActive($boardTabs['table']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['table']['active']) ? 'on' : '' }}" preload="mouseover">
+                    {!! __('links.table') !!}
+                </a>
+            </li>
+            <li class="{{ findActive($boardTabs['list']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['list']['active']) ? 'on' : '' }}" preload="mouseover">
+                    {!! __('links.list') !!}
+                </a>
+            </li>
+        </ul>
+    </nav>
 </div>

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -1,8 +1,8 @@
 @php
     use Leantime\Core\Controller\Frontcontroller;
 
-    if (!function_exists('findActive')) {
-        function findActive($route): bool
+    if (!function_exists('routeIsActive')) {
+        function routeIsActive($route): bool
         {
             return str_contains(Frontcontroller::getCurrentRoute(), $route);
         }
@@ -22,23 +22,31 @@
     $navLabel    = trim("{$plainKanban} / {$plainTable} / {$plainList}");
 @endphp
 
-<link rel="stylesheet" href="{{ BASE_URL }}/assets/css/components/ticket-board-tabs.css" />
+@pushOnce('styles')
+    <link rel="stylesheet" href="{{ BASE_URL }}/assets/css/components/ticket-board-tabs.css" />
+@endPushOnce
 
 <div class="maincontentinner tabs board-tabs-bar hideOnPrint">
     <nav aria-label="{{ $navLabel }}">
         <ul>
-            <li class="{{ findActive($boardTabs['kanban']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" preload="mouseover">
+            <li class="{{ routeIsActive($boardTabs['kanban']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}"
+                   @if (routeIsActive($boardTabs['kanban']['active'])) aria-current="page" @endif
+                   preload="mouseover">
                     {!! __('links.kanban') !!}
                 </a>
             </li>
-            <li class="{{ findActive($boardTabs['table']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" preload="mouseover">
+            <li class="{{ routeIsActive($boardTabs['table']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}"
+                   @if (routeIsActive($boardTabs['table']['active'])) aria-current="page" @endif
+                   preload="mouseover">
                     {!! __('links.table') !!}
                 </a>
             </li>
-            <li class="{{ findActive($boardTabs['list']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" preload="mouseover">
+            <li class="{{ routeIsActive($boardTabs['list']['active']) ? 'active' : '' }}">
+                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}"
+                   @if (routeIsActive($boardTabs['list']['active'])) aria-current="page" @endif
+                   preload="mouseover">
                     {!! __('links.list') !!}
                 </a>
             </li>

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -1,12 +1,7 @@
 @php
     use Leantime\Core\Controller\Frontcontroller;
 
-    if (!function_exists('routeIsActive')) {
-        function routeIsActive($route): bool
-        {
-            return str_contains(Frontcontroller::getCurrentRoute(), $route);
-        }
-    }
+    $currentRoute = Frontcontroller::getCurrentRoute();
 
     // Program boards inject their own kanban/table/list URLs + the route fragments used to
     // highlight the active tab. Per-project views fall back to the core /tickets/* routes.
@@ -15,6 +10,10 @@
         'table'  => ['url' => BASE_URL . '/tickets/showAll',    'active' => 'showAll'],
         'list'   => ['url' => BASE_URL . '/tickets/showList',   'active' => 'showList'],
     ];
+
+    $isKanban = str_contains($currentRoute, $boardTabs['kanban']['active']);
+    $isTable  = str_contains($currentRoute, $boardTabs['table']['active']);
+    $isList   = str_contains($currentRoute, $boardTabs['list']['active']);
 
     $plainKanban = strip_tags(__('links.kanban'));
     $plainTable  = strip_tags(__('links.table'));
@@ -29,23 +28,23 @@
 <div class="maincontentinner tabs board-tabs-bar hideOnPrint">
     <nav aria-label="{{ $navLabel }}">
         <ul>
-            <li class="{{ routeIsActive($boardTabs['kanban']['active']) ? 'active' : '' }}">
+            <li class="{{ $isKanban ? 'active' : '' }}">
                 <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}"
-                   @if (routeIsActive($boardTabs['kanban']['active'])) aria-current="page" @endif
+                   @if ($isKanban) aria-current="page" @endif
                    preload="mouseover">
                     {!! __('links.kanban') !!}
                 </a>
             </li>
-            <li class="{{ routeIsActive($boardTabs['table']['active']) ? 'active' : '' }}">
+            <li class="{{ $isTable ? 'active' : '' }}">
                 <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}"
-                   @if (routeIsActive($boardTabs['table']['active'])) aria-current="page" @endif
+                   @if ($isTable) aria-current="page" @endif
                    preload="mouseover">
                     {!! __('links.table') !!}
                 </a>
             </li>
-            <li class="{{ routeIsActive($boardTabs['list']['active']) ? 'active' : '' }}">
+            <li class="{{ $isList ? 'active' : '' }}">
                 <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}"
-                   @if (routeIsActive($boardTabs['list']['active'])) aria-current="page" @endif
+                   @if ($isList) aria-current="page" @endif
                    preload="mouseover">
                     {!! __('links.list') !!}
                 </a>

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -22,63 +22,7 @@
     $navLabel    = trim("{$plainKanban} / {$plainTable} / {$plainList}");
 @endphp
 
-<style>
-.maincontentinner.tabs.board-tabs-bar {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    padding: 7px 12px;
-    margin-bottom: 10px;
-    border-radius: var(--box-radius, 14px);
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.55) 45%, rgba(255, 255, 255, 0.22) 100%) !important;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.4) !important;
-    box-shadow: var(--large-shadow, 0 4px 12px rgba(0, 0, 0, 0.08));
-}
-.maincontentinner.tabs.board-tabs-bar ul {
-    margin: 0;
-    padding: 0;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    list-style: none;
-}
-.maincontentinner.tabs.board-tabs-bar ul li {
-    display: inline-flex;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-.maincontentinner.tabs.board-tabs-bar ul li a {
-    font-family: inherit;
-    font-size: 13px;
-    font-weight: 500;
-    padding: 6px 14px;
-    border-radius: 8px;
-    line-height: 1.3;
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    color: var(--primary-font-color);
-    text-decoration: none;
-    transition: all 0.15s ease;
-}
-.maincontentinner.tabs.board-tabs-bar ul li a:hover {
-    color: var(--primary-font-color);
-    background: rgba(0, 0, 0, 0.04);
-}
-.maincontentinner.tabs.board-tabs-bar ul li.active a {
-    color: var(--accent1, #007bb3);
-    background: #fff;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
-    font-weight: 600;
-}
-.maincontentinner.tabs.board-tabs-bar ul li.active a:hover {
-    color: var(--accent1, #007bb3);
-    background: #fff;
-}
-</style>
+<link rel="stylesheet" href="{{ BASE_URL }}/assets/css/components/ticket-board-tabs.css" />
 
 <div class="maincontentinner tabs board-tabs-bar hideOnPrint">
     <nav aria-label="{{ $navLabel }}">

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -11,14 +11,25 @@
         'list'   => ['url' => BASE_URL . '/tickets/showList',   'active' => 'showList'],
     ];
 
-    $isKanban = str_contains($currentRoute, $boardTabs['kanban']['active']);
-    $isTable  = str_contains($currentRoute, $boardTabs['table']['active']);
-    $isList   = str_contains($currentRoute, $boardTabs['list']['active']);
+    $tabs = [
+        [
+            'url'      => $boardTabs['kanban']['url'] . $searchParams,
+            'label'    => __('links.kanban'),
+            'isActive' => str_contains($currentRoute, $boardTabs['kanban']['active']),
+        ],
+        [
+            'url'      => $boardTabs['table']['url'] . $searchParams,
+            'label'    => __('links.table'),
+            'isActive' => str_contains($currentRoute, $boardTabs['table']['active']),
+        ],
+        [
+            'url'      => $boardTabs['list']['url'] . $searchParams,
+            'label'    => __('links.list'),
+            'isActive' => str_contains($currentRoute, $boardTabs['list']['active']),
+        ],
+    ];
 
-    $plainKanban = strip_tags(__('links.kanban'));
-    $plainTable  = strip_tags(__('links.table'));
-    $plainList   = strip_tags(__('links.list'));
-    $navLabel    = trim("{$plainKanban} / {$plainTable} / {$plainList}");
+    $navLabel = implode(' / ', array_map(fn($tab) => strip_tags((string) $tab['label']), $tabs));
 @endphp
 
 @pushOnce('styles')
@@ -28,27 +39,15 @@
 <div class="maincontentinner tabs board-tabs-bar hideOnPrint">
     <nav aria-label="{{ $navLabel }}">
         <ul>
-            <li class="{{ $isKanban ? 'active' : '' }}">
-                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}"
-                   @if ($isKanban) aria-current="page" @endif
-                   preload="mouseover">
-                    {!! __('links.kanban') !!}
-                </a>
-            </li>
-            <li class="{{ $isTable ? 'active' : '' }}">
-                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}"
-                   @if ($isTable) aria-current="page" @endif
-                   preload="mouseover">
-                    {!! __('links.table') !!}
-                </a>
-            </li>
-            <li class="{{ $isList ? 'active' : '' }}">
-                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}"
-                   @if ($isList) aria-current="page" @endif
-                   preload="mouseover">
-                    {!! __('links.list') !!}
-                </a>
-            </li>
+            @foreach ($tabs as $tab)
+                <li class="{{ $tab['isActive'] ? 'active' : '' }}">
+                    <a href="{{ $tab['url'] }}"
+                       @if ($tab['isActive']) aria-current="page" @endif
+                       preload="mouseover">
+                        {!! $tab['label'] !!}
+                    </a>
+                </li>
+            @endforeach
         </ul>
     </nav>
 </div>

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -22,23 +22,79 @@
     $navLabel    = trim("{$plainKanban} / {$plainTable} / {$plainList}");
 @endphp
 
-<link rel="stylesheet" href="{{ BASE_URL }}/assets/css/components/tab-group.css" />
+<style>
+.maincontentinner.tabs.board-tabs-bar {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    padding: 7px 12px;
+    margin-bottom: 10px;
+    border-radius: var(--box-radius, 14px);
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.55) 45%, rgba(255, 255, 255, 0.22) 100%) !important;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.4) !important;
+    box-shadow: var(--large-shadow, 0 4px 12px rgba(0, 0, 0, 0.08));
+}
+.maincontentinner.tabs.board-tabs-bar ul {
+    margin: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    list-style: none;
+}
+.maincontentinner.tabs.board-tabs-bar ul li {
+    display: inline-flex;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.maincontentinner.tabs.board-tabs-bar ul li a {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 6px 14px;
+    border-radius: 8px;
+    line-height: 1.3;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--primary-font-color);
+    text-decoration: none;
+    transition: all 0.15s ease;
+}
+.maincontentinner.tabs.board-tabs-bar ul li a:hover {
+    color: var(--primary-font-color);
+    background: rgba(0, 0, 0, 0.04);
+}
+.maincontentinner.tabs.board-tabs-bar ul li.active a {
+    color: var(--accent1, #007bb3);
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    font-weight: 600;
+}
+.maincontentinner.tabs.board-tabs-bar ul li.active a:hover {
+    color: var(--accent1, #007bb3);
+    background: #fff;
+}
+</style>
 
-<div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
-    <nav class="lt-tabs-group" aria-label="{{ $navLabel }}">
+<div class="maincontentinner tabs board-tabs-bar hideOnPrint">
+    <nav aria-label="{{ $navLabel }}">
         <ul>
             <li class="{{ findActive($boardTabs['kanban']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['kanban']['active']) ? 'on' : '' }}" preload="mouseover">
+                <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" preload="mouseover">
                     {!! __('links.kanban') !!}
                 </a>
             </li>
             <li class="{{ findActive($boardTabs['table']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['table']['active']) ? 'on' : '' }}" preload="mouseover">
+                <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" preload="mouseover">
                     {!! __('links.table') !!}
                 </a>
             </li>
             <li class="{{ findActive($boardTabs['list']['active']) ? 'active' : '' }}">
-                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" class="lt-tab {{ findActive($boardTabs['list']['active']) ? 'on' : '' }}" preload="mouseover">
+                <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" preload="mouseover">
                     {!! __('links.list') !!}
                 </a>
             </li>

--- a/public/assets/css/components/ticket-board-tabs.css
+++ b/public/assets/css/components/ticket-board-tabs.css
@@ -1,0 +1,56 @@
+/* Ticket board horizontal view tabs */
+.maincontentinner.tabs.board-tabs-bar {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    padding: 7px 12px;
+    margin-bottom: 10px;
+    border-radius: var(--box-radius, 14px);
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.55) 45%, rgba(255, 255, 255, 0.22) 100%);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    box-shadow: var(--large-shadow, 0 4px 12px rgba(0, 0, 0, 0.08));
+}
+.maincontentinner.tabs.board-tabs-bar ul {
+    margin: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    list-style: none;
+}
+.maincontentinner.tabs.board-tabs-bar ul li {
+    display: inline-flex;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.maincontentinner.tabs.board-tabs-bar ul li a {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 6px 14px;
+    border-radius: 8px;
+    line-height: 1.3;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--primary-font-color);
+    text-decoration: none;
+    transition: all 0.15s ease;
+}
+.maincontentinner.tabs.board-tabs-bar ul li a:hover {
+    color: var(--primary-font-color);
+    background: rgba(0, 0, 0, 0.04);
+}
+.maincontentinner.tabs.board-tabs-bar ul li.active a {
+    color: var(--accent1, #007bb3);
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    font-weight: 600;
+}
+.maincontentinner.tabs.board-tabs-bar ul li.active a:hover {
+    color: var(--accent1, #007bb3);
+    background: #fff;
+}

--- a/public/assets/css/components/ticket-board-tabs.css
+++ b/public/assets/css/components/ticket-board-tabs.css
@@ -38,7 +38,7 @@
     gap: 7px;
     color: var(--primary-font-color);
     text-decoration: none;
-    transition: all 0.15s ease;
+    transition: color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 .maincontentinner.tabs.board-tabs-bar ul li a:hover {
     color: var(--primary-font-color);

--- a/public/assets/css/components/ticket-board-tabs.css
+++ b/public/assets/css/components/ticket-board-tabs.css
@@ -42,15 +42,19 @@
 }
 .maincontentinner.tabs.board-tabs-bar ul li a:hover {
     color: var(--primary-font-color);
-    background: rgba(0, 0, 0, 0.04);
+    background-color: rgba(0, 0, 0, 0.04);
+}
+.maincontentinner.tabs.board-tabs-bar ul li a:focus-visible {
+    outline: 2px solid var(--accent1, #007bb3);
+    outline-offset: 2px;
 }
 .maincontentinner.tabs.board-tabs-bar ul li.active a {
     color: var(--accent1, #007bb3);
-    background: #fff;
+    background-color: #fff;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
     font-weight: 600;
 }
 .maincontentinner.tabs.board-tabs-bar ul li.active a:hover {
     color: var(--accent1, #007bb3);
-    background: #fff;
+    background-color: #fff;
 }

--- a/public/assets/less/main.less
+++ b/public/assets/less/main.less
@@ -73,5 +73,4 @@
 @import "~css/components/mermaid.css";
 @import "~css/components/glass.css";
 @import "~css/components/wiki.css";
-@import "~css/components/ticket-board-tabs.css";
 @import "~css/components/overwrites.css";

--- a/public/assets/less/main.less
+++ b/public/assets/less/main.less
@@ -73,4 +73,5 @@
 @import "~css/components/mermaid.css";
 @import "~css/components/glass.css";
 @import "~css/components/wiki.css";
+@import "~css/components/ticket-board-tabs.css";
 @import "~css/components/overwrites.css";


### PR DESCRIPTION
### Description

This PR fixes multiple layout and styling regressions on the ticket board view navigation and action toolbar:

1. **Restored 2-Row Toolbar Architecture**:
   - Moves the left-hand action cluster (`+ New ▾`, `Filter`, `Group By`) back into the dedicated toolbar `<div class="row">` across `showKanban.blade.php`, `showAll.blade.php`, and `showList.blade.php`.
   - Prevents action buttons from colliding with the top view tabs or leaving DataTables buttons (`Export`, `Columns`) orphaned.
2. **Fixed Board Tabs Styling (`ticketBoardTabs.blade.php`)**:
   - Restores the full-width white-to-glass gradient capsule background with backdrop filter matching the design system.
   - Restores active tab white pill highlighting (`background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,0.12); color: var(--accent1); font-weight: 600;`).
   - Restores clean horizontal flex alignment and removes default browser bullet points (`•`) and vertical stacking.
3. **Accessibility / ARIA Sanitization**:
   - Uses `strip_tags()` on the `<nav aria-label="...">` string to prevent escaped HTML icon tags (`&lt;i class='...'&gt;`) from leaking into the DOM.

### Link to ticket

Closes #3748 (https://github.com/Leantime/leantime/issues/3748)

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup 

### Screenshot of the result

<img width="2057" height="464" alt="image" src="https://github.com/user-attachments/assets/481b77b6-aba8-4ac8-96a4-3480d4390360" />
<img width="2063" height="386" alt="image" src="https://github.com/user-attachments/assets/1496460a-50a5-40c0-9ef5-87e0fcc8dcbe" />
