### PR TITLE
fix: "Edit" option for "Ideas" doesn't work with Kanban

### DIFF
--- a/app/Domain/Ideas/Controllers/BoardDialog.php
+++ b/app/Domain/Ideas/Controllers/BoardDialog.php
@@ -64,7 +64,7 @@ class BoardDialog extends Controller
      *
      * @param  array  $params  Request parameters
      */
-    #[RequiresPermission(IdeasPermissions::VIEW)]
+    #[RequiresPermission(IdeasPermissions::EDIT, entityScoped: true)]
     public function post(array $params): Response
     {
         $currentCanvasId = '';

--- a/app/Domain/Ideas/Templates/advancedBoards.blade.php
+++ b/app/Domain/Ideas/Templates/advancedBoards.blade.php
@@ -45,7 +45,7 @@
                 <a href="javascript:void(0)" class="dropdown-toggle btn btn-transparent" data-toggle="dropdown"><i class="fa-solid fa-ellipsis-v"></i></a>
                 <ul class="dropdown-menu editCanvasDropdown">
                     @if ($login::userIsAtLeast($roles::$editor))
-                        <li><a href="javascript:void(0)" class="editCanvasLink ">{!! __('links.icon.edit') !!}</a></li>
+                        <li><a href="#/ideas/boardDialog/{{ $currentCanvas }}">{!! __('links.icon.edit') !!}</a></li>
                         <li><a href="{{ BASE_URL }}/ideas/delCanvas/{{ $currentCanvas }}" class="delete">{!! __('links.icon.delete') !!}</a></li>
                     @endif
                 </ul>


### PR DESCRIPTION
Fixes #3743

## Root cause

Ideas Kanban "Edit" link relies on an empty JS stub

## Changes

- Point the Kanban view's ellipsis "Edit" entry at the same hash-routed board dialog used by the working Idea Wall view (#/ideas/boardDialog/{currentCanvas}) instead of a javascript:void(0) link whose .editCanvasLink handler (leantime.ideasController.initBoardControlModal) has an empty body and never opens a modal.