### PR TITLE
changing rendering label to unescaping icon code

### DIFF
--- a/app/Domain/Tickets/Templates/showAll.blade.php
+++ b/app/Domain/Tickets/Templates/showAll.blade.php
@@ -63,7 +63,7 @@
             @if ($group['label'] != 'all')
                 <h5 class="accordionTitle {{ $group['class'] }}" @if (!empty($group['color'])) style="color:{{ htmlspecialchars($group['color']) }}" @endif id="accordion_link_{{ $group['id'] }}">
                     <a href="javascript:void(0)" class="accordion-toggle" id="accordion_toggle_{{ $group['id'] }}" onclick="leantime.snippets.accordionToggle('{{ $group['id'] }}');">
-                        <i class="fa fa-angle-down"></i>{{ $group['label'] }}({{ count($group['items']) }})
+                        <i class="fa fa-angle-down"></i>{!! $group['label'] !!}({{ count($group['items']) }})
                     </a><br />
                     <small style="padding-left:20px; color:var(--primary-font-color); font-size:var(--font-size-s);">{{ $group['more-info'] }}</small>
                 </h5>

--- a/app/Domain/Tickets/Templates/showAllMilestones.blade.php
+++ b/app/Domain/Tickets/Templates/showAllMilestones.blade.php
@@ -50,7 +50,7 @@
             @if ($group['label'] != 'all')
         <h5 class="accordionTitle {{ $group['class'] }}" @if (!empty($group['color'])) style="color:{{ htmlspecialchars($group['color']) }}" @endif id="accordion_link_{{ $group['id'] }}">
             <a href="javascript:void(0)" class="accordion-toggle" id="accordion_toggle_{{ $group['id'] }}" onclick="leantime.snippets.accordionToggle('{{ $group['id'] }}');">
-                <i class="fa fa-angle-down"></i>{{ $group['label'] }} ({{ count($group['items']) }})
+                <i class="fa fa-angle-down"></i>{!! $group['label'] !!} ({{ count($group['items']) }})
             </a>
         </h5>
         <div class="simpleAccordionContainer" id="accordion_content-{{ $group['id'] }}">

--- a/app/Domain/Tickets/Templates/showList.blade.php
+++ b/app/Domain/Tickets/Templates/showList.blade.php
@@ -53,7 +53,7 @@
                         @if ($group['label'] != 'all')
                             <h5 class="accordionTitle {{ $group['class'] }}" @if (!empty($group['color'])) style="color:{{ htmlspecialchars($group['color']) }}" @endif id="accordion_link_{{ $group['id'] }}">
                                 <a href="javascript:void(0)" class="accordion-toggle" id="accordion_toggle_{{ $group['id'] }}" onclick="leantime.snippets.accordionToggle('{{ $group['id'] }}');">
-                                    <i class="fa fa-angle-down"></i>{{ $group['label'] }} ({{ count($group['items']) }})
+                                    <i class="fa fa-angle-down"></i>{!! $group['label'] !!} ({{ count($group['items']) }})
                                 </a>
                             </h5>
                             <div class="simpleAccordionContainer" id="accordion_content-{{ $group['id'] }}">


### PR DESCRIPTION
### Description

On ticket lists, when grouped by Type, type icons what not displayed - html was escaped.

To-dos - list:
<img width="251" height="104" alt="image" src="https://github.com/user-attachments/assets/9cb69087-7f90-4810-af7b-a3383d42d244" />

To-dos - table:
<img width="233" height="127" alt="image" src="https://github.com/user-attachments/assets/25979a24-0b38-46de-b0cd-829a753e419f" />

Milestones - table:
<img width="254" height="119" alt="image" src="https://github.com/user-attachments/assets/f79948d6-045c-4b39-afbc-2abae541d8ed" />


### Type

- [ x] Fix
- [ ] Feature
- [x ] Cleanup 

### Screenshot of the result

After fix:
<img width="297" height="251" alt="image" src="https://github.com/user-attachments/assets/3d1f5631-62d9-4558-901b-a38da9345c03" />

<img width="335" height="185" alt="image" src="https://github.com/user-attachments/assets/c84ac378-0b96-438d-aeea-94bdb93d305a" />

<img width="380" height="178" alt="image" src="https://github.com/user-attachments/assets/d8b79ddf-b7c5-4284-8276-24bc42198f6c" />
