### PR TITLE
fix(notifications): send Mattermost attachment fields as an array

### DIFF
--- a/app/Domain/Notifications/Services/Messengers.php
+++ b/app/Domain/Notifications/Services/Messengers.php
@@ -142,6 +142,7 @@ class Messengers
                 $this->httpClient->post($mattermostWebhookURL, [
                     'allow_redirects' => OutboundUrlGuard::redirectOptions(),
                     'body' => $data_string,
+                    'headers' => ['Content-Type' => 'application/json'],
                 ]);
 
                 return true;
@@ -532,7 +533,7 @@ class Messengers
                 'pretext' => $notification->message,
                 'title' => $headline,
                 'title_link' => $notification->url['url'],
-                'fields' => $fields,
+                'fields' => [$fields],
             ],
         ];
 

--- a/tests/Unit/app/Domain/Notifications/Services/MessengersServiceTest.php
+++ b/tests/Unit/app/Domain/Notifications/Services/MessengersServiceTest.php
@@ -10,6 +10,7 @@ use Leantime\Core\Language as LanguageCore;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Notifications\Services\Messengers;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Leantime\Domain\Tickets\Services\Tickets;
 use Unit\TestCase;
 
 class MessengersServiceTest extends TestCase
@@ -168,5 +169,64 @@ class MessengersServiceTest extends TestCase
         $result = $reflectedMethod->invoke($messengers, $this->makeNotification());
 
         $this->assertFalse($result);
+    }
+
+    public function test_mattermost_webhook_sends_fields_as_array_with_json_content_type(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+
+        $client = $this->make(Client::class, [
+            'post' => function ($url, $options) use (&$capturedUrl, &$capturedOptions) {
+                $capturedUrl = $url;
+                $capturedOptions = $options;
+
+                return new Response(200, [], 'ok');
+            },
+        ]);
+
+        // An IP literal keeps OutboundUrlGuard from performing a DNS lookup during the test.
+        $webhookUrl = 'https://203.0.113.10/hooks/abcdefghijklmnopqrstuvwxyz';
+
+        $settingRepo = $this->make(SettingRepository::class, [
+            'getSetting' => fn ($key) => $key === 'projectsettings.1.mattermostWebhookURL' ? $webhookUrl : false,
+        ]);
+
+        $language = $this->make(LanguageCore::class, [
+            '__' => fn ($key) => $key,
+        ]);
+
+        $this->app->instance(Tickets::class, $this->make(Tickets::class, [
+            'getStatusLabels' => fn () => [3 => ['name' => 'New']],
+        ]));
+
+        $notification = new NotificationModel;
+        $notification->projectId = 1;
+        $notification->message = 'Test user added a new To-Do';
+        $notification->url = ['url' => 'https://example.com/ticket/123'];
+        $notification->entity = ['headline' => 'Test Todo', 'status' => 3];
+
+        $messengers = new Messengers($client, $settingRepo, $language);
+        $messengers->sendNotificationToMessengers($notification, 'Acme Project', ['mattermost']);
+
+        $this->assertSame($webhookUrl, $capturedUrl);
+
+        // Mattermost decodes the body as JSON; the header must say so.
+        $this->assertSame('application/json', $capturedOptions['headers']['Content-Type']);
+
+        $payload = json_decode($capturedOptions['body'], true);
+
+        $this->assertSame('Leantime', $payload['username']);
+        $this->assertSame('Test user added a new To-Do', $payload['attachments'][0]['pretext']);
+        $this->assertSame('Test Todo', $payload['attachments'][0]['title']);
+
+        $fields = $payload['attachments'][0]['fields'];
+
+        // Mattermost requires an array of field objects here. A single object makes it
+        // reject the entire payload with 400 web.incoming_webhook.decode.app_error.
+        $this->assertTrue(array_is_list($fields), 'attachments[0].fields must be a JSON array, not an object');
+        $this->assertSame('headlines.project_with_name Acme Project', $fields[0]['title']);
+        $this->assertSame('label.todo_status: New', $fields[0]['value']);
+        $this->assertFalse($fields[0]['short']);
     }
 }


### PR DESCRIPTION
### Description

Mattermost requires `attachments[].fields` to be an **array** of field objects. `prepareMessage()` builds it as a single object, so Mattermost rejects the whole payload with `400 web.incoming_webhook.decode.app_error` and no notification is ever delivered.

Isolated against the same incoming webhook, changing only the `fields` shape:

| payload | Mattermost response |
| --- | --- |
| `"fields": { ... }` (current) | `400 web.incoming_webhook.decode.app_error` |
| `"fields": [ { ... } ]` | `200 ok` |

Slack accepts the object form, which is why this only surfaces on Mattermost. `prepareMessage()` is shared with the Slack webhook, and the array form is what both Slack and Mattermost document, so Slack is unaffected.

This also adds `Content-Type: application/json` to the Mattermost request — `mattermostWebhook()` was the only messenger not sending it; slack, zulip, telegram and discord all pass the header already.

Verified against Mattermost 11.9.0 / Leantime 3.9.8 / PHP 8.3: before the change every to-do create/update was rejected with a 400; after it, messages post to the channel immediately.

One note for triage on #3131, where the discussion had moved toward the queue worker: messenger delivery is **not** queued. `sendNotificationToMessengers()` is called synchronously from `Projects.php:358`, immediately after the *email* queue call, so `schedule:run` has no bearing on this path.

### Link to ticket

Fixes #3131

### Type

- [x] Fix
- [ ] Feature
- [ ] Cleanup

### Screenshot of the result

No user interface changes — this affects the outbound webhook payload only.