### PR TITLE
fix(2fa): close the POST half of the TwoFA open redirect

### DIFF
--- a/app/Domain/TwoFA/Controllers/Verify.php
+++ b/app/Domain/TwoFA/Controllers/Verify.php
@@ -45,7 +45,12 @@ class Verify extends Controller
 
         if (session()->exists('userdata') && $this->authService->use2FA()) {
             if (isset($params['twoFA_code']) === true) {
-                $redirectUrl = filter_var($params['redirectUrl'], FILTER_SANITIZE_URL);
+                // redirectUrl round-trips as a form field, so it is just as
+                // attacker-controllable here as the GET param — and FILTER_SANITIZE_URL is a
+                // sanitizer, not a safety check ("//attacker.com" passes through it
+                // untouched). Run it through the same guard get() uses.
+                $rawRedirect = $params['redirectUrl'] ?? null;
+                $redirectUrl = $this->authService->resolveSafeRedirect(is_string($rawRedirect) ? $rawRedirect : null);
 
                 if ($this->authService->verify2FA($params['twoFA_code'])) {
                     $this->authService->set2FAVerified();


### PR DESCRIPTION
Follow-up to #3750 (thanks @chiliec). That PR closed the GET path; this closes the other half.

## The gap

`Verify::post()` still did:

```php
$redirectUrl = filter_var($params['redirectUrl'], FILTER_SANITIZE_URL);
// ...
return FrontcontrollerCore::redirect($redirectUrl);
```

`FILTER_SANITIZE_URL` is a **sanitizer, not a validator** — it strips characters outside the URL-legal set. `//attacker.com` contains nothing illegal, so it passes through completely unchanged and reaches the `Location` header.

And `redirectUrl` is not internal state: `get()` assigns it to the template, it renders as a hidden form field, and it comes back on the POST. So it is exactly as attacker-controllable as the GET param that #3750 fixed. Closing only the GET half left the actual redirect reachable.

## The fix

Same guard `get()` now uses, including the `is_string()` check so `redirectUrl[]=x` cannot TypeError against `resolveSafeRedirect(?string)`.

`resolveSafeRedirect()` rejects protocol-relative URLs, external absolute URLs, backslash and percent-encoding tricks, control characters, and `/auth/logout`, and returns `BASE_URL.'/dashboard/home'` otherwise — so behavior for a normal same-origin redirect is unchanged.

## Verification

`php -l` clean, Laravel Pint passes. The only remaining mention of `FILTER_SANITIZE_URL` in the file is the comment explaining why it was insufficient.

Note the decode question raised by Copilot on #3750: `resolveSafeRedirect()` already calls `rawurldecode()` internally, so the raw value must be passed in. Decoding beforehand would double-decode and let `%252f%252fevil.com` become `//evil.com` past the guard.