### PR TITLE
fix(tickets): strip markup from the board/timeline tab aria-labels (#3748)

### DIFF
--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -1,15 +1,7 @@
 @php
     use Leantime\Core\Controller\Frontcontroller;
 
-    if (!function_exists('findActive')) {
-        function findActive($route): string
-        {
-            if (str_contains(Frontcontroller::getCurrentRoute(), $route)) {
-                return 'active';
-            }
-            return '';
-        }
-    }
+    $currentRoute = Frontcontroller::getCurrentRoute();
 
     // Program boards inject their own kanban/table/list URLs + the route fragments used to
     // highlight the active tab. Per-project views fall back to the core /tickets/* routes.
@@ -18,27 +10,35 @@
         'table'  => ['url' => BASE_URL . '/tickets/showAll',    'active' => 'showAll'],
         'list'   => ['url' => BASE_URL . '/tickets/showList',   'active' => 'showList'],
     ];
+
+    $tabs = [];
+    foreach (['kanban' => 'links.kanban', 'table' => 'links.table', 'list' => 'links.list'] as $key => $langKey) {
+        $tabs[] = [
+            'url'      => $boardTabs[$key]['url'] . $searchParams,
+            'label'    => __($langKey),
+            'isActive' => str_contains($currentRoute, $boardTabs[$key]['active']),
+        ];
+    }
+
+    // links.* carry a Font Awesome icon (e.g. "<i class='fas fa-columns'></i> Kanban"), which
+    // is what the tab body wants but not the accessible name — an unstripped label puts escaped
+    // markup into the attribute. Strip tags for aria-label, keep the markup in the link. #3748
+    $navLabel = implode(' / ', array_map(fn ($tab) => strip_tags((string) $tab['label']), $tabs));
 @endphp
 
 <div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
-    <nav class="lt-tabs-group" aria-label="{{ __('links.kanban') }} / {{ __('links.table') }} / {{ __('links.list') }}">
-    <ul>
-        <li class="{{ findActive($boardTabs['kanban']['active']) }}">
-            <a href="{{ $boardTabs['kanban']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.kanban') !!}
-            </a>
-        </li>
-        <li class="{{ findActive($boardTabs['table']['active']) }}">
-            <a href="{{ $boardTabs['table']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.table') !!}
-            </a>
-        </li>
-        <li class="{{ findActive($boardTabs['list']['active']) }}">
-            <a href="{{ $boardTabs['list']['url'] }}{{ $searchParams }}" preload="mouseover">
-                {!! __('links.list') !!}
-            </a>
-        </li>
-    </ul>
+    <nav class="lt-tabs-group" aria-label="{{ $navLabel }}">
+        <ul>
+            @foreach ($tabs as $tab)
+                <li class="{{ $tab['isActive'] ? 'active' : '' }}">
+                    <a href="{{ $tab['url'] }}"
+                       @if ($tab['isActive']) aria-current="page" @endif
+                       preload="mouseover">
+                        {!! $tab['label'] !!}
+                    </a>
+                </li>
+            @endforeach
+        </ul>
     </nav>
 
     {{-- Board actions (New / Filter / Group By) live on the right of the nav bar

--- a/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketBoardTabs.blade.php
@@ -23,7 +23,7 @@
     // links.* carry a Font Awesome icon (e.g. "<i class='fas fa-columns'></i> Kanban"), which
     // is what the tab body wants but not the accessible name — an unstripped label puts escaped
     // markup into the attribute. Strip tags for aria-label, keep the markup in the link. #3748
-    $navLabel = implode(' / ', array_map(fn ($tab) => strip_tags((string) $tab['label']), $tabs));
+    $navLabel = implode(' / ', array_map(fn ($tab) => trim(strip_tags((string) $tab['label'])), $tabs));
 @endphp
 
 <div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">

--- a/app/Domain/Tickets/Templates/submodules/timelineTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timelineTabs.blade.php
@@ -13,7 +13,7 @@
 @endphp
 
 <div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
-    <nav class="lt-tabs-group" aria-label="{{ __('links.timeline') }}">
+    <nav class="lt-tabs-group" aria-label="{{ strip_tags(__('links.timeline')) }}">
     <ul>
         <li class="{{ findActive('roadmap') }}">
             <a href="{{ BASE_URL }}/tickets/roadmap{{ $searchParams }}" preload="mouseover">

--- a/app/Domain/Tickets/Templates/submodules/timelineTabs.blade.php
+++ b/app/Domain/Tickets/Templates/submodules/timelineTabs.blade.php
@@ -13,7 +13,7 @@
 @endphp
 
 <div class="lt-tabs lt-tabs--floating lt-tabs--links hideOnPrint">
-    <nav class="lt-tabs-group" aria-label="{{ strip_tags(__('links.timeline')) }}">
+    <nav class="lt-tabs-group" aria-label="{{ trim(strip_tags(__('links.timeline'))) }}">
     <ul>
         <li class="{{ findActive('roadmap') }}">
             <a href="{{ BASE_URL }}/tickets/roadmap{{ $searchParams }}" preload="mouseover">


### PR DESCRIPTION
Closes the genuinely-broken part of #3748. Builds on @maruf-pfc's diagnosis and refactor in #3749 — thanks for finding this.

## What was real

`links.kanban` / `links.table` / `links.list` / `links.timeline` all carry a Font Awesome icon in the translation string:

```ini
links.kanban = "<i class='fas fa-columns'></i> Kanban"
```

The tab body wants that markup, but the `<nav>` aria-label used the same string through `{{ }}`, so the accessible name became escaped markup:

```html
aria-label="&lt;i class='fas fa-columns'&gt;&lt;/i&gt; Kanban / ..."
```

Fixed with `strip_tags` in `ticketBoardTabs` **and** `timelineTabs`, which had the identical bug.

Also carried over from #3749: replacing the `function_exists('findActive')` global helper with a tabs array (two templates declaring the same global function meant whichever rendered first won), and `aria-current="page"` on the active tab.

## What was not real

The other symptoms in #3748 — bullets, vertical stacking, overlapping action buttons — do not reproduce on a built master:

- `tab-group.css` styles this exact `<ul><li><a>` structure under `.lt-tabs--links` (`list-style: none`, `inline-flex` pills) and has been imported in `main.less` and shipped in the bundle since #3716
- the same `lt-tabs lt-tabs--floating lt-tabs--links` combo renders correctly in `timelineTabs`, `plugintabs`, and both Reports views

The screenshots show completely unstyled markup, which is a dev environment running stale assets — `npx mix`.

So #3749's `ticket-board-tabs.css` and toolbar-row revert are intentionally **not** included here: the stylesheet duplicated `tab-group.css` with hardcoded `#fff` / `rgba(255,255,255,…)` values that break dark mode, bypassed the Mix pipeline (no version stamp, no cache busting), and moving board actions out of the nav bar would have made Tickets the only one of five `lt-tabs` consumers with a separate toolbar row.