### PR TITLE
fix(2fa): validate redirect in TwoFA Verify to close open redirect (#3741)

### DIFF
--- a/app/Domain/TwoFA/Controllers/Verify.php
+++ b/app/Domain/TwoFA/Controllers/Verify.php
@@ -28,11 +28,12 @@ class Verify extends Controller
      */
     public function get($params)
     {
-        $redirectUrl = BASE_URL.'/dashboard/home';
-
-        if (isset($_GET['redirect'])) {
-            $redirectUrl = BASE_URL.urldecode($_GET['redirect']);
-        }
+        // Guard the type: redirect[]=x arrives as an array, which would TypeError
+        // against resolveSafeRedirect(?string). Route the user-supplied value
+        // through resolveSafeRedirect() (as Login::get() does) so an open-redirect
+        // target (e.g. //attacker.com) can never reach the redirect.
+        $rawRedirect = $_GET['redirect'] ?? null;
+        $redirectUrl = $this->authService->resolveSafeRedirect(is_string($rawRedirect) ? $rawRedirect : null);
 
         $this->tpl->assign('redirectUrl', $redirectUrl);
 


### PR DESCRIPTION
## What

Closes #3741.

`TwoFA\Controllers\Verify::get()` built its redirect with no validation:

```php
$redirectUrl = BASE_URL.'/dashboard/home';

if (isset($_GET['redirect'])) {
    $redirectUrl = BASE_URL.urldecode($_GET['redirect']);
}
```

A user-supplied `redirect` value is url-decoded and concatenated straight onto `BASE_URL`, never passing through `Auth::resolveSafeRedirect()`. That makes it an open redirect after 2FA verification:

- `//attacker.com` → `BASE_URL//attacker.com` (protocol-relative → external host)
- `https://evil.example.com`, backslash-obfuscated `\/\/attacker.com`, and whitespace/`%09`-padded variants all slip through.
- `urldecode()` also turns `+` into a space, corrupting legitimate query strings — `resolveSafeRedirect()` deliberately uses `rawurldecode()`.

## Fix

Route the value through `Auth::resolveSafeRedirect()` — exactly what `Login::get()` already does — and drop the manual concatenation. Also guard the array case (`redirect[]=x`), which would otherwise `TypeError` against `resolveSafeRedirect(?string)`.

```php
$rawRedirect = $_GET['redirect'] ?? null;
$redirectUrl = $this->authService->resolveSafeRedirect(is_string($rawRedirect) ? $rawRedirect : null);
```

`resolveSafeRedirect()` already rejects protocol-relative and absolute URLs, normalizes backslash tricks, strips control characters, and preserves same-origin relative paths. It is covered by 21 existing assertions in `tests/Unit/app/Domain/Auth/Services/AuthServiceTest.php`, so this change reuses proven-safe logic rather than adding new security code. `$this->authService` is already injected in this controller.

## Verification

I couldn't run the full Codeception suite in my environment, but I verified the security property directly with a standalone PHP 8.3 harness that runs the real `resolveSafeRedirect()` body against the exact open-redirect payloads:

```
payload=//attacker.com          OLD=https://my-leantime.com//attacker.com   LEAKS | NEW=https://my-leantime.com/dashboard/home  SAFE
payload=/\/\attacker.com        OLD=…/\/\attacker.com                       LEAKS | NEW=…/dashboard/home                       SAFE
payload=https://evil.example.com OLD=…https://evil.example.com              LEAKS | NEW=…/dashboard/home                       SAFE
payload=%09//evil.example.com   OLD=…\t//evil.example.com                   LEAKS | NEW=…/dashboard/home                       SAFE
payload= //evil.example.com     OLD=… //evil.example.com                    LEAKS | NEW=…/dashboard/home                       SAFE
legit internal 'tickets/showAll' -> https://my-leantime.com/tickets/showAll  PRESERVED
```

The old construction leaks every payload; the fix neutralizes all of them while preserving a legitimate same-origin redirect. `php -l` on the changed file is clean.

As the issue suggests, other hand-rolled `BASE_URL.$_GET[...]` redirect builders may be worth a follow-up grep; this PR is scoped to the TwoFA Verify controller.
