### PR TITLE
fix: logFailedLogin records the proxy's IP instead of the client's

### DIFF
--- a/app/Domain/Auth/Services/Auth.php
+++ b/app/Domain/Auth/Services/Auth.php
@@ -683,7 +683,7 @@ class Auth implements Authenticatable
         $date = new \DateTime;
         $date = $date->format('y:m:d h:i:s');
 
-        $ip = $_SERVER['REMOTE_ADDR'];
+        $ip = request()->getClientIp();
         $msg = '['.$date.']['.$ip.'] Login failed for user: '.$user;
 
         Log::info($msg);


### PR DESCRIPTION
## What happens

Every failed-login line records the address of the reverse proxy rather than the client that actually failed to authenticate. Behind any proxy — Traefik, nginx, Caddy, a load balancer — all entries collapse to a single address.

## Why this is inconsistent rather than intentional

Leantime is already proxy-aware, deliberately:

- `app/Core/Bootstrap/LoadConfig.php:133` calls `Request::setTrustedProxies($proxies, $this->headers)`.
- The trusted header set at `LoadConfig.php:22-26` includes `HEADER_X_FORWARDED_FOR`.
- `trustedProxies` is configurable and documented as `LEAN_TRUSTED_PROXIES`, defaulting to `'127.0.0.1,REMOTE_ADDR'` (`app/Core/Configuration/DefaultConfig.php:542`).

So the framework resolves the real client address correctly everywhere. This one function bypassed it by reading the superglobal directly.

Other call sites in the same codebase already do it the framework way:

- `app/Core/Middleware/AuthCheck.php:216` — `$request->getClientIp()`
- `app/Core/Middleware/RequestRateLimiter.php:100,122` — `$request->getClientIp()`

## Impact

The failed-login log is the natural input for fail2ban or similar. Because every line carries the proxy's address, such a jail bans the proxy — which means banning every user at once. Self-hosted operators behind a proxy therefore have no working application-layer brute-force response, despite `LEAN_TRUSTED_PROXIES` being present and correctly configured.

## The fix

`Auth` is a service with no request injected, so the `request()` helper is the minimal change — it's already used this way nowhere else in a Service class, but it's a standard global Laravel helper (`laravel/framework ^11.44`), not something Leantime needs to define. Injecting `IncomingRequest` would also work and may fit the codebase's DI style better; happy to switch to that if maintainers prefer it.

## Version

Observed on 3.9.8 and confirmed present on master as of this PR (056835f1c).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)