### PR TITLE
fix(routing): resolve plugin controllers whose folder has an inner capital

### DIFF
--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -274,28 +274,34 @@ class Frontcontroller
             return $classname;
         }
 
-        $classname = 'Leantime\\Plugins\\'.$moduleName.'\\'.$controllerType.'\\'.$actionName;
-
         $enabledPlugins = app()->make(\Leantime\Domain\Plugins\Services\Plugins::class)->getEnabledPlugins();
 
-        $pluginEnabled = false;
+        // $moduleName arrives here as Str::studly() of the URL segment, which
+        // FLATTENS internal capitals: "pgmpro" becomes "Pgmpro", never "PgmPro".
+        // Composer's PSR-4 prefix map is case-sensitive, so every controller in a
+        // plugin whose folder has an inner capital (PgmPro, StrategyPro) failed to
+        // resolve and 404'd. The enabled-plugin record already carries the real
+        // folder name, so match case-insensitively and then adopt that spelling
+        // for the class lookup.
+        $pluginFolder = null;
         foreach ($enabledPlugins as $key => $obj) {
             if (strtolower($obj->foldername) !== strtolower($moduleName)) {
                 continue;
             }
-            $pluginEnabled = true;
+            $pluginFolder = $obj->foldername;
             break;
         }
 
-        if (! $pluginEnabled) {
+        if ($pluginFolder === null) {
             return false;
         }
 
+        $classname = 'Leantime\\Plugins\\'.$pluginFolder.'\\'.$controllerType.'\\'.$actionName;
         if (class_exists($classname)) {
             return $classname;
         }
 
-        $classname = 'Leantime\\Plugins\\'.$moduleName.'\\Hxcontrollers\\'.$actionName;
+        $classname = 'Leantime\\Plugins\\'.$pluginFolder.'\\Hxcontrollers\\'.$actionName;
         if (class_exists($classname)) {
             return $classname;
         }

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -276,6 +276,15 @@ class Frontcontroller
 
         $enabledPlugins = app()->make(\Leantime\Domain\Plugins\Services\Plugins::class)->getEnabledPlugins();
 
+        // The collection itself is as untrustworthy as its elements: the method is
+        // typed `mixed` and the beforeReturnCachedPlugins filter can return
+        // anything, including false/null. foreach over a non-iterable warns on
+        // EVERY route resolution (and is a TypeError under strict error handling),
+        // so degrade to "no enabled plugins" instead.
+        if (! is_iterable($enabledPlugins)) {
+            return false;
+        }
+
         // $moduleName arrives here as Str::studly() of the URL segment, which
         // FLATTENS internal capitals: "pgmpro" becomes "Pgmpro", never "PgmPro".
         // Composer's PSR-4 prefix map is case-sensitive, so every controller in a

--- a/app/Core/Controller/Frontcontroller.php
+++ b/app/Core/Controller/Frontcontroller.php
@@ -285,10 +285,27 @@ class Frontcontroller
         // for the class lookup.
         $pluginFolder = null;
         foreach ($enabledPlugins as $key => $obj) {
-            if (strtolower($obj->foldername) !== strtolower($moduleName)) {
+            // getEnabledPlugins() is typed `mixed` and its payload goes through the
+            // beforeReturnCachedPlugins filter, so a plugin can reshape it — and a
+            // cached entry can come back as __PHP_Incomplete_Class when the model
+            // isn't loaded at unserialize time. Read the folder name defensively:
+            // this runs on every route resolution, so a fatal here would turn one
+            // bad cache entry into a 500 on every request instead of a clean 404.
+            // __PHP_Incomplete_Class must be excluded BEFORE any property access:
+            // even isset() on one raises "tried to access a property on an
+            // incomplete object", so testing for the property is not enough.
+            $folder = match (true) {
+                $obj instanceof \__PHP_Incomplete_Class => null,
+                is_object($obj) && isset($obj->foldername) => $obj->foldername,
+                is_array($obj) && isset($obj['foldername']) => $obj['foldername'],
+                default => null,
+            };
+
+            if (! is_string($folder) || strtolower($folder) !== strtolower($moduleName)) {
                 continue;
             }
-            $pluginFolder = $obj->foldername;
+
+            $pluginFolder = $folder;
             break;
         }
 

--- a/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
+++ b/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
@@ -178,6 +178,38 @@ class FrontcontrollerPluginCasingTest extends TestCase
     }
 
     /**
+     * The enabled-plugin COLLECTION is as untrustworthy as its elements:
+     * getEnabledPlugins() is typed `mixed` and the beforeReturnCachedPlugins
+     * filter can hand back false/null. foreach over a non-iterable would warn on
+     * every route resolution, so it must degrade to "no enabled plugins".
+     *
+     * @dataProvider nonIterablePluginPayloads
+     */
+    public function test_non_iterable_enabled_plugins_degrade_to_no_plugins(mixed $payload): void
+    {
+        $pluginService = $this->createMock(PluginService::class);
+        $pluginService->method('getEnabledPlugins')->willReturn($payload);
+        app()->instance(PluginService::class, $pluginService);
+
+        $fc = new Frontcontroller(
+            IncomingRequest::create('/', 'GET'),
+            $this->createMock(PermissionEnforcer::class),
+        );
+
+        $this->assertFalse($fc->getClassPath('Hxcontrollers', self::STUDLIED_SEGMENT, 'FixtureModal'));
+    }
+
+    public static function nonIterablePluginPayloads(): array
+    {
+        return [
+            'false' => [false],
+            'null' => [null],
+            'string' => ['not-a-list'],
+            'int' => [0],
+        ];
+    }
+
+    /**
      * Core domain controllers resolve before the plugin branch is reached and must
      * be unaffected.
      */

--- a/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
+++ b/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
@@ -96,14 +96,62 @@ class FrontcontrollerPluginCasingTest extends TestCase
         );
     }
 
-    /** Same for the Hxcontrollers branch — the surface that actually 404'd. */
-    public function test_plugin_hxcontroller_resolves_despite_the_studlied_segment(): void
+    /**
+     * The surface that actually 404'd. getControllerType() returns 'Hxcontrollers'
+     * for a real HTMX request, which makes the FIRST plugin lookup the
+     * Hxcontrollers one rather than the fallback — so this has to be asserted with
+     * that controllerType, not with 'Controllers'.
+     */
+    public function test_plugin_hxcontroller_resolves_on_the_htmx_controller_type(): void
+    {
+        $fc = $this->frontcontroller([self::CASED_FOLDER]);
+
+        $this->assertSame(
+            'Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers\\FixtureModal',
+            $fc->getClassPath('Hxcontrollers', self::STUDLIED_SEGMENT, 'FixtureModal')
+        );
+    }
+
+    /** And via the fallback, for a non-HTMX request that names an Hx controller. */
+    public function test_plugin_hxcontroller_resolves_through_the_fallback(): void
     {
         $fc = $this->frontcontroller([self::CASED_FOLDER]);
 
         $this->assertSame(
             'Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers\\FixtureModal',
             $fc->getClassPath('Controllers', self::STUDLIED_SEGMENT, 'FixtureModal')
+        );
+    }
+
+    /**
+     * getEnabledPlugins() is typed `mixed` and its payload passes through a
+     * plugin-modifiable filter; cached entries can also unserialize to
+     * __PHP_Incomplete_Class. Malformed entries must be skipped, not fataled on —
+     * routing resolution runs for every request.
+     */
+    public function test_malformed_enabled_plugin_entries_are_skipped_not_fataled(): void
+    {
+        $incomplete = unserialize('O:22:"SomeClassThatIsNotHere":0:{}');
+
+        $pluginService = $this->createMock(PluginService::class);
+        $pluginService->method('getEnabledPlugins')->willReturn([
+            $incomplete,                                  // __PHP_Incomplete_Class
+            ['foldername' => 'ArrayShapedPlugin'],        // array shape
+            'a-bare-string',                              // neither
+            (object) ['name' => 'no-foldername-key'],     // object missing the key
+            (object) ['foldername' => self::CASED_FOLDER],
+        ]);
+        app()->instance(PluginService::class, $pluginService);
+
+        $fc = new Frontcontroller(
+            IncomingRequest::create('/', 'GET'),
+            $this->createMock(PermissionEnforcer::class),
+        );
+
+        // Reaches the well-formed entry at the end without fataling on the others.
+        $this->assertSame(
+            'Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers\\FixtureModal',
+            $fc->getClassPath('Hxcontrollers', self::STUDLIED_SEGMENT, 'FixtureModal')
         );
     }
 

--- a/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
+++ b/tests/Unit/app/Core/Controller/FrontcontrollerPluginCasingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Unit\app\Core\Controller;
+
+use Leantime\Core\Auth\Permissions\PermissionEnforcer;
+use Leantime\Core\Controller\Frontcontroller;
+use Leantime\Core\Http\IncomingRequest;
+use Leantime\Domain\Plugins\Services\Plugins as PluginService;
+use Unit\TestCase;
+
+/**
+ * Regression coverage for plugin controller resolution when the plugin's folder
+ * name contains an INTERNAL capital.
+ *
+ * getValidControllerCall() runs the URL's module segment through Str::studly(),
+ * which flattens inner capitals: "pgmpro" becomes "Pgmpro", never "PgmPro".
+ * Composer's PSR-4 prefix map is case-sensitive, so
+ * Leantime\Plugins\Pgmpro\Hxcontrollers\X never resolved and every controller in
+ * such a plugin 404'd with "Can't find a valid controller" — the whole of
+ * PgmPro's and StrategyPro's modal surface (add dependency, add project, add
+ * person, link user).
+ *
+ * The enabled-plugin record already carries the true folder name, so resolution
+ * matches case-insensitively and then uses THAT spelling for the class lookup.
+ *
+ * Fixture classes are declared at runtime rather than pointing at a real plugin:
+ * app/Plugins is a private submodule that CI does not check out, so a test
+ * asserting against PgmPro would pass locally and be meaningless on CI.
+ *
+ * One nuance: because the fixtures are declared up front, class_exists() finds
+ * them under EITHER casing (PHP class names are case-insensitive once declared).
+ * So these tests assert on the casing of the resolved class path, whereas in
+ * production the failure is harder — the class was never declared, the
+ * case-sensitive PSR-4 autoloader could not load it, and the request 404'd. Same
+ * root cause, same fix; this guards the resolution logic without needing the
+ * private submodule on disk.
+ */
+class FrontcontrollerPluginCasingTest extends TestCase
+{
+    /** Folder name with an inner capital — the shape that used to fail. */
+    private const CASED_FOLDER = 'FixtureCasedPlugin';
+
+    /** What Str::studly() turns the lowercase URL segment into. */
+    private const STUDLIED_SEGMENT = 'Fixturecasedplugin';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // Declare the fixture controllers inside the namespace the resolver builds,
+        // so class_exists() behaves exactly as it does for a real plugin.
+        if (! class_exists('Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Controllers\\FixtureAction', false)) {
+            eval('namespace Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Controllers; class FixtureAction {}');
+        }
+
+        if (! class_exists('Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers\\FixtureModal', false)) {
+            eval('namespace Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers; class FixtureModal {}');
+        }
+    }
+
+    private function frontcontroller(array $enabledFolderNames): Frontcontroller
+    {
+        // getClassPath() resolves the plugin service out of the container; stub it
+        // so the test needs no database (unit tests have no DB connection).
+        $pluginService = $this->createMock(PluginService::class);
+        $pluginService->method('getEnabledPlugins')->willReturn(
+            array_map(static function (string $folder) {
+                $plugin = new \stdClass;
+                $plugin->foldername = $folder;
+
+                return $plugin;
+            }, $enabledFolderNames)
+        );
+
+        app()->instance(PluginService::class, $pluginService);
+
+        // Built by hand: container resolution would pull in the real
+        // PermissionEnforcer, which needs a database connection.
+        return new Frontcontroller(
+            IncomingRequest::create('/', 'GET'),
+            $this->createMock(PermissionEnforcer::class),
+        );
+    }
+
+    /**
+     * The bug. Before the fix this returned false, because the resolver looked for
+     * Leantime\Plugins\Fixturecasedplugin\Controllers\FixtureAction.
+     */
+    public function test_plugin_controller_resolves_despite_the_studlied_segment_losing_an_inner_capital(): void
+    {
+        $fc = $this->frontcontroller([self::CASED_FOLDER]);
+
+        $this->assertSame(
+            'Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Controllers\\FixtureAction',
+            $fc->getClassPath('Controllers', self::STUDLIED_SEGMENT, 'FixtureAction')
+        );
+    }
+
+    /** Same for the Hxcontrollers branch — the surface that actually 404'd. */
+    public function test_plugin_hxcontroller_resolves_despite_the_studlied_segment(): void
+    {
+        $fc = $this->frontcontroller([self::CASED_FOLDER]);
+
+        $this->assertSame(
+            'Leantime\\Plugins\\'.self::CASED_FOLDER.'\\Hxcontrollers\\FixtureModal',
+            $fc->getClassPath('Controllers', self::STUDLIED_SEGMENT, 'FixtureModal')
+        );
+    }
+
+    /**
+     * The case-insensitive match must not become case-blind about WHICH plugin:
+     * a module that is not in the enabled list still resolves to false.
+     */
+    public function test_a_plugin_that_is_not_enabled_still_does_not_resolve(): void
+    {
+        $fc = $this->frontcontroller([self::CASED_FOLDER]);
+
+        $this->assertFalse($fc->getClassPath('Controllers', 'SomeOtherPlugin', 'FixtureAction'));
+    }
+
+    /**
+     * A known action in an enabled plugin that genuinely has no such class must
+     * still fail, rather than the looser matching inventing a hit.
+     */
+    public function test_unknown_action_in_an_enabled_plugin_does_not_resolve(): void
+    {
+        $fc = $this->frontcontroller([self::CASED_FOLDER]);
+
+        $this->assertFalse($fc->getClassPath('Controllers', self::STUDLIED_SEGMENT, 'NoSuchAction'));
+    }
+
+    /**
+     * Core domain controllers resolve before the plugin branch is reached and must
+     * be unaffected.
+     */
+    public function test_domain_controllers_resolve_ahead_of_the_plugin_branch(): void
+    {
+        $fc = $this->frontcontroller([]);
+
+        $this->assertSame(
+            \Leantime\Domain\Calendar\Controllers\ShowMyCalendar::class,
+            $fc->getClassPath('Controllers', 'Calendar', 'ShowMyCalendar')
+        );
+    }
+}


### PR DESCRIPTION
## The bug

Every controller in **PgmPro** and **StrategyPro** reached through the Frontcontroller 404s:

```
Can't find a valid controller for Pgmpro/NewDependencyModal
```

## Root cause

`getValidControllerCall()` studlies the URL's module segment before resolution, and `Str::studly()` flattens internal capitals:

```
"pgmpro"  ->  "Pgmpro"     (never "PgmPro")
```

`getClassPath()` then builds `Leantime\Plugins\Pgmpro\Hxcontrollers\X`. Composer's PSR-4 prefix map is registered against the real `PgmPro` namespace and **is case-sensitive**, so the autoloader never matches and `class_exists()` returns false.

This is easy to misread, because once a class *is* loaded PHP matches its name case-insensitively — the failure happens strictly at autoload time. Demonstrated:

```
Leantime\Plugins\Pgmpro\Hxcontrollers\NewDependencyModal   not found
Leantime\Plugins\PgmPro\Hxcontrollers\NewDependencyModal   FOUND
```

## The fix

The enabled-plugin record already carries the true folder name, and the loop checking whether the plugin is enabled was *already* comparing case-insensitively. It now keeps that spelling and uses it for the class lookup instead of the studlied segment.

## Surface

Wider than the report suggests. PgmPro has no `routes.php`, so **every** modal goes through this path:

- `newDependencyModal` ← reported
- `newProjectModal`, `addPersonModal`, `linkUserModal` ← broken identically, just hadn't been clicked

StrategyPro has the same shape (`strategypro` → `Strategypro`).

Pre-existing — not a regression from #3771.

## Testing

New `FrontcontrollerPluginCasingTest`, 5 cases: both controller branches resolve, a non-enabled plugin still returns false, an unknown action still returns false, and core domain controllers are unaffected.

Fixtures are declared at runtime rather than pointing at a real plugin, since `app/Plugins` is a private submodule CI does not check out — a test asserting against PgmPro would pass locally and be meaningless on CI.

**Verified failing against the unfixed resolver** (2 failures) and passing with the fix. Full unit suite green (907 tests), Pint clean, PHPStan 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)