### PR TITLE
fix(tickets): escape user-controlled group labels at the source (XSS)

### DIFF
--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -768,7 +768,7 @@ class Tickets extends BaseService
                             break;
                         case 'editorId':
                             $editorName = htmlspecialchars(trim($ticket['editorFirstname'].' '.$ticket['editorLastname']), ENT_QUOTES, 'UTF-8');
-                            $label = "<div class='profileImage'><img src='".BASE_URL.'/api/users?profileImage='.(int) $ticket['editorId']."' /></div> ".$editorName;
+                            $label = "<div class='profileImage'><img alt='' src='".BASE_URL.'/api/users?profileImage='.(int) $ticket['editorId']."' /></div> ".$editorName;
 
                             if ($ticket['editorFirstname'] == '' && $ticket['editorLastname'] == '') {
                                 $label = 'Not Assigned to Anyone';
@@ -800,7 +800,10 @@ class Tickets extends BaseService
                         case 'projectId':
                             // Program cross-project board: group by the ticket's project.
                             $label = htmlspecialchars((string) ($ticket['projectName'] ?? ('Project #'.$groupedFieldValue)), ENT_QUOTES, 'UTF-8');
-                            $sortId = 'a_'.strtolower((string) ($ticket['projectName'] ?? $groupedFieldValue));
+                            // Becomes $group['id'], which templates interpolate into inline
+                            // onclick JS string literals — sanitize like the milestone and
+                            // parent-task branches already do.
+                            $sortId = 'a_'.preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower((string) ($ticket['projectName'] ?? $groupedFieldValue)));
                             break;
                         default:
                             $label = htmlspecialchars((string) $groupedFieldValue, ENT_QUOTES, 'UTF-8');

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -697,12 +697,16 @@ class Tickets extends BaseService
                 if (isset($ticketGroups[$groupedFieldValue])) {
                     $ticketGroups[$groupedFieldValue]['items'][] = $ticket;
                 } else {
+                    // 'label' is rendered RAW by every consumer (kanban swimlane header,
+                    // table/list accordion headers) because some groups embed markup — a type
+                    // icon, the assignee avatar. So this switch is the escaping boundary:
+                    // every branch must htmlspecialchars any user-controlled text it embeds.
                     switch ($searchCriteria['groupBy']) {
                         case 'status':
                             $status = $this->getStatusLabels();
 
                             if (isset($status[$groupedFieldValue])) {
-                                $label = $status[$groupedFieldValue]['name'];
+                                $label = htmlspecialchars((string) $status[$groupedFieldValue]['name'], ENT_QUOTES, 'UTF-8');
                                 $class = $status[$groupedFieldValue]['class'];
                             } else {
                                 $label = 'New';
@@ -755,15 +759,16 @@ class Tickets extends BaseService
                                 }
 
                                 $statusLabels = $this->getStatusLabels($milestone->projectId);
-                                $status = $statusLabels[$milestone->status]['name'];
+                                $status = htmlspecialchars((string) ($statusLabels[$milestone->status]['name'] ?? ''), ENT_QUOTES, 'UTF-8');
                                 $moreInfo = $this->language->__('label.start').': '.$startDate.' • '.$this->language->__('label.end').': '.$endDate.' • '.$this->language->__('label.status_lowercase').': '.$status;
-                                $label = $ticket['milestoneHeadline'];
+                                $label = htmlspecialchars((string) $ticket['milestoneHeadline'], ENT_QUOTES, 'UTF-8');
                                 $sortId = 'a_'.preg_replace('/[^a-zA-Z0-9_-]/', '_', $ticket['milestoneHeadline']); // Named milestones sort first alphabetically
                             }
 
                             break;
                         case 'editorId':
-                            $label = "<div class='profileImage'><img src='".BASE_URL.'/api/users?profileImage='.$ticket['editorId']."' /></div> ".$ticket['editorFirstname'].' '.$ticket['editorLastname'];
+                            $editorName = htmlspecialchars(trim($ticket['editorFirstname'].' '.$ticket['editorLastname']), ENT_QUOTES, 'UTF-8');
+                            $label = "<div class='profileImage'><img src='".BASE_URL.'/api/users?profileImage='.(int) $ticket['editorId']."' /></div> ".$editorName;
 
                             if ($ticket['editorFirstname'] == '' && $ticket['editorLastname'] == '') {
                                 $label = 'Not Assigned to Anyone';
@@ -780,7 +785,7 @@ class Tickets extends BaseService
                             break;
                         case 'type':
                             $icon = $this->getTypeIcons();
-                            $label = "<i class='fa ".($icon[strtolower($ticket['type'])] ?? '')."'></i>".$ticket['type'];
+                            $label = "<i class='fa ".($icon[strtolower($ticket['type'])] ?? '')."'></i>".htmlspecialchars((string) $ticket['type'], ENT_QUOTES, 'UTF-8');
                             break;
                         case 'dependingTicketId':
                             if ($ticket['dependingTicketId'] > 0 && ! empty($ticket['parentHeadline'])) {
@@ -794,7 +799,7 @@ class Tickets extends BaseService
                             break;
                         case 'projectId':
                             // Program cross-project board: group by the ticket's project.
-                            $label = $ticket['projectName'] ?? ('Project #'.$groupedFieldValue);
+                            $label = htmlspecialchars((string) ($ticket['projectName'] ?? ('Project #'.$groupedFieldValue)), ENT_QUOTES, 'UTF-8');
                             $sortId = 'a_'.strtolower((string) ($ticket['projectName'] ?? $groupedFieldValue));
                             break;
                         default:


### PR DESCRIPTION
Found while reviewing #3763 (thanks @mborecki — his report is what surfaced this).

## The bug

`Tickets::getGroups()` builds a `label` that its consumer renders **raw** — `swimlane-row-header.blade.php` does `{!! $label !!}` — because some group types legitimately embed markup (the task-type icon, the assignee avatar). That makes the `switch` in `getGroups()` the escaping boundary.

Only three of its branches escaped. **Five carried user-controlled text straight into raw output:**

| groupBy | unescaped source |
|---|---|
| `status` | project status labels — user-editable, stored in `zp_settings` (`getStateLabels()`) |
| `milestoneid` | milestone headline, **plus** the status name interpolated into `more-info` (also rendered raw in the swimlane header) |
| `editorId` | assignee first/last name |
| `type` | task type value |
| `projectId` | project name |

So a milestone headline, project name, assignee name, task type, or a renamed status containing markup executes for every user who opens that kanban board. This is live on master today.

## The fix

Escape each at the source, and document the contract on the switch so the markup the method builds itself (type icon, assignee avatar) stays raw. Also casts `editorId` to `int` in the avatar URL.

Fixing it here rather than in the templates keeps a single boundary — and it is what makes #3763 safe to merge, since that PR unescapes the table/list accordion headers so the type icon renders instead of showing as markup. Merge this first, then #3763 lands cleanly on top (different files, no conflict).

## Verification

- `php -l` clean, Laravel Pint passes
- `priority` / `storypoints` labels are language-file strings, deliberately left raw
- `sprint`, `dependingTicketId` and the `default` branch already escaped — untouched