### PR TITLE
fix: guard phar:// plugin probes against open_basedir violations

### DIFF
--- a/app/Core/UI/ViewsServiceProvider.php
+++ b/app/Core/UI/ViewsServiceProvider.php
@@ -430,9 +430,9 @@ class ViewsServiceProvider extends LaravelViewServiceProvider
                 $pluginFolder = basename($path);
 
                 // Check phar templates first
-                $pharTemplatesPath = 'phar://'.APP_ROOT.'/app/Plugins/'.$pluginFolder.'/'.$pluginFolder.'.phar/Templates';
-                if (is_dir($pharTemplatesPath)) {
-                    return [strtolower($pluginFolder) => [$pharTemplatesPath]];
+                $pharFile = APP_ROOT.'/app/Plugins/'.$pluginFolder.'/'.$pluginFolder.'.phar';
+                if (is_file($pharFile) && is_dir('phar://'.$pharFile.'/Templates')) {
+                    return [strtolower($pluginFolder) => ['phar://'.$pharFile.'/Templates']];
                 }
 
                 // Check folder templates

--- a/app/Domain/Plugins/Services/Registration.php
+++ b/app/Domain/Plugins/Services/Registration.php
@@ -93,7 +93,7 @@ class Registration
         }
 
         // Check phar if no files found in regular directory (only when the on-disk archive exists)
-        if (empty($languageFiles) && file_exists($pharFile) && file_exists($pharPath)) {
+        if (empty($languageFiles) && is_file($pharFile) && is_dir($pharPath)) {
             $files = scandir($pharPath);
             foreach ($files as $file) {
                 if (substr($file, -4) === '.ini') {
@@ -121,8 +121,8 @@ class Registration
 
         $languagePath = "/Language/{$language}.ini";
 
-        // Check phar first, only after the on-disk archive exists (open_basedir hosts)
-        if (file_exists($pharFile) && file_exists($pharPath.$languagePath)) {
+        // Check phar first, only after the on-disk archive exists as a real file (open_basedir hosts)
+        if (is_file($pharFile) && file_exists($pharPath.$languagePath)) {
             $completeLanguagePath = $pharPath.$languagePath;
         } elseif (file_exists($regularPath.$languagePath)) {
             $completeLanguagePath = $regularPath.$languagePath;
@@ -154,7 +154,7 @@ class Registration
 
         // Stat the on-disk archive first: stat'ing a phar:// path for a missing archive
         // raises a spurious open_basedir error on hosts with open_basedir set.
-        if (file_exists($pharFile) && file_exists($pharPath)) {
+        if (is_file($pharFile) && file_exists($pharPath)) {
             return $pharPath;
         }
 

--- a/app/Domain/Plugins/Services/Registration.php
+++ b/app/Domain/Plugins/Services/Registration.php
@@ -76,7 +76,8 @@ class Registration
         $languageDir = '/Language/';
 
         // Check both possible locations for language files
-        $pharPath = "phar://{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar".$languageDir;
+        $pharFile = "{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar";
+        $pharPath = 'phar://'.$pharFile.$languageDir;
         $regularPath = "{$pluginPath}{$this->pluginId}".$languageDir;
 
         $languageFiles = [];
@@ -91,8 +92,8 @@ class Registration
             }
         }
 
-        // Check phar if no files found in regular directory
-        if (empty($languageFiles) && file_exists($pharPath)) {
+        // Check phar if no files found in regular directory (only when the on-disk archive exists)
+        if (empty($languageFiles) && file_exists($pharFile) && file_exists($pharPath)) {
             $files = scandir($pharPath);
             foreach ($files as $file) {
                 if (substr($file, -4) === '.ini') {
@@ -114,13 +115,14 @@ class Registration
 
         $pluginPath = APP_ROOT.'/app/Plugins/';
 
-        $pharPath = "phar://{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar";
+        $pharFile = "{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar";
+        $pharPath = 'phar://'.$pharFile;
         $regularPath = "{$pluginPath}{$this->pluginId}";
 
         $languagePath = "/Language/{$language}.ini";
 
-        // Check phar first
-        if (file_exists($pharPath.$languagePath)) {
+        // Check phar first, only after the on-disk archive exists (open_basedir hosts)
+        if (file_exists($pharFile) && file_exists($pharPath.$languagePath)) {
             $completeLanguagePath = $pharPath.$languagePath;
         } elseif (file_exists($regularPath.$languagePath)) {
             $completeLanguagePath = $regularPath.$languagePath;
@@ -146,10 +148,13 @@ class Registration
 
         $pluginPath = APP_ROOT.'/app/Plugins/';
 
-        $pharPath = "phar://{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar";
+        $pharFile = "{$pluginPath}{$this->pluginId}/{$this->pluginId}.phar";
+        $pharPath = 'phar://'.$pharFile;
         $regularPath = "{$pluginPath}{$this->pluginId}";
 
-        if (file_exists($pharPath)) {
+        // Stat the on-disk archive first: stat'ing a phar:// path for a missing archive
+        // raises a spurious open_basedir error on hosts with open_basedir set.
+        if (file_exists($pharFile) && file_exists($pharPath)) {
             return $pharPath;
         }
 


### PR DESCRIPTION
## Problem

On hosts running PHP with a restrictive `open_basedir` (typical shared
hosting, where the base dir is locked to the site directory), Leantime
returns **500 on every request** as soon as a plugin is installed.

## Cause

Four code paths probe for a PHAR-packaged variant of a plugin by stat'ing
a `phar://` stream URL for `app/Plugins/<Folder>/<Folder>.phar` — an
archive that **does not exist** for folder-based plugins — unconditionally,
before the plain-folder fallback:

- `ViewsServiceProvider::discoverViewPaths()` — `is_dir('phar://…/Templates')`
  for every folder under `app/Plugins/`
- `Registration::findLanguageFiles()`, `loadPluginLanguage()`,
  `getPluginBasePath()` — `file_exists('phar://…')` for language files and
  the `dist/` build manifest

On such hosts the phar:// stream wrapper resolves the missing archive in a
way that touches a directory outside the allowed set. PHP raises an
`E_WARNING` ("open_basedir restriction in effect"), and Laravel's
`HandleExceptions` bootstrapper escalates any warning into an
`ErrorException` → 500.

The outage is **persistent, not a one-off**: `getViewPaths()` writes its
result to the viewPaths manifest only *after* discovery returns, and
`loadPluginLanguage()` writes its cache entry only after the probe — so the
exception always fires before anything can be cached, and every subsequent
request re-runs discovery/registration and re-throws.

## Fix

Guard each `phar://` probe with `is_file()` on the plain on-disk archive
path first. A folder-based plugin ships no `<Folder>.phar`, so the `&&`
short-circuits and the phar:// stream wrapper is never invoked. A genuine
PHAR-packaged plugin is probed exactly as before.

`is_file()` (not `file_exists()`) is used for the on-disk guard so only a
real regular-file archive can trigger the probe — a directory or other
non-file entry at `<Folder>.phar` must not trigger a `phar://` lookup
against a non-archive. The in-phar checks keep the test matching the entry
type: `file_exists()` on the `.ini` file / phar root, `is_dir()` on the
in-phar `Language/` directory.

Three commits, four probe sites:

- `fix(core)` — guard the view-discovery probe (`ViewsServiceProvider`)
- `fix(plugins)` — guard the three registration probes (`Registration`)
- `fix(plugins)` — tighten on-disk guards to `is_file()`

**No behavioral change** for PHAR-packaged plugins or for hosts without an
`open_basedir` restriction.

## Verification

- [ ] Host/container with `open_basedir` set (as in the report), folder-based
      plugin installed: requests no longer 500; views, plugin language files
      and header/footer JS/CSS load normally.
- [ ] PHAR-packaged plugin installed: templates, language files and dist
      assets still resolve from the phar.
- [ ] Non-file entry at `<Folder>.phar` path: no `phar://` probe attempted.
- [ ] Host without `open_basedir`: behavior unchanged.